### PR TITLE
feat(server): auto-assign lighthouses by host role (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,13 +322,12 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 
 Open issues tracked individually so you can subscribe to the ones you care about:
 
-- [#39](https://github.com/juev/nebula-mesh/issues/39) — Lighthouse auto-assignment based on host role
 - [#40](https://github.com/juev/nebula-mesh/issues/40) — Prometheus exporter (today: `expvar`)
 - [#41](https://github.com/juev/nebula-mesh/issues/41) — Built-in cert-expiry alerts (audit + webhook + metric)
 - [#42](https://github.com/juev/nebula-mesh/issues/42) — Bootstrap recipes (Terraform module, Ansible roles, cloud-init samples)
 - [#43](https://github.com/juev/nebula-mesh/issues/43) — Web UI: live host status via SSE (today: htmx polling on a 30s interval)
 
-Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, distro packages (deb/rpm) and the cross-platform agent build matrix.
+Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, distro packages (deb/rpm) and the cross-platform agent build matrix.
 
 Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -292,6 +292,16 @@ Certificate renewal is part of this same flow: when the server signs a new cert 
 the host (e.g. because the previous one is within its 30-day expiry window), the
 agent picks it up on the next poll.
 
+### Lighthouse routing is automatic
+
+Operators no longer wire lighthouse IPs into every peer host. The server resolves
+the network's currently enrolled `role: lighthouse` hosts (excluding `pending`
+and `blocked` ones) and embeds them in each peer's rendered `config.yml` under
+`static_host_map` and `lighthouse.hosts`. When a lighthouse is added, blocked,
+or deleted, the server bumps the network's `config_version`; each peer's next
+agent poll observes the version change and receives an updated `config.yml` in
+the same response — no manual reconfiguration required.
+
 ## Troubleshooting
 
 ### `dial tcp ...: connect: connection refused`

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/juev/nebula-mesh/internal/configgen"
+	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/slackhq/nebula/cert"
@@ -151,15 +152,43 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get lighthouses for config
-	lighthouses, err := s.getLighthouses(r.Context(), host.NetworkID)
+	// Pin the freshly-enrolled host to the current network config version so the
+	// next agent poll does not redundantly re-send the same config we already
+	// embedded in the enrollment response below.
+	networkVersion, err := s.store.GetNetworkConfigVersion(r.Context(), host.NetworkID)
 	if err != nil {
-		s.logger.Error("get lighthouses", "error", err)
+		s.logger.Error("get network config version", "error", err)
+		writeError(w, http.StatusInternalServerError, "enrollment failed")
+		return
+	}
+	if err := s.store.UpdateHostConfigVersion(r.Context(), host.ID, networkVersion); err != nil {
+		s.logger.Error("update host config version", "error", err)
 		writeError(w, http.StatusInternalServerError, "enrollment failed")
 		return
 	}
 
-	// Generate config (including any per-host advanced overrides)
+	configYAML, err := s.renderHostConfig(r.Context(), host)
+	if err != nil {
+		s.logger.Error("generate config", "error", err)
+		writeError(w, http.StatusInternalServerError, "enrollment failed")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, enrollResponse{
+		CertificatePEM:   string(certPEM),
+		CACertificatePEM: string(caCertPEM),
+		ConfigYAML:       string(configYAML),
+	})
+}
+
+// renderHostConfig produces the Nebula config.yml for the given host, resolving
+// the network's enrolled lighthouses and applying per-host advanced overrides.
+func (s *Server) renderHostConfig(ctx context.Context, host *models.Host) ([]byte, error) {
+	lighthouses, err := s.getLighthouses(ctx, host.NetworkID)
+	if err != nil {
+		return nil, fmt.Errorf("get lighthouses: %w", err)
+	}
+
 	input := configgen.GeneratorInput{
 		HostName:     host.Name,
 		NebulaIP:     host.NebulaIP,
@@ -186,38 +215,34 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 			input.UnsafeRoutes = append(input.UnsafeRoutes, configgen.AdvancedUnsafeRoute{Route: u.Route, Via: u.Via})
 		}
 	}
-	configYAML, err := configgen.Generate(input)
-	if err != nil {
-		s.logger.Error("generate config", "error", err)
-		writeError(w, http.StatusInternalServerError, "enrollment failed")
-		return
-	}
-
-	writeJSON(w, http.StatusOK, enrollResponse{
-		CertificatePEM:   string(certPEM),
-		CACertificatePEM: string(caCertPEM),
-		ConfigYAML:       string(configYAML),
-	})
+	return configgen.Generate(input)
 }
 
+// getLighthouses returns every enrolled lighthouse in the given network. Pending
+// or blocked lighthouses are excluded so peer configs never advertise hosts that
+// cannot yet (or no longer) accept traffic.
 func (s *Server) getLighthouses(ctx context.Context, networkID string) ([]configgen.LighthouseInfo, error) {
-	hosts, err := s.store.ListHosts(ctx, store.HostFilter{NetworkID: networkID})
+	hosts, err := s.store.ListHosts(ctx, store.HostFilter{
+		NetworkID: networkID,
+		Status:    models.HostStatusEnrolled,
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	result := make([]configgen.LighthouseInfo, 0)
 	for _, h := range hosts {
-		if h.IsLighthouse && h.PublicIP != "" {
-			port := h.ListenPort
-			if port == 0 {
-				port = 4242
-			}
-			result = append(result, configgen.LighthouseInfo{
-				NebulaIP:   h.NebulaIP,
-				PublicAddr: fmt.Sprintf("%s:%d", h.PublicIP, port),
-			})
+		if !h.IsLighthouse || h.PublicIP == "" {
+			continue
 		}
+		port := h.ListenPort
+		if port == 0 {
+			port = 4242
+		}
+		result = append(result, configgen.LighthouseInfo{
+			NebulaIP:   h.NebulaIP,
+			PublicAddr: fmt.Sprintf("%s:%d", h.PublicIP, port),
+		})
 	}
 	return result, nil
 }

--- a/internal/api/lighthouse_test.go
+++ b/internal/api/lighthouse_test.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// enrollLighthouse persists a lighthouse host directly in the store so peer
+// configs can find it via getLighthouses. Bypasses the HTTP enrollment flow
+// to keep this unit test small.
+func enrollLighthouse(t *testing.T, srv *Server, networkID, hostID, name, nebulaIP, publicIP, fp string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now()
+	h := &models.Host{
+		ID: hostID, NetworkID: networkID, Name: name,
+		NebulaIP: nebulaIP, Groups: []string{},
+		Role: models.HostRoleLighthouse, IsLighthouse: true,
+		PublicIP: publicIP, ListenPort: 4242,
+		Status:    models.HostStatusEnrolled,
+		CertFingerprint: fp,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := srv.store.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.UpdateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetLighthouses_ExcludesPending(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	// Lighthouse 1 — enrolled
+	enrollLighthouse(t, srv, netID, "lh1", "lh-enrolled", "192.168.100.5", "1.2.3.4", "fp-lh1")
+
+	// Lighthouse 2 — pending (not yet enrolled)
+	pending := &models.Host{
+		ID: "lh2", NetworkID: netID, Name: "lh-pending",
+		NebulaIP: "192.168.100.6", Groups: []string{},
+		Role: models.HostRoleLighthouse, IsLighthouse: true,
+		PublicIP: "5.6.7.8", ListenPort: 4242,
+		Status:    models.HostStatusPending,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := srv.store.CreateHost(ctx, pending); err != nil {
+		t.Fatal(err)
+	}
+
+	lhs, err := srv.getLighthouses(ctx, netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lhs) != 1 {
+		t.Fatalf("got %d lighthouses, want 1 (pending must be excluded): %+v", len(lhs), lhs)
+	}
+	if lhs[0].NebulaIP != "192.168.100.5" {
+		t.Errorf("nebula_ip = %q, want 192.168.100.5", lhs[0].NebulaIP)
+	}
+	if lhs[0].PublicAddr != "1.2.3.4:4242" {
+		t.Errorf("public_addr = %q, want 1.2.3.4:4242", lhs[0].PublicAddr)
+	}
+}
+
+func TestGetLighthouses_ExcludesBlocked(t *testing.T) {
+	srv, st := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	enrollLighthouse(t, srv, netID, "lh1", "lh-keep", "192.168.100.5", "1.2.3.4", "fp-keep")
+	enrollLighthouse(t, srv, netID, "lh2", "lh-block", "192.168.100.6", "5.6.7.8", "fp-block")
+
+	if _, err := st.BlockHostAndAddToBlocklist(ctx, "lh2", "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	lhs, err := srv.getLighthouses(ctx, netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lhs) != 1 {
+		t.Fatalf("got %d lighthouses, want 1 (blocked must be excluded): %+v", len(lhs), lhs)
+	}
+	if lhs[0].NebulaIP != "192.168.100.5" {
+		t.Errorf("kept = %q, want 192.168.100.5", lhs[0].NebulaIP)
+	}
+}
+
+func TestGetLighthouses_ZeroLighthouses(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	lhs, err := srv.getLighthouses(ctx, netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lhs) != 0 {
+		t.Errorf("got %d lighthouses, want 0", len(lhs))
+	}
+	if lhs == nil {
+		t.Error("getLighthouses returned nil, want empty slice")
+	}
+}
+
+func TestGetLighthouses_MultipleEnrolled(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	enrollLighthouse(t, srv, netID, "lh1", "lh-a", "192.168.100.5", "1.2.3.4", "fp-a")
+	enrollLighthouse(t, srv, netID, "lh2", "lh-b", "192.168.100.6", "5.6.7.8", "fp-b")
+
+	lhs, err := srv.getLighthouses(ctx, netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lhs) != 2 {
+		t.Fatalf("got %d, want 2: %+v", len(lhs), lhs)
+	}
+}
+
+func TestRenderHostConfig_EmitsAllEnrolledLighthouses(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	enrollLighthouse(t, srv, netID, "lh1", "lh-a", "192.168.100.5", "1.2.3.4", "fp-a")
+	enrollLighthouse(t, srv, netID, "lh2", "lh-b", "192.168.100.6", "5.6.7.8", "fp-b")
+
+	host := &models.Host{
+		ID: "host_peer", NetworkID: netID, Name: "peer",
+		NebulaIP: "192.168.100.10", Groups: []string{},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := srv.store.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := srv.renderHostConfig(ctx, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(cfg)
+	for _, expected := range []string{"192.168.100.5", "192.168.100.6", "1.2.3.4:4242", "5.6.7.8:4242"} {
+		if !strings.Contains(out, expected) {
+			t.Errorf("rendered config missing %q\n%s", expected, out)
+		}
+	}
+	if !strings.Contains(out, "am_lighthouse: false") {
+		t.Errorf("peer config should have am_lighthouse: false\n%s", out)
+	}
+}

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -80,7 +80,33 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp.HasUpdates = len(blocklist) > 0 || resp.CertificatePEM != nil
+	// Check if the network config version moved since this host's last poll.
+	// If it did, re-render the Nebula config with the current lighthouse list
+	// (and any other network-level config) and ship it to the agent.
+	netVersion, verErr := s.store.GetNetworkConfigVersion(r.Context(), host.NetworkID)
+	if verErr != nil {
+		s.logger.Error("get network config version", "error", verErr)
+	} else {
+		hostVersion, hvErr := s.store.GetHostConfigVersion(r.Context(), host.ID)
+		if hvErr != nil {
+			s.logger.Error("get host config version", "error", hvErr)
+		} else if hostVersion != netVersion {
+			configYAML, cfgErr := s.renderHostConfig(r.Context(), host)
+			if cfgErr != nil {
+				s.logger.Error("render host config", "host", host.Name, "error", cfgErr)
+			} else {
+				if uvErr := s.store.UpdateHostConfigVersion(r.Context(), host.ID, netVersion); uvErr != nil {
+					s.logger.Error("update host config version", "host", host.Name, "error", uvErr)
+				} else {
+					cfgStr := string(configYAML)
+					resp.ConfigYAML = &cfgStr
+					s.logger.Info("config rolled out", "host", host.Name, "from_version", hostVersion, "to_version", netVersion)
+				}
+			}
+		}
+	}
+
+	resp.HasUpdates = len(blocklist) > 0 || resp.CertificatePEM != nil || resp.ConfigYAML != nil
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -560,6 +560,8 @@ func (s *SQLiteStore) DeleteHost(_ context.Context, id string) error {
 }
 
 // BlockHostAndAddToBlocklist atomically blocks a host and adds its cert to the blocklist.
+// If the blocked host was an enrolled lighthouse, the network's config_version is
+// bumped so peers stop directing traffic at it on their next poll.
 func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason string) (*models.Host, error) {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -591,6 +593,8 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason s
 		}
 	}
 
+	wasEnrolledLighthouse := h.IsLighthouse && h.Status == models.HostStatusEnrolled
+
 	result, err := tx.Exec(
 		`UPDATE hosts SET status=?, updated_at=? WHERE id=?`,
 		models.HostStatusBlocked, time.Now(), id,
@@ -604,6 +608,15 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason s
 	}
 	if rows == 0 {
 		return nil, ErrNotFound
+	}
+
+	if wasEnrolledLighthouse {
+		if _, err := tx.Exec(
+			`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`,
+			h.NetworkID,
+		); err != nil {
+			return nil, fmt.Errorf("bump config version: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -667,6 +680,8 @@ func (s *SQLiteStore) UnblockHostAndRemoveFromBlocklist(_ context.Context, id st
 }
 
 // DeleteHostAndBlockCert atomically deletes a host and adds its cert to the blocklist.
+// If the deleted host was an enrolled lighthouse, the network's config_version is
+// bumped so peers stop directing traffic at it on their next poll.
 func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason string) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -698,6 +713,8 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason strin
 		}
 	}
 
+	wasEnrolledLighthouse := h.IsLighthouse && h.Status == models.HostStatusEnrolled
+
 	result, err := tx.Exec(`DELETE FROM hosts WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("delete host: %w", err)
@@ -708,6 +725,15 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason strin
 	}
 	if rows == 0 {
 		return ErrNotFound
+	}
+
+	if wasEnrolledLighthouse {
+		if _, err := tx.Exec(
+			`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`,
+			h.NetworkID,
+		); err != nil {
+			return fmt.Errorf("bump config version: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -844,6 +870,8 @@ func (s *SQLiteStore) SaveCertificate(_ context.Context, hostID string, certPEM 
 }
 
 // SaveCertificateAndEnrollHost atomically saves a certificate and marks the host as enrolled.
+// If the host has role=lighthouse, the network's config_version is bumped so peer
+// agents pick up the new lighthouse on their next poll.
 func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -854,6 +882,18 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID str
 			slog.Error("rollback", "error", err)
 		}
 	}()
+
+	var isLighthouse bool
+	var networkID string
+	err = tx.QueryRow(
+		`SELECT is_lighthouse, network_id FROM hosts WHERE id = ?`, hostID,
+	).Scan(&isLighthouse, &networkID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("get host role: %w", err)
+	}
 
 	if err := s.saveCertificateInTx(tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
 		return err
@@ -873,6 +913,15 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID str
 	}
 	if rows == 0 {
 		return ErrNotFound
+	}
+
+	if isLighthouse {
+		if _, err := tx.Exec(
+			`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`,
+			networkID,
+		); err != nil {
+			return fmt.Errorf("bump config version: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -1064,6 +1113,36 @@ func (s *SQLiteStore) GetNetworkConfigVersion(_ context.Context, networkID strin
 		return 0, fmt.Errorf("get config version: %w", err)
 	}
 	return version, nil
+}
+
+func (s *SQLiteStore) GetHostConfigVersion(_ context.Context, hostID string) (int, error) {
+	var version int
+	err := s.db.QueryRow(`SELECT config_version FROM hosts WHERE id = ?`, hostID).Scan(&version)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("get host config version: %w", err)
+	}
+	return version, nil
+}
+
+func (s *SQLiteStore) UpdateHostConfigVersion(_ context.Context, hostID string, version int) error {
+	result, err := s.db.Exec(
+		`UPDATE hosts SET config_version=?, updated_at=? WHERE id=?`,
+		version, time.Now(), hostID,
+	)
+	if err != nil {
+		return fmt.Errorf("update host config version: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update host config version rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // --- Network Config ---

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1271,3 +1271,266 @@ func TestCreateHostAndToken_DuplicateHost(t *testing.T) {
 		t.Error("token-2 should not exist after rollback")
 	}
 }
+
+// --- Host Config Version ---
+
+func TestHostConfigVersion_DefaultZero(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	h := &models.Host{
+		ID: "host_cv", NetworkID: net.ID, Name: "cv-default",
+		NebulaIP: "192.168.100.10", Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusPending,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := s.GetHostConfigVersion(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 0 {
+		t.Errorf("default version = %d, want 0", v)
+	}
+}
+
+func TestUpdateHostConfigVersion(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	h := &models.Host{
+		ID: "host_cv_update", NetworkID: net.ID, Name: "cv-update",
+		NebulaIP: "192.168.100.11", Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusPending,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.UpdateHostConfigVersion(ctx, h.ID, 7); err != nil {
+		t.Fatal(err)
+	}
+	v, err := s.GetHostConfigVersion(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 7 {
+		t.Errorf("version = %d, want 7", v)
+	}
+}
+
+func TestUpdateHostConfigVersion_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	err := s.UpdateHostConfigVersion(context.Background(), "nonexistent", 1)
+	if err != ErrNotFound {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetHostConfigVersion_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.GetHostConfigVersion(context.Background(), "nonexistent")
+	if err != ErrNotFound {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// --- Lighthouse-driven config_version bumps ---
+
+func TestSaveCertificateAndEnrollHost_BumpsLighthouseVersion(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	lh := &models.Host{
+		ID: "host_lh", NetworkID: net.ID, Name: "lighthouse-a",
+		NebulaIP: "192.168.100.5", Groups: []string{},
+		Role: models.HostRoleLighthouse, IsLighthouse: true,
+		PublicIP: "10.0.0.5", ListenPort: 4242,
+		Status:    models.HostStatusPending,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, lh); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := s.GetNetworkConfigVersion(ctx, net.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	if err := s.SaveCertificateAndEnrollHost(ctx, lh.ID, []byte("dummy-cert-pem"), "fp-lh-1", now, now.Add(24*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := s.GetNetworkConfigVersion(ctx, net.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before+1 {
+		t.Errorf("version = %d, want %d (bump on lighthouse enrollment)", after, before+1)
+	}
+}
+
+func TestSaveCertificateAndEnrollHost_NoBumpForRegularHost(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	h := &models.Host{
+		ID: "host_regular", NetworkID: net.ID, Name: "plain",
+		NebulaIP: "192.168.100.6", Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusPending,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := s.GetNetworkConfigVersion(ctx, net.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	if err := s.SaveCertificateAndEnrollHost(ctx, h.ID, []byte("dummy"), "fp-h-1", now, now.Add(24*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := s.GetNetworkConfigVersion(ctx, net.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Errorf("version = %d, want %d (no bump for plain host)", after, before)
+	}
+}
+
+func TestBlockHostAndAddToBlocklist_BumpsForEnrolledLighthouse(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	lh := &models.Host{
+		ID: "host_lh_block", NetworkID: net.ID, Name: "lh-block",
+		NebulaIP: "192.168.100.7", Groups: []string{},
+		Role: models.HostRoleLighthouse, IsLighthouse: true,
+		PublicIP: "10.0.0.7", ListenPort: 4242,
+		Status:    models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, lh); err != nil {
+		t.Fatal(err)
+	}
+	// Set fingerprint via UpdateHost so block records it on the blocklist
+	lh.CertFingerprint = "fp-lh-block"
+	if err := s.UpdateHost(ctx, lh); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := s.GetNetworkConfigVersion(ctx, net.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.BlockHostAndAddToBlocklist(ctx, lh.ID, "test block"); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := s.GetNetworkConfigVersion(ctx, net.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before+1 {
+		t.Errorf("version = %d, want %d (bump on enrolled lighthouse block)", after, before+1)
+	}
+}
+
+func TestBlockHostAndAddToBlocklist_NoBumpForPendingLighthouse(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	lh := &models.Host{
+		ID: "host_lh_pending", NetworkID: net.ID, Name: "lh-pending",
+		NebulaIP: "192.168.100.8", Groups: []string{},
+		Role: models.HostRoleLighthouse, IsLighthouse: true,
+		Status:    models.HostStatusPending,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, lh); err != nil {
+		t.Fatal(err)
+	}
+
+	before, _ := s.GetNetworkConfigVersion(ctx, net.ID)
+	if _, err := s.BlockHostAndAddToBlocklist(ctx, lh.ID, "test"); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := s.GetNetworkConfigVersion(ctx, net.ID)
+	if after != before {
+		t.Errorf("version = %d, want %d (pending lighthouse — no bump)", after, before)
+	}
+}
+
+func TestDeleteHostAndBlockCert_BumpsForEnrolledLighthouse(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	lh := &models.Host{
+		ID: "host_lh_del", NetworkID: net.ID, Name: "lh-del",
+		NebulaIP: "192.168.100.9", Groups: []string{},
+		Role: models.HostRoleLighthouse, IsLighthouse: true,
+		PublicIP: "10.0.0.9", ListenPort: 4242,
+		Status:    models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, lh); err != nil {
+		t.Fatal(err)
+	}
+	lh.CertFingerprint = "fp-lh-del"
+	if err := s.UpdateHost(ctx, lh); err != nil {
+		t.Fatal(err)
+	}
+
+	before, _ := s.GetNetworkConfigVersion(ctx, net.ID)
+	if err := s.DeleteHostAndBlockCert(ctx, lh.ID, "test delete"); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := s.GetNetworkConfigVersion(ctx, net.ID)
+	if after != before+1 {
+		t.Errorf("version = %d, want %d (bump on enrolled lighthouse delete)", after, before+1)
+	}
+}
+
+func TestDeleteHostAndBlockCert_NoBumpForRegularHost(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	h := &models.Host{
+		ID: "host_plain_del", NetworkID: net.ID, Name: "plain-del",
+		NebulaIP: "192.168.100.13", Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+
+	before, _ := s.GetNetworkConfigVersion(ctx, net.ID)
+	if err := s.DeleteHostAndBlockCert(ctx, h.ID, "test"); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := s.GetNetworkConfigVersion(ctx, net.ID)
+	if after != before {
+		t.Errorf("version = %d, want %d (regular host — no bump)", after, before)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -73,6 +73,8 @@ type Store interface {
 	// Config versioning
 	BumpNetworkConfigVersion(ctx context.Context, networkID string) error
 	GetNetworkConfigVersion(ctx context.Context, networkID string) (int, error)
+	GetHostConfigVersion(ctx context.Context, hostID string) (int, error)
+	UpdateHostConfigVersion(ctx context.Context, hostID string, version int) error
 
 	// Network config (key-value)
 	GetNetworkConfig(ctx context.Context, networkID, key string) (string, error)

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -365,5 +366,210 @@ func TestAgentUpdates_CertSaveFailure(t *testing.T) {
 	if pollResp.StatusCode != http.StatusInternalServerError {
 		body, _ := io.ReadAll(pollResp.Body)
 		t.Errorf("expected 500 when cert save fails, got %d, body: %s", pollResp.StatusCode, string(body))
+	}
+}
+
+// enrollHost is a small helper used by the lighthouse auto-assignment tests
+// below: it creates a host, runs the full enrollment handshake, and returns
+// the host record plus its cert fingerprint (needed for agent polls).
+func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP string, extra map[string]any) (*models.Host, string, string) {
+	t.Helper()
+	payload := map[string]any{
+		"network_id": networkID,
+		"name":       name,
+		"nebula_ip":  nebulaIP,
+	}
+	for k, v := range extra {
+		payload[k] = v
+	}
+	resp := apiCall(t, ts, "POST", "/api/v1/hosts", payload)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create host %s: HTTP %d: %s", name, resp.StatusCode, string(body))
+	}
+	var created struct {
+		Host            *models.Host `json:"host"`
+		EnrollmentToken string       `json:"enrollment_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created %s: %v", name, err)
+	}
+	resp.Body.Close()
+
+	privKey := make([]byte, 32)
+	if _, err := rand.Read(privKey); err != nil {
+		t.Fatal(err)
+	}
+	pubKey, err := curve25519.X25519(privKey, curve25519.Basepoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pubKey)
+
+	enrollData, _ := json.Marshal(map[string]string{
+		"token":          created.EnrollmentToken,
+		"public_key_pem": string(pubKeyPEM),
+	})
+	enrollResp, err := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(enrollData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer enrollResp.Body.Close()
+	if enrollResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(enrollResp.Body)
+		t.Fatalf("enroll %s: HTTP %d: %s", name, enrollResp.StatusCode, string(body))
+	}
+
+	var enrolled struct {
+		CertificatePEM string `json:"certificate_pem"`
+		ConfigYAML     string `json:"config_yaml"`
+	}
+	if err := json.NewDecoder(enrollResp.Body).Decode(&enrolled); err != nil {
+		t.Fatalf("decode enroll %s: %v", name, err)
+	}
+	hostCert, _, err := cert.UnmarshalCertificateFromPEM([]byte(enrolled.CertificatePEM))
+	if err != nil {
+		t.Fatalf("parse cert %s: %v", name, err)
+	}
+	fp, err := hostCert.Fingerprint()
+	if err != nil {
+		t.Fatalf("fingerprint %s: %v", name, err)
+	}
+
+	return created.Host, fp, enrolled.ConfigYAML
+}
+
+// pollAgent runs a single agent updates poll for the given fingerprint and
+// returns the decoded response.
+func pollAgent(t *testing.T, ts *httptest.Server, fingerprint string) struct {
+	HasUpdates bool     `json:"has_updates"`
+	ConfigYAML *string  `json:"config_yaml,omitempty"`
+	Blocklist  []string `json:"blocklist"`
+} {
+	t.Helper()
+	resp, err := http.Get(ts.URL + "/api/v1/agent/updates?fingerprint=" + fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("poll: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	var out struct {
+		HasUpdates bool     `json:"has_updates"`
+		ConfigYAML *string  `json:"config_yaml,omitempty"`
+		Blocklist  []string `json:"blocklist"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode poll: %v", err)
+	}
+	return out
+}
+
+// TestE2E_LighthouseAutoAssignment exercises issue #39: when a lighthouse is
+// promoted, blocked, or deleted, peer agents must pick up the new lighthouse
+// layout on their next poll without any manual reconfiguration.
+func TestE2E_LighthouseAutoAssignment(t *testing.T) {
+	ts, _, _ := setupE2E(t)
+
+	resp := apiCall(t, ts, "POST", "/api/v1/networks", map[string]string{
+		"name": "auto-lh-network",
+		"cidr": "192.168.50.0/24",
+	})
+	var network models.Network
+	if err := json.NewDecoder(resp.Body).Decode(&network); err != nil {
+		t.Fatalf("decode network: %v", err)
+	}
+	resp.Body.Close()
+
+	// 1. Enroll a peer host first, *before* any lighthouse exists. Its
+	// enrollment-time config must contain zero lighthouses.
+	_, peerFP, peerInitialCfg := enrollHost(t, ts, network.ID, "peer-1", "192.168.50.10", nil)
+	if strings.Contains(peerInitialCfg, "203.0.113.") {
+		t.Fatalf("initial peer config unexpectedly references a lighthouse public IP:\n%s", peerInitialCfg)
+	}
+
+	// 2. Initial poll immediately after enrollment — no version drift, no
+	// config redelivery.
+	updates := pollAgent(t, ts, peerFP)
+	if updates.ConfigYAML != nil {
+		t.Errorf("first poll: ConfigYAML must be nil (no version drift), got non-nil")
+	}
+
+	// 3. Now create and enroll a lighthouse. Enrolling a lighthouse must bump
+	// the network config_version.
+	_, _, _ = enrollHost(t, ts, network.ID, "lh-1", "192.168.50.1", map[string]any{
+		"role":        "lighthouse",
+		"public_ip":   "203.0.113.10",
+		"listen_port": 4242,
+	})
+
+	// 4. Peer poll — the agent must now receive a config_yaml that lists the
+	// newly enrolled lighthouse.
+	updates = pollAgent(t, ts, peerFP)
+	if updates.ConfigYAML == nil {
+		t.Fatal("peer poll after lighthouse promotion: ConfigYAML is nil, expected fresh config")
+	}
+	if !strings.Contains(*updates.ConfigYAML, "192.168.50.1") || !strings.Contains(*updates.ConfigYAML, "203.0.113.10:4242") {
+		t.Errorf("peer config does not advertise new lighthouse:\n%s", *updates.ConfigYAML)
+	}
+
+	// 5. Subsequent poll with no further changes — version is back in sync,
+	// no config is pushed.
+	updates = pollAgent(t, ts, peerFP)
+	if updates.ConfigYAML != nil {
+		t.Errorf("second poll: expected ConfigYAML=nil, got %q", *updates.ConfigYAML)
+	}
+
+	// 6. Add a second lighthouse — peer must pick up both on the next poll.
+	_, _, _ = enrollHost(t, ts, network.ID, "lh-2", "192.168.50.2", map[string]any{
+		"role":        "lighthouse",
+		"public_ip":   "203.0.113.20",
+		"listen_port": 4242,
+	})
+	updates = pollAgent(t, ts, peerFP)
+	if updates.ConfigYAML == nil {
+		t.Fatal("peer poll after second lighthouse: ConfigYAML is nil")
+	}
+	for _, want := range []string{"192.168.50.1", "192.168.50.2", "203.0.113.10:4242", "203.0.113.20:4242"} {
+		if !strings.Contains(*updates.ConfigYAML, want) {
+			t.Errorf("peer config missing %q:\n%s", want, *updates.ConfigYAML)
+		}
+	}
+
+	// 7. Block one lighthouse. Peer's next poll must see a config without the
+	// blocked lighthouse.
+	resp = apiCall(t, ts, "GET", "/api/v1/hosts?network_id="+network.ID, nil)
+	var allHosts []models.Host
+	if err := json.NewDecoder(resp.Body).Decode(&allHosts); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	var lh2ID string
+	for _, h := range allHosts {
+		if h.Name == "lh-2" {
+			lh2ID = h.ID
+		}
+	}
+	if lh2ID == "" {
+		t.Fatal("lh-2 not found in host list")
+	}
+	resp = apiCall(t, ts, "POST", "/api/v1/hosts/"+lh2ID+"/block", nil)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("block lh-2: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	resp.Body.Close()
+
+	updates = pollAgent(t, ts, peerFP)
+	if updates.ConfigYAML == nil {
+		t.Fatal("peer poll after lighthouse block: ConfigYAML is nil")
+	}
+	if strings.Contains(*updates.ConfigYAML, "203.0.113.20:4242") {
+		t.Errorf("peer config still references blocked lighthouse public addr:\n%s", *updates.ConfigYAML)
+	}
+	if !strings.Contains(*updates.ConfigYAML, "203.0.113.10:4242") {
+		t.Errorf("peer config missing surviving lighthouse:\n%s", *updates.ConfigYAML)
 	}
 }


### PR DESCRIPTION
## Summary

- Resolve a network's enrolled `role: lighthouse` hosts from the store on enrollment **and** on every agent poll, so operators no longer wire lighthouse IPs into each peer by hand.
- Filter `getLighthouses` by `status=enrolled` — `pending` and `blocked` lighthouses never leak into peer configs.
- Bump `networks.config_version` inside the same transaction whenever a lighthouse goes live (`SaveCertificateAndEnrollHost`), gets blocked, or is deleted; the agent updates handler ships a re-rendered `config.yml` to peers whose `hosts.config_version` drifted, then pins them to the new version.

Closes #39.

## Test plan

- [x] `go test -race ./...` — including new store unit tests (`TestSaveCertificateAndEnrollHost_BumpsLighthouseVersion`, …) and an end-to-end scenario `TestE2E_LighthouseAutoAssignment` that adds/blocks lighthouses and watches a peer's polls.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] README *Roadmap* updated; `docs/agent.md` gains a *Lighthouse routing is automatic* note.