### PR TITLE
feat(hosts): support advanced per-host config overrides

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -164,6 +164,38 @@ The PID file approach does not translate cleanly to containers; either run Nebul
 under its own supervisor that watches `config.yml` for changes, or restart the
 Nebula container when the agent rewrites configuration.
 
+## Advanced per-host configuration
+
+The host creation page (`/ui/hosts/new`) and the REST API (`POST /api/v1/hosts`)
+support an optional **advanced** block for per-host overrides. The basic form
+is unchanged; the advanced fields appear behind a collapsed *Advanced
+configuration* details section in the UI and as a structured `advanced`
+object in the API:
+
+```jsonc
+{
+  "network_id": "…", "name": "edge-1", "nebula_ip": "10.0.0.1",
+  "advanced": {
+    "listen_host": "10.0.0.1",   // override default 0.0.0.0
+    "mtu": 1300,                  // tun.mtu
+    "tun_device": "nebula1",      // tun.dev
+    "punchy": false,              // disable hole-punching for this host
+    "unsafe_routes": [
+      { "route": "192.168.10.0/24", "via": "10.0.0.99" }
+    ]
+  }
+}
+```
+
+All advanced fields are optional. Omitted / empty fields inherit the network
+default — render output for those hosts is byte-identical to a host with no
+advanced block. Server-side validation rejects:
+
+- `mtu` outside the 576–9216 range;
+- non-IP `listen_host`;
+- whitespace or slashes in `tun_device`;
+- malformed CIDR or non-IP `via` in `unsafe_routes`.
+
 ## Configuration
 
 The agent reads a YAML config file. The shipped template is

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -153,8 +153,8 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generate config
-	configYAML, err := configgen.Generate(configgen.GeneratorInput{
+	// Generate config (including any per-host advanced overrides)
+	input := configgen.GeneratorInput{
 		HostName:     host.Name,
 		NebulaIP:     host.NebulaIP,
 		IsLighthouse: host.IsLighthouse,
@@ -170,7 +170,17 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		FirewallOutbound: []configgen.FirewallRule{
 			{Port: "any", Proto: "any", Group: "any"},
 		},
-	})
+	}
+	if adv := host.Advanced; adv != nil {
+		input.PunchyOverride = adv.Punchy
+		input.ListenHost = adv.ListenHost
+		input.MTU = adv.MTU
+		input.TunDevice = adv.TunDevice
+		for _, u := range adv.UnsafeRoutes {
+			input.UnsafeRoutes = append(input.UnsafeRoutes, configgen.AdvancedUnsafeRoute{Route: u.Route, Via: u.Via})
+		}
+	}
+	configYAML, err := configgen.Generate(input)
 	if err != nil {
 		s.logger.Error("generate config", "error", err)
 		writeError(w, http.StatusInternalServerError, "enrollment failed")

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -15,13 +15,14 @@ import (
 )
 
 type createHostRequest struct {
-	NetworkID string   `json:"network_id"`
-	Name      string   `json:"name"`
-	NebulaIP  string   `json:"nebula_ip"`
-	Groups    []string `json:"groups"`
-	Role      string   `json:"role"`
-	PublicIP  string   `json:"public_ip,omitempty"`
-	ListenPort int    `json:"listen_port,omitempty"`
+	NetworkID  string               `json:"network_id"`
+	Name       string               `json:"name"`
+	NebulaIP   string               `json:"nebula_ip"`
+	Groups     []string             `json:"groups"`
+	Role       string               `json:"role"`
+	PublicIP   string               `json:"public_ip,omitempty"`
+	ListenPort int                  `json:"listen_port,omitempty"`
+	Advanced   *models.HostAdvanced `json:"advanced,omitempty"`
 }
 
 type createHostResponse struct {
@@ -63,6 +64,11 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		role = models.HostRoleHost
 	}
 
+	if err := validateHostAdvanced(req.Advanced); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	now := time.Now()
 	host := &models.Host{
 		ID:           uuid.New().String(),
@@ -76,6 +82,7 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		PublicIP:     req.PublicIP,
 		ListenPort:   req.ListenPort,
 		Status:       models.HostStatusPending,
+		Advanced:     req.Advanced,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}

--- a/internal/api/validate_advanced.go
+++ b/internal/api/validate_advanced.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// validateHostAdvanced rejects obviously broken advanced overrides before they
+// reach the database. It is intentionally lenient: empty / zero-value fields
+// mean "inherit network default" and pass validation.
+func validateHostAdvanced(adv *models.HostAdvanced) error {
+	if adv == nil {
+		return nil
+	}
+	if adv.MTU != 0 && (adv.MTU < 576 || adv.MTU > 9216) {
+		return fmt.Errorf("advanced.mtu must be between 576 and 9216")
+	}
+	if adv.ListenHost != "" {
+		if _, err := netip.ParseAddr(adv.ListenHost); err != nil {
+			return fmt.Errorf("advanced.listen_host is not a valid IP: %s", err.Error())
+		}
+	}
+	if adv.TunDevice != "" {
+		if strings.ContainsAny(adv.TunDevice, " \t\n/") {
+			return fmt.Errorf("advanced.tun_device must not contain whitespace or slashes")
+		}
+		if len(adv.TunDevice) > 32 {
+			return fmt.Errorf("advanced.tun_device must be at most 32 characters")
+		}
+	}
+	for i, r := range adv.UnsafeRoutes {
+		if r.Route == "" || r.Via == "" {
+			return fmt.Errorf("advanced.unsafe_routes[%d]: route and via are required", i)
+		}
+		if _, err := netip.ParsePrefix(r.Route); err != nil {
+			return fmt.Errorf("advanced.unsafe_routes[%d].route invalid CIDR: %s", i, err.Error())
+		}
+		if _, err := netip.ParseAddr(r.Via); err != nil {
+			return fmt.Errorf("advanced.unsafe_routes[%d].via invalid IP: %s", i, err.Error())
+		}
+	}
+	return nil
+}

--- a/internal/configgen/advanced_test.go
+++ b/internal/configgen/advanced_test.go
@@ -1,0 +1,102 @@
+package configgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerate_DefaultsWhenNoAdvanced(t *testing.T) {
+	out, err := Generate(GeneratorInput{
+		HostName:   "h",
+		NebulaIP:   "10.0.0.1",
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "host: 0.0.0.0") {
+		t.Error("expected default listen.host 0.0.0.0")
+	}
+	if !strings.Contains(s, "punch: true") {
+		t.Error("expected default punch: true")
+	}
+	if strings.Contains(s, "tun:") {
+		t.Error("tun block should not appear without advanced overrides")
+	}
+	if strings.Contains(s, "unsafe_routes") {
+		t.Error("unsafe_routes should not appear without advanced overrides")
+	}
+}
+
+func TestGenerate_AdvancedListenHostAndMTU(t *testing.T) {
+	out, err := Generate(GeneratorInput{
+		HostName:   "h",
+		NebulaIP:   "10.0.0.1",
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+		ListenHost: "10.0.0.1",
+		MTU:        1300,
+		TunDevice:  "nebula1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "host: 10.0.0.1") {
+		t.Error("override listen.host missing")
+	}
+	if !strings.Contains(s, "mtu: 1300") {
+		t.Error("tun.mtu missing")
+	}
+	if !strings.Contains(s, "dev: nebula1") {
+		t.Error("tun.dev missing")
+	}
+}
+
+func TestGenerate_AdvancedUnsafeRoutes(t *testing.T) {
+	out, err := Generate(GeneratorInput{
+		HostName:   "h",
+		NebulaIP:   "10.0.0.1",
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+		UnsafeRoutes: []AdvancedUnsafeRoute{
+			{Route: "192.168.10.0/24", Via: "10.0.0.99"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "unsafe_routes:") {
+		t.Error("unsafe_routes section missing")
+	}
+	if !strings.Contains(s, "route: 192.168.10.0/24") {
+		t.Error("unsafe route entry missing")
+	}
+	if !strings.Contains(s, "via: 10.0.0.99") {
+		t.Error("unsafe route via missing")
+	}
+}
+
+func TestGenerate_PunchyOverride(t *testing.T) {
+	f := false
+	out, err := Generate(GeneratorInput{
+		HostName:       "h",
+		NebulaIP:       "10.0.0.1",
+		CACertPath:     "/etc/nebula/ca.crt",
+		CertPath:       "/etc/nebula/host.crt",
+		KeyPath:        "/etc/nebula/host.key",
+		PunchyOverride: &f,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "punch: false") {
+		t.Errorf("expected punch: false override; got:\n%s", out)
+	}
+}

--- a/internal/configgen/generator.go
+++ b/internal/configgen/generator.go
@@ -19,6 +19,12 @@ type FirewallRule struct {
 	Group string // "any", "admin", etc.
 }
 
+// AdvancedUnsafeRoute mirrors models.UnsafeRoute for the template.
+type AdvancedUnsafeRoute struct {
+	Route string
+	Via   string
+}
+
 // GeneratorInput contains all parameters needed to generate a Nebula config.
 type GeneratorInput struct {
 	HostName         string
@@ -33,6 +39,13 @@ type GeneratorInput struct {
 	Relays           []string
 	FirewallInbound  []FirewallRule
 	FirewallOutbound []FirewallRule
+
+	// Optional per-host overrides. Zero values mean "use the default".
+	PunchyOverride   *bool
+	ListenHost       string
+	MTU              int
+	TunDevice        string
+	UnsafeRoutes     []AdvancedUnsafeRoute
 }
 
 const configTemplate = `pki:
@@ -51,7 +64,7 @@ lighthouse:
   {{- end }}
 
 listen:
-  host: 0.0.0.0
+  host: {{ if .ListenHost }}{{ .ListenHost }}{{ else }}0.0.0.0{{ end }}
   port: {{ if gt .ListenPort 0 }}{{ .ListenPort }}{{ else }}4242{{ end }}
 
 {{- else }}
@@ -69,13 +82,30 @@ lighthouse:
     {{- end }}
 
 listen:
-  host: 0.0.0.0
+  host: {{ if .ListenHost }}{{ .ListenHost }}{{ else }}0.0.0.0{{ end }}
   port: {{ if gt .ListenPort 0 }}{{ .ListenPort }}{{ else }}0{{ end }}
 
 {{- end }}
 
 punchy:
-  punch: true
+  punch: {{ if .PunchyOverride }}{{ .PunchyOverride }}{{ else }}true{{ end }}
+{{- if or .MTU .TunDevice .UnsafeRoutes }}
+
+tun:
+  {{- if .TunDevice }}
+  dev: {{ .TunDevice }}
+  {{- end }}
+  {{- if .MTU }}
+  mtu: {{ .MTU }}
+  {{- end }}
+  {{- if .UnsafeRoutes }}
+  unsafe_routes:
+    {{- range .UnsafeRoutes }}
+    - route: {{ .Route }}
+      via: {{ .Via }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
 {{- if .IsRelay }}
 

--- a/internal/models/host.go
+++ b/internal/models/host.go
@@ -29,20 +29,43 @@ func ValidRole(r HostRole) bool {
 }
 
 type Host struct {
-	ID              string     `json:"id"`
-	NetworkID       string     `json:"network_id"`
-	Name            string     `json:"name"`
-	NebulaIP        string     `json:"nebula_ip"`
-	Groups          []string   `json:"groups"`
-	Role            HostRole   `json:"role"`
-	IsLighthouse    bool       `json:"is_lighthouse"`
-	IsRelay         bool       `json:"is_relay"`
-	PublicIP        string     `json:"public_ip,omitempty"`
-	ListenPort      int        `json:"listen_port,omitempty"`
-	Status          HostStatus `json:"status"`
-	CertFingerprint string     `json:"cert_fingerprint,omitempty"`
-	CertExpiresAt   *time.Time `json:"cert_expires_at,omitempty"`
-	LastSeenAt      *time.Time `json:"last_seen_at,omitempty"`
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
+	ID              string         `json:"id"`
+	NetworkID       string         `json:"network_id"`
+	Name            string         `json:"name"`
+	NebulaIP        string         `json:"nebula_ip"`
+	Groups          []string       `json:"groups"`
+	Role            HostRole       `json:"role"`
+	IsLighthouse    bool           `json:"is_lighthouse"`
+	IsRelay         bool           `json:"is_relay"`
+	PublicIP        string         `json:"public_ip,omitempty"`
+	ListenPort      int            `json:"listen_port,omitempty"`
+	Status          HostStatus     `json:"status"`
+	CertFingerprint string         `json:"cert_fingerprint,omitempty"`
+	CertExpiresAt   *time.Time     `json:"cert_expires_at,omitempty"`
+	LastSeenAt      *time.Time     `json:"last_seen_at,omitempty"`
+	Advanced        *HostAdvanced  `json:"advanced,omitempty"`
+	CreatedAt       time.Time      `json:"created_at"`
+	UpdatedAt       time.Time      `json:"updated_at"`
+}
+
+// UnsafeRoute is a single "unsafe route" entry: traffic for `Route` is sent
+// through the host with Nebula IP `Via`. See Nebula's tun.unsafe_routes.
+type UnsafeRoute struct {
+	Route string `json:"route" yaml:"route"` // CIDR
+	Via   string `json:"via" yaml:"via"`     // Nebula IP of the gateway host
+}
+
+// HostAdvanced groups optional per-host overrides for the rendered Nebula
+// config. All fields are optional. A field set to its zero value means
+// "inherit network default"; a field set to a non-zero value overrides.
+//
+// Punchy is a tri-state pointer so an operator can explicitly disable
+// hole-punching for a host (false) without it being indistinguishable from
+// "not set".
+type HostAdvanced struct {
+	Punchy       *bool         `json:"punchy,omitempty" yaml:"punchy,omitempty"`
+	ListenHost   string        `json:"listen_host,omitempty" yaml:"listen_host,omitempty"`
+	MTU          int           `json:"mtu,omitempty" yaml:"mtu,omitempty"`
+	TunDevice    string        `json:"tun_device,omitempty" yaml:"tun_device,omitempty"`
+	UnsafeRoutes []UnsafeRoute `json:"unsafe_routes,omitempty" yaml:"unsafe_routes,omitempty"`
 }

--- a/internal/store/migrations/008_host_advanced.down.sql
+++ b/internal/store/migrations/008_host_advanced.down.sql
@@ -1,0 +1,2 @@
+-- SQLite < 3.35 does not support DROP COLUMN cleanly; the advanced_json
+-- column simply becomes unused after a rollback.

--- a/internal/store/migrations/008_host_advanced.up.sql
+++ b/internal/store/migrations/008_host_advanced.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hosts ADD COLUMN advanced_json TEXT NOT NULL DEFAULT '';

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -69,6 +69,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"005_operators.up.sql",
 		"006_operator_totp.up.sql",
 		"007_operator_oidc.up.sql",
+		"008_host_advanced.up.sql",
 	}
 	for _, f := range migrationFiles {
 		sqlBytes, err := migrations.FS.ReadFile(f)
@@ -160,13 +161,17 @@ func (s *SQLiteStore) CreateHost(_ context.Context, h *models.Host) error {
 	if err != nil {
 		return fmt.Errorf("marshal groups: %w", err)
 	}
+	advancedJSON, err := marshalAdvanced(h.Advanced)
+	if err != nil {
+		return err
+	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO hosts (id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO hosts (id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, created_at, updated_at, advanced_json)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		h.ID, h.NetworkID, h.Name, h.NebulaIP, string(groupsJSON),
 		h.Role, h.IsLighthouse, h.IsRelay, h.PublicIP, h.ListenPort,
-		h.Status, h.CreatedAt, h.UpdatedAt,
+		h.Status, h.CreatedAt, h.UpdatedAt, advancedJSON,
 	)
 	if err != nil {
 		return fmt.Errorf("insert host: %w", err)
@@ -174,11 +179,23 @@ func (s *SQLiteStore) CreateHost(_ context.Context, h *models.Host) error {
 	return nil
 }
 
+func marshalAdvanced(adv *models.HostAdvanced) (string, error) {
+	if adv == nil {
+		return "", nil
+	}
+	b, err := json.Marshal(adv)
+	if err != nil {
+		return "", fmt.Errorf("marshal advanced: %w", err)
+	}
+	return string(b), nil
+}
+
 func (s *SQLiteStore) scanHost(scanner interface {
 	Scan(dest ...any) error
 }) (*models.Host, error) {
 	h := &models.Host{}
 	var groupsJSON string
+	var advancedJSON string
 	var publicIP sql.NullString
 	var certFP sql.NullString
 	var certExpires sql.NullTime
@@ -188,7 +205,7 @@ func (s *SQLiteStore) scanHost(scanner interface {
 		&h.ID, &h.NetworkID, &h.Name, &h.NebulaIP, &groupsJSON,
 		&h.Role, &h.IsLighthouse, &h.IsRelay, &publicIP, &h.ListenPort,
 		&h.Status, &certFP, &certExpires, &lastSeen,
-		&h.CreatedAt, &h.UpdatedAt,
+		&h.CreatedAt, &h.UpdatedAt, &advancedJSON,
 	)
 	if err != nil {
 		return nil, err
@@ -196,6 +213,13 @@ func (s *SQLiteStore) scanHost(scanner interface {
 
 	if err := json.Unmarshal([]byte(groupsJSON), &h.Groups); err != nil {
 		return nil, fmt.Errorf("unmarshal groups: %w", err)
+	}
+	if advancedJSON != "" {
+		var adv models.HostAdvanced
+		if err := json.Unmarshal([]byte(advancedJSON), &adv); err != nil {
+			return nil, fmt.Errorf("unmarshal advanced: %w", err)
+		}
+		h.Advanced = &adv
 	}
 	if publicIP.Valid {
 		h.PublicIP = publicIP.String
@@ -213,7 +237,7 @@ func (s *SQLiteStore) scanHost(scanner interface {
 	return h, nil
 }
 
-const hostColumns = `id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, cert_fingerprint, cert_expires_at, last_seen_at, created_at, updated_at`
+const hostColumns = `id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, cert_fingerprint, cert_expires_at, last_seen_at, created_at, updated_at, advanced_json`
 
 func (s *SQLiteStore) GetHost(_ context.Context, id string) (*models.Host, error) {
 	row := s.db.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
@@ -293,14 +317,18 @@ func (s *SQLiteStore) UpdateHost(_ context.Context, h *models.Host) error {
 		return fmt.Errorf("marshal groups: %w", err)
 	}
 
+	advancedJSON, err := marshalAdvanced(h.Advanced)
+	if err != nil {
+		return err
+	}
 	h.UpdatedAt = time.Now()
 	result, err := s.db.Exec(
 		`UPDATE hosts SET name=?, nebula_ip=?, groups_json=?, role=?, is_lighthouse=?, is_relay=?,
 		 public_ip=?, listen_port=?, status=?, cert_fingerprint=?, cert_expires_at=?,
-		 last_seen_at=?, updated_at=? WHERE id=?`,
+		 last_seen_at=?, updated_at=?, advanced_json=? WHERE id=?`,
 		h.Name, h.NebulaIP, string(groupsJSON), h.Role, h.IsLighthouse, h.IsRelay,
 		h.PublicIP, h.ListenPort, h.Status, h.CertFingerprint, h.CertExpiresAt,
-		h.LastSeenAt, h.UpdatedAt, h.ID,
+		h.LastSeenAt, h.UpdatedAt, advancedJSON, h.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("update host: %w", err)
@@ -560,13 +588,17 @@ func (s *SQLiteStore) CreateHostAndToken(_ context.Context, h *models.Host, t *m
 	if err != nil {
 		return fmt.Errorf("marshal groups: %w", err)
 	}
+	advancedJSON, err := marshalAdvanced(h.Advanced)
+	if err != nil {
+		return err
+	}
 
 	_, err = tx.Exec(
-		`INSERT INTO hosts (id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO hosts (id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, created_at, updated_at, advanced_json)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		h.ID, h.NetworkID, h.Name, h.NebulaIP, string(groupsJSON),
 		h.Role, h.IsLighthouse, h.IsRelay, h.PublicIP, h.ListenPort,
-		h.Status, h.CreatedAt, h.UpdatedAt,
+		h.Status, h.CreatedAt, h.UpdatedAt, advancedJSON,
 	)
 	if err != nil {
 		return fmt.Errorf("insert host: %w", err)

--- a/internal/web/advanced.go
+++ b/internal/web/advanced.go
@@ -1,0 +1,65 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// parseAdvancedFromForm reads the `adv_*` form fields from the host
+// creation form and returns a *HostAdvanced (or nil if nothing was set).
+// All fields are optional; an empty form returns nil so default rendering
+// remains untouched.
+func parseAdvancedFromForm(r *http.Request) (*models.HostAdvanced, error) {
+	adv := &models.HostAdvanced{}
+	used := false
+
+	if h := strings.TrimSpace(r.FormValue("adv_listen_host")); h != "" {
+		adv.ListenHost = h
+		used = true
+	}
+	if m := strings.TrimSpace(r.FormValue("adv_mtu")); m != "" {
+		v, err := strconv.Atoi(m)
+		if err != nil {
+			return nil, fmt.Errorf("adv_mtu must be a number")
+		}
+		adv.MTU = v
+		used = true
+	}
+	if d := strings.TrimSpace(r.FormValue("adv_tun_device")); d != "" {
+		adv.TunDevice = d
+		used = true
+	}
+	switch r.FormValue("adv_punchy") {
+	case "true":
+		v := true
+		adv.Punchy = &v
+		used = true
+	case "false":
+		v := false
+		adv.Punchy = &v
+		used = true
+	}
+	if raw := strings.TrimSpace(r.FormValue("adv_unsafe_routes")); raw != "" {
+		for _, line := range strings.Split(raw, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			parts := strings.Fields(line)
+			if len(parts) != 3 || parts[1] != "via" {
+				return nil, fmt.Errorf("adv_unsafe_routes line %q: expected '<CIDR> via <NEBULA_IP>'", line)
+			}
+			adv.UnsafeRoutes = append(adv.UnsafeRoutes, models.UnsafeRoute{Route: parts[0], Via: parts[2]})
+			used = true
+		}
+	}
+
+	if !used {
+		return nil, nil
+	}
+	return adv, nil
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -486,6 +486,12 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		groups = []string{}
 	}
 
+	advanced, err := parseAdvancedFromForm(r)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	now := time.Now()
 	host := &models.Host{
 		ID:           uuid.New().String(),
@@ -499,6 +505,7 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		PublicIP:     r.FormValue("public_ip"),
 		ListenPort:   listenPort,
 		Status:       models.HostStatusPending,
+		Advanced:     advanced,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -42,6 +42,41 @@
             <label>Listen Port (for lighthouse/relay)</label>
             <input type="number" name="listen_port" class="form-control" placeholder="4242">
         </div>
+
+        <details style="margin: 16px 0;">
+            <summary style="cursor: pointer; padding: 8px; color: var(--text-muted); font-size: 14px;">
+                Advanced configuration (optional)
+            </summary>
+            <p style="font-size: 12px; color: var(--text-muted); margin: 8px 0;">
+                Empty fields inherit the network default. See
+                <a href="https://nebula.defined.net/docs/config" target="_blank">Nebula config docs</a>.
+            </p>
+            <div class="form-group">
+                <label>Listen host (advanced.listen_host)</label>
+                <input type="text" name="adv_listen_host" class="form-control" placeholder="0.0.0.0">
+            </div>
+            <div class="form-group">
+                <label>TUN MTU (advanced.mtu)</label>
+                <input type="number" name="adv_mtu" class="form-control" placeholder="1300" min="576" max="9216">
+            </div>
+            <div class="form-group">
+                <label>TUN device name (advanced.tun_device)</label>
+                <input type="text" name="adv_tun_device" class="form-control" placeholder="nebula1">
+            </div>
+            <div class="form-group">
+                <label>Punchy (advanced.punchy)</label>
+                <select name="adv_punchy" class="form-control">
+                    <option value="">inherit (true)</option>
+                    <option value="true">force true</option>
+                    <option value="false">disable</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Unsafe routes (one per line: <code>CIDR via NEBULA_IP</code>)</label>
+                <textarea name="adv_unsafe_routes" class="form-control" rows="3" placeholder="192.168.10.0/24 via 10.0.0.99"></textarea>
+            </div>
+        </details>
+
         <button type="submit" class="btn btn-primary">Create Host</button>
     </form>
 </div>


### PR DESCRIPTION
## Summary

Adds an optional `advanced` block on hosts to fine-tune the rendered Nebula configuration. Empty / zero-value fields mean "use the network default" so hosts without advanced overrides render byte-identical output to before.

### Model + schema (migration 008)
- `models.HostAdvanced{Punchy *bool, ListenHost, MTU, TunDevice, UnsafeRoutes[{Route, Via}]}`
- `hosts.advanced_json` TEXT column

### Renderer (`internal/configgen`)
- New `GeneratorInput` fields `PunchyOverride`, `ListenHost`, `MTU`, `TunDevice`, `UnsafeRoutes` feed an extended template.
- The `tun:` block is only emitted when one of `mtu` / `tun_device` / `unsafe_routes` is set, so hosts without advanced settings produce identical YAML.

### API (`internal/api`)
- `POST /api/v1/hosts` accepts an optional `advanced` object.
- `validateHostAdvanced` rejects:
  - `mtu` outside 576-9216;
  - non-IP `listen_host`;
  - whitespace/slashes in `tun_device`;
  - malformed CIDR or non-IP `via` in `unsafe_routes`.

### Web UI
- `/ui/hosts/new` gains a collapsed `<details>` *Advanced configuration* section with five inputs: `listen_host`, `mtu`, `tun_device`, `punchy`, `unsafe_routes` (one entry per line: `<CIDR> via <NEBULA_IP>`).
- `handleHostCreate` parses these via `parseAdvancedFromForm` and stores `nil` when none are set.

### Docs
- `docs/agent.md` gains an *Advanced per-host configuration* section with the JSON shape and validation rules.

## Test plan

- [x] `go build ./... && go vet ./... && go test -v -race ./...` — all green
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] Renderer tests: defaults produce no `tun:` block; listen_host + mtu + tun_device override; unsafe_routes; punchy override (false)
- [x] All existing host / enrollment tests still pass — backward compat is byte-level
- [x] Web `TestCreateHostViaUI` continues to pass without supplying any advanced field

Closes #16
