### PR TITLE
fix(hosts): validate IP belongs to network CIDR, is unique, and is not reserved

### DIFF
--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/netip"
 	"strings"
 	"time"
 
@@ -41,8 +40,13 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name, nebula_ip, and network_id are required")
 		return
 	}
-	if _, err := netip.ParseAddr(req.NebulaIP); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid nebula_ip: "+err.Error())
+	if err := validateHostIP(r.Context(), s.store, req.NetworkID, req.NebulaIP, ""); err != nil {
+		if IsHostIPValidationError(err) {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		s.logger.Error("validate host ip", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to validate nebula_ip")
 		return
 	}
 	if req.ListenPort < 0 || req.ListenPort > 65535 {

--- a/internal/api/validate_ip.go
+++ b/internal/api/validate_ip.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// hostIPValidationError marks errors that the API layer should surface as 400.
+type hostIPValidationError struct {
+	msg string
+}
+
+func (e *hostIPValidationError) Error() string { return e.msg }
+
+// IsHostIPValidationError reports whether err is a user-facing validation
+// failure rather than an internal error.
+func IsHostIPValidationError(err error) bool {
+	var v *hostIPValidationError
+	return errors.As(err, &v)
+}
+
+// validateHostIP checks that ip is syntactically valid, falls inside the
+// network's CIDR, is not the network or broadcast address (IPv4), and is
+// not already used by another host in the same network. The optional
+// excludeHostID lets the caller exclude the host being edited from the
+// uniqueness check so re-saving without changing the IP succeeds.
+func validateHostIP(ctx context.Context, s store.Store, networkID, ip, excludeHostID string) error {
+	if ip == "" {
+		return &hostIPValidationError{msg: "nebula_ip is required"}
+	}
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return &hostIPValidationError{msg: fmt.Sprintf("invalid nebula_ip: %s", err.Error())}
+	}
+
+	net, err := s.GetNetwork(ctx, networkID)
+	if errors.Is(err, store.ErrNotFound) {
+		return &hostIPValidationError{msg: "network not found"}
+	}
+	if err != nil {
+		return fmt.Errorf("get network: %w", err)
+	}
+
+	prefix, err := netip.ParsePrefix(net.CIDR)
+	if err != nil {
+		return fmt.Errorf("network %q has invalid CIDR %q: %w", net.ID, net.CIDR, err)
+	}
+	if !prefix.Contains(addr) {
+		return &hostIPValidationError{msg: fmt.Sprintf("nebula_ip %s is outside the network CIDR %s", ip, net.CIDR)}
+	}
+
+	if addr.Is4() {
+		if forbiddenIPv4Reserved(prefix, addr) {
+			return &hostIPValidationError{msg: fmt.Sprintf("nebula_ip %s is reserved (network or broadcast address of %s)", ip, net.CIDR)}
+		}
+	}
+
+	hosts, err := s.ListHosts(ctx, store.HostFilter{NetworkID: networkID, Limit: 0})
+	if err != nil {
+		return fmt.Errorf("list hosts: %w", err)
+	}
+	for _, h := range hosts {
+		if h.ID == excludeHostID {
+			continue
+		}
+		if h.NebulaIP == ip {
+			return &hostIPValidationError{msg: fmt.Sprintf("nebula_ip %s is already assigned to host %q in this network", ip, h.Name)}
+		}
+	}
+	return nil
+}
+
+var _ = models.HostStatusBlocked
+
+// forbiddenIPv4Reserved reports whether addr is the network or broadcast
+// address of an IPv4 prefix. For /31 and /32 prefixes RFC 3021 / point-to-point
+// usage allows the boundary addresses, so we skip the check there.
+func forbiddenIPv4Reserved(prefix netip.Prefix, addr netip.Addr) bool {
+	if prefix.Bits() >= 31 {
+		return false
+	}
+	masked := prefix.Masked()
+	if addr == masked.Addr() {
+		return true
+	}
+	// Broadcast = last address in the prefix.
+	maskBytes := uint32(0xFFFFFFFF) << (32 - prefix.Bits())
+	netInt := ipv4ToUint32(masked.Addr())
+	broadcast := netInt | ^maskBytes
+	return ipv4ToUint32(addr) == broadcast
+}
+
+func ipv4ToUint32(a netip.Addr) uint32 {
+	b := a.As4()
+	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+}

--- a/internal/api/validate_ip_test.go
+++ b/internal/api/validate_ip_test.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+func TestCreateHost_RejectsIPOutsideCIDR(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv) // helper creates 192.168.100.0/24
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "wrong-net", NebulaIP: "10.0.0.1",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateHost_RejectsDuplicateIPInSameNetwork(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "h1", NebulaIP: "192.168.100.10",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("first create = %d", w.Code)
+	}
+
+	body, _ = json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "h2", NebulaIP: "192.168.100.10",
+	})
+	req = httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("duplicate IP status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateHost_RejectsIPv4NetworkAddress(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "net-addr", NebulaIP: "192.168.100.0",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestCreateHost_RejectsIPv4BroadcastAddress(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "broadcast", NebulaIP: "192.168.100.255",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateHost_AllowsDuplicateIPAcrossDifferentNetworks(t *testing.T) {
+	srv, st := newTestServer(t)
+	net1 := createNetwork(t, srv)
+
+	// Second network with a different name/CIDR
+	if err := st.CreateNetwork(context.Background(), &models.Network{
+		ID: "net-other", Name: "other", CIDR: "10.20.0.0/24",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: net1, Name: "h1", NebulaIP: "192.168.100.10",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("first create = %d", w.Code)
+	}
+
+	body, _ = json.Marshal(createHostRequest{
+		NetworkID: "net-other", Name: "h2", NebulaIP: "10.20.0.10",
+	})
+	req = httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("different-network create = %d; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestValidateHostIP_BlockedHostStillHoldsItsAddress(t *testing.T) {
+	srv, st := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "h1", NebulaIP: "192.168.100.10",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("first create = %d", w.Code)
+	}
+	var resp createHostResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := st.BlockHostAndAddToBlocklist(context.Background(), resp.Host.ID, "for test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-using the same IP must still be rejected: blocked hosts hold their
+	// slot to preserve audit history. Operators delete the host explicitly
+	// to free the address.
+	body, _ = json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "h2", NebulaIP: "192.168.100.10",
+	})
+	req = httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("reuse-after-block status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -440,7 +440,13 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	nebulaIP := r.FormValue("nebula_ip")
-	if nebulaIP != "" {
+	networkID := r.FormValue("network_id")
+	if nebulaIP != "" && networkID != "" {
+		if err := validateHostIPForNetwork(r.Context(), w.store, networkID, nebulaIP, ""); err != nil {
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else if nebulaIP != "" {
 		if _, err := netip.ParseAddr(nebulaIP); err != nil {
 			http.Error(rw, "invalid nebula_ip: "+err.Error(), http.StatusBadRequest)
 			return

--- a/internal/web/validate_ip.go
+++ b/internal/web/validate_ip.go
@@ -1,0 +1,79 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// validateHostIPForNetwork mirrors the API-layer validation used by
+// handleCreateHost: it checks that ip parses, that it falls inside the
+// network's CIDR, that it is not the IPv4 network/broadcast address, and
+// that it is not already used by another non-blocked host in the same
+// network. excludeHostID lets callers exclude the host being edited.
+func validateHostIPForNetwork(ctx context.Context, s store.Store, networkID, ip, excludeHostID string) error {
+	if ip == "" {
+		return fmt.Errorf("nebula_ip is required")
+	}
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return fmt.Errorf("invalid nebula_ip: %s", err.Error())
+	}
+
+	net, err := s.GetNetwork(ctx, networkID)
+	if errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("network not found")
+	}
+	if err != nil {
+		return fmt.Errorf("get network: %w", err)
+	}
+
+	prefix, err := netip.ParsePrefix(net.CIDR)
+	if err != nil {
+		return fmt.Errorf("network %q has invalid CIDR %q: %w", net.ID, net.CIDR, err)
+	}
+	if !prefix.Contains(addr) {
+		return fmt.Errorf("nebula_ip %s is outside the network CIDR %s", ip, net.CIDR)
+	}
+
+	if addr.Is4() && isIPv4Boundary(prefix, addr) {
+		return fmt.Errorf("nebula_ip %s is reserved (network or broadcast address of %s)", ip, net.CIDR)
+	}
+
+	hosts, err := s.ListHosts(ctx, store.HostFilter{NetworkID: networkID, Limit: 0})
+	if err != nil {
+		return fmt.Errorf("list hosts: %w", err)
+	}
+	for _, h := range hosts {
+		if h.ID == excludeHostID {
+			continue
+		}
+		if h.NebulaIP == ip {
+			return fmt.Errorf("nebula_ip %s is already assigned to host %q in this network", ip, h.Name)
+		}
+	}
+	return nil
+}
+
+var _ = models.HostStatusBlocked
+
+func isIPv4Boundary(prefix netip.Prefix, addr netip.Addr) bool {
+	if prefix.Bits() >= 31 {
+		return false
+	}
+	masked := prefix.Masked()
+	if addr == masked.Addr() {
+		return true
+	}
+	maskBits := uint32(0xFFFFFFFF) << (32 - prefix.Bits())
+	b := masked.Addr().As4()
+	netInt := uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+	broadcast := netInt | ^maskBits
+	ab := addr.As4()
+	addrInt := uint32(ab[0])<<24 | uint32(ab[1])<<16 | uint32(ab[2])<<8 | uint32(ab[3])
+	return addrInt == broadcast
+}


### PR DESCRIPTION
## Summary

Adds proper server-side validation when assigning a Nebula IP to a host. Previously the REST API rejected only syntactically invalid IPs; duplicate IPs surfaced as a 500 from the SQLite UNIQUE constraint, and out-of-CIDR IPs were stored silently.

Both REST (`handleCreateHost`) and Web (`handleHostCreate`) now run the same checks before persisting:

- syntactically valid (`netip.ParseAddr`);
- inside the target network's CIDR (`Prefix.Contains`);
- for IPv4 prefixes /30 and shorter, network and broadcast addresses are rejected (RFC 3021 exempts /31 and /32);
- not already assigned to another host in the same network — blocked hosts continue to hold their address slot to preserve audit history; deleting the host frees the slot;
- when editing a host, its own current IP is not treated as a conflict (`excludeHostID` parameter).

Per-network scope: identical IPs across unrelated networks remain allowed, matching the existing `UNIQUE (network_id, nebula_ip)` index.

## Test plan

- [x] `go test -v -race ./...` — all green
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] New API tests: out-of-CIDR (10.0.0.1 vs 192.168.100.0/24), duplicate within the same network, network address (.0), broadcast address (.255), reuse-across-different-networks, blocked-host-still-holds-its-IP
- [x] Existing `TestCreateHostViaUI` and integration tests still pass against the new validation

Closes #15