### PR TITLE
chore: rename Go module from nebula-mgmt to nebula-mesh

### DIFF
--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -9,8 +9,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/juev/nebula-mgmt/internal/agent"
-	"github.com/juev/nebula-mgmt/internal/config"
+	"github.com/juev/nebula-mesh/internal/agent"
+	"github.com/juev/nebula-mesh/internal/config"
 )
 
 func main() {

--- a/cmd/nebula-mgmt/main.go
+++ b/cmd/nebula-mgmt/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/juev/nebula-mgmt/internal/cli"
+	"github.com/juev/nebula-mesh/internal/cli"
 )
 
 func main() {

--- a/details.md
+++ b/details.md
@@ -8,7 +8,7 @@ Self-hosted платформа для полного управления Nebula
 
 ```
 nebula-mgmt/
-├── go.mod                          # github.com/juev/nebula-mgmt
+├── go.mod                          # github.com/juev/nebula-mesh
 ├── go.sum
 ├── .gitignore
 ├── .golangci.yml                   # Linter configuration
@@ -256,7 +256,7 @@ POST   /api/v1/agent/status               # Report: статус агента (o
 ### 1.1 Инициализация проекта
 
 **Что делаем:**
-- `go mod init github.com/juev/nebula-mgmt`
+- `go mod init github.com/juev/nebula-mesh`
 - Минимальные `main.go` для обоих бинарников (пустые, но компилируемые)
 - `.gitignore` (бинарники, SQLite files, `*.key`, `.env`)
 - `.golangci.yml` (golangci-lint config)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juev/nebula-mgmt
+module github.com/juev/nebula-mesh
 
 go 1.26.1
 

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 const defaultAuditLimit = 100

--- a/internal/api/ca.go
+++ b/internal/api/ca.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/pki"
+	"github.com/juev/nebula-mesh/internal/pki"
 )
 
 type caInfoResponse struct {

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -9,9 +9,9 @@ import (
 	"net/netip"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/configgen"
-	"github.com/juev/nebula-mgmt/internal/pki"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/configgen"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/slackhq/nebula/cert"
 )
 

--- a/internal/api/firewall.go
+++ b/internal/api/firewall.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 type firewallRulesRequest struct {

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"github.com/juev/nebula-mgmt/internal/models"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 type createHostRequest struct {

--- a/internal/api/networks.go
+++ b/internal/api/networks.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"github.com/juev/nebula-mgmt/internal/models"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 type createNetworkRequest struct {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/juev/nebula-mgmt/internal/configgen"
-	"github.com/juev/nebula-mgmt/internal/pki"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/configgen"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 // CAConfig holds paths and passphrase for CA persistence.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/models"
-	"github.com/juev/nebula-mgmt/internal/pki"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 const testAPIKey = "test-api-key-12345"

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -8,9 +8,9 @@ import (
 	"net/netip"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/models"
-	"github.com/juev/nebula-mgmt/internal/pki"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/slackhq/nebula/cert"
 )
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/config"
-	"github.com/juev/nebula-mgmt/internal/pki"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/config"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 // Init initializes the management server: creates CA, generates API key, and initializes the database.

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -11,11 +11,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/api"
-	"github.com/juev/nebula-mgmt/internal/config"
-	"github.com/juev/nebula-mgmt/internal/pki"
-	"github.com/juev/nebula-mgmt/internal/store"
-	"github.com/juev/nebula-mgmt/internal/web"
+	"github.com/juev/nebula-mesh/internal/api"
+	"github.com/juev/nebula-mesh/internal/config"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+	"github.com/juev/nebula-mesh/internal/web"
 	"golang.org/x/term"
 )
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/models"
-	"github.com/juev/nebula-mgmt/internal/store/migrations"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store/migrations"
 
 	_ "modernc.org/sqlite"
 )

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/models"
+	"github.com/juev/nebula-mesh/internal/models"
 )
 
 func newTestStore(t *testing.T) *SQLiteStore {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/models"
+	"github.com/juev/nebula-mesh/internal/models"
 )
 
 // HostFilter specifies filters for listing hosts.

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"github.com/juev/nebula-mgmt/internal/models"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 // requireAuth middleware redirects to login if not authenticated.

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 //go:embed templates/*.html

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/models"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 const testPassword = "test-password-123"

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juev/nebula-mgmt/internal/api"
-	"github.com/juev/nebula-mgmt/internal/models"
-	"github.com/juev/nebula-mgmt/internal/pki"
-	"github.com/juev/nebula-mgmt/internal/store"
+	"github.com/juev/nebula-mesh/internal/api"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
 )


### PR DESCRIPTION
## What

Renames the Go module from `github.com/juev/nebula-mgmt` to `github.com/juev/nebula-mesh`.

## Why

The repository lives at `github.com/juev/nebula-mesh` but the module declared `github.com/juev/nebula-mgmt`, so:
- `go install github.com/juev/nebula-mesh/cmd/nebula-mgmt@latest` failed
- the pkg.go.dev and Go Report Card badges 404'd
- the Go module proxy could not serve the module from the public repo URL

## How

`grep -l 'github.com/juev/nebula-mgmt' | xargs sed -i ...` across `.go`, `go.mod`, `*.md`, `*.yml`. 22 files touched, 46 swaps. Binary names (`nebula-mgmt`, `nebula-agent`), Docker image tag, and default install paths (`/var/lib/nebula-mgmt`, `/etc/nebula-mgmt`) are unchanged — only the import path moves.

## Verification

- `go mod tidy` — no changes needed.
- `go build ./...` — clean.
- `go test -race -count=1 ./...` — all packages pass (full run, including `tests/integration`).
- `grep -r 'github.com/juev/nebula-mgmt' .` — no matches.

Closes #2.
