### PR TITLE
feat(alerts): cert-expiry alerter with audit + webhook sinks (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Nebula gives you a fast, mTLS-authenticated overlay network. But on its own, it 
 - **Per-host advanced overrides** — `listen_host`, `mtu`, `tun_device`, `punchy`, `unsafe_routes` opt-in per host without touching the network default.
 - **Audit trail** — every mutating UI / API / CLI call is recorded with actor, action, target, plus a stable `ca_id` on host events.
 - **Per-network firewall rules** — managed declaratively via API, distributed to all hosts.
-- **Production-ready basics** — `/healthz`, `/readyz`, Prometheus exporter at `/metrics` (legacy `expvar` view at `/debug/vars`), structured `slog` logs, optional in-process TLS, SQLite (WAL) with tracked migrations.
+- **Production-ready basics** — `/healthz`, `/readyz`, Prometheus exporter at `/metrics` (legacy `expvar` view at `/debug/vars`), built-in cert-expiry alerter (audit + webhook + per-host Prometheus gauge), structured `slog` logs, optional in-process TLS, SQLite (WAL) with tracked migrations.
 - **Tiny footprint** — two static binaries (~15–25 MiB each), SQLite, no external deps. Runs on a $5 VM.
 
 ## Architecture
@@ -323,7 +323,6 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 
 Open issues tracked individually so you can subscribe to the ones you care about:
 
-- [#41](https://github.com/juev/nebula-mesh/issues/41) — Built-in cert-expiry alerts (audit + webhook + metric)
 - [#42](https://github.com/juev/nebula-mesh/issues/42) — Bootstrap recipes (Terraform module, Ansible roles, cloud-init samples)
 - [#43](https://github.com/juev/nebula-mesh/issues/43) — Web UI: live host status via SSE (today: htmx polling on a 30s interval)
 

--- a/configs/server.example.yml
+++ b/configs/server.example.yml
@@ -22,6 +22,28 @@ master_key: ""
 # calling POST /api/v1/operators) can add operators in a closed deployment.
 allow_self_registration: false
 
+# Optional /metrics Prometheus exporter. Defaults to enabled; set false in
+# air-gapped deployments to drop the route. Legacy Go expvar stays on
+# /debug/vars regardless.
+# metrics:
+#   prometheus: true
+
+# Cert-expiry alerter (issue #41). Disabled by default. When enabled, a
+# periodic scanner fans out alerts for hosts whose current certificate
+# expires inside `threshold` and that have not yet been alerted.
+#
+# Sinks:
+#   - audit log entry with action="cert.expiring" (always on when enabled)
+#   - HTTPS webhook (optional) — POSTs JSON, HMAC-SHA256 signed via the
+#     X-Nebula-Signature: sha256=<hex> header when `webhook_hmac_secret` is set.
+#
+# alerts:
+#   enabled: true
+#   interval: "5m"
+#   threshold: "72h"
+#   webhook_url: "https://alertmanager.example.com/api/v2/alerts"
+#   webhook_hmac_secret: "change-me"
+
 # Optional OpenID Connect identity provider for operator login. When enabled,
 # the Web UI offers a "Sign in with SSO" button on top of the local password
 # form. Local logins keep working alongside OIDC.

--- a/internal/alerts/scanner.go
+++ b/internal/alerts/scanner.go
@@ -1,0 +1,147 @@
+// Package alerts implements the cert-expiry alerter: a periodic scanner that
+// detects host certificates approaching their expiry without having been
+// auto-renewed and fans the event out to one or more sinks (audit log,
+// webhook, Prometheus gauge).
+//
+// State lives in the cert_alerts table — one row per host — so a given
+// (host, not_after) pair fires at most once even if the scan tick fires
+// many times before someone rotates the cert.
+package alerts
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// Alert is the structured event a Sink receives.
+type Alert struct {
+	HostID             string
+	HostName           string
+	NetworkID          string
+	CAID               string
+	Fingerprint        string
+	NotAfter           time.Time
+	SecondsUntilExpiry float64
+}
+
+// Sink is the interface implemented by alert delivery backends — audit log,
+// webhook, Prometheus gauge, etc. A sink's Notify call is expected to be
+// fast and best-effort; the scanner records the alert as fired regardless
+// of individual sink failures so a flaky webhook does not block the audit
+// log entry or trigger duplicate delivery on the next scan tick.
+type Sink interface {
+	Notify(ctx context.Context, a Alert) error
+}
+
+// Scanner is a periodic cert-expiry watchdog. Wire one up at server start,
+// call StartLoop with a cancellable context, and it ticks every Interval
+// until the context is cancelled.
+type Scanner struct {
+	Store     store.Store
+	Threshold time.Duration
+	Interval  time.Duration
+	Sinks     []Sink
+	Logger    *slog.Logger
+}
+
+// Run performs a single sweep: enumerate enrolled hosts' current certs,
+// filter to those whose remaining lifetime is shorter than Threshold, and
+// emit one Alert per (host, not_after) pair that has not yet been alerted.
+//
+// Errors from individual sinks are logged but do not stop the loop; the
+// dedup record is still written so retries happen at the next threshold
+// crossing (cert rotation) rather than every tick.
+func (s *Scanner) Run(ctx context.Context) error {
+	certs, err := s.Store.ListEnrolledHostCerts(ctx)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	cutoff := now.Add(s.Threshold)
+	for _, ci := range certs {
+		if ci.NotAfter.After(cutoff) {
+			continue
+		}
+
+		prev, getErr := s.Store.GetCertAlert(ctx, ci.HostID)
+		if getErr != nil && !errors.Is(getErr, store.ErrNotFound) {
+			s.logger().Error("get prior cert alert", "host", ci.HostID, "error", getErr)
+			continue
+		}
+		if getErr == nil && prev.Equal(ci.NotAfter) {
+			// Already alerted for this exact expiry instant — wait for
+			// rotation (which mints a new not_after) or cert removal.
+			continue
+		}
+
+		host, hostErr := s.Store.GetHost(ctx, ci.HostID)
+		if hostErr != nil {
+			s.logger().Error("get host for alert", "host", ci.HostID, "error", hostErr)
+			continue
+		}
+		// Defence in depth: ListEnrolledHostCerts already filters by
+		// status=enrolled, but a host may have been blocked/deleted
+		// between that query and this loop iteration.
+		if host.Status != models.HostStatusEnrolled {
+			continue
+		}
+
+		alert := Alert{
+			HostID:             host.ID,
+			HostName:           host.Name,
+			NetworkID:          host.NetworkID,
+			CAID:               host.CAID,
+			Fingerprint:        ci.Fingerprint,
+			NotAfter:           ci.NotAfter,
+			SecondsUntilExpiry: ci.NotAfter.Sub(now).Seconds(),
+		}
+
+		for _, sink := range s.Sinks {
+			if err := sink.Notify(ctx, alert); err != nil {
+				s.logger().Error("alert sink", "host", host.ID, "error", err)
+			}
+		}
+
+		if err := s.Store.RecordCertAlert(ctx, host.ID, ci.NotAfter); err != nil {
+			s.logger().Error("record cert alert", "host", host.ID, "error", err)
+		}
+	}
+	return nil
+}
+
+// StartLoop runs Scan immediately, then on every Interval tick until ctx is
+// cancelled. Returns once the loop exits.
+func (s *Scanner) StartLoop(ctx context.Context) {
+	interval := s.Interval
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	if err := s.Run(ctx); err != nil {
+		s.logger().Error("initial cert-expiry scan", "error", err)
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.Run(ctx); err != nil {
+				s.logger().Error("cert-expiry scan", "error", err)
+			}
+		}
+	}
+}
+
+func (s *Scanner) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.Default()
+}

--- a/internal/alerts/scanner_test.go
+++ b/internal/alerts/scanner_test.go
@@ -1,0 +1,214 @@
+package alerts
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// recordingSink captures every alert it sees so tests can inspect them.
+type recordingSink struct {
+	mu     sync.Mutex
+	events []Alert
+	err    error
+}
+
+func (r *recordingSink) Notify(_ context.Context, a Alert) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, a)
+	return r.err
+}
+
+func (r *recordingSink) snapshot() []Alert {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]Alert, len(r.events))
+	copy(cp, r.events)
+	return cp
+}
+
+func newTestStore(t *testing.T) store.Store {
+	t.Helper()
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func seedNetwork(t *testing.T, s store.Store) string {
+	t.Helper()
+	n := &models.Network{
+		ID:        "net_test",
+		Name:      "test",
+		CIDR:      "192.168.0.0/16",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(context.Background(), n); err != nil {
+		t.Fatal(err)
+	}
+	return n.ID
+}
+
+func seedEnrolledHost(t *testing.T, s store.Store, id, netID string, fp string, notBefore, notAfter time.Time) *models.Host {
+	t.Helper()
+	h := &models.Host{
+		ID:        id,
+		NetworkID: netID,
+		Name:      id,
+		NebulaIP:  "192.168.1." + id,
+		Groups:    []string{},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveCertificateAndEnrollHost(context.Background(), h.ID, []byte("dummy"), fp, notBefore, notAfter); err != nil {
+		t.Fatal(err)
+	}
+	h.Status = models.HostStatusEnrolled
+	h.CertFingerprint = fp
+	return h
+}
+
+func TestScanner_NoExpiringCerts_NoAlerts(t *testing.T) {
+	s := newTestStore(t)
+	netID := seedNetwork(t, s)
+	seedEnrolledHost(t, s, "h1", netID, "fp1", time.Now(), time.Now().Add(30*24*time.Hour))
+
+	sink := &recordingSink{}
+	sc := &Scanner{Store: s, Threshold: 24 * time.Hour, Sinks: []Sink{sink}, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := sc.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := sink.snapshot(); len(got) != 0 {
+		t.Errorf("expected no alerts, got %d: %+v", len(got), got)
+	}
+}
+
+func TestScanner_ExpiringCert_EmitsOnce(t *testing.T) {
+	s := newTestStore(t)
+	netID := seedNetwork(t, s)
+	expiry := time.Now().Add(2 * time.Hour)
+	seedEnrolledHost(t, s, "h1", netID, "fp1", time.Now(), expiry)
+
+	sink := &recordingSink{}
+	sc := &Scanner{Store: s, Threshold: 24 * time.Hour, Sinks: []Sink{sink}, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := sc.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	got := sink.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("first scan: got %d alerts, want 1: %+v", len(got), got)
+	}
+	if got[0].HostID != "h1" {
+		t.Errorf("host_id = %q, want h1", got[0].HostID)
+	}
+	if got[0].SecondsUntilExpiry <= 0 || got[0].SecondsUntilExpiry > 3*60*60 {
+		t.Errorf("seconds_until_expiry = %f, want ~7200s", got[0].SecondsUntilExpiry)
+	}
+
+	// Second scan with the same cert must not re-emit.
+	if err := sc.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := sink.snapshot(); len(got) != 1 {
+		t.Errorf("second scan: got %d alerts, want 1 (dedup)", len(got))
+	}
+}
+
+func TestScanner_CertRotated_AlertsAgain(t *testing.T) {
+	s := newTestStore(t)
+	netID := seedNetwork(t, s)
+	expiry := time.Now().Add(2 * time.Hour)
+	seedEnrolledHost(t, s, "h1", netID, "fp1", time.Now(), expiry)
+
+	sink := &recordingSink{}
+	sc := &Scanner{Store: s, Threshold: 24 * time.Hour, Sinks: []Sink{sink}, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := sc.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := sink.snapshot(); len(got) != 1 {
+		t.Fatalf("first scan: got %d, want 1", len(got))
+	}
+
+	// Rotate cert — but keep it inside the threshold so the scanner still cares.
+	newExpiry := time.Now().Add(3 * time.Hour)
+	if err := s.SaveCertificateAndUpdateHostCert(context.Background(), "h1", []byte("dummy2"), "fp2", time.Now(), newExpiry); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sc.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := sink.snapshot(); len(got) != 2 {
+		t.Errorf("after rotation: got %d alerts, want 2 (re-alert on new not_after)", len(got))
+	}
+}
+
+func TestScanner_BlockedHost_Excluded(t *testing.T) {
+	s := newTestStore(t)
+	netID := seedNetwork(t, s)
+	expiry := time.Now().Add(2 * time.Hour)
+	seedEnrolledHost(t, s, "h1", netID, "fp1", time.Now(), expiry)
+	if _, err := s.BlockHostAndAddToBlocklist(context.Background(), "h1", "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	sink := &recordingSink{}
+	sc := &Scanner{Store: s, Threshold: 24 * time.Hour, Sinks: []Sink{sink}, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := sc.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := sink.snapshot(); len(got) != 0 {
+		t.Errorf("blocked host: got %d alerts, want 0", len(got))
+	}
+}
+
+func TestScanner_SinkFailureDoesNotStopOthers(t *testing.T) {
+	s := newTestStore(t)
+	netID := seedNetwork(t, s)
+	seedEnrolledHost(t, s, "h1", netID, "fp1", time.Now(), time.Now().Add(2*time.Hour))
+
+	failing := &recordingSink{err: errors.New("boom")}
+	good := &recordingSink{}
+	sc := &Scanner{
+		Store:     s,
+		Threshold: 24 * time.Hour,
+		Sinks:     []Sink{failing, good},
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	if err := sc.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(failing.snapshot()) != 1 {
+		t.Errorf("failing sink should still see the event once")
+	}
+	if len(good.snapshot()) != 1 {
+		t.Errorf("good sink should still see the event despite failing sink")
+	}
+
+	// And dedup should still kick in on a second scan: one sink failed,
+	// but the alert was recorded as fired so we don't re-emit.
+	if err := sc.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(good.snapshot()) != 1 {
+		t.Errorf("second scan: good sink should still see exactly 1 alert, got %d", len(good.snapshot()))
+	}
+}

--- a/internal/alerts/sinks.go
+++ b/internal/alerts/sinks.go
@@ -1,0 +1,107 @@
+package alerts
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// Audit action emitted by the cert-expiry alerter. Kept here as a constant
+// so receivers (parsers, dashboards) can match against a stable identifier.
+const AuditActionCertExpiring = "cert.expiring"
+
+// AuditSink writes each Alert to the store's audit log as a structured
+// `cert.expiring` entry. Always-on by design: the audit log is the
+// no-config-required fallback documented in the issue.
+type AuditSink struct {
+	Store store.Store
+}
+
+// Notify appends an audit entry whose details field is a small JSON blob —
+// enough for `/api/v1/audit-log` consumers to extract host_id, ca_id,
+// not_after, and seconds_until_expiry without a join.
+func (a *AuditSink) Notify(ctx context.Context, ev Alert) error {
+	body := map[string]any{
+		"host_id":              ev.HostID,
+		"host_name":            ev.HostName,
+		"network_id":           ev.NetworkID,
+		"ca_id":                ev.CAID,
+		"fingerprint":          ev.Fingerprint,
+		"not_after":            ev.NotAfter.UTC().Format(time.RFC3339),
+		"seconds_until_expiry": strconv.FormatFloat(ev.SecondsUntilExpiry, 'f', 0, 64),
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal audit details: %w", err)
+	}
+	return a.Store.AddAuditEntry(ctx, "cert-expiry-alerter", AuditActionCertExpiring, ev.HostID, string(raw))
+}
+
+// WebhookSink POSTs every alert as JSON to URL with an HMAC-SHA256 signature
+// in the X-Nebula-Signature header (sha256=<hex>). If HMACSecret is empty,
+// the signature header is omitted — useful for trusted-internal alertmanager
+// endpoints behind mTLS where signing is redundant.
+type WebhookSink struct {
+	URL        string
+	HMACSecret string
+	HTTPClient *http.Client
+}
+
+// SignatureHeader is the HTTP header webhook receivers should inspect to
+// authenticate the request body. Exported for documentation tests.
+const SignatureHeader = "X-Nebula-Signature"
+
+func (w *WebhookSink) Notify(ctx context.Context, ev Alert) error {
+	payload, err := json.Marshal(map[string]any{
+		"host_id":              ev.HostID,
+		"host_name":            ev.HostName,
+		"network_id":           ev.NetworkID,
+		"ca_id":                ev.CAID,
+		"fingerprint":          ev.Fingerprint,
+		"not_after":            ev.NotAfter.UTC().Format(time.RFC3339),
+		"seconds_until_expiry": ev.SecondsUntilExpiry,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.URL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if w.HMACSecret != "" {
+		mac := hmac.New(sha256.New, []byte(w.HMACSecret))
+		mac.Write(payload)
+		req.Header.Set(SignatureHeader, "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	}
+
+	client := w.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook POST: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			// nothing meaningful to do — drain failed but the upstream
+			// status was already captured.
+			_ = err
+		}
+	}()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("webhook returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/alerts/sinks_test.go
+++ b/internal/alerts/sinks_test.go
@@ -1,0 +1,140 @@
+package alerts
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+func TestAuditSink_WritesEntry(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	netID := seedNetwork(t, s)
+	seedEnrolledHost(t, s, "ha", netID, "fp", time.Now(), time.Now().Add(2*time.Hour))
+
+	sink := &AuditSink{Store: s}
+	ev := Alert{
+		HostID:             "ha",
+		HostName:           "ha",
+		NetworkID:          netID,
+		CAID:               "ca-test",
+		Fingerprint:        "fp",
+		NotAfter:           time.Now().Add(2 * time.Hour),
+		SecondsUntilExpiry: 7200,
+	}
+	if err := sink.Notify(ctx, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := s.ListAuditEntries(ctx, store.AuditFilter{Action: AuditActionCertExpiring, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("audit entries: got %d, want 1", len(entries))
+	}
+	if entries[0].Action != AuditActionCertExpiring {
+		t.Errorf("action = %q, want %q", entries[0].Action, AuditActionCertExpiring)
+	}
+	if entries[0].Resource != "ha" {
+		t.Errorf("resource = %q, want host id", entries[0].Resource)
+	}
+	if !strings.Contains(entries[0].Details, `"ca_id":"ca-test"`) {
+		t.Errorf("details missing ca_id: %s", entries[0].Details)
+	}
+}
+
+func TestWebhookSink_PostsSignedPayload(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		gotBody []byte
+		gotSig  string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotBody = body
+		gotSig = r.Header.Get(SignatureHeader)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := &WebhookSink{URL: srv.URL, HMACSecret: "shh", HTTPClient: srv.Client()}
+	ev := Alert{
+		HostID:             "h1",
+		HostName:           "name-1",
+		NetworkID:          "n1",
+		CAID:               "ca-1",
+		Fingerprint:        "fp-1",
+		NotAfter:           time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		SecondsUntilExpiry: 3600,
+	}
+	if err := sink.Notify(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(gotBody) == 0 {
+		t.Fatal("webhook receiver got no body")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(gotBody, &decoded); err != nil {
+		t.Fatalf("invalid JSON body: %v\n%s", err, string(gotBody))
+	}
+	if decoded["host_id"] != "h1" {
+		t.Errorf("host_id = %v, want h1", decoded["host_id"])
+	}
+	if decoded["not_after"] != "2026-06-01T00:00:00Z" {
+		t.Errorf("not_after = %v, want 2026-06-01T00:00:00Z", decoded["not_after"])
+	}
+
+	expectMAC := hmac.New(sha256.New, []byte("shh"))
+	expectMAC.Write(gotBody)
+	want := "sha256=" + hex.EncodeToString(expectMAC.Sum(nil))
+	if gotSig != want {
+		t.Errorf("signature header = %q, want %q", gotSig, want)
+	}
+}
+
+func TestWebhookSink_NoSecret_NoSignature(t *testing.T) {
+	var sig string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sig = r.Header.Get(SignatureHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := &WebhookSink{URL: srv.URL, HTTPClient: srv.Client()}
+	if err := sink.Notify(context.Background(), Alert{HostID: "h", NotAfter: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if sig != "" {
+		t.Errorf("expected no signature header when secret is empty, got %q", sig)
+	}
+}
+
+func TestWebhookSink_ReceiverError_PropagatesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	sink := &WebhookSink{URL: srv.URL, HTTPClient: srv.Client()}
+	err := sink.Notify(context.Background(), Alert{HostID: "h", NotAfter: time.Now()})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("expected error mentioning HTTP 500, got %v", err)
+	}
+}

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -232,9 +232,10 @@ func (m *metrics) recordSignature(caID string) {
 // The collector is queried on every Prometheus scrape, so the work is bounded
 // by the scrape cadence (typically 15-60s) and the host/cert table sizes.
 type storeCollector struct {
-	store store.Store
-	hosts *prometheus.Desc
-	exp   *prometheus.Desc
+	store    store.Store
+	hosts    *prometheus.Desc
+	exp      *prometheus.Desc
+	perHost  *prometheus.Desc
 }
 
 func newStoreCollector(s store.Store) *storeCollector {
@@ -250,12 +251,18 @@ func newStoreCollector(s store.Store) *storeCollector {
 			"Seconds remaining until the soonest-to-expire enrolled certificate.",
 			nil, nil,
 		),
+		perHost: prometheus.NewDesc(
+			"nebula_mgmt_cert_expiring_seconds",
+			"Seconds remaining until the current certificate of each enrolled host expires.",
+			[]string{"host", "network"}, nil,
+		),
 	}
 }
 
 func (c *storeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.hosts
 	ch <- c.exp
+	ch <- c.perHost
 }
 
 func (c *storeCollector) Collect(ch chan<- prometheus.Metric) {
@@ -278,16 +285,32 @@ func (c *storeCollector) Collect(ch chan<- prometheus.Metric) {
 	// Soonest-cert-expiry gauge: wall-clock seconds remaining until the
 	// soonest-to-expire enrolled certificate. Negative values mean the cert
 	// has already expired. Reports +Inf when no certs exist so absence is
-	// distinguishable from "expiring now".
+	// distinguishable from "expiring now". Also emits a per-host
+	// nebula_mgmt_cert_expiring_seconds{host, network} so alerting rules
+	// can target individual hosts (see issue #41 Prometheus sink).
 	seconds := math.Inf(1)
-	if certs, err := c.store.ListEnrolledHostCerts(ctx); err == nil && len(certs) > 0 {
-		soonest := certs[0].NotAfter
-		for _, ci := range certs[1:] {
-			if ci.NotAfter.Before(soonest) {
+	if certs, err := c.store.ListEnrolledHostCerts(ctx); err == nil {
+		hostNetwork := map[string]string{}
+		if hosts, herr := c.store.ListHosts(ctx, store.HostFilter{}); herr == nil {
+			for _, h := range hosts {
+				hostNetwork[h.ID] = h.NetworkID
+			}
+		}
+
+		soonest := time.Time{}
+		for _, ci := range certs {
+			remaining := time.Until(ci.NotAfter).Seconds()
+			ch <- prometheus.MustNewConstMetric(
+				c.perHost, prometheus.GaugeValue, remaining,
+				ci.HostID, hostNetwork[ci.HostID],
+			)
+			if soonest.IsZero() || ci.NotAfter.Before(soonest) {
 				soonest = ci.NotAfter
 			}
 		}
-		seconds = time.Until(soonest).Seconds()
+		if !soonest.IsZero() {
+			seconds = time.Until(soonest).Seconds()
+		}
 	}
 	ch <- prometheus.MustNewConstMetric(c.exp, prometheus.GaugeValue, seconds)
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/juev/nebula-mesh/internal/alerts"
 	"github.com/juev/nebula-mesh/internal/api"
 	"github.com/juev/nebula-mesh/internal/config"
 	"github.com/juev/nebula-mesh/internal/keystore"
@@ -198,6 +199,32 @@ func Serve(configPath string) error {
 
 	// Start session cleanup (stops on ctx cancel)
 	webUI.StartSessionCleanup(ctx)
+
+	// Cert-expiry alerter — periodic scan that fans alerts out to audit log
+	// and (optionally) a webhook. Disabled by default; opt in via the
+	// `alerts` block in server config.
+	if cfg.Alerts.Enabled {
+		sinks := []alerts.Sink{&alerts.AuditSink{Store: s}}
+		if cfg.Alerts.WebhookURL != "" {
+			sinks = append(sinks, &alerts.WebhookSink{
+				URL:        cfg.Alerts.WebhookURL,
+				HMACSecret: cfg.Alerts.WebhookHMACSecret,
+			})
+		}
+		scanner := &alerts.Scanner{
+			Store:     s,
+			Threshold: cfg.Alerts.ThresholdDuration(),
+			Interval:  cfg.Alerts.IntervalDuration(),
+			Sinks:     sinks,
+			Logger:    logger,
+		}
+		go scanner.StartLoop(ctx)
+		logger.Info("cert-expiry alerter enabled",
+			"interval", scanner.Interval,
+			"threshold", scanner.Threshold,
+			"webhook", cfg.Alerts.WebhookURL != "",
+		)
+	}
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -35,6 +36,46 @@ type ServerConfig struct {
 	// is "enabled" so out-of-the-box installs can be scraped immediately;
 	// air-gapped deployments can set Prometheus=false to drop the route.
 	Metrics MetricsConfig `yaml:"metrics,omitempty"`
+
+	// Alerts configures the cert-expiry alerter (see issue #41). Disabled
+	// by default — operators must opt in by setting Enabled=true.
+	Alerts AlertsConfig `yaml:"alerts,omitempty"`
+}
+
+// AlertsConfig drives the periodic cert-expiry scanner and its sinks.
+// Threshold and Interval are parsed as Go durations (e.g. "72h", "5m").
+type AlertsConfig struct {
+	Enabled           bool   `yaml:"enabled,omitempty"`
+	Interval          string `yaml:"interval,omitempty"`
+	Threshold         string `yaml:"threshold,omitempty"`
+	WebhookURL        string `yaml:"webhook_url,omitempty"`
+	WebhookHMACSecret string `yaml:"webhook_hmac_secret,omitempty"`
+}
+
+// IntervalDuration returns Interval as a time.Duration. Falls back to 5m
+// when unset or unparseable, matching the documented default.
+func (a AlertsConfig) IntervalDuration() time.Duration {
+	if a.Interval == "" {
+		return 5 * time.Minute
+	}
+	d, err := time.ParseDuration(a.Interval)
+	if err != nil || d <= 0 {
+		return 5 * time.Minute
+	}
+	return d
+}
+
+// ThresholdDuration returns Threshold as a time.Duration. Falls back to 72h
+// (three days) when unset or unparseable, matching the documented default.
+func (a AlertsConfig) ThresholdDuration() time.Duration {
+	if a.Threshold == "" {
+		return 72 * time.Hour
+	}
+	d, err := time.ParseDuration(a.Threshold)
+	if err != nil || d <= 0 {
+		return 72 * time.Hour
+	}
+	return d
 }
 
 // MetricsConfig toggles the Prometheus exporter. Legacy Go expvar stays on

--- a/internal/store/migrations/010_cert_alerts.down.sql
+++ b/internal/store/migrations/010_cert_alerts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS cert_alerts;

--- a/internal/store/migrations/010_cert_alerts.up.sql
+++ b/internal/store/migrations/010_cert_alerts.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS cert_alerts (
+    host_id            TEXT PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
+    alerted_not_after  DATETIME NOT NULL,
+    alerted_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -84,6 +84,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"007_operator_oidc.up.sql",
 		"008_host_advanced.up.sql",
 		"009_per_operator_cas.up.sql",
+		"010_cert_alerts.up.sql",
 	}
 
 	// Tracking table. Created once; idempotent on subsequent starts.
@@ -1091,6 +1092,37 @@ func (s *SQLiteStore) GetBlocklist(_ context.Context) ([]string, error) {
 		result = append(result, fp)
 	}
 	return result, rows.Err()
+}
+
+// --- Cert-expiry alert dedup ---
+
+// RecordCertAlert upserts the (host_id, alerted_not_after) tuple so subsequent
+// scans for the same cert do not re-emit the alert. Update alerted_at to now
+// on every call so dashboards can show "last fired" times.
+func (s *SQLiteStore) RecordCertAlert(_ context.Context, hostID string, alertedNotAfter time.Time) error {
+	_, err := s.db.Exec(
+		`INSERT INTO cert_alerts (host_id, alerted_not_after, alerted_at) VALUES (?, ?, ?)
+		 ON CONFLICT(host_id) DO UPDATE SET alerted_not_after = excluded.alerted_not_after, alerted_at = excluded.alerted_at`,
+		hostID, alertedNotAfter, time.Now(),
+	)
+	if err != nil {
+		return fmt.Errorf("record cert alert: %w", err)
+	}
+	return nil
+}
+
+// GetCertAlert returns the alerted_not_after recorded for hostID, or
+// ErrNotFound when no alert has been recorded yet.
+func (s *SQLiteStore) GetCertAlert(_ context.Context, hostID string) (time.Time, error) {
+	var t time.Time
+	err := s.db.QueryRow(`SELECT alerted_not_after FROM cert_alerts WHERE host_id = ?`, hostID).Scan(&t)
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, ErrNotFound
+	}
+	if err != nil {
+		return time.Time{}, fmt.Errorf("get cert alert: %w", err)
+	}
+	return t, nil
 }
 
 // --- Config Versioning ---

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1510,6 +1510,55 @@ func TestDeleteHostAndBlockCert_BumpsForEnrolledLighthouse(t *testing.T) {
 	}
 }
 
+// --- Cert-expiry alert dedup ---
+
+func TestCertAlerts_RecordAndGet(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	h := &models.Host{
+		ID: "host_alert", NetworkID: net.ID, Name: "alertable",
+		NebulaIP: "192.168.100.50", Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+
+	// No alert yet → ErrNotFound.
+	if _, err := s.GetCertAlert(ctx, h.ID); err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound before any alert, got %v", err)
+	}
+
+	notAfter := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	if err := s.RecordCertAlert(ctx, h.ID, notAfter); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetCertAlert(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(notAfter) {
+		t.Errorf("alerted_not_after = %v, want %v", got, notAfter)
+	}
+
+	// Upsert: same host, new not_after.
+	notAfter2 := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	if err := s.RecordCertAlert(ctx, h.ID, notAfter2); err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.GetCertAlert(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(notAfter2) {
+		t.Errorf("after upsert, alerted_not_after = %v, want %v", got, notAfter2)
+	}
+}
+
 func TestDeleteHostAndBlockCert_NoBumpForRegularHost(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -85,6 +85,13 @@ type Store interface {
 	AddAuditEntry(ctx context.Context, actor, action, resource, details string) error
 	ListAuditEntries(ctx context.Context, filter AuditFilter) ([]*models.AuditEntry, error)
 
+	// Cert-expiry alert dedup state. RecordCertAlert remembers that an
+	// alert was emitted for the given host whose current cert expires at
+	// alertedNotAfter; GetCertAlert returns the previously alerted
+	// not_after, or ErrNotFound if no alert has been recorded yet.
+	RecordCertAlert(ctx context.Context, hostID string, alertedNotAfter time.Time) error
+	GetCertAlert(ctx context.Context, hostID string) (time.Time, error)
+
 	// Operators
 	CreateOperator(ctx context.Context, op *models.Operator) error
 	GetOperator(ctx context.Context, id string) (*models.Operator, error)


### PR DESCRIPTION
## Summary

- Periodic cert-expiry scanner (default 5m interval, 72h threshold) emits at most one alert per (host, not_after) tuple.
- Audit sink writes a structured \`cert.expiring\` log entry (always on); webhook sink posts JSON to a configurable URL with HMAC-SHA256 signature in \`X-Nebula-Signature\`.
- Per-host Prometheus gauge \`nebula_mgmt_cert_expiring_seconds{host, network}\` enables Alertmanager-style rules per host.
- New \`cert_alerts\` table holds dedup state; cert rotation mints a new NotAfter and re-opens the alert window.

Closes #41.

## Test plan

- [x] \`go test -race ./...\` — new package \`internal/alerts\` covers: no expiring, expiring fires once, dedup, rotation re-alerts, blocked host excluded, sink failure does not stop others, audit sink writes entries, webhook signs payload + propagates HTTP 500.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [x] README *Features* updated; \`configs/server.example.yml\` documents the \`alerts:\` block.