### PR TITLE
feat(ui): add profile page and move logout out of the main navigation

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -26,8 +26,8 @@ func (w *Web) requireAuth(next http.Handler) http.Handler {
 	})
 }
 
-func (w *Web) handleLoginPage(rw http.ResponseWriter, _ *http.Request) {
-	w.render(rw, "login.html", map[string]any{
+func (w *Web) handleLoginPage(rw http.ResponseWriter, r *http.Request) {
+	w.renderForRequest(rw, r, "login.html", map[string]any{
 		"Error":                "",
 		"OIDCEnabled":          w.oidc.Enabled(),
 		"AllowSelfRegistration": w.allowSelfRegistration,
@@ -47,7 +47,7 @@ func (w *Web) handleLogin(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !ok {
-		w.render(rw, "login.html", map[string]any{
+		w.renderForRequest(rw, r, "login.html", map[string]any{
 			"Error":                "Invalid username or password",
 			"OIDCEnabled":          w.oidc.Enabled(),
 			"AllowSelfRegistration": w.allowSelfRegistration,
@@ -66,7 +66,7 @@ func (w *Web) handleTOTPLoginPage(rw http.ResponseWriter, r *http.Request) {
 		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
 		return
 	}
-	w.render(rw, "login_totp.html", map[string]any{"Error": ""})
+	w.renderForRequest(rw, r, "login_totp.html", map[string]any{"Error": ""})
 }
 
 func (w *Web) handleTOTPLogin(rw http.ResponseWriter, r *http.Request) {
@@ -91,7 +91,7 @@ func (w *Web) handleTOTPLogin(rw http.ResponseWriter, r *http.Request) {
 
 	if !ok {
 		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.failed", op.ID, "")
-		w.render(rw, "login_totp.html", map[string]any{"Error": "Invalid TOTP code"})
+		w.renderForRequest(rw, r, "login_totp.html", map[string]any{"Error": "Invalid TOTP code"})
 		return
 	}
 	if err := w.session.CompleteTwoFactor(rw, r, op.ID); err != nil {
@@ -114,12 +114,12 @@ func (w *Web) handleLogout(rw http.ResponseWriter, r *http.Request) {
 
 // --- Self-registration ---
 
-func (w *Web) handleRegisterPage(rw http.ResponseWriter, _ *http.Request) {
+func (w *Web) handleRegisterPage(rw http.ResponseWriter, r *http.Request) {
 	if !w.allowSelfRegistration {
 		http.Error(rw, "self-registration is disabled", http.StatusForbidden)
 		return
 	}
-	w.render(rw, "register.html", map[string]any{"Error": ""})
+	w.renderForRequest(rw, r, "register.html", map[string]any{"Error": ""})
 }
 
 func (w *Web) handleRegister(rw http.ResponseWriter, r *http.Request) {
@@ -133,20 +133,20 @@ func (w *Web) handleRegister(rw http.ResponseWriter, r *http.Request) {
 	displayName := strings.TrimSpace(r.FormValue("display_name"))
 
 	if username == "" || password == "" {
-		w.render(rw, "register.html", map[string]any{"Error": "Username and password are required"})
+		w.renderForRequest(rw, r, "register.html", map[string]any{"Error": "Username and password are required"})
 		return
 	}
 	if len(password) < 8 {
-		w.render(rw, "register.html", map[string]any{"Error": "Password must be at least 8 characters long"})
+		w.renderForRequest(rw, r, "register.html", map[string]any{"Error": "Password must be at least 8 characters long"})
 		return
 	}
 	if password != confirm {
-		w.render(rw, "register.html", map[string]any{"Error": "Password confirmation does not match"})
+		w.renderForRequest(rw, r, "register.html", map[string]any{"Error": "Password confirmation does not match"})
 		return
 	}
 
 	if _, err := w.store.GetOperatorByUsername(r.Context(), username); err == nil {
-		w.render(rw, "register.html", map[string]any{"Error": "Username already taken"})
+		w.renderForRequest(rw, r, "register.html", map[string]any{"Error": "Username already taken"})
 		return
 	} else if !errors.Is(err, store.ErrNotFound) {
 		w.logger.Error("register: lookup", "error", err)
@@ -176,6 +176,20 @@ func (w *Web) handleRegister(rw http.ResponseWriter, r *http.Request) {
 	http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
 }
 
+// --- Profile ---
+
+func (w *Web) handleProfilePage(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	w.renderForRequest(rw, r, "profile.html", map[string]any{
+		"Active":   "profile",
+		"Operator": op,
+	})
+}
+
 // --- 2FA management ---
 
 func (w *Web) handleTwoFAPage(rw http.ResponseWriter, r *http.Request) {
@@ -184,7 +198,7 @@ func (w *Web) handleTwoFAPage(rw http.ResponseWriter, r *http.Request) {
 		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
 		return
 	}
-	w.render(rw, "twofa.html", map[string]any{
+	w.renderForRequest(rw, r, "twofa.html", map[string]any{
 		"Active":      "2fa",
 		"Operator":    op,
 		"TOTPEnabled": op.TOTPEnabled,
@@ -222,7 +236,7 @@ func (w *Web) handleTwoFASetup(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
-	w.render(rw, "twofa.html", map[string]any{
+	w.renderForRequest(rw, r, "twofa.html", map[string]any{
 		"Active":      "2fa",
 		"Operator":    op,
 		"TOTPEnabled": false,
@@ -249,7 +263,7 @@ func (w *Web) handleTwoFAEnable(rw http.ResponseWriter, r *http.Request) {
 	code := strings.TrimSpace(r.FormValue("code"))
 	if !verifyTOTP(op.TOTPSecret, code) {
 		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.enable_failed", op.ID, "")
-		w.render(rw, "twofa.html", map[string]any{
+		w.renderForRequest(rw, r, "twofa.html", map[string]any{
 			"Active":      "2fa",
 			"Operator":    op,
 			"TOTPEnabled": false,
@@ -278,7 +292,7 @@ func (w *Web) handleTwoFAEnable(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.enabled", op.ID, "")
-	w.render(rw, "twofa.html", map[string]any{
+	w.renderForRequest(rw, r, "twofa.html", map[string]any{
 		"Active":      "2fa",
 		"Operator":    op,
 		"TOTPEnabled": true,
@@ -296,7 +310,7 @@ func (w *Web) handleTwoFADisable(rw http.ResponseWriter, r *http.Request) {
 	password := r.FormValue("password")
 	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {
 		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.disable_failed", op.ID, "")
-		w.render(rw, "twofa.html", map[string]any{
+		w.renderForRequest(rw, r, "twofa.html", map[string]any{
 			"Active":      "2fa",
 			"Operator":    op,
 			"TOTPEnabled": op.TOTPEnabled,
@@ -335,7 +349,7 @@ func (w *Web) handleTwoFARegenCodes(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.regen_codes", op.ID, "")
-	w.render(rw, "twofa.html", map[string]any{
+	w.renderForRequest(rw, r, "twofa.html", map[string]any{
 		"Active":      "2fa",
 		"Operator":    op,
 		"TOTPEnabled": true,
@@ -437,7 +451,7 @@ func (w *Web) handleDashboard(rw http.ResponseWriter, r *http.Request) {
 		recentHosts = recentHosts[len(recentHosts)-10:]
 	}
 
-	w.render(rw, "dashboard.html", map[string]any{
+	w.renderForRequest(rw, r, "dashboard.html", map[string]any{
 		"Active":      "dashboard",
 		"Stats":       stats,
 		"RecentHosts": buildHostViews(recentHosts, networks),
@@ -458,7 +472,7 @@ func (w *Web) handlePartialStats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	stats := computeStats(hosts, len(networks))
-	w.render(rw, "dashboard.html", map[string]any{
+	w.renderForRequest(rw, r, "dashboard.html", map[string]any{
 		"Active": "dashboard",
 		"Stats":  stats,
 	})
@@ -480,7 +494,7 @@ func (w *Web) handleHosts(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.render(rw, "hosts.html", map[string]any{
+	w.renderForRequest(rw, r, "hosts.html", map[string]any{
 		"Active": "hosts",
 		"Hosts":  buildHostViews(hosts, networks),
 	})
@@ -493,7 +507,7 @@ func (w *Web) handleHostNew(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
 		return
 	}
-	w.render(rw, "host_new.html", map[string]any{
+	w.renderForRequest(rw, r, "host_new.html", map[string]any{
 		"Active":   "hosts",
 		"Networks": networks,
 	})
@@ -589,7 +603,7 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.render(rw, "host_detail.html", map[string]any{
+	w.renderForRequest(rw, r, "host_detail.html", map[string]any{
 		"Active": "hosts",
 		"Host":   host,
 		"Token":  token.Token,
@@ -609,7 +623,7 @@ func (w *Web) handleHostDetail(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.render(rw, "host_detail.html", map[string]any{
+	w.renderForRequest(rw, r, "host_detail.html", map[string]any{
 		"Active": "hosts",
 		"Host":   host,
 	})
@@ -657,7 +671,7 @@ func (w *Web) handleNetworks(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
 		return
 	}
-	w.render(rw, "networks.html", map[string]any{
+	w.renderForRequest(rw, r, "networks.html", map[string]any{
 		"Active":   "networks",
 		"Networks": networks,
 	})

--- a/internal/web/profile_test.go
+++ b/internal/web/profile_test.go
@@ -1,0 +1,61 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestProfilePage_RequiresLogin(t *testing.T) {
+	w, _ := newTestWeb(t)
+	req := httptest.NewRequest("GET", "/ui/profile", nil)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d, want 303", rec.Code)
+	}
+}
+
+func TestProfilePage_ShowsOperatorDetailsAndLogoutButton(t *testing.T) {
+	w, _ := newTestWeb(t)
+	cookies := loginSession(t, w)
+	req := httptest.NewRequest("GET", "/ui/profile", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, testUsername) {
+		t.Error("profile page should display the username")
+	}
+	if !strings.Contains(body, `href="/ui/logout"`) {
+		t.Error("profile page should expose the logout link")
+	}
+}
+
+func TestDashboard_HasProfileChipAndNoLogoutInSidebar(t *testing.T) {
+	w, _ := newTestWeb(t)
+	cookies := loginSession(t, w)
+	req := httptest.NewRequest("GET", "/ui/", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `href="/ui/profile"`) {
+		t.Error("sidebar should contain a profile link")
+	}
+	// Top-level navigation no longer hosts Logout — it lives on /ui/profile now.
+	if strings.Contains(body, `<a href="/ui/logout">Logout</a>`) {
+		t.Error("sidebar should not contain Logout as a peer nav item anymore")
+	}
+}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -45,7 +45,38 @@
             font-weight: 600;
             border-bottom: 1px solid var(--border);
             margin-bottom: 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
         }
+        .profile-chip {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px;
+            border-radius: var(--radius);
+            background: var(--bg);
+            border: 1px solid var(--border);
+            color: var(--text);
+            font-size: 13px;
+            font-weight: 400;
+            text-decoration: none;
+            transition: background 0.15s;
+        }
+        .profile-chip:hover { background: var(--bg-hover); color: var(--text); }
+        .profile-avatar {
+            display: inline-flex;
+            justify-content: center;
+            align-items: center;
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            background: var(--primary);
+            color: #fff;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+        .profile-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
         .sidebar-nav a {
             display: block;
             padding: 10px 20px;
@@ -171,13 +202,17 @@
 <body>
     <div class="layout">
         <nav class="sidebar">
-            <div class="sidebar-brand">Nebula Mesh</div>
+            <div class="sidebar-brand">
+                <span>Nebula Mesh</span>
+                <a href="/ui/profile" class="profile-chip" title="Profile">
+                    <span class="profile-avatar">{{if .CurrentUser}}{{slice .CurrentUser.Username 0 1}}{{else}}?{{end}}</span>
+                    <span class="profile-name">{{if .CurrentUser}}{{or .CurrentUser.DisplayName .CurrentUser.Username}}{{end}}</span>
+                </a>
+            </div>
             <div class="sidebar-nav">
                 <a href="/ui/" {{if eq .Active "dashboard"}}class="active"{{end}}>Dashboard</a>
                 <a href="/ui/networks" {{if eq .Active "networks"}}class="active"{{end}}>Networks</a>
                 <a href="/ui/hosts" {{if eq .Active "hosts"}}class="active"{{end}}>Hosts</a>
-                <a href="/ui/2fa" {{if eq .Active "2fa"}}class="active"{{end}}>Two-factor auth</a>
-                <a href="/ui/logout">Logout</a>
             </div>
         </nav>
         <main class="main">

--- a/internal/web/templates/profile.html
+++ b/internal/web/templates/profile.html
@@ -1,0 +1,24 @@
+{{define "title"}}Profile — Nebula Mesh{{end}}
+
+{{define "content"}}
+<h1>Profile</h1>
+
+<div class="card">
+    <table>
+        <tr><th style="width:200px">Username</th><td><code>{{.Operator.Username}}</code></td></tr>
+        {{if .Operator.DisplayName}}<tr><th>Display name</th><td>{{.Operator.DisplayName}}</td></tr>{{end}}
+        <tr><th>Role</th><td><span class="badge badge-enrolled">{{.Operator.Role}}</span></td></tr>
+        <tr><th>Status</th><td>{{.Operator.Status}}</td></tr>
+        <tr><th>Authentication</th><td>{{.Operator.AuthProvider}}{{if .Operator.TOTPEnabled}} + TOTP{{end}}</td></tr>
+        {{if .Operator.LastLoginAt}}<tr><th>Last login</th><td>{{.Operator.LastLoginAt.Format "2006-01-02 15:04 UTC"}}</td></tr>{{end}}
+        <tr><th>Account ID</th><td><code>{{.Operator.ID}}</code></td></tr>
+        <tr><th>Created</th><td>{{.Operator.CreatedAt.Format "2006-01-02 15:04 UTC"}}</td></tr>
+    </table>
+</div>
+
+<div class="card">
+    <h2>Account actions</h2>
+    <p style="margin-bottom:12px"><a href="/ui/2fa">Manage two-factor authentication →</a></p>
+    <a href="/ui/logout" class="btn btn-danger">Sign out</a>
+</div>
+{{end}}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -68,6 +68,7 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		"host_detail.html",
 		"networks.html",
 		"twofa.html",
+		"profile.html",
 	}
 	for _, page := range pages {
 		tmpl, err := template.ParseFS(templateFS, "templates/layout.html", "templates/"+page)
@@ -120,6 +121,7 @@ func (w *Web) setupRoutes() {
 		r.Delete("/ui/hosts/{id}", w.handleHostDelete)
 		r.Get("/ui/networks", w.handleNetworks)
 		r.Post("/ui/networks", w.handleNetworkCreate)
+		r.Get("/ui/profile", w.handleProfilePage)
 		r.Get("/ui/2fa", w.handleTwoFAPage)
 		r.Post("/ui/2fa/setup", w.handleTwoFASetup)
 		r.Post("/ui/2fa/enable", w.handleTwoFAEnable)
@@ -141,6 +143,20 @@ func (w *Web) StartSessionCleanup(ctx context.Context) {
 // ServeHTTP implements http.Handler.
 func (w *Web) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	w.router.ServeHTTP(rw, r)
+}
+
+// renderForRequest renders a template with the current operator (if any)
+// injected as `.CurrentUser`, so the shared layout can show the profile chip
+// without each handler having to pass it explicitly. Standalone login /
+// register pages take this path too — the field is just unused there.
+func (w *Web) renderForRequest(rw http.ResponseWriter, r *http.Request, name string, data map[string]any) {
+	if data == nil {
+		data = map[string]any{}
+	}
+	if _, present := data["CurrentUser"]; !present {
+		data["CurrentUser"] = w.session.CurrentOperator(r)
+	}
+	w.render(rw, name, data)
 }
 
 func (w *Web) render(rw http.ResponseWriter, name string, data any) {


### PR DESCRIPTION
## Summary

Cleans up the sidebar nav by separating account actions from app sections.

- New `/ui/profile` page with the operator's identity card: username, display name, role, status, auth provider (with TOTP indicator), last login, account ID, creation timestamp. Doubles as the home for account-level actions:
  - link to `/ui/2fa` for managing two-factor auth,
  - **Sign out** button (`/ui/logout`).
- Shared layout now shows a **profile chip** at the top of the sidebar (avatar initial + display name) that links to `/ui/profile`.
- **Logout is no longer a peer of Dashboard / Networks / Hosts.** The main nav contains application sections only.
- New `renderForRequest` helper injects the current operator as `.CurrentUser` into every layout-using template, so the chip stays in sync across pages without each handler having to thread the operator through manually.

## Test plan

- [x] `go test -v -race ./...` — all green
- [x] `golangci-lint run --fix ./...` — 0 issues
- [x] New web tests: profile page requires login (redirect), profile page renders the username and the logout link, dashboard contains a profile link in the sidebar and no longer renders `<a href="/ui/logout">Logout</a>` as a peer nav item

Closes #18