### PR TITLE
feat(cli): add host delete, block, and unblock subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ sudo nebula-agent run --config /etc/nebula-agent/agent.yml
 
 The agent now keeps `host.crt` / `host.key` / `ca.crt` / `config.yml` in sync and signals Nebula on changes.
 
+### 3. Manage hosts from the CLI
+
+```sh
+# List hosts (optionally filter by network)
+nebula-mgmt host list --server https://mgmt.example.com:8080 --api-key "$API_KEY"
+
+# Block a host (revokes cert via blocklist, status → blocked)
+nebula-mgmt host block   --server ... --api-key "$API_KEY" --id "$HOST_ID"
+
+# Unblock a host (status → pending; re-enrollment required for a new cert)
+nebula-mgmt host unblock --server ... --api-key "$API_KEY" --id "$HOST_ID"
+
+# Delete a host (also blocklists any existing cert)
+nebula-mgmt host delete  --server ... --api-key "$API_KEY" --id "$HOST_ID"
+```
+
 ## Deployment
 
 - **Docker** — `docker build -t nebula-mgmt .` (Dockerfile in repo).

--- a/cmd/nebula-mgmt/main.go
+++ b/cmd/nebula-mgmt/main.go
@@ -51,6 +51,8 @@ func run() error {
 func printUsage() {
 	fmt.Fprintln(os.Stderr, "usage: nebula-mgmt <command> [flags]")
 	fmt.Fprintln(os.Stderr, "commands: init, serve, host, network, version")
+	fmt.Fprintln(os.Stderr, "  host <create|list|delete|block|unblock>")
+	fmt.Fprintln(os.Stderr, "  network <create|list>")
 }
 
 func runInit(args []string) error {
@@ -76,7 +78,7 @@ func runServe(args []string) error {
 
 func runHost(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: nebula-mgmt host <create|list>")
+		return fmt.Errorf("usage: nebula-mgmt host <create|list|delete|block|unblock>")
 	}
 
 	switch args[0] {
@@ -84,9 +86,29 @@ func runHost(args []string) error {
 		return runHostCreate(args[1:])
 	case "list":
 		return runHostList(args[1:])
+	case "delete":
+		return runHostAction(args[1:], "host delete", cli.HostDelete)
+	case "block":
+		return runHostAction(args[1:], "host block", cli.HostBlock)
+	case "unblock":
+		return runHostAction(args[1:], "host unblock", cli.HostUnblock)
 	default:
 		return fmt.Errorf("unknown host subcommand: %s", args[0])
 	}
+}
+
+func runHostAction(args []string, name string, action func(serverURL, apiKey, hostID string) error) error {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
+	server := fs.String("server", "http://localhost:8080", "management server URL")
+	apiKey := fs.String("api-key", "", "API key")
+	id := fs.String("id", "", "host ID")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *id == "" || *apiKey == "" {
+		return fmt.Errorf("--id and --api-key are required")
+	}
+	return action(*server, *apiKey, *id)
 }
 
 func runHostCreate(args []string) error {

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -168,6 +168,22 @@ func (s *Server) handleBlockHost(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, host)
 }
 
+func (s *Server) handleUnblockHost(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	host, err := s.store.UnblockHostAndRemoveFromBlocklist(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "host not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("unblock host", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to unblock host")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, host)
+}
+
 func (s *Server) handleGetBlocklist(w http.ResponseWriter, r *http.Request) {
 	list, err := s.store.GetBlocklist(r.Context())
 	if err != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -73,6 +73,7 @@ func (s *Server) setupRoutes() {
 		r.Get("/api/v1/hosts/{id}", s.handleGetHost)
 		r.Delete("/api/v1/hosts/{id}", s.handleDeleteHost)
 		r.Post("/api/v1/hosts/{id}/block", s.handleBlockHost)
+		r.Post("/api/v1/hosts/{id}/unblock", s.handleUnblockHost)
 		r.Get("/api/v1/blocklist", s.handleGetBlocklist)
 		r.Get("/api/v1/ca", s.handleGetCA)
 		r.Post("/api/v1/ca/rotate", s.handleRotateCA)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -303,6 +303,70 @@ func TestDeleteHost(t *testing.T) {
 	}
 }
 
+func TestBlockAndUnblockHost(t *testing.T) {
+	srv, st := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "block-cycle", NebulaIP: "192.168.100.50",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	var resp createHostResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Block
+	req = httptest.NewRequest("POST", "/api/v1/hosts/"+resp.Host.ID+"/block", nil)
+	authRequest(req)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("block status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	// Verify host is blocked
+	got, err := st.GetHost(context.Background(), resp.Host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "blocked" {
+		t.Errorf("status after block = %q, want blocked", got.Status)
+	}
+
+	// Unblock
+	req = httptest.NewRequest("POST", "/api/v1/hosts/"+resp.Host.ID+"/unblock", nil)
+	authRequest(req)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unblock status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	got, err = st.GetHost(context.Background(), resp.Host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "pending" {
+		t.Errorf("status after unblock = %q, want pending", got.Status)
+	}
+}
+
+func TestUnblockHost_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/v1/hosts/nonexistent/unblock", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
 func TestDeleteHost_WithCertBlocklisted(t *testing.T) {
 	srv, st := newTestServer(t)
 	netID := createNetwork(t, srv)

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // HostCreate creates a host via the API.
@@ -68,6 +69,55 @@ func HostCreate(serverURL, apiKey, networkID, name, nebulaIP, role string, group
 
 	fmt.Printf("Host created: %s (ID: %s)\n", result.Host.Name, result.Host.ID)
 	fmt.Printf("Enrollment token: %s\n", result.EnrollmentToken)
+	return nil
+}
+
+// HostDelete deletes a host via the API.
+func HostDelete(serverURL, apiKey, hostID string) error {
+	return doHostAction(serverURL, apiKey, "DELETE", "/api/v1/hosts/"+hostID, http.StatusNoContent, "deleted")
+}
+
+// HostBlock blocks a host via the API.
+func HostBlock(serverURL, apiKey, hostID string) error {
+	return doHostAction(serverURL, apiKey, "POST", "/api/v1/hosts/"+hostID+"/block", http.StatusOK, "blocked")
+}
+
+// HostUnblock unblocks a host via the API. The host is moved back to pending
+// and must re-enroll to obtain a new certificate.
+func HostUnblock(serverURL, apiKey, hostID string) error {
+	return doHostAction(serverURL, apiKey, "POST", "/api/v1/hosts/"+hostID+"/unblock", http.StatusOK, "unblocked (re-enrollment required)")
+}
+
+func doHostAction(serverURL, apiKey, method, path string, wantStatus int, verb string) error {
+	if apiKey == "" {
+		return fmt.Errorf("--api-key is required")
+	}
+	if serverURL == "" {
+		return fmt.Errorf("--server is required")
+	}
+
+	req, err := http.NewRequest(method, serverURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("close response body", "error", err)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != wantStatus {
+		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	fmt.Printf("Host %s.\n", verb)
 	return nil
 }
 

--- a/internal/cli/host_test.go
+++ b/internal/cli/host_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHostBlock_Success(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"h1","status":"blocked"}`))
+	}))
+	defer srv.Close()
+
+	if err := HostBlock(srv.URL, "test-key", "h1"); err != nil {
+		t.Fatalf("HostBlock returned error: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v1/hosts/h1/block" {
+		t.Errorf("path = %q, want /api/v1/hosts/h1/block", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Errorf("auth = %q, want Bearer test-key", gotAuth)
+	}
+}
+
+func TestHostUnblock_Success(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"h1","status":"pending"}`))
+	}))
+	defer srv.Close()
+
+	if err := HostUnblock(srv.URL, "test-key", "h1"); err != nil {
+		t.Fatalf("HostUnblock returned error: %v", err)
+	}
+	if gotPath != "/api/v1/hosts/h1/unblock" {
+		t.Errorf("path = %q, want /api/v1/hosts/h1/unblock", gotPath)
+	}
+}
+
+func TestHostDelete_Success(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if err := HostDelete(srv.URL, "test-key", "h1"); err != nil {
+		t.Fatalf("HostDelete returned error: %v", err)
+	}
+	if gotMethod != "DELETE" {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/api/v1/hosts/h1" {
+		t.Errorf("path = %q, want /api/v1/hosts/h1", gotPath)
+	}
+}
+
+func TestHostAction_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"host not found"}`))
+	}))
+	defer srv.Close()
+
+	err := HostBlock(srv.URL, "test-key", "missing")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("error = %q, should mention HTTP 404", err.Error())
+	}
+}
+
+func TestHostAction_MissingAPIKey(t *testing.T) {
+	if err := HostBlock("http://example.invalid", "", "h1"); err == nil {
+		t.Fatal("expected error for empty api key")
+	}
+}
+
+func TestHostAction_MissingServerURL(t *testing.T) {
+	if err := HostBlock("", "test-key", "h1"); err == nil {
+		t.Fatal("expected error for empty server URL")
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -430,6 +430,58 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason s
 	return h, nil
 }
 
+// UnblockHostAndRemoveFromBlocklist atomically marks a blocked host as pending
+// and removes its certificate fingerprint from the blocklist. The host must
+// re-enroll to obtain a new certificate after unblocking.
+func (s *SQLiteStore) UnblockHostAndRemoveFromBlocklist(_ context.Context, id string) (*models.Host, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Error("rollback", "error", err)
+		}
+	}()
+
+	row := tx.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
+	h, err := s.scanHost(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get host: %w", err)
+	}
+
+	if h.CertFingerprint != "" {
+		if _, err := tx.Exec(`DELETE FROM blocklist WHERE fingerprint = ?`, h.CertFingerprint); err != nil {
+			return nil, fmt.Errorf("remove from blocklist: %w", err)
+		}
+	}
+
+	result, err := tx.Exec(
+		`UPDATE hosts SET status=?, updated_at=? WHERE id=?`,
+		models.HostStatusPending, time.Now(), id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update host status: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("update host status rows affected: %w", err)
+	}
+	if rows == 0 {
+		return nil, ErrNotFound
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit unblock host: %w", err)
+	}
+
+	h.Status = models.HostStatusPending
+	return h, nil
+}
+
 // DeleteHostAndBlockCert atomically deletes a host and adds its cert to the blocklist.
 func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason string) error {
 	tx, err := s.db.Begin()

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1001,6 +1001,80 @@ func TestBlockHostAndAddToBlocklist_NotFound(t *testing.T) {
 	}
 }
 
+// --- Atomic Unblock Host ---
+
+func TestUnblockHostAndRemoveFromBlocklist(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	h := &models.Host{
+		ID: "host_unblock", NetworkID: net.ID, Name: "unblock-me",
+		NebulaIP: "192.168.100.40", Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+	h.CertFingerprint = "fp-unblock-789"
+	if err := s.UpdateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.BlockHostAndAddToBlocklist(ctx, h.ID, "first blocked"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.UnblockHostAndRemoveFromBlocklist(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.HostStatusPending {
+		t.Errorf("status = %q, want pending", got.Status)
+	}
+
+	// fingerprint must be removed from blocklist
+	bl, _ := s.GetBlocklist(ctx)
+	for _, fp := range bl {
+		if fp == "fp-unblock-789" {
+			t.Error("fingerprint still in blocklist after unblock")
+		}
+	}
+}
+
+func TestUnblockHostAndRemoveFromBlocklist_NoCert(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	h := &models.Host{
+		ID: "host_unblock_nocert", NetworkID: net.ID, Name: "no-cert-unblock",
+		NebulaIP: "192.168.100.41", Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusBlocked,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.UnblockHostAndRemoveFromBlocklist(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.HostStatusPending {
+		t.Errorf("status = %q, want pending", got.Status)
+	}
+}
+
+func TestUnblockHostAndRemoveFromBlocklist_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.UnblockHostAndRemoveFromBlocklist(context.Background(), "nonexistent")
+	if err != ErrNotFound {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
 // --- Atomic Delete Host ---
 
 func TestDeleteHostAndBlockCert(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -39,6 +39,7 @@ type Store interface {
 	UpdateHostStatus(ctx context.Context, id string, status models.HostStatus) error
 	DeleteHost(ctx context.Context, id string) error
 	BlockHostAndAddToBlocklist(ctx context.Context, id, reason string) (*models.Host, error)
+	UnblockHostAndRemoveFromBlocklist(ctx context.Context, id string) (*models.Host, error)
 	DeleteHostAndBlockCert(ctx context.Context, id, reason string) error
 
 	// Enrollment tokens


### PR DESCRIPTION
## Summary

- **CLI**: new `nebula-mgmt host delete|block|unblock --id <ID>` subcommands; flag parsing and dispatch follow the existing `host create`/`host list` pattern.
- **API**: new `POST /api/v1/hosts/{id}/unblock` endpoint (delete and block already existed).
- **Store**: new `UnblockHostAndRemoveFromBlocklist(ctx, id)` — a single transaction that removes the host's fingerprint from the blocklist and resets `status = pending`. The host must re-enroll to obtain a fresh certificate.
- **Docs**: README "Manage hosts from the CLI" section documents the new commands.

## Test plan

- [x] `go build ./... && go vet ./... && go test -v -race ./...` — all green
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] New store tests: `TestUnblockHostAndRemoveFromBlocklist` (happy path, no-cert, not-found)
- [x] New API tests: `TestBlockAndUnblockHost`, `TestUnblockHost_NotFound`
- [x] New CLI lib tests: `TestHostBlock_Success`, `TestHostUnblock_Success`, `TestHostDelete_Success`, `TestHostAction_NotFound`, and missing-argument cases

Closes #5
