### PR TITLE
build(release): expand nebula-agent target matrix to Nebula-aligned platforms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,8 +24,21 @@ builds:
     binary: nebula-agent
     main: ./cmd/nebula-agent
     env: [CGO_ENABLED=0]
-    goos: [linux, darwin]
-    goarch: [amd64, arm64]
+    goos: [linux, darwin, freebsd, windows]
+    goarch: [amd64, arm64, arm]
+    goarm: ["7"]
+    ignore:
+      # No 32-bit arm darwin/freebsd/windows targets.
+      - goos: darwin
+        goarch: arm
+      - goos: freebsd
+        goarch: arm
+      - goos: windows
+        goarch: arm
+      # windows/arm64 — buildable but rarely useful for Nebula. Drop until
+      # demand emerges to keep the release matrix manageable.
+      - goos: windows
+        goarch: arm64
     flags: [-trimpath]
     ldflags:
       - -s -w
@@ -48,13 +61,18 @@ archives:
 
   - id: agent
     ids: [nebula-agent]
-    name_template: "nebula-agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: >-
+      nebula-agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
     formats: [tar.gz]
     files:
       - LICENSE
       - README.md
       - CHANGELOG.md
       - configs/agent.example.yml
+      - docs/agent.md
       - deploy/systemd/nebula-agent.service
       - deploy/systemd/README.md
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -43,10 +43,38 @@ running and continue to update certificates as they approach expiry.
 
 ## Installation
 
+### Supported release matrix
+
+Each tagged release ships pre-built `nebula-agent` binaries for the OS/arch
+combinations listed below. The list aligns with the platforms Slack Nebula
+itself supports for production use; less common Nebula targets (mips, ppc64,
+openbsd, netbsd, ios, android) are *not* published — build from source if
+you need them.
+
+| OS | Architecture | Archive suffix | Notes |
+|---|---|---|---|
+| linux | amd64 | `linux_amd64.tar.gz` | Tested. Recommended default. |
+| linux | arm64 | `linux_arm64.tar.gz` | Tested. Raspberry Pi 4/5 64-bit OS, AWS Graviton, … |
+| linux | arm (v7) | `linux_armv7.tar.gz` | Built, not regularly tested. Raspberry Pi 3 / 32-bit Pi OS. |
+| darwin | amd64 | `darwin_amd64.tar.gz` | Intel Macs. |
+| darwin | arm64 | `darwin_arm64.tar.gz` | Apple Silicon. |
+| freebsd | amd64 | `freebsd_amd64.tar.gz` | Built. Use with the FreeBSD Nebula port. |
+| freebsd | arm64 | `freebsd_arm64.tar.gz` | Built, not regularly tested. |
+| windows | amd64 | `windows_amd64.zip` | Built. SIGHUP-based reload is unavailable on Windows — leave `nebula_pid_file` empty and restart Nebula manually. |
+
+Unsupported targets and reasoning:
+
+- `windows/arm64` — buildable, but no demand and no test coverage. Open an
+  issue if you need it.
+- `linux/mips*`, `linux/ppc64*`, `linux/riscv64` — Nebula upstream builds for
+  these; we do not yet, to keep the release size manageable. Build from
+  source: `GOOS=linux GOARCH=riscv64 go build ./cmd/nebula-agent`.
+- `openbsd`, `netbsd`, `ios`, `android` — operationally impractical for a
+  long-running polling agent.
+
 ### 1. From a release archive
 
-Pre-built binaries for Linux, macOS, FreeBSD on amd64 and arm64 are published with
-each tagged release. Replace `<version>` and `<platform>` as needed:
+Replace `<version>` and `<platform>` as needed:
 
 ```sh
 curl -fsSL -o nebula-agent.tar.gz \


### PR DESCRIPTION
## Summary

Adds release builds for the OS/arch combinations Nebula itself targets for production:

| Existing | Added |
|---|---|
| linux amd64/arm64 | linux arm v7 |
| darwin amd64/arm64 | freebsd amd64/arm64 |
| | windows amd64 |

- Archive naming preserves the current `nebula-agent_<version>_<os>_<arch>[v<armver>]` convention.
- Windows ships as `.zip` (goreleaser `format_overrides`), Linux/Darwin/FreeBSD stay as `.tar.gz`.
- All archives now also embed `docs/agent.md` so the deployment guide travels with the binary.

[`docs/agent.md`](docs/agent.md) gains an explicit *Supported release matrix* table covering tested vs built-only targets, plus the reasoning for skipped Nebula platforms (Windows arm64, mips/ppc/riscv linux, openbsd/netbsd/ios/android).

## Test plan

- [x] Local cross-compile of every published target succeeds:
  ```
  GOOS={linux,darwin,freebsd,windows} GOARCH={amd64,arm64} CGO_ENABLED=0 go build -o /dev/null ./cmd/nebula-agent
  GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -o /dev/null ./cmd/nebula-agent
  ```
- [x] `goreleaser check` passes locally.
- [x] No Go source changes — pure release pipeline + docs.

Closes #13