### PR TITLE
feat(auth): support multiple operator users (foundation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,37 @@ nebula-mgmt host unblock --server ... --api-key "$API_KEY" --id "$HOST_ID"
 nebula-mgmt host delete  --server ... --api-key "$API_KEY" --id "$HOST_ID"
 ```
 
+### 4. Manage operators (multi-user)
+
+Each interactive admin should have their own operator account and per-operator
+API key. On `nebula-mgmt init`, an `admin` operator is seeded from the config's
+`ui_password` (or `api_key` as a fallback) and the config `api_key` is registered
+as `admin`'s first API key.
+
+```sh
+# List operators
+nebula-mgmt user list --server ... --api-key "$ADMIN_KEY"
+
+# Create another operator
+nebula-mgmt user create --server ... --api-key "$ADMIN_KEY" \
+  --username alice --password 's3cret!' --display-name "Alice"
+
+# Create a per-operator API key (token shown once)
+nebula-mgmt apikey create --server ... --api-key "$ADMIN_KEY" \
+  --operator "$ALICE_ID" --name laptop-cli
+
+# Revoke a key
+nebula-mgmt apikey revoke --server ... --api-key "$ADMIN_KEY" \
+  --operator "$ALICE_ID" --id "$KEY_ID"
+
+# Disable / re-enable an operator (invalidates sessions and API keys atomically)
+nebula-mgmt user disable --server ... --api-key "$ADMIN_KEY" --id "$ALICE_ID"
+nebula-mgmt user enable  --server ... --api-key "$ADMIN_KEY" --id "$ALICE_ID"
+```
+
+Audit log entries (`/api/v1/audit-log`) record the actor for every mutating
+operator/host action.
+
 ## Deployment
 
 - **Docker** — `docker build -t nebula-mgmt .` (Dockerfile in repo).

--- a/cmd/nebula-mgmt/main.go
+++ b/cmd/nebula-mgmt/main.go
@@ -39,6 +39,10 @@ func run() error {
 		return runHost(os.Args[2:])
 	case "network":
 		return runNetwork(os.Args[2:])
+	case "user":
+		return runUser(os.Args[2:])
+	case "apikey":
+		return runAPIKey(os.Args[2:])
 	case "version", "--version", "-v":
 		version.Print(os.Stdout, "nebula-mgmt", versionStr, commit, date)
 		return nil
@@ -50,9 +54,11 @@ func run() error {
 
 func printUsage() {
 	fmt.Fprintln(os.Stderr, "usage: nebula-mgmt <command> [flags]")
-	fmt.Fprintln(os.Stderr, "commands: init, serve, host, network, version")
+	fmt.Fprintln(os.Stderr, "commands: init, serve, host, network, user, apikey, version")
 	fmt.Fprintln(os.Stderr, "  host <create|list|delete|block|unblock>")
 	fmt.Fprintln(os.Stderr, "  network <create|list>")
+	fmt.Fprintln(os.Stderr, "  user <create|list|disable|enable>")
+	fmt.Fprintln(os.Stderr, "  apikey <create|revoke>")
 }
 
 func runInit(args []string) error {
@@ -184,6 +190,98 @@ func runNetworkCreate(args []string) error {
 	}
 
 	return cli.NetworkCreate(*server, *apiKey, *name, *cidr)
+}
+
+func runUser(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: nebula-mgmt user <create|list|disable|enable>")
+	}
+	switch args[0] {
+	case "create":
+		return runUserCreate(args[1:])
+	case "list":
+		return runUserList(args[1:])
+	case "disable":
+		return runHostAction(args[1:], "user disable", cli.UserDisable)
+	case "enable":
+		return runHostAction(args[1:], "user enable", cli.UserEnable)
+	default:
+		return fmt.Errorf("unknown user subcommand: %s", args[0])
+	}
+}
+
+func runUserCreate(args []string) error {
+	fs := flag.NewFlagSet("user create", flag.ExitOnError)
+	server := fs.String("server", "http://localhost:8080", "management server URL")
+	apiKey := fs.String("api-key", "", "API key")
+	username := fs.String("username", "", "operator username")
+	password := fs.String("password", "", "operator password")
+	displayName := fs.String("display-name", "", "operator display name")
+	role := fs.String("role", "admin", "operator role")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *apiKey == "" {
+		return fmt.Errorf("--api-key is required")
+	}
+	return cli.UserCreate(*server, *apiKey, *username, *password, *displayName, *role)
+}
+
+func runUserList(args []string) error {
+	fs := flag.NewFlagSet("user list", flag.ExitOnError)
+	server := fs.String("server", "http://localhost:8080", "management server URL")
+	apiKey := fs.String("api-key", "", "API key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *apiKey == "" {
+		return fmt.Errorf("--api-key is required")
+	}
+	return cli.UserList(*server, *apiKey)
+}
+
+func runAPIKey(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: nebula-mgmt apikey <create|revoke>")
+	}
+	switch args[0] {
+	case "create":
+		return runAPIKeyCreate(args[1:])
+	case "revoke":
+		return runAPIKeyRevoke(args[1:])
+	default:
+		return fmt.Errorf("unknown apikey subcommand: %s", args[0])
+	}
+}
+
+func runAPIKeyCreate(args []string) error {
+	fs := flag.NewFlagSet("apikey create", flag.ExitOnError)
+	server := fs.String("server", "http://localhost:8080", "management server URL")
+	apiKey := fs.String("api-key", "", "API key")
+	operator := fs.String("operator", "", "operator ID")
+	name := fs.String("name", "", "key name (optional)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *apiKey == "" || *operator == "" {
+		return fmt.Errorf("--api-key and --operator are required")
+	}
+	return cli.APIKeyCreate(*server, *apiKey, *operator, *name)
+}
+
+func runAPIKeyRevoke(args []string) error {
+	fs := flag.NewFlagSet("apikey revoke", flag.ExitOnError)
+	server := fs.String("server", "http://localhost:8080", "management server URL")
+	apiKey := fs.String("api-key", "", "API key")
+	operator := fs.String("operator", "", "operator ID")
+	id := fs.String("id", "", "API key ID")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *apiKey == "" || *operator == "" || *id == "" {
+		return fmt.Errorf("--api-key, --operator, --id are required")
+	}
+	return cli.APIKeyRevoke(*server, *apiKey, *operator, *id)
 }
 
 func runNetworkList(args []string) error {

--- a/internal/api/actor.go
+++ b/internal/api/actor.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// actorContextKey scopes the authenticated operator on the request context.
+type actorContextKeyType struct{}
+
+var actorContextKey = actorContextKeyType{}
+
+// ActorOf returns the operator attached to the request context, if any.
+// Returns nil when the request was authenticated via the legacy config key.
+func ActorOf(ctx context.Context) *models.Operator {
+	op, _ := ctx.Value(actorContextKey).(*models.Operator)
+	return op
+}
+
+// ActorName returns a stable string identifier for the actor, suitable for
+// audit log entries. Falls back to "legacy-admin" for legacy-config-key auth.
+func ActorName(ctx context.Context) string {
+	if op := ActorOf(ctx); op != nil {
+		return op.Username
+	}
+	return "legacy-admin"
+}
+
+func withActor(ctx context.Context, op *models.Operator) context.Context {
+	return context.WithValue(ctx, actorContextKey, op)
+}

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -97,6 +97,7 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to create host")
 		return
 	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "host.create", host.ID, host.Name)
 
 	writeJSON(w, http.StatusCreated, createHostResponse{
 		Host:            host,
@@ -148,6 +149,7 @@ func (s *Server) handleDeleteHost(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to delete host")
 		return
 	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "host.delete", id, "")
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -164,6 +166,7 @@ func (s *Server) handleBlockHost(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to block host")
 		return
 	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "host.block", id, "")
 
 	writeJSON(w, http.StatusOK, host)
 }
@@ -180,6 +183,7 @@ func (s *Server) handleUnblockHost(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to unblock host")
 		return
 	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "host.unblock", id, "")
 
 	writeJSON(w, http.StatusOK, host)
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,10 +1,15 @@
 package api
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 // maxBodySize returns middleware that limits the size of request bodies.
@@ -19,8 +24,12 @@ func maxBodySize(maxBytes int64) func(http.Handler) http.Handler {
 	}
 }
 
-// bearerAuth returns middleware that checks for a valid Bearer token.
-func bearerAuth(apiKey string) func(http.Handler) http.Handler {
+// bearerAuth returns middleware that authenticates the Bearer token against
+// the DB-backed operator API keys. The legacyKey (if non-empty) is accepted
+// as a fallback for backward compatibility with the config-only api_key —
+// in that case no operator is attached to the context and ActorName falls
+// back to "legacy-admin".
+func bearerAuth(s store.Store, legacyKey string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			auth := r.Header.Get("Authorization")
@@ -30,12 +39,36 @@ func bearerAuth(apiKey string) func(http.Handler) http.Handler {
 			}
 
 			token := strings.TrimPrefix(auth, "Bearer ")
-			if token == auth || token != apiKey {
+			if token == auth || token == "" {
 				writeError(w, http.StatusUnauthorized, "invalid API key")
 				return
 			}
 
-			next.ServeHTTP(w, r)
+			// Hash and look up in operator_api_keys.
+			sum := sha256.Sum256([]byte(token))
+			hash := hex.EncodeToString(sum[:])
+			op, key, err := s.GetOperatorByAPIKeyHash(r.Context(), hash)
+			switch {
+			case err == nil:
+				// Best-effort last_used_at update; ignore failure.
+				if err := s.TouchOperatorAPIKey(r.Context(), key.ID, time.Now()); err != nil {
+					slog.Debug("touch api key", "error", err)
+				}
+				next.ServeHTTP(w, r.WithContext(withActor(r.Context(), op)))
+				return
+			case !errors.Is(err, store.ErrNotFound):
+				slog.Error("auth lookup", "error", err)
+				writeError(w, http.StatusInternalServerError, "auth lookup failed")
+				return
+			}
+
+			// Fallback: legacy config-file API key.
+			if legacyKey != "" && token == legacyKey {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			writeError(w, http.StatusUnauthorized, "invalid API key")
 		})
 	}
 }

--- a/internal/api/operators.go
+++ b/internal/api/operators.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type createOperatorRequest struct {
+	Username    string `json:"username"`
+	DisplayName string `json:"display_name"`
+	Password    string `json:"password"`
+	Role        string `json:"role"`
+}
+
+func (s *Server) handleCreateOperator(w http.ResponseWriter, r *http.Request) {
+	var req createOperatorRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Username == "" || req.Password == "" {
+		writeError(w, http.StatusBadRequest, "username and password are required")
+		return
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		s.logger.Error("hash password", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to hash password")
+		return
+	}
+	op := &models.Operator{
+		ID:           uuid.New().String(),
+		Username:     req.Username,
+		DisplayName:  req.DisplayName,
+		PasswordHash: string(hash),
+		Role:         req.Role,
+	}
+	if err := s.store.CreateOperator(r.Context(), op); err != nil {
+		s.logger.Error("create operator", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create operator")
+		return
+	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "operator.create", op.ID, op.Username)
+	writeJSON(w, http.StatusCreated, op)
+}
+
+func (s *Server) handleListOperators(w http.ResponseWriter, r *http.Request) {
+	ops, err := s.store.ListOperators(r.Context())
+	if err != nil {
+		s.logger.Error("list operators", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list operators")
+		return
+	}
+	if ops == nil {
+		ops = []*models.Operator{}
+	}
+	writeJSON(w, http.StatusOK, ops)
+}
+
+func (s *Server) handleDisableOperator(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.store.DisableOperator(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "operator not found")
+			return
+		}
+		s.logger.Error("disable operator", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to disable operator")
+		return
+	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "operator.disable", id, "")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleEnableOperator(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.store.EnableOperator(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "operator not found")
+			return
+		}
+		s.logger.Error("enable operator", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to enable operator")
+		return
+	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "operator.enable", id, "")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type createAPIKeyRequest struct {
+	Name string `json:"name"`
+}
+
+type createAPIKeyResponse struct {
+	Key   string                  `json:"key"`   // shown once
+	Entry *models.OperatorAPIKey  `json:"entry"`
+}
+
+func (s *Server) handleCreateOperatorAPIKey(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := s.store.GetOperator(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "operator not found")
+			return
+		}
+		s.logger.Error("get operator", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load operator")
+		return
+	}
+	var req createAPIKeyRequest
+	if r.ContentLength > 0 {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+
+	keyBytes := make([]byte, 32)
+	if _, err := rand.Read(keyBytes); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate api key")
+		return
+	}
+	plaintext := hex.EncodeToString(keyBytes)
+	sum := sha256.Sum256([]byte(plaintext))
+
+	entry := &models.OperatorAPIKey{
+		ID:         uuid.New().String(),
+		OperatorID: id,
+		Name:       req.Name,
+		KeyHash:    hex.EncodeToString(sum[:]),
+	}
+	if err := s.store.CreateOperatorAPIKey(r.Context(), entry); err != nil {
+		s.logger.Error("create api key", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to store api key")
+		return
+	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "operator.api_key.create", id, entry.ID)
+	writeJSON(w, http.StatusCreated, createAPIKeyResponse{Key: plaintext, Entry: entry})
+}
+
+func (s *Server) handleRevokeOperatorAPIKey(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	kid := chi.URLParam(r, "kid")
+	if err := s.store.RevokeOperatorAPIKey(r.Context(), kid); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "api key not found")
+			return
+		}
+		s.logger.Error("revoke api key", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to revoke api key")
+		return
+	}
+	_ = s.store.AddAuditEntry(r.Context(), ActorName(r.Context()), "operator.api_key.revoke", id, kid)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleListOperatorAPIKeys(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	keys, err := s.store.ListOperatorAPIKeys(r.Context(), id)
+	if err != nil {
+		s.logger.Error("list api keys", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list api keys")
+		return
+	}
+	if keys == nil {
+		keys = []*models.OperatorAPIKey{}
+	}
+	writeJSON(w, http.StatusOK, keys)
+}

--- a/internal/api/operators_test.go
+++ b/internal/api/operators_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+func TestOperatorLifecycle_CreateListDisable(t *testing.T) {
+	srv, st := newTestServer(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"username": "bob", "password": "supersecret", "display_name": "Bob",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	authRequest(req)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create operator status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var created models.Operator
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	if created.Username != "bob" {
+		t.Errorf("username = %q, want bob", created.Username)
+	}
+
+	// List should include bob
+	req = httptest.NewRequest("GET", "/api/v1/operators", nil)
+	authRequest(req)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list operators = %d", rec.Code)
+	}
+	var list []models.Operator
+	if err := json.NewDecoder(rec.Body).Decode(&list); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, o := range list {
+		if o.Username == "bob" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("created operator not in list response")
+	}
+
+	// Disable bob
+	req = httptest.NewRequest("POST", "/api/v1/operators/"+created.ID+"/disable", nil)
+	authRequest(req)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("disable status = %d", rec.Code)
+	}
+	got, _ := st.GetOperator(context.Background(), created.ID)
+	if got.Status != models.OperatorStatusDisabled {
+		t.Errorf("status after disable = %q", got.Status)
+	}
+}
+
+func TestOperatorAPIKey_CreateAndUse(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"username": "carol", "password": "secret123",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	authRequest(req)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create operator status = %d", rec.Code)
+	}
+	var op models.Operator
+	if err := json.NewDecoder(rec.Body).Decode(&op); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create API key
+	req = httptest.NewRequest("POST", "/api/v1/operators/"+op.ID+"/api-keys", bytes.NewBufferString(`{"name":"cli"}`))
+	authRequest(req)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create api key status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var keyResp createAPIKeyResponse
+	if err := json.NewDecoder(rec.Body).Decode(&keyResp); err != nil {
+		t.Fatal(err)
+	}
+	if keyResp.Key == "" {
+		t.Fatal("plaintext key is empty")
+	}
+	// The plain key length is 64 (32 bytes hex)
+	if _, err := hex.DecodeString(keyResp.Key); err != nil {
+		t.Errorf("key is not hex: %v", err)
+	}
+
+	// Use the new key to access a protected endpoint
+	req = httptest.NewRequest("GET", "/api/v1/operators", nil)
+	req.Header.Set("Authorization", "Bearer "+keyResp.Key)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("using new key: status = %d", rec.Code)
+	}
+
+	// Revoke it
+	req = httptest.NewRequest("DELETE", "/api/v1/operators/"+op.ID+"/api-keys/"+keyResp.Entry.ID, nil)
+	authRequest(req)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("revoke status = %d", rec.Code)
+	}
+
+	// Now the key should not authenticate
+	req = httptest.NewRequest("GET", "/api/v1/operators", nil)
+	req.Header.Set("Authorization", "Bearer "+keyResp.Key)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("revoked key status = %d, want 401", rec.Code)
+	}
+}
+
+func TestDisableOperator_InvalidatesAPIKey(t *testing.T) {
+	srv, st := newTestServer(t)
+
+	// Create operator
+	body, _ := json.Marshal(map[string]string{"username": "dan", "password": "p"})
+	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	authRequest(req)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	var op models.Operator
+	_ = json.NewDecoder(rec.Body).Decode(&op)
+
+	req = httptest.NewRequest("POST", "/api/v1/operators/"+op.ID+"/api-keys", bytes.NewBufferString(`{}`))
+	authRequest(req)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	var keyResp createAPIKeyResponse
+	_ = json.NewDecoder(rec.Body).Decode(&keyResp)
+
+	// Disable
+	if err := st.DisableOperator(context.Background(), op.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Key should no longer authenticate
+	req = httptest.NewRequest("GET", "/api/v1/operators", nil)
+	req.Header.Set("Authorization", "Bearer "+keyResp.Key)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestAuditLogActorIsRecorded(t *testing.T) {
+	srv, st := newTestServer(t)
+
+	body, _ := json.Marshal(map[string]string{"username": "eve", "password": "p"})
+	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	authRequest(req)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create operator status = %d", rec.Code)
+	}
+
+	entries, err := st.ListAuditEntries(context.Background(), store.AuditFilter{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, e := range entries {
+		if e.Action == "operator.create" && e.Actor == "legacy-admin" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("audit entry for operator.create with actor=legacy-admin not found")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -64,7 +64,7 @@ func (s *Server) setupRoutes() {
 
 	// Protected endpoints (require API key)
 	r.Group(func(r chi.Router) {
-		r.Use(bearerAuth(s.apiKey))
+		r.Use(bearerAuth(s.store, s.apiKey))
 		r.Post("/api/v1/networks", s.handleCreateNetwork)
 		r.Get("/api/v1/networks", s.handleListNetworks)
 		r.Get("/api/v1/networks/{id}", s.handleGetNetwork)
@@ -80,6 +80,13 @@ func (s *Server) setupRoutes() {
 		r.Get("/api/v1/networks/{id}/firewall", s.handleGetFirewall)
 		r.Put("/api/v1/networks/{id}/firewall", s.handleUpdateFirewall)
 		r.Get("/api/v1/audit-log", s.handleGetAuditLog)
+		r.Get("/api/v1/operators", s.handleListOperators)
+		r.Post("/api/v1/operators", s.handleCreateOperator)
+		r.Post("/api/v1/operators/{id}/disable", s.handleDisableOperator)
+		r.Post("/api/v1/operators/{id}/enable", s.handleEnableOperator)
+		r.Get("/api/v1/operators/{id}/api-keys", s.handleListOperatorAPIKeys)
+		r.Post("/api/v1/operators/{id}/api-keys", s.handleCreateOperatorAPIKey)
+		r.Delete("/api/v1/operators/{id}/api-keys/{kid}", s.handleRevokeOperatorAPIKey)
 	})
 
 	s.router = r

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// DefaultAdminUsername is the username assigned to the auto-seeded admin operator.
+const DefaultAdminUsername = "admin"
+
+// SeedAdminOperator creates the initial admin operator from the configured
+// password and API key when no operators exist yet. It is safe to call on
+// every startup: it is idempotent and a no-op if the operators table is
+// already populated. Either uiPassword or apiKey may be empty.
+//
+// It returns true if a new admin was seeded so the caller can log it.
+func SeedAdminOperator(ctx context.Context, s store.Store, uiPassword, apiKey string) (bool, error) {
+	existing, err := s.ListOperators(ctx)
+	if err != nil {
+		return false, fmt.Errorf("list operators: %w", err)
+	}
+	if len(existing) > 0 {
+		return false, nil
+	}
+
+	secret := uiPassword
+	if secret == "" {
+		secret = apiKey
+	}
+	if secret == "" {
+		return false, nil // nothing to seed
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(secret), bcrypt.DefaultCost)
+	if err != nil {
+		return false, fmt.Errorf("hash admin password: %w", err)
+	}
+
+	op := &models.Operator{
+		ID:           uuid.New().String(),
+		Username:     DefaultAdminUsername,
+		DisplayName:  "Administrator",
+		PasswordHash: string(hash),
+		Role:         "admin",
+	}
+	if err := s.CreateOperator(ctx, op); err != nil {
+		return false, fmt.Errorf("create admin operator: %w", err)
+	}
+
+	if apiKey != "" {
+		keyHash := sha256.Sum256([]byte(apiKey))
+		err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+			ID:         uuid.New().String(),
+			OperatorID: op.ID,
+			Name:       "legacy-config-key",
+			KeyHash:    hex.EncodeToString(keyHash[:]),
+		})
+		if err != nil {
+			return false, fmt.Errorf("seed admin api key: %w", err)
+		}
+	}
+
+	return true, nil
+}
+
+// HashAPIKey hashes an API key for storage. Used by both bootstrap and the
+// API auth middleware so the same algorithm is applied on insert and lookup.
+func HashAPIKey(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -92,6 +92,16 @@ func Init(configPath string) error {
 		return fmt.Errorf("migrate database: %w", err)
 	}
 
+	uiPassword := cfg.UIPassword
+	if uiPassword == "" {
+		uiPassword = cfg.APIKey
+	}
+	if seeded, err := SeedAdminOperator(migrateCtx, s, uiPassword, cfg.APIKey); err != nil {
+		return fmt.Errorf("seed admin operator: %w", err)
+	} else if seeded {
+		fmt.Printf("Admin operator created: %s (password = ui_password from config; api_key seeded as their key)\n", DefaultAdminUsername)
+	}
+
 	fmt.Printf("Database initialized: %s\n", cfg.DBPath)
 	fmt.Println("Initialization complete.")
 	return nil

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -103,6 +103,17 @@ func Serve(configPath string) error {
 		return fmt.Errorf("migrate: %w", err)
 	}
 
+	// Seed an admin operator if the operators table is still empty (idempotent).
+	uiPassword := cfg.UIPassword
+	if uiPassword == "" {
+		uiPassword = cfg.APIKey
+	}
+	if seeded, err := SeedAdminOperator(migrateCtx, s, uiPassword, cfg.APIKey); err != nil {
+		return fmt.Errorf("seed admin operator: %w", err)
+	} else if seeded {
+		logger.Info("seeded initial admin operator", "username", DefaultAdminUsername)
+	}
+
 	// Create API server
 	apiSrv := api.NewServer(s, ca, cfg.APIKey, logger, api.CAConfig{
 		CertPath:   certPath,
@@ -111,11 +122,7 @@ func Serve(configPath string) error {
 	})
 
 	// Create Web UI
-	uiPassword := cfg.UIPassword
-	if uiPassword == "" {
-		uiPassword = cfg.APIKey // fallback to API key as password
-	}
-	webUI, err := web.New(s, uiPassword, logger)
+	webUI, err := web.New(s, logger)
 	if err != nil {
 		return fmt.Errorf("init web UI: %w", err)
 	}

--- a/internal/cli/user.go
+++ b/internal/cli/user.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+type userCreateRequest struct {
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	DisplayName string `json:"display_name,omitempty"`
+	Role        string `json:"role,omitempty"`
+}
+
+type userResponse struct {
+	ID          string `json:"id"`
+	Username    string `json:"username"`
+	DisplayName string `json:"display_name"`
+	Status      string `json:"status"`
+	Role        string `json:"role"`
+}
+
+// UserCreate creates a new operator via the API.
+func UserCreate(serverURL, apiKey, username, password, displayName, role string) error {
+	if username == "" || password == "" {
+		return fmt.Errorf("--username and --password are required")
+	}
+	body, err := json.Marshal(userCreateRequest{
+		Username: username, Password: password, DisplayName: displayName, Role: role,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequest("POST", serverURL+"/api/v1/operators", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("close response body", "error", err)
+		}
+	}()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+	var out userResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	fmt.Printf("Operator created: %s (ID: %s)\n", out.Username, out.ID)
+	return nil
+}
+
+// UserList lists operators via the API.
+func UserList(serverURL, apiKey string) error {
+	req, err := http.NewRequest("GET", serverURL+"/api/v1/operators", nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("close response body", "error", err)
+		}
+	}()
+	var ops []userResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if len(ops) == 0 {
+		fmt.Println("No operators found.")
+		return nil
+	}
+	fmt.Printf("%-36s  %-20s  %-10s  %-10s  %s\n", "ID", "USERNAME", "STATUS", "ROLE", "DISPLAY NAME")
+	for _, o := range ops {
+		fmt.Printf("%-36s  %-20s  %-10s  %-10s  %s\n", o.ID, o.Username, o.Status, o.Role, o.DisplayName)
+	}
+	return nil
+}
+
+// UserDisable disables an operator via the API. Their sessions are
+// invalidated and API keys revoked atomically.
+func UserDisable(serverURL, apiKey, id string) error {
+	return doHostAction(serverURL, apiKey, "POST", "/api/v1/operators/"+id+"/disable", http.StatusNoContent, "operator disabled")
+}
+
+// UserEnable re-enables a disabled operator.
+func UserEnable(serverURL, apiKey, id string) error {
+	return doHostAction(serverURL, apiKey, "POST", "/api/v1/operators/"+id+"/enable", http.StatusNoContent, "operator enabled")
+}
+
+type apiKeyCreateResponse struct {
+	Key   string `json:"key"`
+	Entry struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"entry"`
+}
+
+// APIKeyCreate creates a new per-operator API key. The plaintext key is
+// printed once.
+func APIKeyCreate(serverURL, apiKey, operatorID, name string) error {
+	body, _ := json.Marshal(map[string]string{"name": name})
+	req, err := http.NewRequest("POST", serverURL+"/api/v1/operators/"+operatorID+"/api-keys", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("close response body", "error", err)
+		}
+	}()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+	var out apiKeyCreateResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	fmt.Printf("API key created (id: %s)\n", out.Entry.ID)
+	fmt.Printf("Token (shown once): %s\n", out.Key)
+	return nil
+}
+
+// APIKeyRevoke revokes an existing per-operator API key.
+func APIKeyRevoke(serverURL, apiKey, operatorID, keyID string) error {
+	return doHostAction(serverURL, apiKey, "DELETE", "/api/v1/operators/"+operatorID+"/api-keys/"+keyID, http.StatusNoContent, "api key revoked")
+}

--- a/internal/models/operator.go
+++ b/internal/models/operator.go
@@ -1,0 +1,52 @@
+package models
+
+import "time"
+
+// OperatorStatus represents the active/disabled state of an operator.
+type OperatorStatus string
+
+const (
+	OperatorStatusActive   OperatorStatus = "active"
+	OperatorStatusDisabled OperatorStatus = "disabled"
+)
+
+// OperatorAuthProvider identifies the authentication backend for an operator.
+type OperatorAuthProvider string
+
+const (
+	OperatorAuthLocal OperatorAuthProvider = "local"
+	OperatorAuthOIDC  OperatorAuthProvider = "oidc"
+)
+
+// Operator is an administrative user of the management server.
+type Operator struct {
+	ID            string               `json:"id"`
+	Username      string               `json:"username"`
+	DisplayName   string               `json:"display_name"`
+	PasswordHash  string               `json:"-"`
+	AuthProvider  OperatorAuthProvider `json:"auth_provider"`
+	Status        OperatorStatus       `json:"status"`
+	Role          string               `json:"role"`
+	CreatedAt     time.Time            `json:"created_at"`
+	UpdatedAt     time.Time            `json:"updated_at"`
+	LastLoginAt   *time.Time           `json:"last_login_at,omitempty"`
+}
+
+// OperatorAPIKey is a per-operator API key. Only the hash is stored.
+type OperatorAPIKey struct {
+	ID         string     `json:"id"`
+	OperatorID string     `json:"operator_id"`
+	Name       string     `json:"name"`
+	KeyHash    string     `json:"-"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
+}
+
+// OperatorSession represents an authenticated UI session.
+type OperatorSession struct {
+	Token      string
+	OperatorID string
+	ExpiresAt  time.Time
+	CreatedAt  time.Time
+}

--- a/internal/store/migrations/005_operators.down.sql
+++ b/internal/store/migrations/005_operators.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_op_sessions_expires;
+DROP INDEX IF EXISTS idx_op_sessions_operator;
+DROP TABLE IF EXISTS operator_sessions;
+DROP INDEX IF EXISTS idx_op_api_keys_operator;
+DROP TABLE IF EXISTS operator_api_keys;
+DROP TABLE IF EXISTS operators;

--- a/internal/store/migrations/005_operators.up.sql
+++ b/internal/store/migrations/005_operators.up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS operators (
+    id             TEXT PRIMARY KEY,
+    username       TEXT NOT NULL UNIQUE,
+    display_name   TEXT NOT NULL DEFAULT '',
+    password_hash  TEXT NOT NULL,
+    auth_provider  TEXT NOT NULL DEFAULT 'local',
+    status         TEXT NOT NULL DEFAULT 'active',
+    role           TEXT NOT NULL DEFAULT 'admin',
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_login_at  DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS operator_api_keys (
+    id           TEXT PRIMARY KEY,
+    operator_id  TEXT NOT NULL REFERENCES operators(id) ON DELETE CASCADE,
+    name         TEXT NOT NULL DEFAULT '',
+    key_hash     TEXT NOT NULL UNIQUE,
+    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME,
+    revoked_at   DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_op_api_keys_operator ON operator_api_keys(operator_id);
+
+CREATE TABLE IF NOT EXISTS operator_sessions (
+    token        TEXT PRIMARY KEY,
+    operator_id  TEXT NOT NULL REFERENCES operators(id) ON DELETE CASCADE,
+    expires_at   DATETIME NOT NULL,
+    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_op_sessions_operator ON operator_sessions(operator_id);
+CREATE INDEX IF NOT EXISTS idx_op_sessions_expires ON operator_sessions(expires_at);

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -36,6 +36,13 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
 
+	// SQLite ":memory:" creates a per-connection database; restrict the
+	// connection pool to a single connection so migrations and subsequent
+	// queries hit the same store.
+	if dbPath == ":memory:" {
+		db.SetMaxOpenConns(1)
+	}
+
 	// Enable WAL mode and foreign keys
 	for _, pragma := range []string{
 		"PRAGMA journal_mode=WAL",
@@ -59,6 +66,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"002_config_version.up.sql",
 		"003_audit_log.up.sql",
 		"004_blocklist_fk.up.sql",
+		"005_operators.up.sql",
 	}
 	for _, f := range migrationFiles {
 		sqlBytes, err := migrations.FS.ReadFile(f)

--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -1,0 +1,390 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+const operatorColumns = `id, username, display_name, password_hash, auth_provider, status, role, created_at, updated_at, last_login_at`
+
+func scanOperator(scanner interface {
+	Scan(dest ...any) error
+}) (*models.Operator, error) {
+	var op models.Operator
+	var lastLogin sql.NullTime
+	if err := scanner.Scan(
+		&op.ID, &op.Username, &op.DisplayName, &op.PasswordHash,
+		&op.AuthProvider, &op.Status, &op.Role,
+		&op.CreatedAt, &op.UpdatedAt, &lastLogin,
+	); err != nil {
+		return nil, err
+	}
+	if lastLogin.Valid {
+		t := lastLogin.Time
+		op.LastLoginAt = &t
+	}
+	return &op, nil
+}
+
+// CreateOperator inserts a new operator. Caller fills in PasswordHash.
+func (s *SQLiteStore) CreateOperator(_ context.Context, op *models.Operator) error {
+	if op.ID == "" || op.Username == "" || op.PasswordHash == "" {
+		return fmt.Errorf("operator id, username, password_hash are required")
+	}
+	now := time.Now()
+	if op.CreatedAt.IsZero() {
+		op.CreatedAt = now
+	}
+	if op.UpdatedAt.IsZero() {
+		op.UpdatedAt = now
+	}
+	if op.AuthProvider == "" {
+		op.AuthProvider = models.OperatorAuthLocal
+	}
+	if op.Status == "" {
+		op.Status = models.OperatorStatusActive
+	}
+	if op.Role == "" {
+		op.Role = "admin"
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO operators (id, username, display_name, password_hash, auth_provider, status, role, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		op.ID, op.Username, op.DisplayName, op.PasswordHash,
+		op.AuthProvider, op.Status, op.Role,
+		op.CreatedAt, op.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert operator: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetOperator(_ context.Context, id string) (*models.Operator, error) {
+	row := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE id = ?`, id)
+	op, err := scanOperator(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get operator: %w", err)
+	}
+	return op, nil
+}
+
+func (s *SQLiteStore) GetOperatorByUsername(_ context.Context, username string) (*models.Operator, error) {
+	row := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE username = ?`, username)
+	op, err := scanOperator(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get operator by username: %w", err)
+	}
+	return op, nil
+}
+
+func (s *SQLiteStore) ListOperators(_ context.Context) ([]*models.Operator, error) {
+	rows, err := s.db.Query(`SELECT ` + operatorColumns + ` FROM operators ORDER BY username`)
+	if err != nil {
+		return nil, fmt.Errorf("list operators: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("close rows", "error", err)
+		}
+	}()
+	var out []*models.Operator
+	for rows.Next() {
+		op, err := scanOperator(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan operator: %w", err)
+		}
+		out = append(out, op)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteStore) UpdateOperatorPassword(_ context.Context, id, passwordHash string) error {
+	result, err := s.db.Exec(
+		`UPDATE operators SET password_hash=?, updated_at=? WHERE id=?`,
+		passwordHash, time.Now(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("update operator password: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update operator password rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) UpdateOperatorLastLogin(_ context.Context, id string, t time.Time) error {
+	_, err := s.db.Exec(`UPDATE operators SET last_login_at=?, updated_at=? WHERE id=?`, t, t, id)
+	if err != nil {
+		return fmt.Errorf("update last_login_at: %w", err)
+	}
+	return nil
+}
+
+// DisableOperator marks operator as disabled and atomically deletes their
+// sessions and revokes all of their non-revoked API keys.
+func (s *SQLiteStore) DisableOperator(_ context.Context, id string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Error("rollback", "error", err)
+		}
+	}()
+
+	now := time.Now()
+	result, err := tx.Exec(
+		`UPDATE operators SET status=?, updated_at=? WHERE id=?`,
+		models.OperatorStatusDisabled, now, id,
+	)
+	if err != nil {
+		return fmt.Errorf("disable operator: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("disable operator rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+
+	if _, err := tx.Exec(`DELETE FROM operator_sessions WHERE operator_id=?`, id); err != nil {
+		return fmt.Errorf("delete operator sessions: %w", err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE operator_api_keys SET revoked_at=? WHERE operator_id=? AND revoked_at IS NULL`,
+		now, id,
+	); err != nil {
+		return fmt.Errorf("revoke operator api keys: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func (s *SQLiteStore) EnableOperator(_ context.Context, id string) error {
+	result, err := s.db.Exec(
+		`UPDATE operators SET status=?, updated_at=? WHERE id=?`,
+		models.OperatorStatusActive, time.Now(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("enable operator: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("enable operator rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// --- API keys ---
+
+func (s *SQLiteStore) CreateOperatorAPIKey(_ context.Context, k *models.OperatorAPIKey) error {
+	if k.ID == "" || k.OperatorID == "" || k.KeyHash == "" {
+		return fmt.Errorf("api key id, operator_id, key_hash are required")
+	}
+	if k.CreatedAt.IsZero() {
+		k.CreatedAt = time.Now()
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO operator_api_keys (id, operator_id, name, key_hash, created_at) VALUES (?, ?, ?, ?, ?)`,
+		k.ID, k.OperatorID, k.Name, k.KeyHash, k.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert api key: %w", err)
+	}
+	return nil
+}
+
+// GetOperatorByAPIKeyHash returns the operator associated with a non-revoked
+// API key, ensuring the operator is active.
+func (s *SQLiteStore) GetOperatorByAPIKeyHash(_ context.Context, keyHash string) (*models.Operator, *models.OperatorAPIKey, error) {
+	var (
+		k          models.OperatorAPIKey
+		lastUsed   sql.NullTime
+		revokedAt  sql.NullTime
+	)
+	row := s.db.QueryRow(
+		`SELECT id, operator_id, name, key_hash, created_at, last_used_at, revoked_at FROM operator_api_keys WHERE key_hash=? AND revoked_at IS NULL`,
+		keyHash,
+	)
+	if err := row.Scan(&k.ID, &k.OperatorID, &k.Name, &k.KeyHash, &k.CreatedAt, &lastUsed, &revokedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, ErrNotFound
+		}
+		return nil, nil, fmt.Errorf("get api key: %w", err)
+	}
+	if lastUsed.Valid {
+		t := lastUsed.Time
+		k.LastUsedAt = &t
+	}
+
+	opRow := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE id = ?`, k.OperatorID)
+	op, err := scanOperator(opRow)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("get operator: %w", err)
+	}
+	if op.Status != models.OperatorStatusActive {
+		return nil, nil, ErrNotFound
+	}
+	return op, &k, nil
+}
+
+func (s *SQLiteStore) ListOperatorAPIKeys(_ context.Context, operatorID string) ([]*models.OperatorAPIKey, error) {
+	rows, err := s.db.Query(
+		`SELECT id, operator_id, name, key_hash, created_at, last_used_at, revoked_at FROM operator_api_keys WHERE operator_id=? ORDER BY created_at DESC`,
+		operatorID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list api keys: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("close rows", "error", err)
+		}
+	}()
+	var out []*models.OperatorAPIKey
+	for rows.Next() {
+		var (
+			k         models.OperatorAPIKey
+			lastUsed  sql.NullTime
+			revokedAt sql.NullTime
+		)
+		if err := rows.Scan(&k.ID, &k.OperatorID, &k.Name, &k.KeyHash, &k.CreatedAt, &lastUsed, &revokedAt); err != nil {
+			return nil, fmt.Errorf("scan api key: %w", err)
+		}
+		if lastUsed.Valid {
+			t := lastUsed.Time
+			k.LastUsedAt = &t
+		}
+		if revokedAt.Valid {
+			t := revokedAt.Time
+			k.RevokedAt = &t
+		}
+		out = append(out, &k)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteStore) RevokeOperatorAPIKey(_ context.Context, keyID string) error {
+	result, err := s.db.Exec(
+		`UPDATE operator_api_keys SET revoked_at=? WHERE id=? AND revoked_at IS NULL`,
+		time.Now(), keyID,
+	)
+	if err != nil {
+		return fmt.Errorf("revoke api key: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("revoke api key rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) TouchOperatorAPIKey(_ context.Context, keyID string, t time.Time) error {
+	_, err := s.db.Exec(`UPDATE operator_api_keys SET last_used_at=? WHERE id=?`, t, keyID)
+	if err != nil {
+		return fmt.Errorf("touch api key: %w", err)
+	}
+	return nil
+}
+
+// --- Sessions ---
+
+func (s *SQLiteStore) CreateOperatorSession(_ context.Context, sess *models.OperatorSession) error {
+	if sess.Token == "" || sess.OperatorID == "" {
+		return fmt.Errorf("session token and operator_id are required")
+	}
+	if sess.CreatedAt.IsZero() {
+		sess.CreatedAt = time.Now()
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO operator_sessions (token, operator_id, expires_at, created_at) VALUES (?, ?, ?, ?)`,
+		sess.Token, sess.OperatorID, sess.ExpiresAt, sess.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert session: %w", err)
+	}
+	return nil
+}
+
+// GetOperatorBySession returns the operator associated with a non-expired session
+// whose operator is still active. Expired sessions are not auto-deleted here.
+func (s *SQLiteStore) GetOperatorBySession(_ context.Context, token string) (*models.Operator, error) {
+	row := s.db.QueryRow(
+		`SELECT operator_id, expires_at FROM operator_sessions WHERE token=?`,
+		token,
+	)
+	var operatorID string
+	var expiresAt time.Time
+	if err := row.Scan(&operatorID, &expiresAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get session: %w", err)
+	}
+	if time.Now().After(expiresAt) {
+		return nil, ErrNotFound
+	}
+	opRow := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE id=?`, operatorID)
+	op, err := scanOperator(opRow)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get session operator: %w", err)
+	}
+	if op.Status != models.OperatorStatusActive {
+		return nil, ErrNotFound
+	}
+	return op, nil
+}
+
+func (s *SQLiteStore) DeleteOperatorSession(_ context.Context, token string) error {
+	_, err := s.db.Exec(`DELETE FROM operator_sessions WHERE token=?`, token)
+	if err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteOperatorSessionsByOperator(_ context.Context, operatorID string) error {
+	_, err := s.db.Exec(`DELETE FROM operator_sessions WHERE operator_id=?`, operatorID)
+	if err != nil {
+		return fmt.Errorf("delete sessions by operator: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteExpiredOperatorSessions(_ context.Context, before time.Time) error {
+	_, err := s.db.Exec(`DELETE FROM operator_sessions WHERE expires_at < ?`, before)
+	if err != nil {
+		return fmt.Errorf("delete expired sessions: %w", err)
+	}
+	return nil
+}

--- a/internal/store/sqlite_operators_test.go
+++ b/internal/store/sqlite_operators_test.go
@@ -1,0 +1,211 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+func newTestOperator(t *testing.T, s *SQLiteStore, username string) *models.Operator {
+	t.Helper()
+	op := &models.Operator{
+		ID:           "op-" + username,
+		Username:     username,
+		DisplayName:  username,
+		PasswordHash: "bcrypt$hash$" + username,
+	}
+	if err := s.CreateOperator(context.Background(), op); err != nil {
+		t.Fatalf("create operator: %v", err)
+	}
+	return op
+}
+
+func TestCreateOperator_Defaults(t *testing.T) {
+	s := newTestStore(t)
+	op := newTestOperator(t, s, "alice")
+
+	got, err := s.GetOperator(context.Background(), op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.OperatorStatusActive {
+		t.Errorf("status = %q, want active", got.Status)
+	}
+	if got.AuthProvider != models.OperatorAuthLocal {
+		t.Errorf("auth_provider = %q, want local", got.AuthProvider)
+	}
+	if got.Role != "admin" {
+		t.Errorf("role = %q, want admin", got.Role)
+	}
+}
+
+func TestGetOperatorByUsername(t *testing.T) {
+	s := newTestStore(t)
+	op := newTestOperator(t, s, "bob")
+
+	got, err := s.GetOperatorByUsername(context.Background(), "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != op.ID {
+		t.Errorf("id = %q, want %q", got.ID, op.ID)
+	}
+
+	if _, err := s.GetOperatorByUsername(context.Background(), "nobody"); err != ErrNotFound {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDisableOperator_CascadesSessionsAndAPIKeys(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := newTestOperator(t, s, "carol")
+
+	// One API key, one session
+	if err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID: "k1", OperatorID: op.ID, Name: "cli", KeyHash: "hash1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateOperatorSession(ctx, &models.OperatorSession{
+		Token: "tok1", OperatorID: op.ID, ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.DisableOperator(ctx, op.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Status disabled
+	got, _ := s.GetOperator(ctx, op.ID)
+	if got.Status != models.OperatorStatusDisabled {
+		t.Errorf("status = %q, want disabled", got.Status)
+	}
+
+	// Sessions gone
+	if _, err := s.GetOperatorBySession(ctx, "tok1"); err != ErrNotFound {
+		t.Errorf("session still valid after disable: %v", err)
+	}
+
+	// API keys revoked
+	keys, _ := s.ListOperatorAPIKeys(ctx, op.ID)
+	if len(keys) != 1 {
+		t.Fatalf("keys len = %d", len(keys))
+	}
+	if keys[0].RevokedAt == nil {
+		t.Error("api key not revoked after disable")
+	}
+
+	// Lookup by hash returns nothing (revoked + operator disabled)
+	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "hash1"); err != ErrNotFound {
+		t.Errorf("disabled operator's key still resolves: %v", err)
+	}
+}
+
+func TestGetOperatorByAPIKeyHash_Lookup(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := newTestOperator(t, s, "dave")
+	if err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID: "k-dave", OperatorID: op.ID, Name: "main", KeyHash: "dave-hash",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	gotOp, gotKey, err := s.GetOperatorByAPIKeyHash(ctx, "dave-hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotOp.ID != op.ID {
+		t.Errorf("operator id = %q, want %q", gotOp.ID, op.ID)
+	}
+	if gotKey.Name != "main" {
+		t.Errorf("key name = %q, want main", gotKey.Name)
+	}
+
+	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "nonexistent"); err != ErrNotFound {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestRevokeOperatorAPIKey(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := newTestOperator(t, s, "eve")
+	if err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID: "k-eve", OperatorID: op.ID, KeyHash: "eve-hash",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.RevokeOperatorAPIKey(ctx, "k-eve"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "eve-hash"); err != ErrNotFound {
+		t.Errorf("revoked key still resolves: %v", err)
+	}
+
+	if err := s.RevokeOperatorAPIKey(ctx, "k-eve"); err != ErrNotFound {
+		t.Errorf("err = %v, want ErrNotFound on second revoke", err)
+	}
+}
+
+func TestSessionLifecycle(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := newTestOperator(t, s, "frank")
+
+	exp := time.Now().Add(time.Hour)
+	if err := s.CreateOperatorSession(ctx, &models.OperatorSession{
+		Token: "frank-tok", OperatorID: op.ID, ExpiresAt: exp,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetOperatorBySession(ctx, "frank-tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != op.ID {
+		t.Errorf("operator id = %q, want %q", got.ID, op.ID)
+	}
+
+	if err := s.DeleteOperatorSession(ctx, "frank-tok"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.GetOperatorBySession(ctx, "frank-tok"); err != ErrNotFound {
+		t.Errorf("session still valid after delete: %v", err)
+	}
+}
+
+func TestDeleteExpiredOperatorSessions(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := newTestOperator(t, s, "gina")
+
+	if err := s.CreateOperatorSession(ctx, &models.OperatorSession{
+		Token: "old", OperatorID: op.ID, ExpiresAt: time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateOperatorSession(ctx, &models.OperatorSession{
+		Token: "fresh", OperatorID: op.ID, ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.DeleteExpiredOperatorSessions(ctx, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.GetOperatorBySession(ctx, "fresh"); err != nil {
+		t.Errorf("fresh session removed: %v", err)
+	}
+	if _, err := s.GetOperatorBySession(ctx, "old"); err != ErrNotFound {
+		t.Errorf("old session still present: %v", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -73,6 +73,30 @@ type Store interface {
 	AddAuditEntry(ctx context.Context, actor, action, resource, details string) error
 	ListAuditEntries(ctx context.Context, filter AuditFilter) ([]*models.AuditEntry, error)
 
+	// Operators
+	CreateOperator(ctx context.Context, op *models.Operator) error
+	GetOperator(ctx context.Context, id string) (*models.Operator, error)
+	GetOperatorByUsername(ctx context.Context, username string) (*models.Operator, error)
+	ListOperators(ctx context.Context) ([]*models.Operator, error)
+	UpdateOperatorPassword(ctx context.Context, id, passwordHash string) error
+	UpdateOperatorLastLogin(ctx context.Context, id string, t time.Time) error
+	DisableOperator(ctx context.Context, id string) error
+	EnableOperator(ctx context.Context, id string) error
+
+	// Operator API keys
+	CreateOperatorAPIKey(ctx context.Context, k *models.OperatorAPIKey) error
+	GetOperatorByAPIKeyHash(ctx context.Context, keyHash string) (*models.Operator, *models.OperatorAPIKey, error)
+	ListOperatorAPIKeys(ctx context.Context, operatorID string) ([]*models.OperatorAPIKey, error)
+	RevokeOperatorAPIKey(ctx context.Context, keyID string) error
+	TouchOperatorAPIKey(ctx context.Context, keyID string, t time.Time) error
+
+	// Operator sessions
+	CreateOperatorSession(ctx context.Context, s *models.OperatorSession) error
+	GetOperatorBySession(ctx context.Context, token string) (*models.Operator, error)
+	DeleteOperatorSession(ctx context.Context, token string) error
+	DeleteOperatorSessionsByOperator(ctx context.Context, operatorID string) error
+	DeleteExpiredOperatorSessions(ctx context.Context, before time.Time) error
+
 	// Lifecycle
 	Migrate(ctx context.Context) error
 	Ping(ctx context.Context) error

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -30,8 +30,12 @@ func (w *Web) handleLoginPage(rw http.ResponseWriter, _ *http.Request) {
 }
 
 func (w *Web) handleLogin(rw http.ResponseWriter, r *http.Request) {
+	username := r.FormValue("username")
+	if username == "" {
+		username = "admin"
+	}
 	password := r.FormValue("password")
-	ok, err := w.session.Login(rw, password)
+	_, ok, err := w.session.Login(rw, r, username, password)
 	if err != nil {
 		w.logger.Error("login", "error", err)
 		http.Error(rw, "internal error", http.StatusInternalServerError)
@@ -41,7 +45,7 @@ func (w *Web) handleLogin(rw http.ResponseWriter, r *http.Request) {
 		http.Redirect(rw, r, "/ui/", http.StatusSeeOther)
 		return
 	}
-	w.render(rw, "login.html", map[string]any{"Error": "Invalid password"})
+	w.render(rw, "login.html", map[string]any{"Error": "Invalid username or password"})
 }
 
 func (w *Web) handleLogout(rw http.ResponseWriter, r *http.Request) {

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
-	"sync"
 	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -15,38 +20,52 @@ const (
 	sessionDuration   = 24 * time.Hour
 )
 
-type session struct {
-	expiresAt time.Time
-}
-
-// SessionManager handles cookie-based sessions.
+// SessionManager handles DB-backed cookie sessions for operator users.
 type SessionManager struct {
-	password string
-	mu       sync.RWMutex
-	sessions map[string]session
+	store store.Store
 }
 
-// NewSessionManager creates a new session manager.
-func NewSessionManager(password string) *SessionManager {
-	return &SessionManager{
-		password: password,
-		sessions: make(map[string]session),
+// NewSessionManager creates a new session manager backed by the given store.
+func NewSessionManager(s store.Store) *SessionManager {
+	return &SessionManager{store: s}
+}
+
+// Login looks up the operator by username, verifies the password (bcrypt),
+// records a session, sets the cookie, and returns the operator. The boolean
+// is true when the credentials were valid.
+func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username, password string) (*models.Operator, bool, error) {
+	if username == "" || password == "" {
+		return nil, false, nil
 	}
-}
-
-// Login validates the password and creates a session cookie.
-func (sm *SessionManager) Login(w http.ResponseWriter, password string) (bool, error) {
-	if password != sm.password {
-		return false, nil
+	op, err := sm.store.GetOperatorByUsername(r.Context(), username)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("lookup operator: %w", err)
+	}
+	if op.Status != models.OperatorStatusActive {
+		return nil, false, nil
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {
+		return nil, false, nil
 	}
 
 	token, err := generateToken()
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
-	sm.mu.Lock()
-	sm.sessions[token] = session{expiresAt: time.Now().Add(sessionDuration)}
-	sm.mu.Unlock()
+	expires := time.Now().Add(sessionDuration)
+	if err := sm.store.CreateOperatorSession(r.Context(), &models.OperatorSession{
+		Token:      token,
+		OperatorID: op.ID,
+		ExpiresAt:  expires,
+	}); err != nil {
+		return nil, false, fmt.Errorf("create session: %w", err)
+	}
+	if err := sm.store.UpdateOperatorLastLogin(r.Context(), op.ID, time.Now()); err != nil {
+		slog.Debug("update last login", "error", err)
+	}
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
@@ -56,18 +75,17 @@ func (sm *SessionManager) Login(w http.ResponseWriter, password string) (bool, e
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(sessionDuration.Seconds()),
 	})
-	return true, nil
+	return op, true, nil
 }
 
-// Logout invalidates the session.
+// Logout invalidates the session cookie and removes the DB record.
 func (sm *SessionManager) Logout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(sessionCookieName)
 	if err == nil {
-		sm.mu.Lock()
-		delete(sm.sessions, cookie.Value)
-		sm.mu.Unlock()
+		if err := sm.store.DeleteOperatorSession(r.Context(), cookie.Value); err != nil {
+			slog.Debug("delete session", "error", err)
+		}
 	}
-
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
 		Value:    "",
@@ -77,26 +95,28 @@ func (sm *SessionManager) Logout(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// IsAuthenticated checks if the request has a valid session.
-func (sm *SessionManager) IsAuthenticated(r *http.Request) bool {
+// CurrentOperator returns the operator owning the request's session cookie,
+// or nil if there is no valid session. A disabled operator's session is also
+// treated as invalid.
+func (sm *SessionManager) CurrentOperator(r *http.Request) *models.Operator {
 	cookie, err := r.Cookie(sessionCookieName)
 	if err != nil {
-		return false
+		return nil
 	}
-
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-
-	sess, ok := sm.sessions[cookie.Value]
-	if !ok || time.Now().After(sess.expiresAt) {
-		delete(sm.sessions, cookie.Value)
-		return false
+	op, err := sm.store.GetOperatorBySession(r.Context(), cookie.Value)
+	if err != nil {
+		return nil
 	}
-	return true
+	return op
 }
 
-// StartCleanup runs a background goroutine that periodically removes expired sessions.
-// It stops when ctx is cancelled.
+// IsAuthenticated reports whether the request carries a valid session.
+func (sm *SessionManager) IsAuthenticated(r *http.Request) bool {
+	return sm.CurrentOperator(r) != nil
+}
+
+// StartCleanup runs a background goroutine that periodically deletes expired
+// sessions from the store. It stops when ctx is cancelled.
 func (sm *SessionManager) StartCleanup(ctx context.Context, interval time.Duration) {
 	go func() {
 		ticker := time.NewTicker(interval)
@@ -106,21 +126,12 @@ func (sm *SessionManager) StartCleanup(ctx context.Context, interval time.Durati
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				sm.removeExpired()
+				if err := sm.store.DeleteExpiredOperatorSessions(ctx, time.Now()); err != nil {
+					slog.Debug("cleanup expired sessions", "error", err)
+				}
 			}
 		}
 	}()
-}
-
-func (sm *SessionManager) removeExpired() {
-	now := time.Now()
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-	for token, sess := range sm.sessions {
-		if now.After(sess.expiresAt) {
-			delete(sm.sessions, token)
-		}
-	}
 }
 
 func generateToken() (string, error) {

--- a/internal/web/templates/login.html
+++ b/internal/web/templates/login.html
@@ -68,8 +68,12 @@
         {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
         <form method="POST" action="/ui/login">
             <div class="form-group">
+                <label>Username</label>
+                <input type="text" name="username" class="form-control" value="admin" autocomplete="username" autofocus required>
+            </div>
+            <div class="form-group">
                 <label>Password</label>
-                <input type="password" name="password" class="form-control" autofocus required>
+                <input type="password" name="password" class="form-control" autocomplete="current-password" required>
             </div>
             <button type="submit" class="btn">Sign In</button>
         </form>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -31,11 +31,11 @@ type Web struct {
 }
 
 // New creates a new Web UI handler.
-func New(s store.Store, password string, logger *slog.Logger) (*Web, error) {
+func New(s store.Store, logger *slog.Logger) (*Web, error) {
 	w := &Web{
 		store:     s,
 		logger:    logger,
-		session:   NewSessionManager(password),
+		session:   NewSessionManager(s),
 		templates: make(map[string]*template.Template),
 	}
 

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -13,9 +13,13 @@ import (
 
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
-const testPassword = "test-password-123"
+const (
+	testPassword = "test-password-123"
+	testUsername = "admin"
+)
 
 func newTestWeb(t *testing.T) (*Web, *store.SQLiteStore) {
 	t.Helper()
@@ -28,8 +32,22 @@ func newTestWeb(t *testing.T) (*Web, *store.SQLiteStore) {
 	}
 	t.Cleanup(func() { s.Close() })
 
+	// Seed an admin operator that tests can log in as.
+	hash, err := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.MinCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateOperator(context.Background(), &models.Operator{
+		ID:           "admin-test-id",
+		Username:     testUsername,
+		DisplayName:  "Administrator",
+		PasswordHash: string(hash),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	w, err := New(s, testPassword, logger)
+	w, err := New(s, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +56,7 @@ func newTestWeb(t *testing.T) (*Web, *store.SQLiteStore) {
 
 func loginSession(t *testing.T, w *Web) []*http.Cookie {
 	t.Helper()
-	form := url.Values{"password": {testPassword}}
+	form := url.Values{"username": {testUsername}, "password": {testPassword}}
 	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
@@ -82,7 +100,7 @@ func TestLogin_Success(t *testing.T) {
 
 func TestLogin_WrongPassword(t *testing.T) {
 	w, _ := newTestWeb(t)
-	form := url.Values{"password": {"wrong"}}
+	form := url.Values{"username": {testUsername}, "password": {"wrong"}}
 	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
@@ -91,8 +109,25 @@ func TestLogin_WrongPassword(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), "Invalid password") {
+	if !strings.Contains(rec.Body.String(), "Invalid username or password") {
 		t.Error("should show error message")
+	}
+}
+
+func TestLogin_DisabledOperator(t *testing.T) {
+	w, s := newTestWeb(t)
+	ctx := context.Background()
+	if err := s.DisableOperator(ctx, "admin-test-id"); err != nil {
+		t.Fatal(err)
+	}
+	form := url.Values{"username": {testUsername}, "password": {testPassword}}
+	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if !strings.Contains(rec.Body.String(), "Invalid username or password") {
+		t.Error("disabled operator should not be able to log in")
 	}
 }
 
@@ -297,13 +332,15 @@ func TestLogout(t *testing.T) {
 }
 
 func TestIsAuthenticated_ExpiredSession(t *testing.T) {
-	sm := NewSessionManager(testPassword)
+	_, s := newTestWeb(t)
+	sm := NewSessionManager(s)
 
-	// Manually inject an expired session
 	token := "expired-token-123"
-	sm.mu.Lock()
-	sm.sessions[token] = session{expiresAt: time.Now().Add(-1 * time.Hour)}
-	sm.mu.Unlock()
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token: token, OperatorID: "admin-test-id", ExpiresAt: time.Now().Add(-1 * time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
@@ -311,23 +348,18 @@ func TestIsAuthenticated_ExpiredSession(t *testing.T) {
 	if sm.IsAuthenticated(req) {
 		t.Error("expired session should not be authenticated")
 	}
-
-	// Session should be deleted from map
-	sm.mu.RLock()
-	_, exists := sm.sessions[token]
-	sm.mu.RUnlock()
-	if exists {
-		t.Error("expired session should be removed from sessions map")
-	}
 }
 
 func TestIsAuthenticated_ValidSession(t *testing.T) {
-	sm := NewSessionManager(testPassword)
+	_, s := newTestWeb(t)
+	sm := NewSessionManager(s)
 
 	token := "valid-token-456"
-	sm.mu.Lock()
-	sm.sessions[token] = session{expiresAt: time.Now().Add(1 * time.Hour)}
-	sm.mu.Unlock()
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token: token, OperatorID: "admin-test-id", ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
@@ -338,7 +370,8 @@ func TestIsAuthenticated_ValidSession(t *testing.T) {
 }
 
 func TestIsAuthenticated_NoCookie(t *testing.T) {
-	sm := NewSessionManager(testPassword)
+	_, s := newTestWeb(t)
+	sm := NewSessionManager(s)
 	req := httptest.NewRequest("GET", "/", nil)
 
 	if sm.IsAuthenticated(req) {
@@ -346,33 +379,54 @@ func TestIsAuthenticated_NoCookie(t *testing.T) {
 	}
 }
 
+func TestIsAuthenticated_DisabledOperator(t *testing.T) {
+	_, s := newTestWeb(t)
+	sm := NewSessionManager(s)
+
+	token := "tok-disabled"
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token: token, OperatorID: "admin-test-id", ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DisableOperator(context.Background(), "admin-test-id"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+
+	if sm.IsAuthenticated(req) {
+		t.Error("disabled operator's session should not be authenticated")
+	}
+}
+
 func TestSessionCleanup(t *testing.T) {
-	sm := NewSessionManager(testPassword)
+	_, s := newTestWeb(t)
+	sm := NewSessionManager(s)
+	ctx := context.Background()
 
-	// Inject expired sessions
-	sm.mu.Lock()
-	sm.sessions["expired-1"] = session{expiresAt: time.Now().Add(-2 * time.Hour)}
-	sm.sessions["expired-2"] = session{expiresAt: time.Now().Add(-1 * time.Hour)}
-	sm.sessions["valid-1"] = session{expiresAt: time.Now().Add(1 * time.Hour)}
-	sm.mu.Unlock()
+	if err := s.CreateOperatorSession(ctx, &models.OperatorSession{
+		Token: "expired-1", OperatorID: "admin-test-id", ExpiresAt: time.Now().Add(-2 * time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateOperatorSession(ctx, &models.OperatorSession{
+		Token: "valid-1", OperatorID: "admin-test-id", ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	sm.StartCleanup(ctx, 50*time.Millisecond) // short interval for test
-
-	// Wait for cleanup tick
+	cleanupCtx, cancel := context.WithCancel(context.Background())
+	sm.StartCleanup(cleanupCtx, 50*time.Millisecond)
 	time.Sleep(150 * time.Millisecond)
 	cancel()
 
-	sm.mu.RLock()
-	count := len(sm.sessions)
-	_, validExists := sm.sessions["valid-1"]
-	sm.mu.RUnlock()
-
-	if count != 1 {
-		t.Errorf("sessions count = %d, want 1 (only valid)", count)
+	if _, err := s.GetOperatorBySession(ctx, "valid-1"); err != nil {
+		t.Errorf("valid session removed: %v", err)
 	}
-	if !validExists {
-		t.Error("valid session should survive cleanup")
+	if _, err := s.GetOperatorBySession(ctx, "expired-1"); err == nil {
+		t.Error("expired session should have been cleaned up")
 	}
 }
 


### PR DESCRIPTION
## Summary

Foundational multi-operator support. Replaces the implicit single-admin / single-api-key model with a proper operator user layer, while preserving backward compatibility for existing deployments.

### Schema (migration 005)
- `operators` — id, username, display_name, password_hash (bcrypt), auth_provider, status, role, last_login_at
- `operator_api_keys` — per-operator, SHA-256 hashed at rest, with `revoked_at`
- `operator_sessions` — DB-backed UI sessions for atomic invalidation when an operator is disabled

### Auth
- **Web login**: `username` + `password`; bcrypt-verified against `operators.password_hash`. Sessions persist in `operator_sessions`.
- **API auth**: bearer token is SHA-256-hashed and looked up in `operator_api_keys`. The legacy config `api_key` is still accepted as a fallback (actor recorded as `legacy-admin`).
- Disabling an operator atomically deletes their sessions and revokes their API keys.

### Bootstrap
`SeedAdminOperator` runs in `init` and on every `serve` startup. If the operators table is empty and the config has a `ui_password` or `api_key`, it creates an `admin` operator and registers the config `api_key` as their first key. **Existing deployments continue to log in with the same password and API key.**

### Public API
- `GET/POST /api/v1/operators`
- `POST /api/v1/operators/{id}/disable|enable`
- `GET/POST /api/v1/operators/{id}/api-keys`
- `DELETE /api/v1/operators/{id}/api-keys/{kid}`

### CLI
- `nebula-mgmt user <create|list|disable|enable>`
- `nebula-mgmt apikey <create|revoke>`

### Audit
Audit log entries now record the actor for `operator.*`, `host.create`, `host.block`, `host.unblock`, `host.delete`. Actor = operator username or `legacy-admin` for the config-key fallback.

### Other
- `internal/store`: `:memory:` SQLite stores now set `MaxOpenConns=1` so per-connection in-memory DBs do not drop the table between calls in concurrent tests.

### Out of scope
- UI for operator management (#17, #18)
- RBAC enforcement; OIDC (#9); 2FA (#8)

## Test plan

- [x] `go build ./... && go vet ./... && go test -v -race ./...` — all green
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] Store tests: operator create/get/disable, API-key lookup/revoke, session lifecycle, expired-session cleanup, cascading-disable invariants
- [x] API tests: operator CRUD via REST, per-operator API-key auth happy/revoked paths, disabled-operator keys rejected, audit-log actor recorded
- [x] Web tests: bcrypt password login (success/wrong/disabled), DB-backed session expiry, disabled-operator session rejected

Closes #10
