### PR TITLE
fix(web): show network name instead of UUID in dashboard and hosts list

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -51,6 +51,32 @@ func (w *Web) handleLogout(rw http.ResponseWriter, r *http.Request) {
 
 // --- Dashboard ---
 
+// hostView is a view-model that augments models.Host with the resolved
+// human-readable network name. Embedding keeps every existing template
+// field access (.ID, .Name, .NebulaIP, …) working unchanged.
+type hostView struct {
+	*models.Host
+	NetworkName string
+}
+
+// buildHostViews resolves NetworkID → Network.Name for each host. If the
+// host's network is not present in networks, NetworkName is left empty so
+// the template can fall back to displaying the UUID.
+func buildHostViews(hosts []*models.Host, networks []*models.Network) []hostView {
+	if len(hosts) == 0 {
+		return nil
+	}
+	idx := make(map[string]string, len(networks))
+	for _, n := range networks {
+		idx[n.ID] = n.Name
+	}
+	out := make([]hostView, len(hosts))
+	for i, h := range hosts {
+		out[i] = hostView{Host: h, NetworkName: idx[h.NetworkID]}
+	}
+	return out
+}
+
 type dashboardStats struct {
 	TotalHosts    int
 	EnrolledHosts int
@@ -105,7 +131,7 @@ func (w *Web) handleDashboard(rw http.ResponseWriter, r *http.Request) {
 	w.render(rw, "dashboard.html", map[string]any{
 		"Active":      "dashboard",
 		"Stats":       stats,
-		"RecentHosts": recentHosts,
+		"RecentHosts": buildHostViews(recentHosts, networks),
 	})
 }
 
@@ -132,6 +158,12 @@ func (w *Web) handlePartialStats(rw http.ResponseWriter, r *http.Request) {
 // --- Hosts ---
 
 func (w *Web) handleHosts(rw http.ResponseWriter, r *http.Request) {
+	networks, err := w.store.ListNetworks(r.Context())
+	if err != nil {
+		w.logger.Error("list networks", "error", err)
+		http.Error(rw, "Failed to load hosts", http.StatusInternalServerError)
+		return
+	}
 	hosts, err := w.store.ListHosts(r.Context(), store.HostFilter{Limit: 1000})
 	if err != nil {
 		w.logger.Error("list hosts", "error", err)
@@ -141,7 +173,7 @@ func (w *Web) handleHosts(rw http.ResponseWriter, r *http.Request) {
 
 	w.render(rw, "hosts.html", map[string]any{
 		"Active": "hosts",
-		"Hosts":  hosts,
+		"Hosts":  buildHostViews(hosts, networks),
 	})
 }
 

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -40,7 +40,7 @@
         <tr>
             <td><a href="/ui/hosts/{{.ID}}">{{.Name}}</a></td>
             <td>{{.NebulaIP}}</td>
-            <td>{{.NetworkID}}</td>
+            <td><span title="{{.NetworkID}}">{{if .NetworkName}}{{.NetworkName}}{{else}}{{.NetworkID}}{{end}}</span></td>
             <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
         </tr>
         {{end}}

--- a/internal/web/templates/hosts.html
+++ b/internal/web/templates/hosts.html
@@ -9,12 +9,13 @@
 {{if .Hosts}}
 <div class="card">
     <table>
-        <thead><tr><th>Name</th><th>Nebula IP</th><th>Role</th><th>Status</th><th>Last Seen</th><th></th></tr></thead>
+        <thead><tr><th>Name</th><th>Nebula IP</th><th>Network</th><th>Role</th><th>Status</th><th>Last Seen</th><th></th></tr></thead>
         <tbody>
         {{range .Hosts}}
         <tr>
             <td><a href="/ui/hosts/{{.ID}}">{{.Name}}</a></td>
             <td>{{.NebulaIP}}</td>
+            <td><span title="{{.NetworkID}}">{{if .NetworkName}}{{.NetworkName}}{{else}}{{.NetworkID}}{{end}}</span></td>
             <td>{{.Role}}</td>
             <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
             <td>{{if .LastSeenAt}}{{.LastSeenAt.Format "2006-01-02 15:04"}}{{else}}—{{end}}</td>

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -111,8 +111,20 @@ func TestProtectedRouteRedirect(t *testing.T) {
 }
 
 func TestDashboard_Authenticated(t *testing.T) {
-	w, _ := newTestWeb(t)
+	w, s := newTestWeb(t)
 	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	if err := s.CreateNetwork(ctx, &models.Network{ID: "net1", Name: "demo", CIDR: "10.0.0.0/24", CreatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateHost(ctx, &models.Host{
+		ID: "h1", NetworkID: "net1", Name: "web-1", NebulaIP: "10.0.0.1",
+		Groups: []string{"web"}, Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	req := httptest.NewRequest("GET", "/ui/", nil)
 	for _, c := range cookies {
@@ -124,8 +136,15 @@ func TestDashboard_Authenticated(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), "Dashboard") {
+	body := rec.Body.String()
+	if !strings.Contains(body, "Dashboard") {
 		t.Error("dashboard should contain 'Dashboard' title")
+	}
+	if !strings.Contains(body, `title="net1"`) {
+		t.Error("Recent Hosts cell should contain network UUID as tooltip")
+	}
+	if !strings.Contains(body, ">demo<") {
+		t.Error("Recent Hosts cell should render network name 'demo'")
 	}
 }
 
@@ -155,6 +174,15 @@ func TestHostsPage(t *testing.T) {
 	body := rec.Body.String()
 	if !strings.Contains(body, "web-1") {
 		t.Error("hosts page should contain host name 'web-1'")
+	}
+	if !strings.Contains(body, "<th>Network</th>") {
+		t.Error("hosts page should contain Network column header")
+	}
+	if !strings.Contains(body, `title="net1"`) {
+		t.Error("hosts page should contain network UUID as tooltip")
+	}
+	if !strings.Contains(body, ">test<") {
+		t.Error("hosts page should render network name 'test'")
 	}
 }
 
@@ -345,6 +373,74 @@ func TestSessionCleanup(t *testing.T) {
 	}
 	if !validExists {
 		t.Error("valid session should survive cleanup")
+	}
+}
+
+func TestBuildHostViews(t *testing.T) {
+	netA := &models.Network{ID: "net-a", Name: "alpha"}
+	netB := &models.Network{ID: "net-b", Name: "beta"}
+	h1 := &models.Host{ID: "h1", NetworkID: "net-a", Name: "web-1"}
+	h2 := &models.Host{ID: "h2", NetworkID: "net-b", Name: "web-2"}
+	hOrphan := &models.Host{ID: "h3", NetworkID: "missing", Name: "orphan"}
+
+	tests := []struct {
+		name     string
+		hosts    []*models.Host
+		networks []*models.Network
+		want     []struct {
+			hostID, networkName string
+		}
+	}{
+		{
+			name:     "empty hosts and networks",
+			hosts:    nil,
+			networks: nil,
+			want:     nil,
+		},
+		{
+			name:     "empty hosts, networks present",
+			hosts:    nil,
+			networks: []*models.Network{netA},
+			want:     nil,
+		},
+		{
+			name:     "hosts with known networks",
+			hosts:    []*models.Host{h1, h2},
+			networks: []*models.Network{netA, netB},
+			want: []struct{ hostID, networkName string }{
+				{"h1", "alpha"},
+				{"h2", "beta"},
+			},
+		},
+		{
+			name:     "host with unknown network falls back to empty NetworkName",
+			hosts:    []*models.Host{h1, hOrphan},
+			networks: []*models.Network{netA},
+			want: []struct{ hostID, networkName string }{
+				{"h1", "alpha"},
+				{"h3", ""},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildHostViews(tc.hosts, tc.networks)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d", len(got), len(tc.want))
+			}
+			for i, w := range tc.want {
+				if got[i].Host == nil {
+					t.Fatalf("got[%d].Host is nil", i)
+				}
+				if got[i].ID != w.hostID {
+					t.Errorf("got[%d].ID = %q, want %q", i, got[i].ID, w.hostID)
+				}
+				if got[i].NetworkName != w.networkName {
+					t.Errorf("got[%d].NetworkName = %q, want %q", i, got[i].NetworkName, w.networkName)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace network UUID with network name in dashboard's *Recent Hosts* table.
- Add a *Network* column to `/ui/hosts` showing the network name.
- UUID is preserved as a `title=` tooltip in both tables (and falls back to UUID when the name cannot be resolved).

Implementation: a new `hostView` view-model embeds `*models.Host` and adds a resolved `NetworkName`, populated by a pure `buildHostViews(hosts, networks)` helper.

## Test plan

- [x] `go test -v -race ./...` — all green
- [x] `go vet ./...`
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] Unit test `TestBuildHostViews` covers: empty inputs, normal mapping, orphan hosts referencing a missing network, multiple networks.
- [x] `TestDashboard_Authenticated` and `TestHostsPage` extended to assert the rendered network name and UUID tooltip.

Closes #3
