### PR TITLE
feat(web): live host status via SSE (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,9 +323,8 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 
 Open issues tracked individually so you can subscribe to the ones you care about:
 
-- [#43](https://github.com/juev/nebula-mesh/issues/43) — Web UI: live host status via SSE (today: htmx polling on a 30s interval)
 
-Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), distro packages (deb/rpm) and the cross-platform agent build matrix.
+Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), distro packages (deb/rpm) and the cross-platform agent build matrix.
 
 Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -39,6 +39,7 @@ type Server struct {
 	apiKey         string
 	metrics        *metrics
 	metricsEnabled bool
+	hostSeen       HostSeenEmitter
 }
 
 // NewServer creates a new API server.
@@ -82,6 +83,19 @@ func (s *Server) RecordLogin(result, factor string) {
 func (s *Server) WithMetricsEnabled(enabled bool) {
 	s.metricsEnabled = enabled
 	s.setupRoutes()
+}
+
+// HostSeenEmitter is invoked after every successful agent poll so the Web
+// UI can stream a live "host X just polled" event over its SSE endpoint.
+// hostID is the DB id, lastSeen is the wall-clock timestamp the agent's
+// poll was observed at, and networkID is included so per-network views can
+// filter without an extra lookup.
+type HostSeenEmitter func(hostID string, lastSeen time.Time, networkID string)
+
+// WithHostSeenEmitter wires the callback the API server fires when an
+// agent polls. Passing nil disables emission.
+func (s *Server) WithHostSeenEmitter(emit HostSeenEmitter) {
+	s.hostSeen = emit
 }
 
 // WithDefaultCAID records the id of the CA seeded from the legacy

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -44,6 +44,8 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 	now := time.Now()
 	if err := s.store.UpdateHostLastSeen(r.Context(), host.ID, now); err != nil {
 		s.logger.Error("update last seen", "error", err)
+	} else if s.hostSeen != nil {
+		s.hostSeen(host.ID, now, host.NetworkID)
 	}
 
 	// Get blocklist

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -168,6 +168,18 @@ func Serve(configPath string) error {
 	webUI.AllowSelfRegistration(cfg.AllowSelfRegistration)
 	webUI.WithLoginRecorder(apiSrv.RecordLogin)
 
+	// Live host-status SSE: API server fires HostSeenEmitter on each agent
+	// poll, EventBus fans out to subscribed browser tabs.
+	eventBus := web.NewEventBus()
+	webUI.WithEventBus(eventBus)
+	apiSrv.WithHostSeenEmitter(func(hostID string, lastSeen time.Time, networkID string) {
+		eventBus.Publish(web.HostSeenEvent{
+			HostID:    hostID,
+			LastSeen:  lastSeen,
+			NetworkID: networkID,
+		})
+	})
+
 	// Optional OIDC integration
 	if cfg.OIDC != nil && cfg.OIDC.Enabled {
 		oidcCtx, oidcCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -1,0 +1,146 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HostSeenEvent is the wire format the SSE stream pushes to each subscriber
+// whenever a host's last_seen_at moves forward. The shape is intentionally
+// flat so the htmx-sse swap in the Hosts table can target a specific row
+// without an extra fetch.
+type HostSeenEvent struct {
+	HostID    string    `json:"host_id"`
+	LastSeen  time.Time `json:"last_seen"`
+	NetworkID string    `json:"network_id,omitempty"`
+}
+
+// EventBus is a small in-memory publish/subscribe channel for host-state
+// events. The API server publishes; the Web UI's SSE handler subscribes.
+// Subscribers must drain quickly — publishes drop into a buffered queue
+// and stale subscribers get unblocked by dropping the event, never the
+// publisher.
+type EventBus struct {
+	mu      sync.Mutex
+	subs    map[chan HostSeenEvent]struct{}
+}
+
+// NewEventBus creates a fresh bus.
+func NewEventBus() *EventBus {
+	return &EventBus{subs: make(map[chan HostSeenEvent]struct{})}
+}
+
+// Publish fans the event out to every subscriber. Each subscriber's queue
+// is small (8 events) so a stuck consumer drops events rather than stalling
+// the agent-poll path that called Publish.
+func (b *EventBus) Publish(ev HostSeenEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subs {
+		select {
+		case ch <- ev:
+		default:
+			// subscriber is too slow — drop this event for them.
+		}
+	}
+}
+
+// Subscribe registers a new listener and returns the receive channel plus
+// a cleanup func that must be called (typically via defer) when the
+// subscriber is done.
+func (b *EventBus) Subscribe() (<-chan HostSeenEvent, func()) {
+	ch := make(chan HostSeenEvent, 8)
+	b.mu.Lock()
+	b.subs[ch] = struct{}{}
+	b.mu.Unlock()
+
+	cancel := func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if _, ok := b.subs[ch]; ok {
+			delete(b.subs, ch)
+			close(ch)
+		}
+	}
+	return ch, cancel
+}
+
+// WithEventBus wires the bus the SSE endpoint listens on. Must be set
+// before ServeHTTP is invoked. Without a bus, /ui/events 404s.
+func (w *Web) WithEventBus(bus *EventBus) {
+	w.events = bus
+}
+
+// handleHostEvents streams `host.seen` SSE messages to the operator's
+// browser. Each event carries a JSON HostSeenEvent so client-side code
+// can patch the matching row without re-fetching the table.
+func (w *Web) handleHostEvents(rw http.ResponseWriter, r *http.Request) {
+	if w.events == nil {
+		http.NotFound(rw, r)
+		return
+	}
+	flusher, ok := rw.(http.Flusher)
+	if !ok {
+		http.Error(rw, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/event-stream")
+	rw.Header().Set("Cache-Control", "no-cache")
+	rw.Header().Set("Connection", "keep-alive")
+	rw.Header().Set("X-Accel-Buffering", "no") // nginx hint
+	rw.WriteHeader(http.StatusOK)
+
+	// Initial comment so the browser knows the stream is alive.
+	if _, err := fmt.Fprintf(rw, ": connected\n\n"); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	ch, cancel := w.events.Subscribe()
+	defer cancel()
+
+	ctx := r.Context()
+	heartbeat := time.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeat.C:
+			// Keep proxies from closing idle connections.
+			if _, err := fmt.Fprintf(rw, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			payload, err := json.Marshal(ev)
+			if err != nil {
+				continue
+			}
+			if _, err := fmt.Fprintf(rw, "event: host.seen\ndata: %s\n\n", payload); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// Stop closes every active subscription. Useful in tests.
+func (b *EventBus) Stop(ctx context.Context) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subs {
+		delete(b.subs, ch)
+		close(ch)
+	}
+	_ = ctx
+}

--- a/internal/web/events_test.go
+++ b/internal/web/events_test.go
@@ -1,0 +1,114 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEventBus_PublishToSubscriber(t *testing.T) {
+	bus := NewEventBus()
+	ch, cancel := bus.Subscribe()
+	defer cancel()
+
+	go bus.Publish(HostSeenEvent{HostID: "h1", LastSeen: time.Now()})
+
+	select {
+	case ev := <-ch:
+		if ev.HostID != "h1" {
+			t.Errorf("host_id = %q, want h1", ev.HostID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscriber did not receive event")
+	}
+}
+
+func TestEventBus_Unsubscribe(t *testing.T) {
+	bus := NewEventBus()
+	ch, cancel := bus.Subscribe()
+	cancel()
+
+	bus.Publish(HostSeenEvent{HostID: "h1"})
+	// Channel should be closed.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed after cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("channel did not close")
+	}
+}
+
+func TestEventBus_SlowSubscriberDropped(t *testing.T) {
+	bus := NewEventBus()
+	_, cancel := bus.Subscribe()
+	defer cancel()
+
+	// Pump more events than the subscriber buffer (8). None should block.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			bus.Publish(HostSeenEvent{HostID: "h1"})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("publish blocked on slow subscriber")
+	}
+}
+
+func TestHandleHostEvents_StreamsEvent(t *testing.T) {
+	bus := NewEventBus()
+	w := &Web{events: bus}
+
+	// Standalone request: bypass the auth middleware since we just want
+	// to test the SSE producer.
+	r := httptest.NewRequest(http.MethodGet, "/ui/events", nil)
+	ctx, cancel := context.WithCancel(r.Context())
+	r = r.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		w.handleHostEvents(rec, r)
+		close(done)
+	}()
+
+	// Give the goroutine time to write the initial ": connected" comment
+	// and subscribe.
+	time.Sleep(50 * time.Millisecond)
+
+	bus.Publish(HostSeenEvent{HostID: "h1", LastSeen: time.Now()})
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: host.seen") {
+		t.Errorf("body missing host.seen event:\n%s", body)
+	}
+	if !strings.Contains(body, `"host_id":"h1"`) {
+		t.Errorf("body missing host_id payload:\n%s", body)
+	}
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("content-type = %q, want text/event-stream", rec.Header().Get("Content-Type"))
+	}
+}
+
+func TestHandleHostEvents_NoBus_NotFound(t *testing.T) {
+	w := &Web{}
+	r := httptest.NewRequest(http.MethodGet, "/ui/events", nil)
+	rec := httptest.NewRecorder()
+	w.handleHostEvents(rec, r)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 when event bus is unset", rec.Code)
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -402,16 +402,19 @@ func (w *Web) handleFavicon(rw http.ResponseWriter, _ *http.Request) {
 // --- Dashboard ---
 
 // hostView is a view-model that augments models.Host with the resolved
-// human-readable network name. Embedding keeps every existing template
-// field access (.ID, .Name, .NebulaIP, …) working unchanged.
+// human-readable network name and the computed "online" flag. Embedding
+// keeps every existing template field access (.ID, .Name, .NebulaIP, …)
+// working unchanged.
 type hostView struct {
 	*models.Host
 	NetworkName string
+	Online      bool
 }
 
-// buildHostViews resolves NetworkID → Network.Name for each host. If the
-// host's network is not present in networks, NetworkName is left empty so
-// the template can fall back to displaying the UUID.
+// buildHostViews resolves NetworkID → Network.Name for each host and
+// stamps the "online" flag (last_seen_at within hostOnlineThreshold). If
+// the host's network is not present in networks, NetworkName is left
+// empty so the template can fall back to displaying the UUID.
 func buildHostViews(hosts []*models.Host, networks []*models.Network) []hostView {
 	if len(hosts) == 0 {
 		return nil
@@ -420,9 +423,14 @@ func buildHostViews(hosts []*models.Host, networks []*models.Network) []hostView
 	for _, n := range networks {
 		idx[n.ID] = n.Name
 	}
+	now := time.Now()
 	out := make([]hostView, len(hosts))
 	for i, h := range hosts {
-		out[i] = hostView{Host: h, NetworkName: idx[h.NetworkID]}
+		out[i] = hostView{
+			Host:        h,
+			NetworkName: idx[h.NetworkID],
+			Online:      isHostOnline(h.LastSeenAt, hostOnlineThreshold, now),
+		}
 	}
 	return out
 }

--- a/internal/web/online.go
+++ b/internal/web/online.go
@@ -1,0 +1,19 @@
+package web
+
+import "time"
+
+// hostOnlineThreshold is the wall-clock window inside which a host is
+// considered "online": the most recent agent poll happened no more than
+// this duration ago. Defaults to twice the default agent poll interval
+// (30s), giving one missed poll of headroom before flipping to offline.
+const hostOnlineThreshold = 60 * time.Second
+
+// isHostOnline reports whether a host whose last poll happened at
+// lastSeen should be rendered as "online" right now. nil / zero values
+// (a host that never polled) are always offline.
+func isHostOnline(lastSeen *time.Time, threshold time.Duration, now time.Time) bool {
+	if lastSeen == nil || lastSeen.IsZero() {
+		return false
+	}
+	return now.Sub(*lastSeen) < threshold
+}

--- a/internal/web/online_test.go
+++ b/internal/web/online_test.go
@@ -1,0 +1,59 @@
+package web
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsHostOnline(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		lastSeen  *time.Time
+		threshold time.Duration
+		want      bool
+	}{
+		{name: "never polled", lastSeen: nil, threshold: time.Minute, want: false},
+		{
+			name:      "polled just now",
+			lastSeen:  ptr(now),
+			threshold: time.Minute,
+			want:      true,
+		},
+		{
+			name:      "polled inside threshold",
+			lastSeen:  ptr(now.Add(-30 * time.Second)),
+			threshold: time.Minute,
+			want:      true,
+		},
+		{
+			name:      "polled exactly at threshold (excluded)",
+			lastSeen:  ptr(now.Add(-time.Minute)),
+			threshold: time.Minute,
+			want:      false,
+		},
+		{
+			name:      "polled long ago",
+			lastSeen:  ptr(now.Add(-1 * time.Hour)),
+			threshold: time.Minute,
+			want:      false,
+		},
+		{
+			name:      "zero time",
+			lastSeen:  ptr(time.Time{}),
+			threshold: time.Minute,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isHostOnline(tt.lastSeen, tt.threshold, now)
+			if got != tt.want {
+				t.Errorf("isHostOnline(%v) = %v, want %v", tt.lastSeen, got, tt.want)
+			}
+		})
+	}
+}
+
+func ptr(t time.Time) *time.Time { return &t }

--- a/internal/web/templates/hosts.html
+++ b/internal/web/templates/hosts.html
@@ -8,17 +8,18 @@
 
 {{if .Hosts}}
 <div class="card">
-    <table>
-        <thead><tr><th>Name</th><th>Nebula IP</th><th>Network</th><th>Role</th><th>Status</th><th>Last Seen</th><th></th></tr></thead>
+    <table id="hosts-table">
+        <thead><tr><th>Name</th><th>Nebula IP</th><th>Network</th><th>Role</th><th>Status</th><th>Online</th><th>Last Seen</th><th></th></tr></thead>
         <tbody>
         {{range .Hosts}}
-        <tr>
+        <tr id="host-{{.ID}}" data-host-id="{{.ID}}">
             <td><a href="/ui/hosts/{{.ID}}">{{.Name}}</a></td>
             <td>{{.NebulaIP}}</td>
             <td><span title="{{.NetworkID}}">{{if .NetworkName}}{{.NetworkName}}{{else}}{{.NetworkID}}{{end}}</span></td>
             <td>{{.Role}}</td>
             <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
-            <td>{{if .LastSeenAt}}{{.LastSeenAt.Format "2006-01-02 15:04"}}{{else}}—{{end}}</td>
+            <td><span class="badge badge-online" data-online="{{.Online}}">{{if .Online}}online{{else}}offline{{end}}</span></td>
+            <td class="host-last-seen">{{if .LastSeenAt}}{{.LastSeenAt.Format "2006-01-02 15:04"}}{{else}}—{{end}}</td>
             <td>
                 {{if ne (printf "%s" .Status) "blocked"}}
                 <button class="btn btn-sm btn-danger"
@@ -33,6 +34,33 @@
         </tbody>
     </table>
 </div>
+<script>
+// Subscribe to live host.seen events. When SSE is unavailable (proxy
+// stripping text/event-stream, ancient browser) we silently fall back to
+// the existing 30s htmx polling.
+(function () {
+    if (!window.EventSource) { return; }
+    var es = new EventSource("/ui/events");
+    es.addEventListener("host.seen", function (msg) {
+        try {
+            var ev = JSON.parse(msg.data);
+            var row = document.getElementById("host-" + ev.host_id);
+            if (!row) { return; }
+            var badge = row.querySelector(".badge-online");
+            if (badge) {
+                badge.dataset.online = "true";
+                badge.textContent = "online";
+            }
+            var lastSeen = row.querySelector(".host-last-seen");
+            if (lastSeen && ev.last_seen) {
+                var d = new Date(ev.last_seen);
+                lastSeen.textContent = d.toISOString().slice(0, 16).replace("T", " ");
+            }
+        } catch (e) { /* ignore malformed events */ }
+    });
+    es.onerror = function () { /* browser auto-retries; nothing to do */ };
+})();
+</script>
 {{else}}
 <div class="card empty">No hosts found.</div>
 {{end}}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -35,6 +35,7 @@ type Web struct {
 	oidc                  *OIDC
 	allowSelfRegistration bool
 	loginRecorder         func(result, factor string)
+	events                *EventBus
 }
 
 // WithLoginRecorder wires an external sink (typically the API server's
@@ -143,6 +144,7 @@ func (w *Web) setupRoutes() {
 		r.Post("/ui/2fa/disable", w.handleTwoFADisable)
 		r.Post("/ui/2fa/recovery-codes", w.handleTwoFARegenCodes)
 		r.Get("/ui/partials/stats", w.handlePartialStats)
+		r.Get("/ui/events", w.handleHostEvents)
 		r.Get("/ui/logout", w.handleLogout)
 	})
 


### PR DESCRIPTION
## Summary

- New \`GET /ui/events\` SSE endpoint streams \`host.seen\` events to every open Web UI tab.
- API server emits the event right after \`UpdateHostLastSeen\` via an injectable \`HostSeenEmitter\` callback (no \`api → web\` import cycle).
- Hosts table grows a per-row \"online\" badge (60s threshold = 2× default poll interval) and a small EventSource client that patches just the affected row when an event lands. The existing 30s htmx polling fallback still works when SSE is unreachable.

Closes #43.

## Test plan

- [x] \`go test -race ./...\` — new tests: \`TestEventBus_*\`, \`TestHandleHostEvents_*\`, \`TestIsHostOnline\`.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [x] README *Already delivered* updated.