### PR TITLE
feat(web): add SVG favicon and /favicon.ico route

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -49,6 +49,20 @@ func (w *Web) handleLogout(rw http.ResponseWriter, r *http.Request) {
 	http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
 }
 
+func (w *Web) handleFavicon(rw http.ResponseWriter, _ *http.Request) {
+	data, err := staticFS.ReadFile("static/favicon.svg")
+	if err != nil {
+		w.logger.Error("read favicon", "error", err)
+		http.Error(rw, "favicon not found", http.StatusNotFound)
+		return
+	}
+	rw.Header().Set("Content-Type", "image/svg+xml")
+	rw.Header().Set("Cache-Control", "public, max-age=86400")
+	if _, err := rw.Write(data); err != nil {
+		w.logger.Error("write favicon", "error", err)
+	}
+}
+
 // --- Dashboard ---
 
 // hostView is a view-model that augments models.Host with the resolved

--- a/internal/web/static/favicon.svg
+++ b/internal/web/static/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#0f1117"/>
+  <g stroke="#6c7aee" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="32" cy="14" r="4" fill="#6c7aee"/>
+    <circle cx="14" cy="42" r="4" fill="#6c7aee"/>
+    <circle cx="50" cy="42" r="4" fill="#6c7aee"/>
+    <circle cx="32" cy="50" r="4" fill="#6c7aee"/>
+    <line x1="32" y1="14" x2="14" y2="42"/>
+    <line x1="32" y1="14" x2="50" y2="42"/>
+    <line x1="14" y1="42" x2="50" y2="42"/>
+    <line x1="14" y1="42" x2="32" y2="50"/>
+    <line x1="50" y1="42" x2="32" y2="50"/>
+    <line x1="32" y1="14" x2="32" y2="50"/>
+  </g>
+</svg>

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{block "title" .}}Nebula Mesh{{end}}</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico">
     <script src="/static/htmx.min.js"></script>
     <style>
         :root {

--- a/internal/web/templates/login.html
+++ b/internal/web/templates/login.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login — Nebula Mesh</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico">
     <style>
         :root {
             --bg: #0f1117;

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -73,6 +73,9 @@ func (w *Web) setupRoutes() {
 	staticSub, _ := fs.Sub(staticFS, "static")
 	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))
 
+	// Favicon (public, served from embedded SVG)
+	r.Get("/favicon.ico", w.handleFavicon)
+
 	// Login (public)
 	r.Get("/ui/login", w.handleLoginPage)
 	r.Post("/ui/login", w.handleLogin)

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -444,6 +444,23 @@ func TestBuildHostViews(t *testing.T) {
 	}
 }
 
+func TestFavicon(t *testing.T) {
+	w, _ := newTestWeb(t)
+	req := httptest.NewRequest("GET", "/favicon.ico", nil)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "image/svg+xml") {
+		t.Errorf("Content-Type = %q, want image/svg+xml", ct)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("favicon body should not be empty")
+	}
+}
+
 func TestStaticFiles(t *testing.T) {
 	w, _ := newTestWeb(t)
 	req := httptest.NewRequest("GET", "/static/htmx.min.js", nil)


### PR DESCRIPTION
## Summary

- Add `internal/web/static/favicon.svg` — a small original hexagon-mesh icon (~700 bytes), neutral and unrelated to the official Nebula branding.
- Expose it via a public `/favicon.ico` route (`Content-Type: image/svg+xml`, 1-day cache).
- Reference the icon from both `layout.html` and `login.html` so the browser tab shows it everywhere.

## Test plan

- [x] `go build ./... && go vet ./... && go test -v -race ./...`
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] New `TestFavicon`: 200 + `image/svg+xml` + non-empty body
- [x] `curl -I http://localhost:8080/favicon.ico` returns `200 OK` with `Content-Type: image/svg+xml`

Closes #4
