### PR TITLE
feat(auth): add TOTP 2FA with recovery codes for operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,21 @@ nebula-mgmt user enable  --server ... --api-key "$ADMIN_KEY" --id "$ALICE_ID"
 Audit log entries (`/api/v1/audit-log`) record the actor for every mutating
 operator/host action.
 
+### 5. Enable two-factor authentication (TOTP)
+
+Open `/ui/2fa`, click **Enable 2FA**, scan the displayed `otpauth://` URL with
+1Password / Bitwarden / Google Authenticator / Aegis / Authy / any compatible
+app, and confirm with a 6-digit code. The server then shows ten one-time
+recovery codes — save them offline.
+
+On the next login the UI asks for the 6-digit code (or one recovery code) after
+the password. Disabling 2FA requires re-confirming the current password. All
+sensitive operations (`operator.2fa.enabled`, `disabled`, `regen_codes`,
+`failed`, `verified`) appear in the audit log.
+
+API tokens are not affected — they continue to authenticate non-interactive
+clients.
+
 ## Deployment
 
 - **Docker** — `docker build -t nebula-mgmt .` (Dockerfile in repo).

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,12 @@ require (
 
 require (
 	filippo.io/bigmod v0.1.0 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
 filippo.io/bigmod v0.1.0 h1:UNzDk7y9ADKST+axd9skUpBQeW7fG2KrTZyOE4uGQy8=
 filippo.io/bigmod v0.1.0/go.mod h1:OjOXDNlClLblvXdwgFFOQFJEocLhhtai8vGLy0JCZlI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -29,6 +32,8 @@ github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJm
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
@@ -38,6 +43,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/slackhq/nebula v1.10.3 h1:EstYj8ODEcv6T0R9X5BVq1zgWZnyU5gtPzk99QF1PMU=
 github.com/slackhq/nebula v1.10.3/go.mod h1:IL5TUQm4x9IFx2kCKPYm1gP47pwd5b8QGnnBH2RHnvs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=

--- a/internal/models/operator.go
+++ b/internal/models/operator.go
@@ -27,6 +27,8 @@ type Operator struct {
 	AuthProvider  OperatorAuthProvider `json:"auth_provider"`
 	Status        OperatorStatus       `json:"status"`
 	Role          string               `json:"role"`
+	TOTPSecret    string               `json:"-"`
+	TOTPEnabled   bool                 `json:"totp_enabled"`
 	CreatedAt     time.Time            `json:"created_at"`
 	UpdatedAt     time.Time            `json:"updated_at"`
 	LastLoginAt   *time.Time           `json:"last_login_at,omitempty"`
@@ -43,10 +45,20 @@ type OperatorAPIKey struct {
 	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
 }
 
-// OperatorSession represents an authenticated UI session.
+// SessionState is the lifecycle phase of an operator session.
+type SessionState string
+
+const (
+	SessionStateAuthenticated SessionState = "authenticated"
+	SessionStatePendingTOTP   SessionState = "pending_totp"
+)
+
+// OperatorSession represents a UI session. A session in `pending_totp` state
+// is awaiting a second-factor verification and is not yet authenticated.
 type OperatorSession struct {
 	Token      string
 	OperatorID string
+	State      SessionState
 	ExpiresAt  time.Time
 	CreatedAt  time.Time
 }

--- a/internal/store/migrations/006_operator_totp.down.sql
+++ b/internal/store/migrations/006_operator_totp.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS operator_recovery_codes;
+-- SQLite doesn't support DROP COLUMN cleanly before 3.35; leaving operators
+-- columns in place on rollback is acceptable here.

--- a/internal/store/migrations/006_operator_totp.up.sql
+++ b/internal/store/migrations/006_operator_totp.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE operators ADD COLUMN totp_secret TEXT NOT NULL DEFAULT '';
+ALTER TABLE operators ADD COLUMN totp_enabled INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS operator_recovery_codes (
+    operator_id  TEXT NOT NULL REFERENCES operators(id) ON DELETE CASCADE,
+    code_hash    TEXT NOT NULL,
+    consumed_at  DATETIME,
+    PRIMARY KEY (operator_id, code_hash)
+);
+
+-- Sessions can be either fully authenticated or pending a second factor.
+ALTER TABLE operator_sessions ADD COLUMN state TEXT NOT NULL DEFAULT 'authenticated';

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -67,6 +67,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"003_audit_log.up.sql",
 		"004_blocklist_fk.up.sql",
 		"005_operators.up.sql",
+		"006_operator_totp.up.sql",
 	}
 	for _, f := range migrationFiles {
 		sqlBytes, err := migrations.FS.ReadFile(f)

--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -11,20 +11,25 @@ import (
 	"github.com/juev/nebula-mesh/internal/models"
 )
 
-const operatorColumns = `id, username, display_name, password_hash, auth_provider, status, role, created_at, updated_at, last_login_at`
+const operatorColumns = `id, username, display_name, password_hash, auth_provider, status, role, totp_secret, totp_enabled, created_at, updated_at, last_login_at`
 
 func scanOperator(scanner interface {
 	Scan(dest ...any) error
 }) (*models.Operator, error) {
 	var op models.Operator
-	var lastLogin sql.NullTime
+	var (
+		lastLogin   sql.NullTime
+		totpEnabled int
+	)
 	if err := scanner.Scan(
 		&op.ID, &op.Username, &op.DisplayName, &op.PasswordHash,
 		&op.AuthProvider, &op.Status, &op.Role,
+		&op.TOTPSecret, &totpEnabled,
 		&op.CreatedAt, &op.UpdatedAt, &lastLogin,
 	); err != nil {
 		return nil, err
 	}
+	op.TOTPEnabled = totpEnabled != 0
 	if lastLogin.Valid {
 		t := lastLogin.Time
 		op.LastLoginAt = &t
@@ -196,6 +201,118 @@ func (s *SQLiteStore) EnableOperator(_ context.Context, id string) error {
 	return nil
 }
 
+// --- TOTP / recovery codes ---
+
+// SetOperatorTOTP records the operator's TOTP secret and enabled flag.
+// Passing enabled=false with secret="" clears 2FA entirely.
+func (s *SQLiteStore) SetOperatorTOTP(_ context.Context, id, secret string, enabled bool) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Error("rollback", "error", err)
+		}
+	}()
+	enabledInt := 0
+	if enabled {
+		enabledInt = 1
+	}
+	result, err := tx.Exec(
+		`UPDATE operators SET totp_secret=?, totp_enabled=?, updated_at=? WHERE id=?`,
+		secret, enabledInt, time.Now(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("update totp: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update totp rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	if !enabled {
+		if _, err := tx.Exec(`DELETE FROM operator_recovery_codes WHERE operator_id=?`, id); err != nil {
+			return fmt.Errorf("clear recovery codes: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// ReplaceOperatorRecoveryCodes deletes any existing codes for the operator
+// and inserts the provided list of hashes (atomic).
+func (s *SQLiteStore) ReplaceOperatorRecoveryCodes(_ context.Context, id string, codeHashes []string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Error("rollback", "error", err)
+		}
+	}()
+	if _, err := tx.Exec(`DELETE FROM operator_recovery_codes WHERE operator_id=?`, id); err != nil {
+		return fmt.Errorf("delete recovery codes: %w", err)
+	}
+	for _, h := range codeHashes {
+		if _, err := tx.Exec(
+			`INSERT INTO operator_recovery_codes (operator_id, code_hash) VALUES (?, ?)`,
+			id, h,
+		); err != nil {
+			return fmt.Errorf("insert recovery code: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// ConsumeOperatorRecoveryCode marks the given hash as consumed if it exists
+// and is unused. Returns ErrNotFound otherwise.
+func (s *SQLiteStore) ConsumeOperatorRecoveryCode(_ context.Context, id, codeHash string) error {
+	result, err := s.db.Exec(
+		`UPDATE operator_recovery_codes SET consumed_at=? WHERE operator_id=? AND code_hash=? AND consumed_at IS NULL`,
+		time.Now(), id, codeHash,
+	)
+	if err != nil {
+		return fmt.Errorf("consume recovery code: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("consume recovery code rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListOperatorRecoveryCodes returns the hashes of all non-consumed recovery
+// codes for the operator. Used by tests and integrity checks.
+func (s *SQLiteStore) ListOperatorRecoveryCodes(_ context.Context, id string) ([]string, error) {
+	rows, err := s.db.Query(
+		`SELECT code_hash FROM operator_recovery_codes WHERE operator_id=? AND consumed_at IS NULL`,
+		id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list recovery codes: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("close rows", "error", err)
+		}
+	}()
+	var out []string
+	for rows.Next() {
+		var h string
+		if err := rows.Scan(&h); err != nil {
+			return nil, fmt.Errorf("scan recovery code: %w", err)
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
 // --- API keys ---
 
 func (s *SQLiteStore) CreateOperatorAPIKey(_ context.Context, k *models.OperatorAPIKey) error {
@@ -323,9 +440,13 @@ func (s *SQLiteStore) CreateOperatorSession(_ context.Context, sess *models.Oper
 	if sess.CreatedAt.IsZero() {
 		sess.CreatedAt = time.Now()
 	}
+	state := sess.State
+	if state == "" {
+		state = models.SessionStateAuthenticated
+	}
 	_, err := s.db.Exec(
-		`INSERT INTO operator_sessions (token, operator_id, expires_at, created_at) VALUES (?, ?, ?, ?)`,
-		sess.Token, sess.OperatorID, sess.ExpiresAt, sess.CreatedAt,
+		`INSERT INTO operator_sessions (token, operator_id, expires_at, created_at, state) VALUES (?, ?, ?, ?, ?)`,
+		sess.Token, sess.OperatorID, sess.ExpiresAt, sess.CreatedAt, state,
 	)
 	if err != nil {
 		return fmt.Errorf("insert session: %w", err)
@@ -333,20 +454,27 @@ func (s *SQLiteStore) CreateOperatorSession(_ context.Context, sess *models.Oper
 	return nil
 }
 
-// GetOperatorBySession returns the operator associated with a non-expired session
-// whose operator is still active. Expired sessions are not auto-deleted here.
+// GetOperatorBySession returns the operator associated with a non-expired,
+// fully-authenticated session whose operator is still active. Sessions in
+// pending_totp state are NOT returned here.
 func (s *SQLiteStore) GetOperatorBySession(_ context.Context, token string) (*models.Operator, error) {
 	row := s.db.QueryRow(
-		`SELECT operator_id, expires_at FROM operator_sessions WHERE token=?`,
+		`SELECT operator_id, expires_at, state FROM operator_sessions WHERE token=?`,
 		token,
 	)
-	var operatorID string
-	var expiresAt time.Time
-	if err := row.Scan(&operatorID, &expiresAt); err != nil {
+	var (
+		operatorID string
+		expiresAt  time.Time
+		state      models.SessionState
+	)
+	if err := row.Scan(&operatorID, &expiresAt, &state); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("get session: %w", err)
+	}
+	if state != models.SessionStateAuthenticated {
+		return nil, ErrNotFound
 	}
 	if time.Now().After(expiresAt) {
 		return nil, ErrNotFound
@@ -363,6 +491,66 @@ func (s *SQLiteStore) GetOperatorBySession(_ context.Context, token string) (*mo
 		return nil, ErrNotFound
 	}
 	return op, nil
+}
+
+// GetPendingTwoFactorOperator returns the operator associated with a session
+// that is awaiting a second factor (`pending_totp`). The operator must still
+// be active. Sessions already authenticated are not returned.
+func (s *SQLiteStore) GetPendingTwoFactorOperator(_ context.Context, token string) (*models.Operator, error) {
+	row := s.db.QueryRow(
+		`SELECT operator_id, expires_at, state FROM operator_sessions WHERE token=?`,
+		token,
+	)
+	var (
+		operatorID string
+		expiresAt  time.Time
+		state      models.SessionState
+	)
+	if err := row.Scan(&operatorID, &expiresAt, &state); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get pending session: %w", err)
+	}
+	if state != models.SessionStatePendingTOTP {
+		return nil, ErrNotFound
+	}
+	if time.Now().After(expiresAt) {
+		return nil, ErrNotFound
+	}
+	opRow := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE id=?`, operatorID)
+	op, err := scanOperator(opRow)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get pending session operator: %w", err)
+	}
+	if op.Status != models.OperatorStatusActive {
+		return nil, ErrNotFound
+	}
+	return op, nil
+}
+
+// PromoteOperatorSession upgrades a pending_totp session to authenticated and
+// resets the expiry to a fresh 24h window. Returns ErrNotFound if the session
+// does not exist or is not pending.
+func (s *SQLiteStore) PromoteOperatorSession(_ context.Context, token string, newExpiry time.Time) error {
+	result, err := s.db.Exec(
+		`UPDATE operator_sessions SET state=?, expires_at=? WHERE token=? AND state=?`,
+		models.SessionStateAuthenticated, newExpiry, token, models.SessionStatePendingTOTP,
+	)
+	if err != nil {
+		return fmt.Errorf("promote session: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("promote session rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func (s *SQLiteStore) DeleteOperatorSession(_ context.Context, token string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -83,6 +83,12 @@ type Store interface {
 	DisableOperator(ctx context.Context, id string) error
 	EnableOperator(ctx context.Context, id string) error
 
+	// Operator TOTP / recovery codes
+	SetOperatorTOTP(ctx context.Context, id, secret string, enabled bool) error
+	ReplaceOperatorRecoveryCodes(ctx context.Context, id string, codeHashes []string) error
+	ConsumeOperatorRecoveryCode(ctx context.Context, id, codeHash string) error
+	ListOperatorRecoveryCodes(ctx context.Context, id string) ([]string, error)
+
 	// Operator API keys
 	CreateOperatorAPIKey(ctx context.Context, k *models.OperatorAPIKey) error
 	GetOperatorByAPIKeyHash(ctx context.Context, keyHash string) (*models.Operator, *models.OperatorAPIKey, error)
@@ -93,6 +99,8 @@ type Store interface {
 	// Operator sessions
 	CreateOperatorSession(ctx context.Context, s *models.OperatorSession) error
 	GetOperatorBySession(ctx context.Context, token string) (*models.Operator, error)
+	GetPendingTwoFactorOperator(ctx context.Context, token string) (*models.Operator, error)
+	PromoteOperatorSession(ctx context.Context, token string, newExpiry time.Time) error
 	DeleteOperatorSession(ctx context.Context, token string) error
 	DeleteOperatorSessionsByOperator(ctx context.Context, operatorID string) error
 	DeleteExpiredOperatorSessions(ctx context.Context, before time.Time) error

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // requireAuth middleware redirects to login if not authenticated.
@@ -35,22 +36,240 @@ func (w *Web) handleLogin(rw http.ResponseWriter, r *http.Request) {
 		username = "admin"
 	}
 	password := r.FormValue("password")
-	_, ok, err := w.session.Login(rw, r, username, password)
+	result, ok, err := w.session.Login(rw, r, username, password)
 	if err != nil {
 		w.logger.Error("login", "error", err)
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
-	if ok {
-		http.Redirect(rw, r, "/ui/", http.StatusSeeOther)
+	if !ok {
+		w.render(rw, "login.html", map[string]any{"Error": "Invalid username or password"})
 		return
 	}
-	w.render(rw, "login.html", map[string]any{"Error": "Invalid username or password"})
+	if result.NeedsTOTP {
+		http.Redirect(rw, r, "/ui/login/totp", http.StatusSeeOther)
+		return
+	}
+	http.Redirect(rw, r, "/ui/", http.StatusSeeOther)
+}
+
+func (w *Web) handleTOTPLoginPage(rw http.ResponseWriter, r *http.Request) {
+	if op := w.session.PendingOperator(r); op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	w.render(rw, "login_totp.html", map[string]any{"Error": ""})
+}
+
+func (w *Web) handleTOTPLogin(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.PendingOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	code := strings.TrimSpace(r.FormValue("code"))
+	recovery := strings.TrimSpace(r.FormValue("recovery_code"))
+
+	ok := false
+	usedRecovery := false
+	if code != "" && verifyTOTP(op.TOTPSecret, code) {
+		ok = true
+	} else if recovery != "" {
+		if err := w.store.ConsumeOperatorRecoveryCode(r.Context(), op.ID, hashRecoveryCode(recovery)); err == nil {
+			ok = true
+			usedRecovery = true
+		}
+	}
+
+	if !ok {
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.failed", op.ID, "")
+		w.render(rw, "login_totp.html", map[string]any{"Error": "Invalid TOTP code"})
+		return
+	}
+	if err := w.session.CompleteTwoFactor(rw, r, op.ID); err != nil {
+		w.logger.Error("complete 2fa", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	details := "totp"
+	if usedRecovery {
+		details = "recovery"
+	}
+	_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.verified", op.ID, details)
+	http.Redirect(rw, r, "/ui/", http.StatusSeeOther)
 }
 
 func (w *Web) handleLogout(rw http.ResponseWriter, r *http.Request) {
 	w.session.Logout(rw, r)
 	http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+}
+
+// --- 2FA management ---
+
+func (w *Web) handleTwoFAPage(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	w.render(rw, "twofa.html", map[string]any{
+		"Active":      "2fa",
+		"Operator":    op,
+		"TOTPEnabled": op.TOTPEnabled,
+		"Setup":       nil,
+		"NewCodes":    nil,
+		"Error":       "",
+	})
+}
+
+type totpSetup struct {
+	OTPURL       string
+	SecretGroup  string
+	SecretRaw    string
+}
+
+func (w *Web) handleTwoFASetup(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	if op.TOTPEnabled {
+		http.Redirect(rw, r, "/ui/2fa", http.StatusSeeOther)
+		return
+	}
+	url, secret, err := generateTOTPSecret(op.Username)
+	if err != nil {
+		w.logger.Error("generate totp", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	// Save the secret but keep totp_enabled=false until verification.
+	if err := w.store.SetOperatorTOTP(r.Context(), op.ID, secret, false); err != nil {
+		w.logger.Error("save pending totp", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.render(rw, "twofa.html", map[string]any{
+		"Active":      "2fa",
+		"Operator":    op,
+		"TOTPEnabled": false,
+		"Setup": &totpSetup{
+			OTPURL:      url,
+			SecretGroup: encodeSecretForDisplay(secret),
+			SecretRaw:   secret,
+		},
+		"NewCodes": nil,
+		"Error":    "",
+	})
+}
+
+func (w *Web) handleTwoFAEnable(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	if op.TOTPSecret == "" {
+		http.Redirect(rw, r, "/ui/2fa", http.StatusSeeOther)
+		return
+	}
+	code := strings.TrimSpace(r.FormValue("code"))
+	if !verifyTOTP(op.TOTPSecret, code) {
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.enable_failed", op.ID, "")
+		w.render(rw, "twofa.html", map[string]any{
+			"Active":      "2fa",
+			"Operator":    op,
+			"TOTPEnabled": false,
+			"Setup": &totpSetup{
+				SecretGroup: encodeSecretForDisplay(op.TOTPSecret),
+				SecretRaw:   op.TOTPSecret,
+			},
+			"Error": "Invalid code; try again",
+		})
+		return
+	}
+	if err := w.store.SetOperatorTOTP(r.Context(), op.ID, op.TOTPSecret, true); err != nil {
+		w.logger.Error("enable totp", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	codes, hashes, err := generateRecoveryCodes(totpRecoveryCodeCount)
+	if err != nil {
+		w.logger.Error("generate recovery codes", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := w.store.ReplaceOperatorRecoveryCodes(r.Context(), op.ID, hashes); err != nil {
+		w.logger.Error("save recovery codes", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.enabled", op.ID, "")
+	w.render(rw, "twofa.html", map[string]any{
+		"Active":      "2fa",
+		"Operator":    op,
+		"TOTPEnabled": true,
+		"NewCodes":    codes,
+		"Error":       "",
+	})
+}
+
+func (w *Web) handleTwoFADisable(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	password := r.FormValue("password")
+	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.disable_failed", op.ID, "")
+		w.render(rw, "twofa.html", map[string]any{
+			"Active":      "2fa",
+			"Operator":    op,
+			"TOTPEnabled": op.TOTPEnabled,
+			"Error":       "Password does not match",
+		})
+		return
+	}
+	if err := w.store.SetOperatorTOTP(r.Context(), op.ID, "", false); err != nil {
+		w.logger.Error("disable totp", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.disabled", op.ID, "")
+	http.Redirect(rw, r, "/ui/2fa", http.StatusSeeOther)
+}
+
+func (w *Web) handleTwoFARegenCodes(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	if !op.TOTPEnabled {
+		http.Redirect(rw, r, "/ui/2fa", http.StatusSeeOther)
+		return
+	}
+	codes, hashes, err := generateRecoveryCodes(totpRecoveryCodeCount)
+	if err != nil {
+		w.logger.Error("generate recovery codes", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := w.store.ReplaceOperatorRecoveryCodes(r.Context(), op.ID, hashes); err != nil {
+		w.logger.Error("save recovery codes", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.regen_codes", op.ID, "")
+	w.render(rw, "twofa.html", map[string]any{
+		"Active":      "2fa",
+		"Operator":    op,
+		"TOTPEnabled": true,
+		"NewCodes":    codes,
+		"Error":       "",
+	})
 }
 
 func (w *Web) handleFavicon(rw http.ResponseWriter, _ *http.Request) {

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	sessionCookieName = "nebula_session"
-	sessionDuration   = 24 * time.Hour
+	sessionCookieName  = "nebula_session"
+	sessionDuration    = 24 * time.Hour
+	pendingTOTPMaxLife = 5 * time.Minute
 )
 
 // SessionManager handles DB-backed cookie sessions for operator users.
@@ -30,41 +31,60 @@ func NewSessionManager(s store.Store) *SessionManager {
 	return &SessionManager{store: s}
 }
 
+// LoginResult is the outcome of the first authentication step.
+type LoginResult struct {
+	Operator   *models.Operator
+	NeedsTOTP  bool
+}
+
 // Login looks up the operator by username, verifies the password (bcrypt),
-// records a session, sets the cookie, and returns the operator. The boolean
-// is true when the credentials were valid.
-func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username, password string) (*models.Operator, bool, error) {
+// records a session, sets the cookie, and returns the operator. The second
+// return value is false when the credentials were invalid. When the operator
+// has TOTP enabled, the created session is in `pending_totp` state and the
+// caller must complete authentication via FinishTOTP.
+func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username, password string) (LoginResult, bool, error) {
 	if username == "" || password == "" {
-		return nil, false, nil
+		return LoginResult{}, false, nil
 	}
 	op, err := sm.store.GetOperatorByUsername(r.Context(), username)
 	if errors.Is(err, store.ErrNotFound) {
-		return nil, false, nil
+		return LoginResult{}, false, nil
 	}
 	if err != nil {
-		return nil, false, fmt.Errorf("lookup operator: %w", err)
+		return LoginResult{}, false, fmt.Errorf("lookup operator: %w", err)
 	}
 	if op.Status != models.OperatorStatusActive {
-		return nil, false, nil
+		return LoginResult{}, false, nil
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {
-		return nil, false, nil
+		return LoginResult{}, false, nil
 	}
 
 	token, err := generateToken()
 	if err != nil {
-		return nil, false, err
+		return LoginResult{}, false, err
 	}
+	state := models.SessionStateAuthenticated
 	expires := time.Now().Add(sessionDuration)
+	if op.TOTPEnabled {
+		state = models.SessionStatePendingTOTP
+		expires = time.Now().Add(pendingTOTPMaxLife)
+	}
 	if err := sm.store.CreateOperatorSession(r.Context(), &models.OperatorSession{
 		Token:      token,
 		OperatorID: op.ID,
+		State:      state,
 		ExpiresAt:  expires,
 	}); err != nil {
-		return nil, false, fmt.Errorf("create session: %w", err)
+		return LoginResult{}, false, fmt.Errorf("create session: %w", err)
 	}
-	if err := sm.store.UpdateOperatorLastLogin(r.Context(), op.ID, time.Now()); err != nil {
-		slog.Debug("update last login", "error", err)
+	cookieMaxAge := int(sessionDuration.Seconds())
+	if op.TOTPEnabled {
+		cookieMaxAge = int(pendingTOTPMaxLife.Seconds())
+	} else {
+		if err := sm.store.UpdateOperatorLastLogin(r.Context(), op.ID, time.Now()); err != nil {
+			slog.Debug("update last login", "error", err)
+		}
 	}
 
 	http.SetCookie(w, &http.Cookie{
@@ -73,9 +93,48 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 		Path:     "/",
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
+		MaxAge:   cookieMaxAge,
+	})
+	return LoginResult{Operator: op, NeedsTOTP: op.TOTPEnabled}, true, nil
+}
+
+// PendingOperator returns the operator awaiting second-factor confirmation
+// on the current session cookie, or nil if no pending session exists.
+func (sm *SessionManager) PendingOperator(r *http.Request) *models.Operator {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return nil
+	}
+	op, err := sm.store.GetPendingTwoFactorOperator(r.Context(), cookie.Value)
+	if err != nil {
+		return nil
+	}
+	return op
+}
+
+// CompleteTwoFactor promotes the current pending session to fully
+// authenticated, refreshes the cookie expiry, and updates last_login_at.
+func (sm *SessionManager) CompleteTwoFactor(w http.ResponseWriter, r *http.Request, operatorID string) error {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return fmt.Errorf("missing session cookie: %w", err)
+	}
+	newExpiry := time.Now().Add(sessionDuration)
+	if err := sm.store.PromoteOperatorSession(r.Context(), cookie.Value, newExpiry); err != nil {
+		return fmt.Errorf("promote session: %w", err)
+	}
+	if err := sm.store.UpdateOperatorLastLogin(r.Context(), operatorID, time.Now()); err != nil {
+		slog.Debug("update last login", "error", err)
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    cookie.Value,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(sessionDuration.Seconds()),
 	})
-	return op, true, nil
+	return nil
 }
 
 // Logout invalidates the session cookie and removes the DB record.

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -176,6 +176,7 @@
                 <a href="/ui/" {{if eq .Active "dashboard"}}class="active"{{end}}>Dashboard</a>
                 <a href="/ui/networks" {{if eq .Active "networks"}}class="active"{{end}}>Networks</a>
                 <a href="/ui/hosts" {{if eq .Active "hosts"}}class="active"{{end}}>Hosts</a>
+                <a href="/ui/2fa" {{if eq .Active "2fa"}}class="active"{{end}}>Two-factor auth</a>
                 <a href="/ui/logout">Logout</a>
             </div>
         </nav>

--- a/internal/web/templates/login_totp.html
+++ b/internal/web/templates/login_totp.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Two-factor authentication — Nebula Mesh</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico">
+    <style>
+        :root {
+            --bg: #0f1117;
+            --bg-card: #1a1d27;
+            --border: #2d3148;
+            --text: #e1e4ed;
+            --text-muted: #8b8fa3;
+            --primary: #6c7aee;
+            --primary-hover: #5a68d6;
+            --danger: #e05555;
+            --radius: 8px;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+        }
+        .login-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 40px; width: 360px; }
+        .login-card h1 { font-size: 22px; margin-bottom: 16px; text-align: center; }
+        .login-card p { font-size: 13px; color: var(--text-muted); margin-bottom: 16px; text-align: center; }
+        .form-group { margin-bottom: 16px; }
+        .form-group label { display: block; font-size: 13px; color: var(--text-muted); margin-bottom: 4px; }
+        .form-control { width: 100%; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); color: var(--text); font-size: 14px; font-family: monospace; letter-spacing: 0.1em; }
+        .btn { width: 100%; padding: 10px; border-radius: var(--radius); font-size: 14px; font-weight: 500; cursor: pointer; border: none; background: var(--primary); color: #fff; }
+        .btn:hover { background: var(--primary-hover); }
+        .error { color: var(--danger); font-size: 13px; text-align: center; margin-bottom: 12px; }
+        .divider { color: var(--text-muted); text-align: center; font-size: 12px; margin: 12px 0; }
+    </style>
+</head>
+<body>
+    <div class="login-card">
+        <h1>Two-factor authentication</h1>
+        <p>Enter the 6-digit code from your authenticator app, or use a recovery code.</p>
+        {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+        <form method="POST" action="/ui/login/totp">
+            <div class="form-group">
+                <label>Authenticator code</label>
+                <input type="text" name="code" class="form-control" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" autofocus>
+            </div>
+            <div class="divider">— or —</div>
+            <div class="form-group">
+                <label>Recovery code</label>
+                <input type="text" name="recovery_code" class="form-control" autocomplete="off">
+            </div>
+            <button type="submit" class="btn">Verify</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/internal/web/templates/twofa.html
+++ b/internal/web/templates/twofa.html
@@ -1,0 +1,51 @@
+{{define "title"}}Two-factor authentication — Nebula Mesh{{end}}
+
+{{define "content"}}
+<h1>Two-factor authentication</h1>
+
+{{if .Error}}<div class="flash flash-error">{{.Error}}</div>{{end}}
+
+{{if .NewCodes}}
+<div class="card flash flash-success">
+    <h2>Recovery codes</h2>
+    <p>Save these codes somewhere safe — they are shown only once. Each code can be used once if you lose access to your authenticator app.</p>
+    <div class="token-display">
+{{range .NewCodes}}{{.}}
+{{end}}
+    </div>
+</div>
+{{end}}
+
+<div class="card">
+    <h2>Status</h2>
+    {{if .TOTPEnabled}}
+    <p>Two-factor authentication is <strong>enabled</strong> for <code>{{.Operator.Username}}</code>.</p>
+    <form method="POST" action="/ui/2fa/disable" style="margin-top:16px">
+        <div class="form-group">
+            <label>Confirm with current password to disable</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-danger">Disable 2FA</button>
+    </form>
+    <form method="POST" action="/ui/2fa/recovery-codes" style="margin-top:16px">
+        <button type="submit" class="btn">Regenerate recovery codes</button>
+    </form>
+    {{else if .Setup}}
+    <p>Scan this URL in your authenticator app, or enter the secret manually:</p>
+    <div class="token-display">{{.Setup.OTPURL}}</div>
+    <p>Secret: <code>{{.Setup.SecretGroup}}</code></p>
+    <form method="POST" action="/ui/2fa/enable" style="margin-top:16px">
+        <div class="form-group">
+            <label>Enter the 6-digit code from your app to confirm</label>
+            <input type="text" name="code" class="form-control" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" required autofocus>
+        </div>
+        <button type="submit" class="btn btn-primary">Enable 2FA</button>
+    </form>
+    {{else}}
+    <p>Two-factor authentication is <strong>not enabled</strong>.</p>
+    <form method="POST" action="/ui/2fa/setup" style="margin-top:16px">
+        <button type="submit" class="btn btn-primary">Enable 2FA</button>
+    </form>
+    {{end}}
+</div>
+{{end}}

--- a/internal/web/time.go
+++ b/internal/web/time.go
@@ -1,0 +1,6 @@
+package web
+
+import "time"
+
+// timeNow is overridable in tests.
+var timeNow = time.Now

--- a/internal/web/totp.go
+++ b/internal/web/totp.go
@@ -1,0 +1,96 @@
+package web
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+)
+
+const (
+	totpIssuer            = "Nebula Mesh"
+	totpRecoveryCodeCount = 10
+)
+
+// generateTOTPSecret creates a new TOTP secret keyed for the operator's
+// username. It returns the otpauth:// URL (for QR rendering) and the raw
+// base32-encoded secret to persist.
+func generateTOTPSecret(username string) (string, string, error) {
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      totpIssuer,
+		AccountName: username,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("generate totp: %w", err)
+	}
+	return key.URL(), key.Secret(), nil
+}
+
+// verifyTOTP validates a 6-digit code against the operator's secret.
+func verifyTOTP(secret, code string) bool {
+	code = strings.TrimSpace(code)
+	if secret == "" || code == "" {
+		return false
+	}
+	ok, err := totp.ValidateCustom(code, secret, timeNow(), totp.ValidateOpts{
+		Period:    30,
+		Skew:      1,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+// generateRecoveryCodes returns N random 10-character codes (uppercase
+// alphanumeric) and their SHA-256 hex hashes for storage.
+func generateRecoveryCodes(n int) (codes []string, hashes []string, err error) {
+	const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // base32-ish, no 0/O/I/1
+	for i := 0; i < n; i++ {
+		buf := make([]byte, 10)
+		if _, err := rand.Read(buf); err != nil {
+			return nil, nil, fmt.Errorf("rand: %w", err)
+		}
+		var sb strings.Builder
+		for _, b := range buf {
+			sb.WriteByte(alphabet[int(b)%len(alphabet)])
+		}
+		code := sb.String()
+		codes = append(codes, code)
+		hashes = append(hashes, hashRecoveryCode(code))
+	}
+	return codes, hashes, nil
+}
+
+// hashRecoveryCode normalizes a code (uppercase, strip spaces/dashes) and
+// returns its SHA-256 hex digest so plain codes can be matched.
+func hashRecoveryCode(code string) string {
+	norm := strings.ToUpper(strings.NewReplacer(" ", "", "-", "").Replace(strings.TrimSpace(code)))
+	sum := sha256.Sum256([]byte(norm))
+	return hex.EncodeToString(sum[:])
+}
+
+// encodeSecretForDisplay formats the base32 secret into groups of 4 for
+// manual entry into an authenticator app.
+func encodeSecretForDisplay(secret string) string {
+	// Strip any padding so display is uniform.
+	clean := strings.TrimRight(secret, "=")
+	var sb strings.Builder
+	for i, c := range clean {
+		if i > 0 && i%4 == 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteRune(c)
+	}
+	return sb.String()
+}
+
+// dummy import guard so test builds don't fail when base32 is only used via totp.
+var _ = base32.StdEncoding

--- a/internal/web/totp_test.go
+++ b/internal/web/totp_test.go
@@ -1,0 +1,356 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+	"github.com/pquerna/otp/totp"
+)
+
+func TestGenerateAndVerifyTOTP(t *testing.T) {
+	_, secret, err := generateTOTPSecret("alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	code, err := totp.GenerateCode(secret, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	timeNow = func() time.Time { return now }
+	t.Cleanup(func() { timeNow = time.Now })
+
+	if !verifyTOTP(secret, code) {
+		t.Error("expected verifyTOTP to accept current code")
+	}
+	if verifyTOTP(secret, "000000") {
+		t.Error("verifyTOTP accepted bogus code")
+	}
+}
+
+func TestGenerateRecoveryCodes_HashesMatch(t *testing.T) {
+	codes, hashes, err := generateRecoveryCodes(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(codes) != 5 || len(hashes) != 5 {
+		t.Fatalf("got %d codes / %d hashes", len(codes), len(hashes))
+	}
+	for i, c := range codes {
+		if hashRecoveryCode(c) != hashes[i] {
+			t.Errorf("hash mismatch for code %d", i)
+		}
+		if hashRecoveryCode(strings.ToLower(c)) != hashes[i] {
+			t.Errorf("case-insensitive normalization broke for code %d", i)
+		}
+	}
+}
+
+// enableTOTPForAdmin programmatically enables TOTP for the seeded admin user
+// and returns the secret and a valid current code.
+func enableTOTPForAdmin(t *testing.T, w *Web) (secret, code string) {
+	t.Helper()
+	_, secret, err := generateTOTPSecret("admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.store.SetOperatorTOTP(context.Background(), "admin-test-id", secret, true); err != nil {
+		t.Fatal(err)
+	}
+	code, err = totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return secret, code
+}
+
+func TestLogin_TOTPFlow(t *testing.T) {
+	w, _ := newTestWeb(t)
+	_, code := enableTOTPForAdmin(t, w)
+
+	// Step 1: password
+	form := url.Values{"username": {testUsername}, "password": {testPassword}}
+	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("step1 status = %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/ui/login/totp" {
+		t.Errorf("step1 redirect = %q, want /ui/login/totp", loc)
+	}
+	cookies := rec.Result().Cookies()
+
+	// Visiting /ui/ should still redirect to login because session is pending_totp
+	req = httptest.NewRequest("GET", "/ui/", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("pending session protected = %d, want 303", rec.Code)
+	}
+
+	// Step 2: TOTP code
+	form = url.Values{"code": {code}}
+	req = httptest.NewRequest("POST", "/ui/login/totp", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("step2 status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/ui/" {
+		t.Errorf("step2 redirect = %q", loc)
+	}
+
+	// Now session should be fully authenticated
+	req = httptest.NewRequest("GET", "/ui/", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("authenticated dashboard status = %d", rec.Code)
+	}
+}
+
+func TestLogin_TOTPInvalidCode(t *testing.T) {
+	w, _ := newTestWeb(t)
+	_, _ = enableTOTPForAdmin(t, w)
+
+	form := url.Values{"username": {testUsername}, "password": {testPassword}}
+	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	cookies := rec.Result().Cookies()
+
+	form = url.Values{"code": {"000000"}}
+	req = httptest.NewRequest("POST", "/ui/login/totp", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "Invalid TOTP code") {
+		t.Errorf("expected Invalid TOTP code error; body=%s", rec.Body.String())
+	}
+}
+
+func TestLogin_TOTPRecoveryCode(t *testing.T) {
+	w, _ := newTestWeb(t)
+	_, _ = enableTOTPForAdmin(t, w)
+
+	// Seed a recovery code we know.
+	plainCode := "RECOVER123"
+	if err := w.store.ReplaceOperatorRecoveryCodes(context.Background(), "admin-test-id", []string{hashRecoveryCode(plainCode)}); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{"username": {testUsername}, "password": {testPassword}}
+	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	cookies := rec.Result().Cookies()
+
+	form = url.Values{"recovery_code": {plainCode}}
+	req = httptest.NewRequest("POST", "/ui/login/totp", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("recovery code login status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Second attempt with same code should fail (single-use)
+	form = url.Values{"username": {testUsername}, "password": {testPassword}}
+	req = httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	cookies = rec.Result().Cookies()
+
+	form = url.Values{"recovery_code": {plainCode}}
+	req = httptest.NewRequest("POST", "/ui/login/totp", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "Invalid TOTP code") {
+		t.Errorf("expected reuse to fail; body=%s", rec.Body.String())
+	}
+}
+
+func TestTwoFASetupAndEnable(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	// Setup
+	req := httptest.NewRequest("POST", "/ui/2fa/setup", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("setup status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "otpauth://") {
+		t.Errorf("setup page should contain otpauth URL; body=%s", body)
+	}
+
+	// Reload operator and generate code
+	op, _ := s.GetOperator(context.Background(), "admin-test-id")
+	if op.TOTPSecret == "" {
+		t.Fatal("totp secret not stored after setup")
+	}
+	if op.TOTPEnabled {
+		t.Error("totp_enabled should still be false after setup")
+	}
+	code, err := totp.GenerateCode(op.TOTPSecret, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Enable
+	form := url.Values{"code": {code}}
+	req = httptest.NewRequest("POST", "/ui/2fa/enable", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("enable status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	body = rec.Body.String()
+	if !strings.Contains(body, "Recovery codes") {
+		t.Error("recovery codes block missing after enable")
+	}
+
+	op, _ = s.GetOperator(context.Background(), "admin-test-id")
+	if !op.TOTPEnabled {
+		t.Error("totp_enabled should be true after enable")
+	}
+
+	// Audit log entry recorded
+	entries, _ := s.ListAuditEntries(context.Background(), store.AuditFilter{Limit: 100})
+	found := false
+	for _, e := range entries {
+		if e.Action == "operator.2fa.enabled" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("audit entry operator.2fa.enabled missing")
+	}
+}
+
+func TestTwoFADisable_RequiresPassword(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	// Pre-enable TOTP
+	_, _ = enableTOTPForAdmin(t, w)
+
+	// Wrong password — should fail
+	form := url.Values{"password": {"wrong"}}
+	req := httptest.NewRequest("POST", "/ui/2fa/disable", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "Password does not match") {
+		t.Error("expected password mismatch error")
+	}
+	op, _ := s.GetOperator(context.Background(), "admin-test-id")
+	if !op.TOTPEnabled {
+		t.Error("TOTP should still be enabled after failed disable")
+	}
+
+	// Correct password — should succeed
+	form = url.Values{"password": {testPassword}}
+	req = httptest.NewRequest("POST", "/ui/2fa/disable", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("disable status = %d", rec.Code)
+	}
+
+	op, _ = s.GetOperator(context.Background(), "admin-test-id")
+	if op.TOTPEnabled {
+		t.Error("TOTP should be disabled after successful disable")
+	}
+	codes, _ := s.ListOperatorRecoveryCodes(context.Background(), "admin-test-id")
+	if len(codes) != 0 {
+		t.Error("recovery codes should be cleared after disable")
+	}
+}
+
+func TestTwoFAAuditEntries(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+	_, _ = enableTOTPForAdmin(t, w)
+
+	// Trigger failed disable
+	form := url.Values{"password": {"wrong"}}
+	req := httptest.NewRequest("POST", "/ui/2fa/disable", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	_ = rec
+
+	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.Action == "operator.2fa.disable_failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("audit entry operator.2fa.disable_failed not recorded")
+	}
+
+	// Sanity check: operator still has TOTP enabled
+	op, _ := s.GetOperator(context.Background(), "admin-test-id")
+	if !op.TOTPEnabled {
+		t.Error("totp should still be enabled")
+	}
+	_ = op
+	_ = models.OperatorStatusActive
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -46,6 +46,7 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		"host_new.html",
 		"host_detail.html",
 		"networks.html",
+		"twofa.html",
 	}
 	for _, page := range pages {
 		tmpl, err := template.ParseFS(templateFS, "templates/layout.html", "templates/"+page)
@@ -55,12 +56,14 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		w.templates[page] = tmpl
 	}
 
-	// Login is standalone (no layout)
-	loginTmpl, err := template.ParseFS(templateFS, "templates/login.html")
-	if err != nil {
-		return nil, fmt.Errorf("parse login template: %w", err)
+	// Login pages are standalone (no layout)
+	for _, page := range []string{"login.html", "login_totp.html"} {
+		tmpl, err := template.ParseFS(templateFS, "templates/"+page)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", page, err)
+		}
+		w.templates[page] = tmpl
 	}
-	w.templates["login.html"] = loginTmpl
 
 	w.setupRoutes()
 	return w, nil
@@ -79,6 +82,8 @@ func (w *Web) setupRoutes() {
 	// Login (public)
 	r.Get("/ui/login", w.handleLoginPage)
 	r.Post("/ui/login", w.handleLogin)
+	r.Get("/ui/login/totp", w.handleTOTPLoginPage)
+	r.Post("/ui/login/totp", w.handleTOTPLogin)
 
 	// Protected routes
 	r.Group(func(r chi.Router) {
@@ -92,6 +97,11 @@ func (w *Web) setupRoutes() {
 		r.Delete("/ui/hosts/{id}", w.handleHostDelete)
 		r.Get("/ui/networks", w.handleNetworks)
 		r.Post("/ui/networks", w.handleNetworkCreate)
+		r.Get("/ui/2fa", w.handleTwoFAPage)
+		r.Post("/ui/2fa/setup", w.handleTwoFASetup)
+		r.Post("/ui/2fa/enable", w.handleTwoFAEnable)
+		r.Post("/ui/2fa/disable", w.handleTwoFADisable)
+		r.Post("/ui/2fa/recovery-codes", w.handleTwoFARegenCodes)
 		r.Get("/ui/partials/stats", w.handlePartialStats)
 		r.Get("/ui/logout", w.handleLogout)
 	})
@@ -119,7 +129,7 @@ func (w *Web) render(rw http.ResponseWriter, name string, data any) {
 	}
 	// For pages with layout, execute "layout.html"; for standalone pages, execute the file directly
 	execName := "layout.html"
-	if name == "login.html" {
+	if name == "login.html" || name == "login_totp.html" {
 		execName = name
 	}
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary

Optional second factor for interactive web logins, built on the multi-operator foundation from #10.

### What an operator sees
- New sidebar entry **Two-factor auth** → `/ui/2fa`. Click **Enable 2FA**; the page shows an `otpauth://` URL and the base32 secret in groups of four for any TOTP app (1Password, Bitwarden, Google Authenticator, Aegis, Authy, …). Confirm with a 6-digit code; the server then displays ten one-time recovery codes.
- On the next login, the password screen is followed by a TOTP screen at `/ui/login/totp` that accepts either the 6-digit code or one recovery code.
- Disabling 2FA requires re-entering the current password and also wipes recovery codes.

### Schema (migration 006)
- `operators.totp_secret`, `totp_enabled`
- `operator_recovery_codes` (SHA-256 of normalized code, single-use)
- `operator_sessions.state` — `authenticated` or `pending_totp` (5-min window)

### Auth flow
1. `POST /ui/login` → if password ok and TOTP enabled, create a `pending_totp` session and redirect to `/ui/login/totp`.
2. `POST /ui/login/totp` → verify TOTP or recovery code, then promote to `authenticated` (fresh 24h expiry, `last_login_at` bumped).
3. Protected routes treat `pending_totp` sessions as unauthenticated (no leakage of `/ui/`).

### Audit log
`operator.2fa.enabled`, `disabled`, `regen_codes`, `enable_failed`, `disable_failed`, `verified` (with `details=totp|recovery`), `failed`.

### Library
- `github.com/pquerna/otp v1.5.0` (SHA1, 6 digits, 30s period, skew 1).

### Out of scope
- API-key 2FA (API clients are non-interactive).
- Global enforcement of 2FA for all operators / mandatory 2FA on bootstrap.

## Test plan

- [x] `go build ./... && go vet ./... && go test -v -race ./...` — all green
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] TOTP unit tests: generate/verify, recovery-code hashing/normalization
- [x] Login flow: pending session blocks protected routes; valid TOTP completes; invalid TOTP rejected; recovery code consumed (single-use); reuse fails
- [x] 2FA UI: setup stores secret without enabling; enable confirms code and shows recovery codes; disable requires correct password
- [x] Audit log: `operator.2fa.enabled` and `disable_failed` entries recorded

Closes #8
