### PR TITLE
fix(store): apply each migration once and split multi-statement scripts

### DIFF
--- a/internal/store/migration_repro_test.go
+++ b/internal/store/migration_repro_test.go
@@ -1,0 +1,115 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestMigration_BlocklistHasCAID is the regression test for issue #37 —
+// migration 009's multi-statement Exec used to silently drop the
+// `ALTER TABLE blocklist ADD COLUMN ca_id` statement on modernc/sqlite,
+// leaving blocklist out of sync with the other three tables.
+func TestMigration_BlocklistHasCAID(t *testing.T) {
+	s := newTestStore(t)
+	if !columnExists(t, s, "blocklist", "ca_id") {
+		t.Fatal("blocklist is missing the ca_id column after Migrate()")
+	}
+	idxRows, err := s.DB().Query(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_blocklist_ca';`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idxRows.Close()
+	if !idxRows.Next() {
+		t.Error("idx_blocklist_ca is missing after Migrate()")
+	}
+}
+
+// TestMigration_StableAcrossRestarts guards against the second half of
+// issue #37 — a second Migrate() pass used to silently re-run the
+// destructive 004 recreate and then bail out on the duplicate ALTER in
+// 009, leaving `blocklist` without `ca_id`. The tracking table fixes that.
+func TestMigration_StableAcrossRestarts(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("second Migrate: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("third Migrate: %v", err)
+	}
+	if !columnExists(t, s, "blocklist", "ca_id") {
+		t.Fatal("blocklist lost ca_id across repeated Migrate() calls (regression of #37)")
+	}
+}
+
+// TestMigration_HealsLegacyMissingCAID exercises the repair path for
+// databases that were initialised by the pre-#37 loader and ended up
+// without `blocklist.ca_id`. After Migrate(), the column and its index
+// must be back.
+func TestMigration_HealsLegacyMissingCAID(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.DB().Exec(`CREATE TABLE blocklist_legacy (
+		fingerprint TEXT PRIMARY KEY,
+		host_id     TEXT REFERENCES hosts(id) ON DELETE SET NULL,
+		reason      TEXT,
+		created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().Exec(`INSERT INTO blocklist_legacy SELECT fingerprint, host_id, reason, created_at FROM blocklist`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().Exec(`DROP TABLE blocklist`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().Exec(`ALTER TABLE blocklist_legacy RENAME TO blocklist`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().Exec(`DROP INDEX IF EXISTS idx_blocklist_ca`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !columnExists(t, s, "blocklist", "ca_id") {
+		t.Fatal("repair path did not restore blocklist.ca_id")
+	}
+}
+
+func TestSplitSQLStatements(t *testing.T) {
+	in := `CREATE TABLE foo (
+    id   INTEGER PRIMARY KEY,
+    name TEXT DEFAULT ''
+);
+
+-- comment with ; semicolon inside
+ALTER TABLE foo ADD COLUMN extra TEXT DEFAULT 'a; b';
+CREATE INDEX idx_foo_extra ON foo(extra);`
+	got := splitSQLStatements(in)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3; got=%q", len(got), got)
+	}
+}
+
+func columnExists(t *testing.T, s *SQLiteStore, table, column string) bool {
+	t.Helper()
+	rows, err := s.DB().Query("PRAGMA table_info(" + table + ");")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var dflt sql.NullString
+		var notnull, pk int
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatal(err)
+		}
+		if name == column {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -59,7 +59,20 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	return &SQLiteStore{db: db}, nil
 }
 
-// Migrate applies all pending migrations.
+// Migrate applies all pending migrations. Each migration file is executed
+// at most once per database — its name is recorded in `schema_migrations`
+// once applied. This fixes two latent issues:
+//
+//   - Destructive recreate-style migrations (e.g. 004_blocklist_fk, which
+//     rebuilds `blocklist` via blocklist_new + RENAME) used to run on every
+//     start, silently dropping columns that later migrations had added.
+//   - Multi-statement migration files used to be Exec'd as one string;
+//     `modernc.org/sqlite` stops processing the remainder of the blob on
+//     the first error (e.g. a duplicate-column ALTER), so the trailing
+//     statements were skipped. We now split each file by top-level `;`
+//     boundaries and Exec one statement at a time.
+//
+// See https://github.com/juev/nebula-mesh/issues/37.
 func (s *SQLiteStore) Migrate(_ context.Context) error {
 	migrationFiles := []string{
 		"001_initial.up.sql",
@@ -72,19 +85,151 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"008_host_advanced.up.sql",
 		"009_per_operator_cas.up.sql",
 	}
+
+	// Tracking table. Created once; idempotent on subsequent starts.
+	if _, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		name        TEXT PRIMARY KEY,
+		applied_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+
 	for _, f := range migrationFiles {
+		applied, err := s.migrationApplied(f)
+		if err != nil {
+			return fmt.Errorf("check migration %s: %w", f, err)
+		}
+		if applied {
+			continue
+		}
 		sqlBytes, err := migrations.FS.ReadFile(f)
 		if err != nil {
 			return fmt.Errorf("read migration %s: %w", f, err)
 		}
-		if _, err := s.db.Exec(string(sqlBytes)); err != nil {
-			// Ignore "duplicate column" errors for idempotent ALTER TABLE
-			if !isDuplicateColumnErr(err) {
-				return fmt.Errorf("apply migration %s: %w", f, err)
+		for _, stmt := range splitSQLStatements(string(sqlBytes)) {
+			if _, err := s.db.Exec(stmt); err != nil {
+				if isDuplicateColumnErr(err) {
+					// Tolerated for backward compatibility with DBs that
+					// partially applied a buggy earlier version of this
+					// migration loader.
+					continue
+				}
+				return fmt.Errorf("apply migration %s stmt %q: %w", f, firstLine(stmt), err)
 			}
 		}
+		if _, err := s.db.Exec(`INSERT OR REPLACE INTO schema_migrations(name) VALUES (?)`, f); err != nil {
+			return fmt.Errorf("record migration %s: %w", f, err)
+		}
+	}
+
+	// Repair path for databases that applied the broken pre-#37 loader:
+	// `blocklist` may be missing the `ca_id` column even though every
+	// migration is now flagged as applied. Re-run the affected ALTER
+	// outside the normal migration flow so existing installs heal on the
+	// next start.
+	if err := s.repairBlocklistCAID(); err != nil {
+		return fmt.Errorf("repair blocklist ca_id: %w", err)
 	}
 	return nil
+}
+
+func (s *SQLiteStore) migrationApplied(name string) (bool, error) {
+	var got string
+	row := s.db.QueryRow(`SELECT name FROM schema_migrations WHERE name = ?`, name)
+	if err := row.Scan(&got); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return got == name, nil
+}
+
+// repairBlocklistCAID heals databases that ran the buggy multi-statement
+// migration loader before issue #37 was fixed. If `blocklist.ca_id` is
+// absent, add it (together with its index) so multi-CA logic works.
+func (s *SQLiteStore) repairBlocklistCAID() error {
+	row := s.db.QueryRow(`SELECT COUNT(1) FROM pragma_table_info('blocklist') WHERE name = 'ca_id'`)
+	var n int
+	if err := row.Scan(&n); err != nil {
+		return err
+	}
+	if n > 0 {
+		return nil
+	}
+	if _, err := s.db.Exec(`ALTER TABLE blocklist ADD COLUMN ca_id TEXT NOT NULL DEFAULT ''`); err != nil {
+		if !isDuplicateColumnErr(err) {
+			return err
+		}
+	}
+	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_blocklist_ca ON blocklist(ca_id)`); err != nil {
+		return err
+	}
+	return nil
+}
+
+// splitSQLStatements splits a SQL script on top-level `;` boundaries. It
+// understands single- and double-quoted strings and `--` line comments,
+// which is enough for the migration files we ship (no nested BEGIN/END or
+// string-quoted semicolons elsewhere). Empty trailing statements are
+// dropped.
+func splitSQLStatements(src string) []string {
+	var (
+		out      []string
+		current  []byte
+		inSingle bool
+		inDouble bool
+		inLine   bool
+		paren    int
+	)
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		if inLine {
+			current = append(current, c)
+			if c == '\n' {
+				inLine = false
+			}
+			continue
+		}
+		switch {
+		case !inSingle && !inDouble && c == '-' && i+1 < len(src) && src[i+1] == '-':
+			inLine = true
+			current = append(current, c)
+		case !inDouble && c == '\'':
+			inSingle = !inSingle
+			current = append(current, c)
+		case !inSingle && c == '"':
+			inDouble = !inDouble
+			current = append(current, c)
+		case !inSingle && !inDouble && c == '(':
+			paren++
+			current = append(current, c)
+		case !inSingle && !inDouble && c == ')':
+			if paren > 0 {
+				paren--
+			}
+			current = append(current, c)
+		case !inSingle && !inDouble && paren == 0 && c == ';':
+			stmt := strings.TrimSpace(string(current))
+			if stmt != "" {
+				out = append(out, stmt)
+			}
+			current = current[:0]
+		default:
+			current = append(current, c)
+		}
+	}
+	if tail := strings.TrimSpace(string(current)); tail != "" {
+		out = append(out, tail)
+	}
+	return out
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 func isDuplicateColumnErr(err error) bool {


### PR DESCRIPTION
## Summary

Two latent bugs combined to drop `blocklist.ca_id` on every server restart after the initial `init`:

1. **No migration tracking** — every `Migrate()` call re-played every `*.up.sql`. Migration 004's destructive `blocklist_new → DROP blocklist → RENAME` cycle therefore ran on every start and silently wiped any columns later migrations had added (notably `ca_id` from 009).
2. **Multi-statement Exec stops on first error** — `modernc.org/sqlite` halts a multi-statement blob on the first failure. The duplicate-column ALTER on `networks` in 009 (benign on a re-run, but still an error) short-circuited the loader before it reached `ALTER TABLE blocklist`. So step 1 wiped the column and step 2 never restored it.

Result: `serve` printed `backfill ca_id: backfill ca_id on blocklist: SQL logic error: no such column: ca_id (1)` and left the schema in an inconsistent state.

## Fixes

- Add a `schema_migrations(name, applied_at)` table; each `*.up.sql` runs at most once per database.
- Split every migration file by top-level `;` boundaries (single/double-quote aware, line-comment aware) and `Exec` each statement individually — siblings can no longer cascade-fail.
- Add a one-off **repair pass** that detects a `blocklist` missing `ca_id` on already-migrated databases and adds the column + `idx_blocklist_ca` back. This heals deployments that already ran the buggy loader without operator intervention.

## Tests

- `TestMigration_BlocklistHasCAID` — fresh migration leaves `blocklist.ca_id` + `idx_blocklist_ca` in place.
- `TestMigration_StableAcrossRestarts` — three consecutive `Migrate()` calls keep the schema stable (previously regressed `ca_id`).
- `TestMigration_HealsLegacyMissingCAID` — pre-fix DBs (blocklist artificially recreated without `ca_id`) are repaired on the next start.
- `TestSplitSQLStatements` — splitter handles trailing semicolons inside string literals and SQL line comments.

## Manual end-to-end

```sh
nebula-mgmt init  --config server.yml
nebula-mgmt serve --config server.yml &
# serve.log no longer contains 'backfill ca_id: ... no such column'
sqlite3 nebula.db "PRAGMA table_info(blocklist);"
# 4|ca_id|TEXT|1|''|0   ← present
sqlite3 nebula.db "SELECT name FROM schema_migrations;"
# 001…009 all listed
```

Closes #37
