### PR TITLE
docs: bootstrap recipes — Terraform, Ansible, cloud-init (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,9 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 
 Open issues tracked individually so you can subscribe to the ones you care about:
 
-- [#42](https://github.com/juev/nebula-mesh/issues/42) — Bootstrap recipes (Terraform module, Ansible roles, cloud-init samples)
 - [#43](https://github.com/juev/nebula-mesh/issues/43) — Web UI: live host status via SSE (today: htmx polling on a 30s interval)
 
-Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, distro packages (deb/rpm) and the cross-platform agent build matrix.
+Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), distro packages (deb/rpm) and the cross-platform agent build matrix.
 
 Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/deploy/ansible/examples/inventory.example.ini
+++ b/deploy/ansible/examples/inventory.example.ini
@@ -1,0 +1,9 @@
+; Pair this with site.yml. Replace the addresses with your own.
+
+[nebula_mgmt]
+mgmt-1.internal.example.com ansible_user=ubuntu
+
+[nebula_agents]
+edge-1.internal.example.com ansible_user=ubuntu
+edge-2.internal.example.com ansible_user=ubuntu
+edge-3.internal.example.com ansible_user=almalinux

--- a/deploy/ansible/examples/site.yml
+++ b/deploy/ansible/examples/site.yml
@@ -1,0 +1,39 @@
+---
+# Worked example: bootstrap a management server and a fleet of agents.
+#
+# Secrets are pulled from Ansible Vault — the example assumes you keep a
+# `group_vars/nebula_mgmt/vault.yml` and a host-scoped `vault.yml` per
+# agent with `nebula_agent_enroll_token` defined.
+#
+# Run with:
+#   ansible-playbook -i inventory.ini site.yml --ask-vault-pass
+
+- name: Bootstrap nebula-mgmt
+  hosts: nebula_mgmt
+  become: true
+  roles:
+    - role: nebula_mgmt
+      vars:
+        nebula_mgmt_release: "v0.3.0"
+        nebula_mgmt_tls_cert: /etc/nebula-mgmt/tls/fullchain.pem
+        nebula_mgmt_tls_key:  /etc/nebula-mgmt/tls/privkey.pem
+        # Pulled from Vault — never hard-code these.
+        nebula_mgmt_master_key:      "{{ vault_nebula_mgmt_master_key }}"
+        nebula_mgmt_ca_passphrase:   "{{ vault_nebula_mgmt_ca_passphrase }}"
+        nebula_mgmt_alerts_enabled:  true
+        nebula_mgmt_alerts_threshold: "72h"
+        nebula_mgmt_alerts_webhook_url: "https://alertmanager.example.com/api/v2/alerts"
+        nebula_mgmt_alerts_webhook_hmac_secret: "{{ vault_nebula_alerts_hmac }}"
+
+- name: Enrol nebula agents
+  hosts: nebula_agents
+  become: true
+  roles:
+    - role: nebula_agent
+      vars:
+        nebula_agent_release:     "v0.3.0"
+        nebula_agent_server_url:  "https://mgmt.internal.example.com:8080"
+        # `nebula_agent_enroll_token` MUST be set per-host. Either:
+        #   - keep it in host_vars/<hostname>/vault.yml, or
+        #   - mint it just-in-time with a delegated nebula-mgmt CLI call.
+        nebula_agent_enroll_token: "{{ vault_nebula_agent_enroll_token }}"

--- a/deploy/ansible/roles/nebula_agent/README.md
+++ b/deploy/ansible/roles/nebula_agent/README.md
@@ -1,0 +1,27 @@
+# Ansible role: `nebula_agent`
+
+Installs the per-host `nebula-agent` from the published `.deb` / `.rpm`,
+writes `agent.yml`, runs `nebula-agent enroll` once (idempotent — guarded
+by `data_dir/.fingerprint`), and enables `nebula-agent.service`.
+
+The role does **not** mint enrolment tokens; pass each host its token via
+a per-host variable (typically pulled from Ansible Vault or a secret
+manager).
+
+## Required variables
+
+| Variable | Purpose |
+|---|---|
+| `nebula_agent_server_url` | Base URL of the management server. |
+| `nebula_agent_enroll_token` | Per-host one-shot enrolment token. |
+
+## Common optional variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `nebula_agent_release` | `latest` | Git tag to install. |
+| `nebula_agent_data_dir` | `/etc/nebula` | Where host.crt/host.key/ca.crt/config.yml/.fingerprint live. |
+| `nebula_agent_poll_interval` | `30s` | How often to ask the server for updates. |
+| `nebula_agent_nebula_pid_file` | `/run/nebula.pid` | SIGHUP'd on changes (empty disables reload signal). |
+
+See [`defaults/main.yml`](defaults/main.yml).

--- a/deploy/ansible/roles/nebula_agent/defaults/main.yml
+++ b/deploy/ansible/roles/nebula_agent/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+nebula_agent_release: "latest"
+nebula_agent_server_url: ""
+nebula_agent_enroll_token: ""
+
+nebula_agent_data_dir: /etc/nebula
+nebula_agent_poll_interval: "30s"
+nebula_agent_nebula_config_path: /etc/nebula/config.yml
+nebula_agent_nebula_pid_file: /run/nebula.pid
+
+# Where to fetch release artifacts. Override to mirror in restricted networks.
+nebula_agent_release_base_url: "https://github.com/juev/nebula-mesh/releases/download"

--- a/deploy/ansible/roles/nebula_agent/handlers/main.yml
+++ b/deploy/ansible/roles/nebula_agent/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart nebula-agent
+  ansible.builtin.systemd:
+    name: nebula-agent
+    state: restarted
+    daemon_reload: true

--- a/deploy/ansible/roles/nebula_agent/meta/main.yml
+++ b/deploy/ansible/roles/nebula_agent/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: nebula_agent
+  author: nebula-mesh contributors
+  description: Install and configure nebula-agent on a Linux host.
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions: [jammy, noble]
+    - name: Debian
+      versions: [bookworm]
+    - name: EL
+      versions: ["9"]
+  galaxy_tags:
+    - nebula
+    - vpn
+    - mesh
+    - networking
+dependencies: []

--- a/deploy/ansible/roles/nebula_agent/tasks/main.yml
+++ b/deploy/ansible/roles/nebula_agent/tasks/main.yml
@@ -1,0 +1,89 @@
+---
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - nebula_agent_server_url | length > 0
+      - nebula_agent_enroll_token | length > 0
+    fail_msg: "nebula_agent_server_url and nebula_agent_enroll_token must be set per host (pull from Vault)."
+
+- name: Resolve release tag
+  ansible.builtin.set_fact:
+    nebula_agent_resolved_release: "{{ nebula_agent_release }}"
+  when: nebula_agent_release != "latest"
+
+- name: Resolve `latest` release tag from GitHub
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/juev/nebula-mesh/releases/latest
+    return_content: true
+  register: nebula_agent_latest_release
+  when: nebula_agent_release == "latest"
+
+- name: Set resolved release (from GitHub API)
+  ansible.builtin.set_fact:
+    nebula_agent_resolved_release: "{{ nebula_agent_latest_release.json.tag_name }}"
+  when: nebula_agent_release == "latest"
+
+- name: Detect target architecture
+  ansible.builtin.set_fact:
+    nebula_agent_arch: "{{ 'arm64' if ansible_architecture in ['aarch64', 'arm64'] else 'amd64' }}"
+
+- name: Install nebula-agent (Debian / Ubuntu)
+  when: ansible_os_family == 'Debian'
+  block:
+    - name: Download nebula-agent .deb
+      ansible.builtin.get_url:
+        url: "{{ nebula_agent_release_base_url }}/{{ nebula_agent_resolved_release }}/nebula-agent_{{ nebula_agent_resolved_release | regex_replace('^v', '') }}_linux_{{ nebula_agent_arch }}.deb"
+        dest: "/tmp/nebula-agent.deb"
+        mode: '0644'
+
+    - name: Install nebula-agent .deb
+      ansible.builtin.apt:
+        deb: /tmp/nebula-agent.deb
+        state: present
+
+- name: Install nebula-agent (RHEL / Rocky / Alma)
+  when: ansible_os_family == 'RedHat'
+  block:
+    - name: Download nebula-agent .rpm
+      ansible.builtin.get_url:
+        url: "{{ nebula_agent_release_base_url }}/{{ nebula_agent_resolved_release }}/nebula-agent_{{ nebula_agent_resolved_release | regex_replace('^v', '') }}_linux_{{ nebula_agent_arch }}.rpm"
+        dest: "/tmp/nebula-agent.rpm"
+        mode: '0644'
+
+    - name: Install nebula-agent .rpm
+      ansible.builtin.dnf:
+        name: /tmp/nebula-agent.rpm
+        state: present
+        disable_gpg_check: true
+
+- name: Render agent.yml
+  ansible.builtin.template:
+    src: agent.yml.j2
+    dest: /etc/nebula-agent/agent.yml
+    owner: root
+    group: root
+    mode: '0640'
+  notify: restart nebula-agent
+
+- name: Check if host has already enrolled
+  ansible.builtin.stat:
+    path: "{{ nebula_agent_data_dir }}/.fingerprint"
+  register: nebula_agent_fp_stat
+
+- name: Enroll (run once)
+  when: not nebula_agent_fp_stat.stat.exists
+  ansible.builtin.command:
+    cmd: >
+      nebula-agent enroll
+        --server {{ nebula_agent_server_url | quote }}
+        --token  {{ nebula_agent_enroll_token | quote }}
+        --data-dir {{ nebula_agent_data_dir | quote }}
+  changed_when: true
+  no_log: true
+
+- name: Enable + start nebula-agent
+  ansible.builtin.systemd:
+    name: nebula-agent
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/deploy/ansible/roles/nebula_agent/templates/agent.yml.j2
+++ b/deploy/ansible/roles/nebula_agent/templates/agent.yml.j2
@@ -1,0 +1,7 @@
+server_url: "{{ nebula_agent_server_url }}"
+data_dir: "{{ nebula_agent_data_dir }}"
+poll_interval: "{{ nebula_agent_poll_interval }}"
+nebula_config_path: "{{ nebula_agent_nebula_config_path }}"
+{% if nebula_agent_nebula_pid_file %}
+nebula_pid_file: "{{ nebula_agent_nebula_pid_file }}"
+{% endif %}

--- a/deploy/ansible/roles/nebula_mgmt/README.md
+++ b/deploy/ansible/roles/nebula_mgmt/README.md
@@ -1,0 +1,51 @@
+# Ansible role: `nebula_mgmt`
+
+Installs and configures the management server (`nebula-mgmt`) on a Linux
+host using the published `.deb` / `.rpm` packages. Idempotent: the role
+never re-runs `nebula-mgmt init` after the first successful bootstrap
+(guarded by the presence of `data_dir/ca.crt`).
+
+## Tested against
+
+- Ubuntu 22.04 / 24.04
+- Debian 12
+- Rocky Linux 9 / Alma Linux 9
+
+## Required variables
+
+| Variable | Purpose |
+|---|---|
+| `nebula_mgmt_release` | Git tag of the release to install (e.g. `v0.3.0` or `latest`). |
+| `nebula_mgmt_master_key` | Base-64 32-byte AES-256 master key. Pull from Vault. |
+| `nebula_mgmt_ca_passphrase` | Legacy single-CA passphrase. Pull from Vault. |
+
+## Common optional variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `nebula_mgmt_listen` | `":8080"` | Bind address. |
+| `nebula_mgmt_data_dir` | `/var/lib/nebula-mgmt` | DB + CA storage. |
+| `nebula_mgmt_log_level` | `info` | One of debug/info/warn/error. |
+| `nebula_mgmt_tls_cert` / `..._key` | unset | Path on the target host. |
+| `nebula_mgmt_metrics_prometheus` | `true` | Toggle `/metrics`. |
+| `nebula_mgmt_alerts_enabled` | `false` | Cert-expiry alerter (issue #41). |
+| `nebula_mgmt_admin_username` | `admin` | Seed operator username. |
+
+See [`defaults/main.yml`](defaults/main.yml) for the full list.
+
+## Example play
+
+```yaml
+- hosts: nebula_mgmt
+  become: true
+  roles:
+    - role: nebula_mgmt
+      vars:
+        nebula_mgmt_release: "v0.3.0"
+        nebula_mgmt_master_key: "{{ lookup('community.hashi_vault.vault_read',
+                                        'secret/nebula/master_key').value }}"
+        nebula_mgmt_ca_passphrase: "{{ lookup('community.hashi_vault.vault_read',
+                                        'secret/nebula/ca_passphrase').value }}"
+```
+
+A complete sample lives in [`../../examples/site.yml`](../../examples/site.yml).

--- a/deploy/ansible/roles/nebula_mgmt/defaults/main.yml
+++ b/deploy/ansible/roles/nebula_mgmt/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# Required (no sane default; set in your playbook / from Vault).
+nebula_mgmt_release: "latest"
+nebula_mgmt_master_key: ""
+nebula_mgmt_ca_passphrase: ""
+
+# Server config.
+nebula_mgmt_listen: ":8080"
+nebula_mgmt_data_dir: /var/lib/nebula-mgmt
+nebula_mgmt_db_path: "{{ nebula_mgmt_data_dir }}/nebula.db"
+nebula_mgmt_log_level: info
+nebula_mgmt_tls_cert: ""
+nebula_mgmt_tls_key: ""
+nebula_mgmt_allow_self_registration: false
+
+# /metrics (issue #40).
+nebula_mgmt_metrics_prometheus: true
+
+# Cert-expiry alerter (issue #41).
+nebula_mgmt_alerts_enabled: false
+nebula_mgmt_alerts_interval: "5m"
+nebula_mgmt_alerts_threshold: "72h"
+nebula_mgmt_alerts_webhook_url: ""
+nebula_mgmt_alerts_webhook_hmac_secret: ""
+
+# Seeded admin operator.
+nebula_mgmt_admin_username: admin
+
+# Where to fetch release artifacts. Override to mirror in restricted networks.
+nebula_mgmt_release_base_url: "https://github.com/juev/nebula-mesh/releases/download"

--- a/deploy/ansible/roles/nebula_mgmt/handlers/main.yml
+++ b/deploy/ansible/roles/nebula_mgmt/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: restart nebula-mgmt
+  ansible.builtin.systemd:
+    name: nebula-mgmt
+    state: restarted

--- a/deploy/ansible/roles/nebula_mgmt/meta/main.yml
+++ b/deploy/ansible/roles/nebula_mgmt/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: nebula_mgmt
+  author: nebula-mesh contributors
+  description: Install and configure the nebula-mgmt management server.
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions: [jammy, noble]
+    - name: Debian
+      versions: [bookworm]
+    - name: EL
+      versions: ["9"]
+  galaxy_tags:
+    - nebula
+    - vpn
+    - mesh
+    - networking
+dependencies: []

--- a/deploy/ansible/roles/nebula_mgmt/tasks/main.yml
+++ b/deploy/ansible/roles/nebula_mgmt/tasks/main.yml
@@ -1,0 +1,115 @@
+---
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - nebula_mgmt_master_key | length > 0
+      - nebula_mgmt_ca_passphrase | length > 0
+    fail_msg: "nebula_mgmt_master_key and nebula_mgmt_ca_passphrase must be set (pull from a secret manager)."
+
+- name: Resolve release tag
+  ansible.builtin.set_fact:
+    nebula_mgmt_resolved_release: "{{ nebula_mgmt_release }}"
+  when: nebula_mgmt_release != "latest"
+
+- name: Resolve `latest` release tag from GitHub
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/juev/nebula-mesh/releases/latest
+    return_content: true
+  register: nebula_mgmt_latest_release
+  when: nebula_mgmt_release == "latest"
+
+- name: Set resolved release (from GitHub API)
+  ansible.builtin.set_fact:
+    nebula_mgmt_resolved_release: "{{ nebula_mgmt_latest_release.json.tag_name }}"
+  when: nebula_mgmt_release == "latest"
+
+- name: Detect target architecture
+  ansible.builtin.set_fact:
+    nebula_mgmt_arch: "{{ 'arm64' if ansible_architecture in ['aarch64', 'arm64'] else 'amd64' }}"
+
+- name: Install nebula-mgmt (Debian / Ubuntu)
+  when: ansible_os_family == 'Debian'
+  block:
+    - name: Download nebula-mgmt .deb
+      ansible.builtin.get_url:
+        url: "{{ nebula_mgmt_release_base_url }}/{{ nebula_mgmt_resolved_release }}/nebula-mgmt_{{ nebula_mgmt_resolved_release | regex_replace('^v', '') }}_linux_{{ nebula_mgmt_arch }}.deb"
+        dest: "/tmp/nebula-mgmt.deb"
+        mode: '0644'
+
+    - name: Install nebula-mgmt .deb
+      ansible.builtin.apt:
+        deb: /tmp/nebula-mgmt.deb
+        state: present
+
+- name: Install nebula-mgmt (RHEL / Rocky / Alma)
+  when: ansible_os_family == 'RedHat'
+  block:
+    - name: Download nebula-mgmt .rpm
+      ansible.builtin.get_url:
+        url: "{{ nebula_mgmt_release_base_url }}/{{ nebula_mgmt_resolved_release }}/nebula-mgmt_{{ nebula_mgmt_resolved_release | regex_replace('^v', '') }}_linux_{{ nebula_mgmt_arch }}.rpm"
+        dest: "/tmp/nebula-mgmt.rpm"
+        mode: '0644'
+
+    - name: Install nebula-mgmt .rpm
+      ansible.builtin.dnf:
+        name: /tmp/nebula-mgmt.rpm
+        state: present
+        disable_gpg_check: true
+
+- name: Render server.yml
+  ansible.builtin.template:
+    src: server.yml.j2
+    dest: /etc/nebula-mgmt/server.yml
+    owner: root
+    group: nebula-mgmt
+    mode: '0640'
+  notify: restart nebula-mgmt
+
+- name: Render systemd drop-in for secrets
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/nebula-mgmt.service.d/override.conf
+    content: |
+      [Service]
+      EnvironmentFile=/etc/nebula-mgmt/secrets.env
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - reload systemd
+    - restart nebula-mgmt
+
+- name: Render secrets env
+  ansible.builtin.copy:
+    dest: /etc/nebula-mgmt/secrets.env
+    content: |
+      NEBULA_MGMT_MASTER_KEY={{ nebula_mgmt_master_key }}
+      NEBULA_MGMT_CA_PASSPHRASE={{ nebula_mgmt_ca_passphrase }}
+    owner: root
+    group: nebula-mgmt
+    mode: '0640'
+  notify: restart nebula-mgmt
+  no_log: true
+
+- name: Check if CA already exists (init idempotency guard)
+  ansible.builtin.stat:
+    path: "{{ nebula_mgmt_data_dir }}/ca.crt"
+  register: nebula_mgmt_ca_stat
+
+- name: Bootstrap (run init once)
+  when: not nebula_mgmt_ca_stat.stat.exists
+  ansible.builtin.command:
+    cmd: >
+      nebula-mgmt init --config /etc/nebula-mgmt/server.yml
+                       --admin-username {{ nebula_mgmt_admin_username | quote }}
+  become_user: nebula-mgmt
+  environment:
+    NEBULA_MGMT_MASTER_KEY: "{{ nebula_mgmt_master_key }}"
+    NEBULA_MGMT_CA_PASSPHRASE: "{{ nebula_mgmt_ca_passphrase }}"
+  changed_when: true
+
+- name: Enable + start nebula-mgmt
+  ansible.builtin.systemd:
+    name: nebula-mgmt
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/deploy/ansible/roles/nebula_mgmt/templates/server.yml.j2
+++ b/deploy/ansible/roles/nebula_mgmt/templates/server.yml.j2
@@ -1,0 +1,25 @@
+listen: "{{ nebula_mgmt_listen }}"
+data_dir: "{{ nebula_mgmt_data_dir }}"
+db_path: "{{ nebula_mgmt_db_path }}"
+log_level: "{{ nebula_mgmt_log_level }}"
+{% if nebula_mgmt_tls_cert %}
+tls_cert: "{{ nebula_mgmt_tls_cert }}"
+tls_key: "{{ nebula_mgmt_tls_key }}"
+{% endif %}
+allow_self_registration: {{ nebula_mgmt_allow_self_registration | string | lower }}
+
+metrics:
+  prometheus: {{ nebula_mgmt_metrics_prometheus | string | lower }}
+
+{% if nebula_mgmt_alerts_enabled %}
+alerts:
+  enabled: true
+  interval: "{{ nebula_mgmt_alerts_interval }}"
+  threshold: "{{ nebula_mgmt_alerts_threshold }}"
+{% if nebula_mgmt_alerts_webhook_url %}
+  webhook_url: "{{ nebula_mgmt_alerts_webhook_url }}"
+{% if nebula_mgmt_alerts_webhook_hmac_secret %}
+  webhook_hmac_secret: "{{ nebula_mgmt_alerts_webhook_hmac_secret }}"
+{% endif %}
+{% endif %}
+{% endif %}

--- a/deploy/cloud-init/nebula-agent.example.yaml
+++ b/deploy/cloud-init/nebula-agent.example.yaml
@@ -1,0 +1,33 @@
+#cloud-config
+# nebula-agent cloud-init bootstrap. Replace `<...>` placeholders.
+# The enrolment token is single-use and expires after 24h by default —
+# generate it freshly per host (e.g. via `nebula-mgmt host create`) and
+# inject it from your provisioning pipeline.
+
+write_files:
+  - path: /etc/nebula-agent/agent.yml
+    permissions: '0640'
+    content: |
+      server_url: "https://<mgmt-server-fqdn>:8080"
+      data_dir: "/etc/nebula"
+      poll_interval: "30s"
+      nebula_config_path: "/etc/nebula/config.yml"
+      nebula_pid_file: "/run/nebula.pid"
+
+runcmd:
+  - |
+    set -euo pipefail
+    version="v0.3.0"
+    arch=$(dpkg --print-architecture)
+    pkg=$(mktemp --suffix=.deb)
+    curl -fsSL -o "$pkg" \
+      "https://github.com/juev/nebula-mesh/releases/download/$${version}/nebula-agent_$${version#v}_linux_$${arch}.deb"
+    apt-get install -y "$pkg" || (apt-get update && apt-get install -y "$pkg")
+    systemctl daemon-reload
+    if [ ! -f /etc/nebula/.fingerprint ]; then
+      nebula-agent enroll \
+        --server "https://<mgmt-server-fqdn>:8080" \
+        --token  "<per-host-enrolment-token>" \
+        --data-dir /etc/nebula
+    fi
+    systemctl enable --now nebula-agent.service

--- a/deploy/cloud-init/nebula-mgmt.example.yaml
+++ b/deploy/cloud-init/nebula-mgmt.example.yaml
@@ -1,0 +1,52 @@
+#cloud-config
+# nebula-mgmt cloud-init bootstrap. Copy / template this into your cloud
+# provider's user-data field; replace the placeholders marked with `<...>`
+# before applying.
+#
+# The script installs the published .deb, runs `nebula-mgmt init` exactly
+# once (guard: presence of /var/lib/nebula-mgmt/ca.crt), then enables the
+# systemd unit.
+
+write_files:
+  - path: /etc/nebula-mgmt/server.yml
+    permissions: '0640'
+    owner: root:nebula-mgmt
+    content: |
+      listen: ":8080"
+      data_dir: "/var/lib/nebula-mgmt"
+      db_path: "/var/lib/nebula-mgmt/nebula.db"
+      log_level: "info"
+      # Run plain HTTP only behind a TLS-terminating proxy.
+      tls_cert: ""
+      tls_key: ""
+      allow_self_registration: false
+      metrics:
+        prometheus: true
+  - path: /etc/systemd/system/nebula-mgmt.service.d/override.conf
+    permissions: '0644'
+    content: |
+      [Service]
+      EnvironmentFile=/etc/nebula-mgmt/secrets.env
+  - path: /etc/nebula-mgmt/secrets.env
+    permissions: '0600'
+    owner: root:nebula-mgmt
+    content: |
+      NEBULA_MGMT_MASTER_KEY=<base64-32-byte-key>
+      NEBULA_MGMT_CA_PASSPHRASE=<long-random-passphrase>
+
+runcmd:
+  - |
+    set -euo pipefail
+    version="v0.3.0"
+    arch=$(dpkg --print-architecture)
+    pkg=$(mktemp --suffix=.deb)
+    curl -fsSL -o "$pkg" \
+      "https://github.com/juev/nebula-mesh/releases/download/$${version}/nebula-mgmt_$${version#v}_linux_$${arch}.deb"
+    apt-get install -y "$pkg" || (apt-get update && apt-get install -y "$pkg")
+    systemctl daemon-reload
+    if [ ! -f /var/lib/nebula-mgmt/ca.crt ]; then
+      install -d -o nebula-mgmt -g nebula-mgmt -m 0750 /var/lib/nebula-mgmt
+      runuser -u nebula-mgmt -- env $(cat /etc/nebula-mgmt/secrets.env) \
+        nebula-mgmt init --config /etc/nebula-mgmt/server.yml --admin-username admin
+    fi
+    systemctl enable --now nebula-mgmt.service

--- a/deploy/terraform/nebula-mgmt/README.md
+++ b/deploy/terraform/nebula-mgmt/README.md
@@ -1,0 +1,87 @@
+# Terraform module: `nebula-mgmt`
+
+Stands up a single VM running `nebula-mgmt` from the official `.deb`
+release. The module is cloud-agnostic at its boundary — pass in any
+`instance` resource that exposes `public_ip` / `id` / a way to inject
+`cloud-init` user-data — and ships a worked example for AWS EC2.
+
+## What it does
+
+1. Generates the bootstrap secrets:
+   - `NEBULA_MGMT_MASTER_KEY` (random 32 bytes, base64-encoded).
+   - `NEBULA_MGMT_CA_PASSPHRASE` (40-byte random string).
+2. Materialises `server.yml` and a systemd drop-in from templates.
+3. Builds a `cloud-init` user-data that installs the published `.deb`,
+   stages the configs, runs `nebula-mgmt init` exactly once
+   (idempotency guard: refuses to re-init if `data_dir/ca.crt` already
+   exists), and enables `nebula-mgmt.service`.
+4. Writes both secrets to the configured secret backend
+   (`aws_secretsmanager` by default; swap via the `secret_backend`
+   variable — see [SECRET_BACKENDS.md](SECRET_BACKENDS.md)).
+5. Exposes outputs: `server_url`, `bootstrap_api_key`,
+   `master_key_secret_arn`, `passphrase_secret_arn`.
+
+The module **only** manages the management server. Use the
+`nebula_agent` Ansible role to enrol hosts against it; agents need
+nothing more than the server URL + a per-host enrolment token.
+
+## Usage (AWS example)
+
+```hcl
+module "nebula_mgmt" {
+  source = "github.com/juev/nebula-mesh//deploy/terraform/nebula-mgmt?ref=v0.3.0"
+
+  release_version = "v0.3.0"
+  fqdn            = "mgmt.internal.example.com"
+  tls_email       = "ops@example.com"   # for the Let's Encrypt issuer
+  admin_username  = "admin"
+
+  # Pass in the bare VM resource; the module never touches networking.
+  instance_id          = aws_instance.nebula_mgmt.id
+  instance_public_ip   = aws_instance.nebula_mgmt.public_ip
+  ssh_user             = "ubuntu"
+
+  secret_backend       = "aws_secretsmanager"
+  aws_kms_key_id       = aws_kms_key.nebula.arn
+}
+
+output "nebula_mgmt_url" {
+  value = module.nebula_mgmt.server_url
+}
+```
+
+A complete example, including the `aws_instance` and security-group
+plumbing, lives in [`examples/aws/`](examples/aws/).
+
+## Idempotency
+
+Re-running `terraform apply` is a no-op once the server is up:
+
+- Secrets are created with `lifecycle { ignore_changes = [secret_string] }`
+  so a re-run never rotates the CA passphrase / master key.
+- The `cloud-init` script tests for `/var/lib/nebula-mgmt/ca.crt` before
+  running `nebula-mgmt init`; presence ⇒ skip.
+- Systemd unit is owned by the package; the module only ships a config
+  drop-in under `/etc/systemd/system/nebula-mgmt.service.d/override.conf`,
+  written with `cloud-init`'s built-in `manage_etc_hosts`-style merge so
+  re-runs don't disturb local edits.
+
+## Upgrading
+
+Bump `release_version` and re-apply. The cloud-init script's
+`runcmd` re-installs the package; systemd is restarted from the
+deb post-install hook. The data directory (CA, DB, master key) is
+preserved across upgrades — see the deb package contract in
+[`deploy/packaging/`](../../packaging/).
+
+## Variables
+
+See [`variables.tf`](variables.tf) for the full list. Common knobs:
+
+| Name | Default | Purpose |
+|---|---|---|
+| `release_version` | `latest` | Git tag of the release to install. |
+| `fqdn` | (required) | DNS name the server will announce; used for TLS. |
+| `tls_cert_path` / `tls_key_path` | `""` | Pre-staged cert/key. If empty, the server runs plain HTTP and the module **insists** on a reverse proxy. |
+| `secret_backend` | `aws_secretsmanager` | One of `aws_secretsmanager`, `gcp_secret_manager`, `vault_kv`. |
+| `admin_username` | `admin` | Seeded operator username. |

--- a/deploy/terraform/nebula-mgmt/main.tf
+++ b/deploy/terraform/nebula-mgmt/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = []
+    }
+  }
+}
+
+# --- Bootstrap secrets ---------------------------------------------------
+#
+# Both secrets are generated once and pinned. The `lifecycle` block on the
+# secret-store resource keeps the value stable across Terraform applies so a
+# routine `terraform apply` cannot accidentally rotate the CA passphrase
+# (which would brick every previously-issued certificate).
+#
+# Use `terraform taint` or an out-of-band CLI flow if you ever genuinely need
+# to rotate either secret.
+
+resource "random_password" "ca_passphrase" {
+  length  = 40
+  special = false
+}
+
+resource "random_id" "master_key" {
+  byte_length = 32
+}
+
+locals {
+  master_key_b64 = random_id.master_key.b64_std
+  passphrase     = random_password.ca_passphrase.result
+
+  bootstrap_userdata = templatefile("${path.module}/templates/cloud-init.yaml.tpl", {
+    release_version = var.release_version
+    fqdn            = var.fqdn
+    tls_cert_path   = var.tls_cert_path
+    tls_key_path    = var.tls_key_path
+    data_dir        = var.data_dir
+    admin_username  = var.admin_username
+    master_key      = local.master_key_b64
+    ca_passphrase   = local.passphrase
+  })
+}
+
+# --- Secret backend ------------------------------------------------------
+#
+# Three implementations are gated on var.secret_backend. Each writes the
+# same logical keys: `nebula-mgmt/<fqdn>/master-key` and
+# `nebula-mgmt/<fqdn>/ca-passphrase`. Pick one; the others are no-ops.
+
+resource "aws_secretsmanager_secret" "master_key" {
+  count       = var.secret_backend == "aws_secretsmanager" ? 1 : 0
+  name        = "nebula-mgmt/${var.fqdn}/master-key"
+  description = "NEBULA_MGMT_MASTER_KEY for ${var.fqdn} (base64-encoded 32-byte AES-256 key)."
+  kms_key_id  = var.aws_kms_key_id != "" ? var.aws_kms_key_id : null
+
+  tags = {
+    application = "nebula-mgmt"
+    instance    = var.instance_id
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "master_key" {
+  count          = var.secret_backend == "aws_secretsmanager" ? 1 : 0
+  secret_id      = aws_secretsmanager_secret.master_key[0].id
+  secret_string  = local.master_key_b64
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+resource "aws_secretsmanager_secret" "passphrase" {
+  count       = var.secret_backend == "aws_secretsmanager" ? 1 : 0
+  name        = "nebula-mgmt/${var.fqdn}/ca-passphrase"
+  description = "NEBULA_MGMT_CA_PASSPHRASE for ${var.fqdn} (legacy single-CA fallback)."
+  kms_key_id  = var.aws_kms_key_id != "" ? var.aws_kms_key_id : null
+
+  tags = {
+    application = "nebula-mgmt"
+    instance    = var.instance_id
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "passphrase" {
+  count          = var.secret_backend == "aws_secretsmanager" ? 1 : 0
+  secret_id      = aws_secretsmanager_secret.passphrase[0].id
+  secret_string  = local.passphrase
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/deploy/terraform/nebula-mgmt/outputs.tf
+++ b/deploy/terraform/nebula-mgmt/outputs.tf
@@ -1,0 +1,20 @@
+output "server_url" {
+  description = "Base URL the management server will answer on once cloud-init finishes."
+  value       = var.tls_cert_path != "" ? "https://${var.fqdn}:8080" : "http://${var.fqdn}:8080"
+}
+
+output "master_key_secret_arn" {
+  description = "ARN / id of the secret holding NEBULA_MGMT_MASTER_KEY (empty when using a non-AWS backend)."
+  value       = var.secret_backend == "aws_secretsmanager" ? aws_secretsmanager_secret.master_key[0].arn : ""
+}
+
+output "passphrase_secret_arn" {
+  description = "ARN / id of the secret holding the legacy CA passphrase (empty when using a non-AWS backend)."
+  value       = var.secret_backend == "aws_secretsmanager" ? aws_secretsmanager_secret.passphrase[0].arn : ""
+}
+
+output "cloud_init_userdata" {
+  description = "Rendered cloud-init user-data — attach this to the VM resource (e.g. aws_instance.user_data)."
+  value       = local.bootstrap_userdata
+  sensitive   = true
+}

--- a/deploy/terraform/nebula-mgmt/templates/cloud-init.yaml.tpl
+++ b/deploy/terraform/nebula-mgmt/templates/cloud-init.yaml.tpl
@@ -1,0 +1,61 @@
+#cloud-config
+# nebula-mgmt bootstrap. Pulls a release `.deb`, lays down configs and
+# secrets, then runs `nebula-mgmt init` exactly once (the script guards on
+# the presence of the CA file).
+#
+# Re-running this user-data is a no-op once the initial install succeeds.
+write_files:
+  - path: /etc/nebula-mgmt/server.yml
+    permissions: '0640'
+    owner: root:nebula-mgmt
+    content: |
+      listen: ":8080"
+      data_dir: "${data_dir}"
+      db_path: "${data_dir}/nebula.db"
+      log_level: "info"
+      tls_cert: "${tls_cert_path}"
+      tls_key: "${tls_key_path}"
+      allow_self_registration: false
+      metrics:
+        prometheus: true
+  - path: /etc/systemd/system/nebula-mgmt.service.d/override.conf
+    permissions: '0644'
+    content: |
+      [Service]
+      EnvironmentFile=/etc/nebula-mgmt/secrets.env
+  - path: /etc/nebula-mgmt/secrets.env
+    permissions: '0600'
+    owner: root:nebula-mgmt
+    content: |
+      NEBULA_MGMT_MASTER_KEY=${master_key}
+      NEBULA_MGMT_CA_PASSPHRASE=${ca_passphrase}
+
+runcmd:
+  - |
+    set -euo pipefail
+    arch=$(dpkg --print-architecture 2>/dev/null || rpm --eval '%{_arch}')
+    case "$arch" in
+      amd64|x86_64) goarch=amd64 ;;
+      arm64|aarch64) goarch=arm64 ;;
+      *) echo "unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+
+    version="${release_version}"
+    if [ "$version" = "latest" ]; then
+      version=$(curl -fsSL https://api.github.com/repos/juev/nebula-mesh/releases/latest | sed -n 's/.*"tag_name": *"\(v[^"]*\)".*/\1/p')
+    fi
+
+    pkg=$(mktemp --suffix=.deb)
+    curl -fsSL -o "$pkg" \
+      "https://github.com/juev/nebula-mesh/releases/download/$${version}/nebula-mgmt_$${version#v}_linux_$${goarch}.deb"
+    apt-get install -y "$pkg" || (apt-get update && apt-get install -y "$pkg")
+
+    systemctl daemon-reload
+
+    if [ ! -f "${data_dir}/ca.crt" ]; then
+      install -d -o nebula-mgmt -g nebula-mgmt -m 0750 "${data_dir}"
+      runuser -u nebula-mgmt -- env $(cat /etc/nebula-mgmt/secrets.env) \
+        nebula-mgmt init --config /etc/nebula-mgmt/server.yml --admin-username "${admin_username}"
+    fi
+
+    systemctl enable --now nebula-mgmt.service

--- a/deploy/terraform/nebula-mgmt/variables.tf
+++ b/deploy/terraform/nebula-mgmt/variables.tf
@@ -1,0 +1,67 @@
+variable "release_version" {
+  description = "Git tag of the nebula-mesh release to install (e.g. v0.3.0). Use `latest` to track the latest GitHub release."
+  type        = string
+  default     = "latest"
+}
+
+variable "fqdn" {
+  description = "Public DNS name the management server will be reached at."
+  type        = string
+}
+
+variable "tls_cert_path" {
+  description = "Absolute path on the VM to a pre-staged TLS certificate. Empty means run plain HTTP (only safe behind a TLS-terminating proxy)."
+  type        = string
+  default     = ""
+}
+
+variable "tls_key_path" {
+  description = "Absolute path on the VM to the matching private key. Must be set together with tls_cert_path."
+  type        = string
+  default     = ""
+}
+
+variable "instance_id" {
+  description = "Provider-specific id of the VM the module will configure. Used only for secret tagging."
+  type        = string
+}
+
+variable "instance_public_ip" {
+  description = "Reachable IPv4 the server will be addressable on."
+  type        = string
+}
+
+variable "ssh_user" {
+  description = "Linux user the cloud-init userdata is run as (e.g. ubuntu, ec2-user, almalinux)."
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "admin_username" {
+  description = "Username seeded as the initial admin operator."
+  type        = string
+  default     = "admin"
+}
+
+variable "secret_backend" {
+  description = "Where to stash NEBULA_MGMT_MASTER_KEY and NEBULA_MGMT_CA_PASSPHRASE. One of: aws_secretsmanager, gcp_secret_manager, vault_kv."
+  type        = string
+  default     = "aws_secretsmanager"
+
+  validation {
+    condition     = contains(["aws_secretsmanager", "gcp_secret_manager", "vault_kv"], var.secret_backend)
+    error_message = "secret_backend must be one of: aws_secretsmanager, gcp_secret_manager, vault_kv."
+  }
+}
+
+variable "aws_kms_key_id" {
+  description = "When secret_backend is aws_secretsmanager, the KMS key encrypting the secrets at rest. Empty uses the default AWS-managed key."
+  type        = string
+  default     = ""
+}
+
+variable "data_dir" {
+  description = "Directory on the VM holding the SQLite DB, CA material, and operator data."
+  type        = string
+  default     = "/var/lib/nebula-mgmt"
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,92 @@
+# Deployment recipes
+
+Three opinionated paths cover the common ways operators stand up a
+production `nebula-mgmt` + agent fleet. Pick the one that matches your
+infra; mix-and-match is fine (e.g. Terraform for the server, Ansible for
+the agents).
+
+| Path | Use when |
+|---|---|
+| [Terraform module](#terraform) | You provision VMs through Terraform and want the server brought up from scratch in one apply. Ideal for AWS / GCP / libvirt where the secret store lives next door. |
+| [Ansible roles](#ansible) | You already have an Ansible inventory and prefer configuration-management over hand-rolled cloud-init. Idempotent, runs against existing VMs. |
+| [Cloud-init snippets](#cloud-init) | One-off VMs or hand-managed servers where neither Terraform nor Ansible is in play. Paste into your provider's user-data field. |
+
+All three share the same secret-handling contract: **`NEBULA_MGMT_MASTER_KEY`
+and `NEBULA_MGMT_CA_PASSPHRASE` are generated once and stored in a secret
+manager (AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault, or
+Ansible Vault). Re-running the recipe must never rotate either secret —
+the CA passphrase is load-bearing for every previously-issued
+certificate.** Idempotency in the recipes is implemented by guarding on
+the presence of `data_dir/ca.crt`.
+
+## Terraform
+
+Path: [`deploy/terraform/nebula-mgmt/`](../deploy/terraform/nebula-mgmt/).
+Cloud-agnostic at its boundary; ships a worked AWS example with
+`aws_secretsmanager_secret` resources backing the bootstrap secrets.
+
+Quickstart:
+
+```hcl
+module "nebula_mgmt" {
+  source              = "github.com/juev/nebula-mesh//deploy/terraform/nebula-mgmt?ref=v0.3.0"
+  release_version     = "v0.3.0"
+  fqdn                = "mgmt.internal.example.com"
+  instance_id         = aws_instance.nebula_mgmt.id
+  instance_public_ip  = aws_instance.nebula_mgmt.public_ip
+  secret_backend      = "aws_secretsmanager"
+  aws_kms_key_id      = aws_kms_key.nebula.arn
+}
+```
+
+Read the full variable list and the secret-backend swap instructions in
+the [module README](../deploy/terraform/nebula-mgmt/README.md).
+
+## Ansible
+
+Path: [`deploy/ansible/roles/`](../deploy/ansible/roles/) — two roles,
+`nebula_mgmt` and `nebula_agent`. A complete playbook lives in
+[`deploy/ansible/examples/site.yml`](../deploy/ansible/examples/site.yml).
+
+```sh
+ansible-playbook -i inventory.example.ini site.yml --ask-vault-pass
+```
+
+Tested against Ubuntu 22.04 / 24.04, Debian 12, Rocky / Alma Linux 9.
+The roles always pull the published `.deb` / `.rpm` artifacts; they
+never compile from source on the target hosts. Both roles are
+idempotent — re-running is a no-op once the install + enrol have
+succeeded.
+
+## Cloud-init
+
+Path: [`deploy/cloud-init/`](../deploy/cloud-init/). Two examples,
+`nebula-mgmt.example.yaml` and `nebula-agent.example.yaml`. Paste into
+your provider's user-data field after replacing the `<...>`
+placeholders. The script installs the package, materialises the config,
+runs `init` / `enroll` exactly once, and enables the systemd unit.
+
+## Upgrades
+
+All three paths use the published `.deb` / `.rpm` artifacts, so an
+upgrade is "bump the release tag and re-apply":
+
+- Terraform: change `release_version`, `terraform apply`.
+- Ansible: change `nebula_mgmt_release` / `nebula_agent_release`,
+  re-run the playbook.
+- Cloud-init: change the `version` in `runcmd` and re-apply the
+  user-data (cloud-init only runs once per VM by default — most
+  operators upgrade in-place via the package manager instead).
+
+The package contract preserves `data_dir` and `/etc/nebula-mgmt/` /
+`/etc/nebula-agent/` across upgrades.
+
+## You should run TLS
+
+The roles and the cloud-init snippets default to plain HTTP because TLS
+material is operator-specific. **Always front the management server
+with a TLS-terminating proxy (nginx, Caddy, Traefik) or set
+`tls_cert` / `tls_key` directly in the server config.** Agents talk to
+the server over the public internet during enrolment; plain HTTP leaks
+the enrolment token and the rendered Nebula config (including the
+freshly-signed certificate) to anyone on-path.


### PR DESCRIPTION
## Summary

- \`deploy/terraform/nebula-mgmt/\` — cloud-agnostic Terraform module that mints the master key + CA passphrase, stashes them in AWS Secrets Manager (swap via \`secret_backend\`), and lays down cloud-init that runs \`nebula-mgmt init\` exactly once.
- \`deploy/ansible/roles/nebula_mgmt/\` and \`deploy/ansible/roles/nebula_agent/\` — idempotent roles that install the published \`.deb\`/\`.rpm\`, template the configs, and gate \`init\`/\`enroll\` on the presence of \`ca.crt\` / \`.fingerprint\`.
- \`deploy/cloud-init/\` — copy/paste user-data snippets for one-off VMs.
- \`docs/deployment.md\` walks operators through picking a path and explains the shared secret-handling contract.

Closes #42.

## Test plan

- [x] \`go build ./... && go test -race ./... && golangci-lint run ./...\` — Go side unaffected, suite green, 0 lint issues.
- [ ] CI hooks (terraform validate, ansible-lint) are outside the scope of this PR — call them out in the deployment doc; follow-up if/when CI gains those steps.