### PR TITLE
feat(auth): add configurable self-registration flow with admin-only operator API

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ sensitive operations (`operator.2fa.enabled`, `disabled`, `regen_codes`,
 API tokens are not affected — they continue to authenticate non-interactive
 clients.
 
+### Configurable self-registration
+
+By default, only administrators can create operator accounts (via the
+`nebula-mgmt user create` CLI or the REST API). To let unauthenticated
+visitors sign up themselves, set in `server.yml`:
+
+```yaml
+allow_self_registration: true
+```
+
+The login page then shows a *Create an account* link to `/ui/register`.
+Server-side checks gate the endpoint regardless of UI state — disabling
+the flag is sufficient to block self-registration. Newly self-registered
+operators get the `user` role; only operators with `role: admin` can
+call the operator-management API (`POST /api/v1/operators`,
+`disable`, etc).
+
 ### 6. Single sign-on via OIDC (optional)
 
 Configure an `oidc:` block in `server.yml` (see `configs/server.example.yml`)

--- a/configs/server.example.yml
+++ b/configs/server.example.yml
@@ -10,6 +10,11 @@ log_level: "info"
 tls_cert: ""
 tls_key: ""
 
+# Allow unauthenticated visitors to register their own operator account via
+# /ui/register. Default is false: only the seeded admin (or an existing admin
+# calling POST /api/v1/operators) can add operators in a closed deployment.
+allow_self_registration: false
+
 # Optional OpenID Connect identity provider for operator login. When enabled,
 # the Web UI offers a "Sign in with SSO" button on top of the local password
 # form. Local logins keep working alongside OIDC.

--- a/internal/api/actor.go
+++ b/internal/api/actor.go
@@ -30,3 +30,14 @@ func ActorName(ctx context.Context) string {
 func withActor(ctx context.Context, op *models.Operator) context.Context {
 	return context.WithValue(ctx, actorContextKey, op)
 }
+
+// actorIsAdmin reports whether the request's authenticated actor has the
+// admin role. The legacy config-key fallback (no operator on context) is
+// also treated as admin, matching its pre-multi-operator behavior.
+func actorIsAdmin(ctx context.Context) bool {
+	op := ActorOf(ctx)
+	if op == nil {
+		return true // legacy config api_key — effectively root
+	}
+	return op.Role == "admin"
+}

--- a/internal/api/operators.go
+++ b/internal/api/operators.go
@@ -23,6 +23,10 @@ type createOperatorRequest struct {
 }
 
 func (s *Server) handleCreateOperator(w http.ResponseWriter, r *http.Request) {
+	if !actorIsAdmin(r.Context()) {
+		writeError(w, http.StatusForbidden, "operator management requires the admin role")
+		return
+	}
 	var req createOperatorRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")

--- a/internal/api/operators_admin_test.go
+++ b/internal/api/operators_admin_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// createUserWithAPIKey seeds a non-admin operator + API key directly via the
+// store, then returns the plaintext key.
+func createUserWithAPIKey(t *testing.T, srv *Server, role string) string {
+	t.Helper()
+	ctx := context.Background()
+	op := &models.Operator{
+		ID:           uuid.New().String(),
+		Username:     "non-admin-" + uuid.New().String()[:6],
+		PasswordHash: "x",
+		Role:         role,
+	}
+	if err := srv.store.CreateOperator(ctx, op); err != nil {
+		t.Fatal(err)
+	}
+	rawKey := uuid.New().String()
+	keySum := sha256.Sum256([]byte(rawKey))
+	if err := srv.store.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID: uuid.New().String(), OperatorID: op.ID, KeyHash: hex.EncodeToString(keySum[:]),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return rawKey
+}
+
+func TestCreateOperator_RequiresAdminRole(t *testing.T) {
+	srv, _ := newTestServer(t)
+	userKey := createUserWithAPIKey(t, srv, "user")
+
+	body, _ := json.Marshal(map[string]string{"username": "bob", "password": "pw"})
+	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+userKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-admin status = %d, want 403", rec.Code)
+	}
+}
+
+func TestCreateOperator_AdminCanCreate(t *testing.T) {
+	srv, _ := newTestServer(t)
+	adminKey := createUserWithAPIKey(t, srv, "admin")
+
+	body, _ := json.Marshal(map[string]string{"username": "carol", "password": "pw"})
+	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+adminKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Errorf("admin status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -126,6 +126,7 @@ func Serve(configPath string) error {
 	if err != nil {
 		return fmt.Errorf("init web UI: %w", err)
 	}
+	webUI.AllowSelfRegistration(cfg.AllowSelfRegistration)
 
 	// Optional OIDC integration
 	if cfg.OIDC != nil && cfg.OIDC.Enabled {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -18,6 +18,13 @@ type ServerConfig struct {
 	TLSCert    string      `yaml:"tls_cert,omitempty"`
 	TLSKey     string      `yaml:"tls_key,omitempty"`
 	OIDC       *OIDCConfig `yaml:"oidc,omitempty"`
+
+	// AllowSelfRegistration controls whether unauthenticated visitors can
+	// create their own operator account through /ui/register. Defaults to
+	// false so closed deployments stay closed by default; administrators
+	// can still create operators manually via the existing
+	// `nebula-mgmt user create` CLI or `POST /api/v1/operators` API.
+	AllowSelfRegistration bool `yaml:"allow_self_registration,omitempty"`
 }
 
 // OIDCConfig configures an OpenID Connect identity provider for operator

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -28,8 +28,9 @@ func (w *Web) requireAuth(next http.Handler) http.Handler {
 
 func (w *Web) handleLoginPage(rw http.ResponseWriter, _ *http.Request) {
 	w.render(rw, "login.html", map[string]any{
-		"Error":       "",
-		"OIDCEnabled": w.oidc.Enabled(),
+		"Error":                "",
+		"OIDCEnabled":          w.oidc.Enabled(),
+		"AllowSelfRegistration": w.allowSelfRegistration,
 	})
 }
 
@@ -47,8 +48,9 @@ func (w *Web) handleLogin(rw http.ResponseWriter, r *http.Request) {
 	}
 	if !ok {
 		w.render(rw, "login.html", map[string]any{
-			"Error":       "Invalid username or password",
-			"OIDCEnabled": w.oidc.Enabled(),
+			"Error":                "Invalid username or password",
+			"OIDCEnabled":          w.oidc.Enabled(),
+			"AllowSelfRegistration": w.allowSelfRegistration,
 		})
 		return
 	}
@@ -107,6 +109,70 @@ func (w *Web) handleTOTPLogin(rw http.ResponseWriter, r *http.Request) {
 
 func (w *Web) handleLogout(rw http.ResponseWriter, r *http.Request) {
 	w.session.Logout(rw, r)
+	http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+}
+
+// --- Self-registration ---
+
+func (w *Web) handleRegisterPage(rw http.ResponseWriter, _ *http.Request) {
+	if !w.allowSelfRegistration {
+		http.Error(rw, "self-registration is disabled", http.StatusForbidden)
+		return
+	}
+	w.render(rw, "register.html", map[string]any{"Error": ""})
+}
+
+func (w *Web) handleRegister(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowSelfRegistration {
+		http.Error(rw, "self-registration is disabled", http.StatusForbidden)
+		return
+	}
+	username := strings.TrimSpace(r.FormValue("username"))
+	password := r.FormValue("password")
+	confirm := r.FormValue("password_confirm")
+	displayName := strings.TrimSpace(r.FormValue("display_name"))
+
+	if username == "" || password == "" {
+		w.render(rw, "register.html", map[string]any{"Error": "Username and password are required"})
+		return
+	}
+	if len(password) < 8 {
+		w.render(rw, "register.html", map[string]any{"Error": "Password must be at least 8 characters long"})
+		return
+	}
+	if password != confirm {
+		w.render(rw, "register.html", map[string]any{"Error": "Password confirmation does not match"})
+		return
+	}
+
+	if _, err := w.store.GetOperatorByUsername(r.Context(), username); err == nil {
+		w.render(rw, "register.html", map[string]any{"Error": "Username already taken"})
+		return
+	} else if !errors.Is(err, store.ErrNotFound) {
+		w.logger.Error("register: lookup", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		w.logger.Error("register: hash", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	op := &models.Operator{
+		ID:           uuid.New().String(),
+		Username:     username,
+		DisplayName:  displayName,
+		PasswordHash: string(hash),
+		Role:         "user",
+	}
+	if err := w.store.CreateOperator(r.Context(), op); err != nil {
+		w.logger.Error("register: create", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	_ = w.store.AddAuditEntry(r.Context(), username, "operator.self_register", op.ID, "")
 	http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
 }
 

--- a/internal/web/register_test.go
+++ b/internal/web/register_test.go
@@ -1,0 +1,121 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestRegister_DisabledByDefault(t *testing.T) {
+	w, _ := newTestWeb(t)
+
+	req := httptest.NewRequest("GET", "/ui/register", nil)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("GET /ui/register = %d, want 403", rec.Code)
+	}
+
+	form := url.Values{"username": {"alice"}, "password": {"correcthorse"}, "password_confirm": {"correcthorse"}}
+	req = httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("POST /ui/register = %d, want 403", rec.Code)
+	}
+}
+
+func TestRegister_Enabled_CreatesOperator(t *testing.T) {
+	w, s := newTestWeb(t)
+	w.AllowSelfRegistration(true)
+
+	form := url.Values{
+		"username":         {"alice"},
+		"display_name":     {"Alice"},
+		"password":         {"correcthorse"},
+		"password_confirm": {"correcthorse"},
+	}
+	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", rec.Code, rec.Body.String())
+	}
+
+	op, err := s.GetOperatorByUsername(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("operator not created: %v", err)
+	}
+	if op.Role != "user" {
+		t.Errorf("role = %q, want user", op.Role)
+	}
+}
+
+func TestRegister_RejectsDuplicateUsername(t *testing.T) {
+	w, _ := newTestWeb(t)
+	w.AllowSelfRegistration(true)
+
+	form := url.Values{
+		"username":         {testUsername}, // admin from newTestWeb seed
+		"password":         {"correcthorse"},
+		"password_confirm": {"correcthorse"},
+	}
+	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "Username already taken") {
+		t.Errorf("expected duplicate-username error; body=%s", rec.Body.String())
+	}
+}
+
+func TestRegister_RejectsShortPassword(t *testing.T) {
+	w, _ := newTestWeb(t)
+	w.AllowSelfRegistration(true)
+
+	form := url.Values{"username": {"bob"}, "password": {"short"}, "password_confirm": {"short"}}
+	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "at least 8") {
+		t.Errorf("expected short-password error; body=%s", rec.Body.String())
+	}
+}
+
+func TestRegister_RejectsMismatchedConfirmation(t *testing.T) {
+	w, _ := newTestWeb(t)
+	w.AllowSelfRegistration(true)
+
+	form := url.Values{"username": {"carol"}, "password": {"correcthorse"}, "password_confirm": {"different1"}}
+	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "confirmation does not match") {
+		t.Errorf("expected confirmation-mismatch error; body=%s", rec.Body.String())
+	}
+}
+
+func TestLoginPage_ShowsRegisterLinkOnlyWhenEnabled(t *testing.T) {
+	w, _ := newTestWeb(t)
+	req := httptest.NewRequest("GET", "/ui/login", nil)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if strings.Contains(rec.Body.String(), "Create an account") {
+		t.Error("register link should be hidden when self-registration is disabled")
+	}
+
+	w.AllowSelfRegistration(true)
+	req = httptest.NewRequest("GET", "/ui/login", nil)
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "Create an account") {
+		t.Error("register link should appear when self-registration is enabled")
+	}
+}

--- a/internal/web/templates/login.html
+++ b/internal/web/templates/login.html
@@ -81,6 +81,9 @@
         <div style="text-align:center; margin-top:16px; color:var(--text-muted); font-size:13px">or</div>
         <a href="/ui/oidc/login" class="btn" style="display:block; text-align:center; margin-top:12px; background:transparent; color:var(--text); border:1px solid var(--border); text-decoration:none">Sign in with SSO</a>
         {{end}}
+        {{if .AllowSelfRegistration}}
+        <a href="/ui/register" style="display:block; text-align:center; margin-top:16px; color:var(--text-muted); font-size:13px; text-decoration:none">Create an account</a>
+        {{end}}
     </div>
 </body>
 </html>

--- a/internal/web/templates/register.html
+++ b/internal/web/templates/register.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Register — Nebula Mesh</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico">
+    <style>
+        :root {
+            --bg: #0f1117;
+            --bg-card: #1a1d27;
+            --border: #2d3148;
+            --text: #e1e4ed;
+            --text-muted: #8b8fa3;
+            --primary: #6c7aee;
+            --primary-hover: #5a68d6;
+            --danger: #e05555;
+            --radius: 8px;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: var(--bg); color: var(--text); display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+        .login-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 40px; width: 360px; }
+        .login-card h1 { font-size: 22px; margin-bottom: 24px; text-align: center; }
+        .form-group { margin-bottom: 16px; }
+        .form-group label { display: block; font-size: 13px; color: var(--text-muted); margin-bottom: 4px; }
+        .form-control { width: 100%; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); color: var(--text); font-size: 14px; }
+        .form-control:focus { outline: none; border-color: var(--primary); }
+        .btn { width: 100%; padding: 10px; border-radius: var(--radius); font-size: 14px; font-weight: 500; cursor: pointer; border: none; background: var(--primary); color: #fff; }
+        .btn:hover { background: var(--primary-hover); }
+        .error { color: var(--danger); font-size: 13px; text-align: center; margin-bottom: 12px; }
+        .muted-link { display: block; text-align: center; margin-top: 12px; color: var(--text-muted); font-size: 13px; }
+    </style>
+</head>
+<body>
+    <div class="login-card">
+        <h1>Create an account</h1>
+        {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+        <form method="POST" action="/ui/register">
+            <div class="form-group">
+                <label>Username</label>
+                <input type="text" name="username" class="form-control" autocomplete="username" autofocus required>
+            </div>
+            <div class="form-group">
+                <label>Display name</label>
+                <input type="text" name="display_name" class="form-control" autocomplete="name">
+            </div>
+            <div class="form-group">
+                <label>Password (min 8 characters)</label>
+                <input type="password" name="password" class="form-control" autocomplete="new-password" minlength="8" required>
+            </div>
+            <div class="form-group">
+                <label>Confirm password</label>
+                <input type="password" name="password_confirm" class="form-control" autocomplete="new-password" minlength="8" required>
+            </div>
+            <button type="submit" class="btn">Create account</button>
+        </form>
+        <a href="/ui/login" class="muted-link">Already have an account? Sign in.</a>
+    </div>
+</body>
+</html>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -27,13 +27,18 @@ func (w *Web) Session() *SessionManager { return w.session }
 
 // Web is the web UI handler.
 type Web struct {
-	router    chi.Router
-	store     store.Store
-	templates map[string]*template.Template
-	logger    *slog.Logger
-	session   *SessionManager
-	oidc      *OIDC
+	router                 chi.Router
+	store                  store.Store
+	templates              map[string]*template.Template
+	logger                 *slog.Logger
+	session                *SessionManager
+	oidc                   *OIDC
+	allowSelfRegistration  bool
 }
+
+// AllowSelfRegistration enables the public /ui/register flow. Must be set
+// before ServeHTTP is invoked. Default is false.
+func (w *Web) AllowSelfRegistration(allow bool) { w.allowSelfRegistration = allow }
 
 // WithOIDC attaches an OIDC provider and registers its login/callback routes.
 // Must be called before ServeHTTP is invoked.
@@ -73,7 +78,7 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 	}
 
 	// Login pages are standalone (no layout)
-	for _, page := range []string{"login.html", "login_totp.html"} {
+	for _, page := range []string{"login.html", "login_totp.html", "register.html"} {
 		tmpl, err := template.ParseFS(templateFS, "templates/"+page)
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", page, err)
@@ -100,6 +105,8 @@ func (w *Web) setupRoutes() {
 	r.Post("/ui/login", w.handleLogin)
 	r.Get("/ui/login/totp", w.handleTOTPLoginPage)
 	r.Post("/ui/login/totp", w.handleTOTPLogin)
+	r.Get("/ui/register", w.handleRegisterPage)
+	r.Post("/ui/register", w.handleRegister)
 
 	// Protected routes
 	r.Group(func(r chi.Router) {
@@ -145,7 +152,7 @@ func (w *Web) render(rw http.ResponseWriter, name string, data any) {
 	}
 	// For pages with layout, execute "layout.html"; for standalone pages, execute the file directly
 	execName := "layout.html"
-	if name == "login.html" || name == "login_totp.html" {
+	if name == "login.html" || name == "login_totp.html" || name == "register.html" {
 		execName = name
 	}
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary

Adds a controlled self-registration flow gated by `allow_self_registration` in `server.yml` (default: `false`).

### Config
```yaml
allow_self_registration: true
```

When enabled, the login page shows a *Create an account* link to `/ui/register`. Self-registered operators get role `user`.

### Server-side enforcement (independent of UI)
- `/ui/register` returns **403** when the flag is false — GET and POST both refuse.
- `POST /api/v1/operators` (and the `enable`/`disable` siblings) now require the caller's authenticated operator to have `role: admin`. The legacy config-key fallback continues to behave like root for backward compatibility.

### UI
- `/ui/register` standalone page: username, display name, password, password confirmation. Validates: required fields, password length ≥ 8, matching confirmation, no duplicate username.
- `/ui/login` shows the register link only when the flag is on.

### Docs
- `README.md` gains a *Configurable self-registration* paragraph.
- `configs/server.example.yml` documents the new key.

## Test plan

- [x] `go test -v -race ./...` — all green
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] New web tests: disabled-by-default (403), enabled path creates operator with `user` role, duplicate-username, short-password, mismatched-confirm, login-page register-link visibility toggle
- [x] New API tests: non-admin operator gets 403 on `POST /api/v1/operators`; admin gets 201

Closes #17
