### PR TITLE
build(release): produce .deb and .rpm packages for nebula-agent

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,6 +76,51 @@ archives:
       - deploy/systemd/nebula-agent.service
       - deploy/systemd/README.md
 
+nfpms:
+  - id: nebula-agent
+    package_name: nebula-agent
+    ids: [nebula-agent]
+    vendor: "juev"
+    homepage: "https://github.com/juev/nebula-mesh"
+    maintainer: "juev <https://github.com/juev>"
+    description: |
+      Polling agent for the nebula-mesh management server.
+      Enrolls a host, keeps host.crt/host.key/ca.crt/config.yml in sync,
+      and signals Slack Nebula on changes.
+    license: MIT
+    formats: [deb, rpm]
+    bindir: /usr/bin
+    section: net
+    contents:
+      - src: configs/agent.example.yml
+        dst: /etc/nebula-agent/agent.example.yml
+        type: config|noreplace
+      - src: deploy/systemd/nebula-agent.service
+        dst: /lib/systemd/system/nebula-agent.service
+      - src: docs/agent.md
+        dst: /usr/share/doc/nebula-agent/agent.md
+      - src: LICENSE
+        dst: /usr/share/doc/nebula-agent/LICENSE
+    overrides:
+      rpm:
+        dependencies:
+          - shadow-utils
+      deb:
+        dependencies:
+          - adduser
+    scripts:
+      postinstall: deploy/packaging/postinstall.sh
+      preremove:   deploy/packaging/preremove.sh
+      postremove:  deploy/packaging/postremove.sh
+    rpm:
+      group: System Environment/Daemons
+      summary: Polling agent for nebula-mesh
+    deb:
+      fields:
+        Bugs: "https://github.com/juev/nebula-mesh/issues"
+      lintian_overrides:
+        - "statically-linked-binary"
+
 dockers:
   - id: server-amd64
     goos: linux

--- a/deploy/packaging/postinstall.sh
+++ b/deploy/packaging/postinstall.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e
+
+# Create system user/group if missing. Used to give the operator a clear
+# target for hardening, even though the shipped systemd unit still runs as
+# root because the agent needs to write into /etc/nebula and SIGHUP nebula.
+if ! getent group nebula-agent >/dev/null 2>&1; then
+    groupadd --system nebula-agent
+fi
+if ! getent passwd nebula-agent >/dev/null 2>&1; then
+    useradd --system --gid nebula-agent --home-dir /var/lib/nebula-agent \
+        --shell /usr/sbin/nologin --comment "nebula-agent" nebula-agent
+fi
+
+# /etc/nebula-agent/agent.yml is intentionally NOT created automatically —
+# operators copy from the shipped example and edit before first run.
+if [ ! -f /etc/nebula-agent/agent.yml ]; then
+    cat <<EOF >&2
+
+  nebula-agent: configuration not yet present.
+  Copy the example and edit before starting the service:
+
+    sudo cp /etc/nebula-agent/agent.example.yml /etc/nebula-agent/agent.yml
+    sudoedit /etc/nebula-agent/agent.yml
+    sudo nebula-agent enroll --server <url> --token <token> --data-dir /etc/nebula
+    sudo systemctl enable --now nebula-agent.service
+
+EOF
+fi
+
+# Reload systemd so the new unit is visible, but never enable/start
+# automatically — operators must enroll first.
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+fi
+
+exit 0

--- a/deploy/packaging/postremove.sh
+++ b/deploy/packaging/postremove.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Reload systemd after unit file disappearance. Keep /etc/nebula-agent and
+# /etc/nebula intact so host keys, certs, and operator edits survive a
+# package removal — operators clean these up manually if desired.
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+fi
+
+case "$1" in
+    purge)
+        # dpkg purge only: also remove the system user.
+        if getent passwd nebula-agent >/dev/null 2>&1; then
+            userdel nebula-agent 2>/dev/null || true
+        fi
+        if getent group nebula-agent >/dev/null 2>&1; then
+            groupdel nebula-agent 2>/dev/null || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/deploy/packaging/preremove.sh
+++ b/deploy/packaging/preremove.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Stop and disable the service if it is running, but only on full removal —
+# not on upgrade. Both dpkg and rpm pass an argument distinguishing these.
+case "$1" in
+    remove|purge|0)
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl stop nebula-agent.service 2>/dev/null || true
+            systemctl disable nebula-agent.service 2>/dev/null || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -72,9 +72,34 @@ Unsupported targets and reasoning:
 - `openbsd`, `netbsd`, `ios`, `android` — operationally impractical for a
   long-running polling agent.
 
-### 1. From a release archive
+### 1a. From a Linux distro package (recommended on Debian / Ubuntu / RHEL)
 
-Replace `<version>` and `<platform>` as needed:
+Each tagged release publishes `.deb` and `.rpm` packages for `amd64` and `arm64`:
+
+```sh
+# Debian / Ubuntu
+curl -fsSL -O https://github.com/juev/nebula-mesh/releases/download/<version>/nebula-agent_<version>_linux_amd64.deb
+sudo apt install ./nebula-agent_<version>_linux_amd64.deb
+
+# RHEL / Fedora / CentOS Stream / Rocky / Alma
+sudo rpm -i https://github.com/juev/nebula-mesh/releases/download/<version>/nebula-agent_<version>_linux_amd64.rpm
+```
+
+The package:
+
+- installs `/usr/bin/nebula-agent` and `/lib/systemd/system/nebula-agent.service`;
+- ships an example config at `/etc/nebula-agent/agent.example.yml`;
+- creates the `nebula-agent` system user/group for future hardening;
+- **does not** create `/etc/nebula-agent/agent.yml`, start, or enable the service — you must copy the example, edit it, run `nebula-agent enroll`, then `systemctl enable --now nebula-agent`;
+- on upgrade, leaves `/etc/nebula-agent/agent.yml` and `/etc/nebula/{host.crt,host.key,ca.crt,config.yml}` untouched;
+- on removal, stops and disables the service but keeps `/etc/nebula-agent` and `/etc/nebula` intact (so host keys survive accidental removals). `apt purge` / `dnf remove --purge` will additionally delete the system user.
+
+Checksums for every artifact are published in `checksums.txt` next to the package.
+
+### 1b. From a release archive (other platforms)
+
+For platforms without a native package (macOS, FreeBSD, Windows, Linux/arm v7),
+replace `<version>` and `<platform>` as needed:
 
 ```sh
 curl -fsSL -o nebula-agent.tar.gz \


### PR DESCRIPTION
## Summary

Adds a goreleaser `nfpms` config that produces Linux distro packages for nebula-agent on every release, for amd64 and arm64:

- `nebula-agent_<version>_linux_amd64.deb` / `linux_arm64.deb` — Debian / Ubuntu
- `nebula-agent_<version>_linux_amd64.rpm` / `linux_arm64.rpm` — RHEL / Fedora / CentOS Stream / Rocky / Alma

### Package layout
- `/usr/bin/nebula-agent`
- `/lib/systemd/system/nebula-agent.service`
- `/etc/nebula-agent/agent.example.yml` (marked `config|noreplace` — preserved on upgrade)
- `/usr/share/doc/nebula-agent/{agent.md,LICENSE}`

### Behavior
- **post-install**: creates the `nebula-agent` system user/group (for future hardening of the unit), reloads systemd, prints operator instructions. **Does not** start or enable the service — operators must copy the example, edit `/etc/nebula-agent/agent.yml`, run `nebula-agent enroll`, then `systemctl enable --now nebula-agent`.
- **pre-remove**: stops & disables the service only on full removal (`dpkg --remove`, `rpm -e`); upgrades keep it running.
- **post-remove**: reloads systemd; on `apt purge` only, also removes the system user. **/etc/nebula-agent and /etc/nebula are deliberately left in place** so a hasty remove cannot wipe enrollment / host keys.

### Out of scope
- Homebrew tap, Windows MSI, FreeBSD pkg — issue #14 lists these as candidates; deferred to follow-up issues to keep this PR reviewable. The release matrix is still expanded by #13.

### Docs
- `docs/agent.md` gains a *From a Linux distro package* install section covering deb, rpm, upgrade, and uninstall semantics.

### Provenance / checksums
Checksums for every artifact (binaries, archives, packages) are published in `checksums.txt` next to the release files — already configured in the existing `checksum:` block.

## Test plan

- [x] `goreleaser check` — config validates
- [x] Local cross-compile still succeeds for all targets in `builds:`
- [x] No Go source changes

Closes #14