### PR TITLE
docs(readme): document agent install from deb/rpm package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ Each release ships **two** independent artifact sets — install only what you n
 | Linux distro packages | — | `nebula-agent_<v>_linux_<arch>.{deb,rpm}` |
 | Docker image | `ghcr.io/juev/nebula-mgmt` | `ghcr.io/juev/nebula-agent` |
 
+### Linux distro packages — recommended for the agent
+
+`nebula-agent` ships as `.deb` and `.rpm` for `amd64`, `arm64`, and `armv7` on every release. The package installs the binary at `/usr/bin/nebula-agent`, the systemd unit at `/lib/systemd/system/nebula-agent.service`, an example config at `/etc/nebula-agent/agent.example.yml`, and the operations guide at `/usr/share/doc/nebula-agent/agent.md`. The post-install script creates the `nebula-agent` system user but does **not** enable the service — you must enroll the host first.
+
+```sh
+TAG=$(curl -fsSL https://api.github.com/repos/juev/nebula-mesh/releases/latest | grep -m1 tag_name | cut -d'"' -f4)
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/;s/armv7l/armv7/')
+
+# Debian / Ubuntu
+curl -fsSL -O "https://github.com/juev/nebula-mesh/releases/download/${TAG}/nebula-agent_${TAG#v}_linux_${ARCH}.deb"
+sudo apt install -y "./nebula-agent_${TAG#v}_linux_${ARCH}.deb"
+
+# RHEL / Fedora / CentOS Stream / Rocky / Alma
+sudo rpm -i "https://github.com/juev/nebula-mesh/releases/download/${TAG}/nebula-agent_${TAG#v}_linux_${ARCH}.rpm"
+
+# After install: edit the example, enroll, then enable the unit.
+sudo cp /etc/nebula-agent/agent.example.yml /etc/nebula-agent/agent.yml
+sudoedit /etc/nebula-agent/agent.yml
+sudo nebula-agent enroll --server <url> --token <token> --data-dir /etc/nebula
+sudo systemctl enable --now nebula-agent.service
+```
+
+`/etc/nebula-agent/agent.yml` is marked `config|noreplace`, so upgrades preserve your edits. `apt purge` / `dnf remove --purge` drops the system user but keeps `/etc/nebula-agent` and `/etc/nebula` intact so host keys survive an accidental removal. Full lifecycle reference: [`docs/agent.md`](docs/agent.md#from-a-linux-distro-package-recommended-on-debian--ubuntu--rhel).
+
+For `nebula-mgmt`, the agent on non-deb/rpm Linux distros, and non-Linux hosts, use the prebuilt tarball or Docker image below.
+
 ### Prebuilt binary (Linux / macOS / FreeBSD / Windows)
 
 ```sh


### PR DESCRIPTION
## Summary

v0.2.0 publishes `.deb` and `.rpm` for `nebula-agent` on `amd64`, `arm64`, and `armv7` (#28), but the README `Install` section still only described the prebuilt tarball path. Add a first-class subsection that walks an operator through:

- `apt install` on Debian / Ubuntu
- `rpm -i` on RHEL / Fedora / CentOS Stream / Rocky / Alma
- the post-install enrol + `systemctl enable --now` follow-up

Notes the operator should care about:

- `config|noreplace` on `/etc/nebula-agent/agent.yml` — upgrades preserve edits
- `apt purge` / `dnf remove --purge` drops the system user but keeps `/etc/nebula-agent` + `/etc/nebula` so host keys survive an accidental removal
- post-install does **not** auto-enable the service — enrolment is a prerequisite

Cross-links into `docs/agent.md` for the full lifecycle reference. Tarball / Docker / from-source paths stay where they were; the deb/rpm section is positioned first under *Install* because for a Linux Nebula host it is the recommended path.

## Test plan

- [x] Released artifacts inspected against the doc: `.deb` for v0.2.0 contains `/usr/bin/nebula-agent`, `/lib/systemd/system/nebula-agent.service`, `/etc/nebula-agent/agent.example.yml`, `/usr/share/doc/nebula-agent/{LICENSE,agent.md}` and depends on `adduser`.
- [x] Local Markdown preview confirms the new subsection lands at the top of *Install* and the existing tarball/Docker/from-source paths stay below it.