### PR TITLE
feat(packaging): ship nebula-mgmt as deb/rpm + reverse-proxy snippets (#51)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,6 +77,60 @@ archives:
       - deploy/systemd/README.md
 
 nfpms:
+  - id: nebula-mgmt
+    package_name: nebula-mgmt
+    ids: [nebula-mgmt]
+    vendor: "juev"
+    homepage: "https://github.com/juev/nebula-mesh"
+    maintainer: "juev <https://github.com/juev>"
+    description: |
+      Self-hosted control plane for Slack Nebula. Issues certificates,
+      manages hosts, distributes config to nebula-agent instances, and
+      exposes a Web UI + REST API + CLI for operators.
+    license: MIT
+    formats: [deb, rpm]
+    bindir: /usr/bin
+    section: net
+    contents:
+      - src: configs/server.example.yml
+        dst: /etc/nebula-mgmt/server.example.yml
+        type: config|noreplace
+      - src: deploy/systemd/nebula-mgmt.service
+        dst: /lib/systemd/system/nebula-mgmt.service
+      - src: README.md
+        dst: /usr/share/doc/nebula-mgmt/README.md
+      - src: LICENSE
+        dst: /usr/share/doc/nebula-mgmt/LICENSE
+      - src: CHANGELOG.md
+        dst: /usr/share/doc/nebula-mgmt/CHANGELOG.md
+      - src: docs/server.md
+        dst: /usr/share/doc/nebula-mgmt/server.md
+      - src: deploy/reverse-proxy/nginx/nebula-mgmt.conf
+        dst: /usr/share/doc/nebula-mgmt/reverse-proxy/nginx.conf
+      - src: deploy/reverse-proxy/caddy/Caddyfile
+        dst: /usr/share/doc/nebula-mgmt/reverse-proxy/Caddyfile
+      - src: deploy/reverse-proxy/traefik/dynamic.yml
+        dst: /usr/share/doc/nebula-mgmt/reverse-proxy/traefik-dynamic.yml
+    overrides:
+      rpm:
+        dependencies:
+          - shadow-utils
+      deb:
+        dependencies:
+          - adduser
+    scripts:
+      postinstall: deploy/packaging/postinstall-mgmt.sh
+      preremove:   deploy/packaging/preremove-mgmt.sh
+      postremove:  deploy/packaging/postremove-mgmt.sh
+    rpm:
+      group: System Environment/Daemons
+      summary: Self-hosted control plane for Slack Nebula
+    deb:
+      fields:
+        Bugs: "https://github.com/juev/nebula-mesh/issues"
+      lintian_overrides:
+        - "statically-linked-binary"
+
   - id: nebula-agent
     package_name: nebula-agent
     ids: [nebula-agent]

--- a/README.md
+++ b/README.md
@@ -119,12 +119,30 @@ Each release ships **two** independent artifact sets — install only what you n
 |---|---|---|
 | Where it runs | one VM / container — the control plane | every Nebula host — next to `nebula` |
 | Binary tarball | `nebula-mgmt_<v>_<os>_<arch>.tar.gz` | `nebula-agent_<v>_<os>_<arch>.tar.gz` |
-| Linux distro packages | — | `nebula-agent_<v>_linux_<arch>.{deb,rpm}` |
+| Linux distro packages | `nebula-mgmt_<v>_linux_<arch>.{deb,rpm}` | `nebula-agent_<v>_linux_<arch>.{deb,rpm}` |
 | Docker image | `ghcr.io/juev/nebula-mgmt` | `ghcr.io/juev/nebula-agent` |
 
-### Linux distro packages — recommended for the agent
+### Linux distro packages — recommended for both server and agent
 
-`nebula-agent` ships as `.deb` and `.rpm` for `amd64`, `arm64`, and `armv7` on every release. The package installs the binary at `/usr/bin/nebula-agent`, the systemd unit at `/lib/systemd/system/nebula-agent.service`, an example config at `/etc/nebula-agent/agent.example.yml`, and the operations guide at `/usr/share/doc/nebula-agent/agent.md`. The post-install script creates the `nebula-agent` system user but does **not** enable the service — you must enroll the host first.
+`nebula-mgmt` and `nebula-agent` both ship as `.deb` and `.rpm`. The server is published for `amd64` and `arm64`; the agent additionally covers `armv7`. Each package installs the binary at `/usr/bin/`, the systemd unit at `/lib/systemd/system/`, an example config at `/etc/nebula-{mgmt,agent}/`, and the operations guide at `/usr/share/doc/nebula-{mgmt,agent}/`. The post-install creates the matching system user but never auto-starts the service — operators run `nebula-mgmt init` (for the server) or `nebula-agent enroll` (for each host) first.
+
+```sh
+TAG=$(curl -fsSL https://api.github.com/repos/juev/nebula-mesh/releases/latest | grep -m1 tag_name | cut -d'"' -f4)
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+
+# nebula-mgmt (server VM)
+curl -fsSL -O "https://github.com/juev/nebula-mesh/releases/download/${TAG}/nebula-mgmt_${TAG#v}_linux_${ARCH}.deb"
+sudo apt install -y "./nebula-mgmt_${TAG#v}_linux_${ARCH}.deb"
+# server.yml lives at /etc/nebula-mgmt/server.example.yml — copy, edit, set
+# NEBULA_MGMT_MASTER_KEY / NEBULA_MGMT_CA_PASSPHRASE via a systemd drop-in,
+# then `nebula-mgmt init` and `systemctl enable --now nebula-mgmt`.
+```
+
+Full server lifecycle reference: [`docs/server.md`](docs/server.md).
+
+#### Agent
+
+`nebula-agent` is published with the same package shape, plus an `armv7` build for 32-bit Raspberry Pi targets.
 
 ```sh
 TAG=$(curl -fsSL https://api.github.com/repos/juev/nebula-mesh/releases/latest | grep -m1 tag_name | cut -d'"' -f4)
@@ -343,7 +361,7 @@ Non-admin operators see and manage only the CAs they own; admins see all. Hosts 
 
 - **Docker** — `docker build -t nebula-mgmt .` (Dockerfile in repo).
 - **systemd** — unit files in [`deploy/systemd/`](deploy/systemd/).
-- **TLS** — set `tls_cert` + `tls_key` for in-process TLS, or front with nginx/caddy/traefik.
+- **TLS** — set `tls_cert` + `tls_key` for in-process TLS, or front with nginx/caddy/traefik. Working snippets for all three live in [`deploy/reverse-proxy/`](deploy/reverse-proxy/) and ship inside the `.deb`/`.rpm` at `/usr/share/doc/nebula-mgmt/reverse-proxy/`. Each is opinionated, preserves `X-Forwarded-For`, and disables buffering on `/ui/events` so the SSE feed reaches the browser in real time.
 - **Rate limiting** — on by default. The Web UI, auth endpoints, `/api/v1/enroll`, and the bearer-authenticated admin API each run their own per-IP token bucket. Defaults: 5 req/s on login forms (burst 10), 2 req/s on enrolment (burst 5), 30 req/s on UI + admin API (burst 60), 60 req/s on agent polls (burst 120). Health (`/healthz`, `/readyz`, `/metrics`, `/debug/vars`, `/favicon.ico`, `/static/*`) is exempt. Run behind a reverse proxy? Set `rate_limit.trust_proxy_header: true` so the limiter keys on `X-Forwarded-For` instead of the proxy's connection address.
 
 ### Backups & key handling
@@ -388,7 +406,7 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 </details>
 
 <details open>
-<summary><strong>Roadmap</strong> — what's next (5 open issues)</summary>
+<summary><strong>Roadmap</strong> — what's next (4 open issues)</summary>
 <a name="roadmap"></a>
 
 
@@ -398,9 +416,8 @@ Open issues tracked individually so you can subscribe to the ones you care about
 - [#46](https://github.com/juev/nebula-mesh/issues/46) — Web UI: per-operator CA management (create / list / retire / delete)
 - [#47](https://github.com/juev/nebula-mesh/issues/47) — Web UI: admin Settings page (toggle self-reg, log level, policy flags …)
 - [#49](https://github.com/juev/nebula-mesh/issues/49) — Admin-enforced 2FA: `enforce_2fa` toggle, forced enrolment gate after login
-- [#51](https://github.com/juev/nebula-mesh/issues/51) — `.deb`/`.rpm` packaging polish + official nginx/caddy/traefik snippets
 
-Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, distro packages (deb/rpm) and the cross-platform agent build matrix.
+Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
 
 Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/deploy/packaging/postinstall-mgmt.sh
+++ b/deploy/packaging/postinstall-mgmt.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+# Create system user/group if missing. The service unit runs the
+# nebula-mgmt binary under this user; the operator is expected to
+# pre-stage NEBULA_MGMT_MASTER_KEY / NEBULA_MGMT_CA_PASSPHRASE via a
+# systemd drop-in or EnvironmentFile before enabling the unit.
+if ! getent group nebula-mgmt >/dev/null 2>&1; then
+    groupadd --system nebula-mgmt
+fi
+if ! getent passwd nebula-mgmt >/dev/null 2>&1; then
+    useradd --system --gid nebula-mgmt --home-dir /var/lib/nebula-mgmt \
+        --shell /usr/sbin/nologin --comment "nebula-mgmt" nebula-mgmt
+fi
+
+# Data + config directories with conservative permissions. The CA and
+# SQLite DB live under /var/lib/nebula-mgmt — keep it 0750 so casual
+# package upgrades cannot leak them.
+install -d -o nebula-mgmt -g nebula-mgmt -m 0750 /var/lib/nebula-mgmt
+install -d -o root         -g nebula-mgmt -m 0750 /etc/nebula-mgmt
+
+# /etc/nebula-mgmt/server.yml is intentionally NOT created automatically —
+# operators copy from the shipped example, set secrets via env, then
+# `nebula-mgmt init` before starting the service.
+if [ ! -f /etc/nebula-mgmt/server.yml ]; then
+    cat <<EOF >&2
+
+  nebula-mgmt: configuration not yet present.
+  Bootstrap steps:
+
+    sudo cp /etc/nebula-mgmt/server.example.yml /etc/nebula-mgmt/server.yml
+    sudoedit /etc/nebula-mgmt/server.yml
+
+    # Provide the master key + CA passphrase via a systemd drop-in,
+    # NOT in server.yml. Example:
+    #   sudo systemctl edit nebula-mgmt.service
+    #   [Service]
+    #   Environment=NEBULA_MGMT_MASTER_KEY=<base64>
+    #   Environment=NEBULA_MGMT_CA_PASSPHRASE=<passphrase>
+
+    # Then run init once and enable:
+    sudo -u nebula-mgmt -E nebula-mgmt init --config /etc/nebula-mgmt/server.yml
+    sudo systemctl enable --now nebula-mgmt.service
+
+EOF
+fi
+
+# Reload systemd but never auto-start.
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+fi
+
+exit 0

--- a/deploy/packaging/postremove-mgmt.sh
+++ b/deploy/packaging/postremove-mgmt.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+fi
+
+case "$1" in
+    purge)
+        # dpkg purge only: drop the system user. Keep /var/lib/nebula-mgmt
+        # and /etc/nebula-mgmt intact — they contain the CA + DB and must
+        # survive a package removal.
+        if getent passwd nebula-mgmt >/dev/null 2>&1; then
+            userdel nebula-mgmt 2>/dev/null || true
+        fi
+        if getent group nebula-mgmt >/dev/null 2>&1; then
+            groupdel nebula-mgmt 2>/dev/null || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/deploy/packaging/preremove-mgmt.sh
+++ b/deploy/packaging/preremove-mgmt.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    remove|purge|0)
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl stop nebula-mgmt.service 2>/dev/null || true
+            systemctl disable nebula-mgmt.service 2>/dev/null || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/deploy/reverse-proxy/README.md
+++ b/deploy/reverse-proxy/README.md
@@ -1,0 +1,26 @@
+# Reverse-proxy snippets
+
+Working configurations for the three reverse proxies operators reach
+for most often when fronting `nebula-mgmt` with TLS. Each file is
+opinionated, commented, and copy-pasteable — pick one, change the
+hostname, reload the proxy.
+
+| Path | Use when |
+|---|---|
+| [`nginx/nebula-mgmt.conf`](nginx/nebula-mgmt.conf) | nginx ≥ 1.18; certificates managed by certbot. |
+| [`caddy/Caddyfile`](caddy/Caddyfile) | Caddy 2.x; automatic Let's Encrypt with zero config. |
+| [`traefik/dynamic.yml`](traefik/dynamic.yml) | Traefik v3 with the file provider. |
+
+All three:
+
+- terminate TLS on `:443` and proxy plain HTTP to `127.0.0.1:8080`;
+- preserve the real client IP via `X-Forwarded-For` (works with
+  `rate_limit.trust_proxy_header: true` in `server.yml`);
+- disable buffering on `/ui/events` so the Server-Sent Events feed
+  (issue #43) reaches the browser in real time;
+- set HSTS, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+  and `Referrer-Policy: no-referrer`.
+
+The agent endpoints (`/api/v1/enroll`, `/api/v1/agent/updates`) carry
+their own bearer / token authentication — do **not** stack HTTP basic
+auth in the proxy on top of them.

--- a/deploy/reverse-proxy/caddy/Caddyfile
+++ b/deploy/reverse-proxy/caddy/Caddyfile
@@ -1,0 +1,39 @@
+# nebula-mgmt — opinionated Caddy reverse-proxy snippet.
+#
+# Drop this into /etc/caddy/Caddyfile (or include from your existing
+# Caddyfile) and replace `mgmt.example.com`. Caddy will automatically
+# obtain and renew a Let's Encrypt certificate.
+#
+# Reload after editing:
+#   sudo systemctl reload caddy
+#
+# In server.yml, set `rate_limit.trust_proxy_header: true` so the
+# management server's rate limiter keys on the real client IP instead
+# of Caddy's loopback.
+
+mgmt.example.com {
+    encode gzip
+
+    # Security headers.
+    header {
+        Strict-Transport-Security "max-age=63072000; includeSubDomains"
+        X-Content-Type-Options    "nosniff"
+        X-Frame-Options           "DENY"
+        Referrer-Policy           "no-referrer"
+    }
+
+    # SSE endpoint — disable buffering so /ui/events streams immediately.
+    @sse path /ui/events
+    reverse_proxy @sse 127.0.0.1:8080 {
+        flush_interval -1
+        transport http {
+            read_timeout  24h
+            write_timeout 24h
+        }
+    }
+
+    # Everything else — straight reverse proxy. Caddy auto-fills X-Forwarded-*
+    # headers; nothing extra to configure for the rate limiter to see the
+    # real client IP.
+    reverse_proxy 127.0.0.1:8080
+}

--- a/deploy/reverse-proxy/nginx/nebula-mgmt.conf
+++ b/deploy/reverse-proxy/nginx/nebula-mgmt.conf
@@ -1,0 +1,96 @@
+# nebula-mgmt — opinionated nginx reverse-proxy snippet.
+#
+# Usage:
+#   1. Drop this file into /etc/nginx/sites-available/nebula-mgmt.conf
+#      (or /etc/nginx/conf.d/ on RHEL-family distros).
+#   2. Replace `mgmt.example.com` and the certificate paths with yours.
+#      Let's Encrypt: `certbot --nginx -d mgmt.example.com` rewrites the
+#      cert paths and reloads nginx in one step.
+#   3. Symlink into sites-enabled (Debian/Ubuntu) and reload:
+#        sudo ln -s ../sites-available/nebula-mgmt.conf /etc/nginx/sites-enabled/
+#        sudo nginx -t && sudo systemctl reload nginx
+#   4. Set `rate_limit.trust_proxy_header: true` in server.yml so the
+#      management server's per-IP rate limiter keys on the real client
+#      IP instead of nginx's loopback connection.
+#
+# The block intentionally serves /api/v1/enroll and /api/v1/agent/updates
+# the same way the rest of the API is served — those endpoints already
+# carry their own bearer / token authentication; do not add HTTP basic
+# auth on top.
+
+# Redirect plain HTTP → HTTPS.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name mgmt.example.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/letsencrypt;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name mgmt.example.com;
+
+    # TLS — paths created by certbot. Swap in your own paths if you use
+    # another CA or pre-staged cert material.
+    ssl_certificate     /etc/letsencrypt/live/mgmt.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mgmt.example.com/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options    "nosniff"                              always;
+    add_header X-Frame-Options           "DENY"                                 always;
+    add_header Referrer-Policy           "no-referrer"                          always;
+
+    # Keep request bodies small — the management API only ever exchanges
+    # JSON or short form-urlencoded bodies. 1 MiB matches the server-side
+    # MaxBytesReader limit.
+    client_max_body_size 1m;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection        "";
+
+        # Buffer settings — disable buffering on the SSE event stream so
+        # /ui/events delivers host.seen events without waiting for nginx
+        # to fill its buffer. The location below overrides for SSE only.
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+
+    # Server-Sent Events for live host status (issue #43).
+    location = /ui/events {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection        "";
+
+        # SSE essentials: no buffering, no gzip, long read timeout.
+        proxy_buffering    off;
+        gzip               off;
+        proxy_read_timeout 24h;
+        chunked_transfer_encoding off;
+    }
+}

--- a/deploy/reverse-proxy/traefik/dynamic.yml
+++ b/deploy/reverse-proxy/traefik/dynamic.yml
@@ -1,0 +1,62 @@
+# nebula-mgmt — Traefik dynamic configuration (file provider).
+#
+# Drop this into /etc/traefik/dynamic/nebula-mgmt.yml (Traefik v3) and
+# point your file provider at /etc/traefik/dynamic/ — typically via
+# traefik.yml:
+#
+#   providers:
+#     file:
+#       directory: /etc/traefik/dynamic
+#       watch: true
+#
+# Adjust the entrypoints, host rule, and certResolver to your setup.
+# In server.yml, set `rate_limit.trust_proxy_header: true` so the
+# management server's rate limiter keys on the real client IP that
+# Traefik forwards.
+
+http:
+  routers:
+    nebula-mgmt:
+      rule: "Host(`mgmt.example.com`)"
+      entryPoints: [websecure]
+      service: nebula-mgmt
+      middlewares: [nebula-mgmt-headers]
+      tls:
+        certResolver: letsencrypt
+
+    # Dedicated router for /ui/events so we can attach an SSE-friendly
+    # middleware. The order is important: rule matches a path prefix
+    # first, falling back to the catch-all above.
+    nebula-mgmt-sse:
+      rule: "Host(`mgmt.example.com`) && Path(`/ui/events`)"
+      entryPoints: [websecure]
+      service: nebula-mgmt-sse
+      middlewares: [nebula-mgmt-headers]
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    nebula-mgmt:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:8080"
+        passHostHeader: true
+
+    # Same backend; separate service so we can tune timeouts without
+    # affecting the regular HTTP traffic.
+    nebula-mgmt-sse:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:8080"
+        passHostHeader: true
+        responseForwarding:
+          flushInterval: "100ms"
+
+  middlewares:
+    nebula-mgmt-headers:
+      headers:
+        stsSeconds: 63072000
+        stsIncludeSubdomains: true
+        contentTypeNosniff: true
+        frameDeny: true
+        referrerPolicy: "no-referrer"

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,188 @@
+# nebula-mgmt
+
+The `nebula-mgmt` server is the control plane for the mesh. It issues
+host certificates, manages networks and operators, distributes config to
+agents via `/api/v1/agent/updates`, and exposes the Web UI + REST API +
+CLI from a single Go binary.
+
+This document covers production usage — installation, configuration,
+day-2 operations, upgrade. The 30-second walkthrough lives in the
+project [README](../README.md).
+
+## Runtime requirements
+
+- A Linux host (Debian / Ubuntu / RHEL family supported by the
+  packages below; tarball fallback for the rest).
+- Persistent storage for `data_dir` (default `/var/lib/nebula-mgmt`) —
+  the SQLite database, the encrypted CA material, and the operator
+  data all live here.
+- The `NEBULA_MGMT_MASTER_KEY` (base64 32-byte AES-256 key) **must** be
+  supplied at startup via an environment variable. The key is never
+  written to disk by the server; loss of the key means loss of the
+  ability to mint new certificates against existing CAs.
+- ~25 MiB of disk for the binary; runtime memory typically < 100 MiB.
+
+## Installation
+
+### Linux distro packages (recommended)
+
+Each tagged release publishes `.deb` and `.rpm` packages for `amd64` and
+`arm64` alongside the agent package:
+
+```sh
+TAG=$(curl -fsSL https://api.github.com/repos/juev/nebula-mesh/releases/latest | grep -m1 tag_name | cut -d'"' -f4)
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+
+# Debian / Ubuntu
+curl -fsSL -O "https://github.com/juev/nebula-mesh/releases/download/${TAG}/nebula-mgmt_${TAG#v}_linux_${ARCH}.deb"
+sudo apt install -y "./nebula-mgmt_${TAG#v}_linux_${ARCH}.deb"
+
+# RHEL / Rocky / Alma / Fedora
+sudo rpm -i "https://github.com/juev/nebula-mesh/releases/download/${TAG}/nebula-mgmt_${TAG#v}_linux_${ARCH}.rpm"
+```
+
+The package installs:
+
+- `/usr/bin/nebula-mgmt` — the server binary;
+- `/lib/systemd/system/nebula-mgmt.service` — the systemd unit;
+- `/etc/nebula-mgmt/server.example.yml` — example config (marked
+  `config|noreplace` so upgrades preserve your edits);
+- `/var/lib/nebula-mgmt/` — empty data dir, mode `0750`, owned by the
+  newly-created `nebula-mgmt` system user;
+- `/usr/share/doc/nebula-mgmt/{README,LICENSE,CHANGELOG,server.md}` —
+  docs;
+- `/usr/share/doc/nebula-mgmt/reverse-proxy/{nginx.conf,Caddyfile,traefik-dynamic.yml}` —
+  reverse-proxy snippets you can `cp` into the right system directory.
+
+The post-install script **does not** start or enable the unit; you
+must complete bootstrap first (see *Bootstrap* below).
+
+### Tarball / Docker
+
+For platforms without a native package (macOS dev install, FreeBSD,
+non-standard Linux distros) or container deployments, fall back to the
+prebuilt tarball or the published Docker image — see the
+[Install](../README.md#install) section in the README.
+
+## Bootstrap
+
+```sh
+# 1. Drop the secrets into a systemd drop-in so they never appear in
+#    /etc/nebula-mgmt/server.yml and never enter your VCS.
+sudo systemctl edit nebula-mgmt.service
+# [Service]
+# Environment=NEBULA_MGMT_MASTER_KEY=<base64-32-byte-key>
+# Environment=NEBULA_MGMT_CA_PASSPHRASE=<long-random-passphrase>
+
+# 2. Materialise the config from the shipped example and edit.
+sudo cp /etc/nebula-mgmt/server.example.yml /etc/nebula-mgmt/server.yml
+sudoedit /etc/nebula-mgmt/server.yml
+
+# 3. Run init exactly once. The script creates the initial admin
+#    operator and seeds the first CA.
+sudo -u nebula-mgmt -E nebula-mgmt init --config /etc/nebula-mgmt/server.yml
+
+# 4. Enable + start.
+sudo systemctl enable --now nebula-mgmt.service
+sudo journalctl -u nebula-mgmt -f
+```
+
+The post-install reminder printed by the package walks operators
+through these same steps.
+
+## Reverse proxy
+
+The server speaks plain HTTP on the bind address by default. Always
+front it with a TLS-terminating proxy unless your network is
+unconditionally trusted.
+
+Three working snippets ship in the package at
+`/usr/share/doc/nebula-mgmt/reverse-proxy/` (and in the repo under
+[`deploy/reverse-proxy/`](../deploy/reverse-proxy/)):
+
+- `nginx.conf` — nginx ≥ 1.18 + certbot.
+- `Caddyfile`  — Caddy 2.x with automatic Let's Encrypt.
+- `traefik-dynamic.yml` — Traefik v3 file provider.
+
+All three preserve `X-Forwarded-For` so the management server's per-IP
+rate limiter (issue #52) keys on the real client IP — set
+`rate_limit.trust_proxy_header: true` in `server.yml` to opt into that.
+
+## Upgrade
+
+```sh
+sudo apt install -y "./nebula-mgmt_<new-version>_linux_<arch>.deb"
+# rpm equivalent:
+# sudo rpm -U "./nebula-mgmt_<new-version>_linux_<arch>.rpm"
+```
+
+The deb / rpm post-install runs `systemctl daemon-reload`; if the unit
+was already enabled, systemd auto-restarts the service. `/etc/nebula-mgmt/server.yml`
+and the data dir survive across upgrades.
+
+When upgrading across a minor version, check the
+[CHANGELOG](../CHANGELOG.md) for migration notes — every database
+migration is tracked in `internal/store/migrations/`, applied
+automatically on startup, and recorded in `schema_migrations`.
+
+## Removal
+
+```sh
+sudo apt remove nebula-mgmt      # stops + disables the service, keeps data
+sudo apt purge  nebula-mgmt      # additionally drops the system user
+```
+
+`apt purge` **never** deletes `/var/lib/nebula-mgmt` (CA + DB) or
+`/etc/nebula-mgmt/`. Clean them up manually if you really mean to
+nuke the install:
+
+```sh
+sudo rm -rf /var/lib/nebula-mgmt /etc/nebula-mgmt
+```
+
+The rpm equivalents are `rpm -e nebula-mgmt` and the same manual
+clean-up afterwards.
+
+## Backups
+
+The whole server state collapses to a single SQLite file. With the
+service running:
+
+```sh
+sudo -u nebula-mgmt sqlite3 /var/lib/nebula-mgmt/nebula.db \
+  ".backup /backups/nebula-$(date +%F).db"
+```
+
+The `NEBULA_MGMT_MASTER_KEY` is **load-bearing**: the DB on its own
+is useless without the matching key. Keep both in your secret manager.
+
+## Troubleshooting
+
+### `database is locked` errors at startup
+
+Most often a leftover `*-wal` / `*-shm` file from a hard crash. Stop
+the service, run `sqlite3 /var/lib/nebula-mgmt/nebula.db "PRAGMA
+wal_checkpoint(TRUNCATE);"`, then start again.
+
+### Bootstrap admin password not shown
+
+`nebula-mgmt init` prints the seeded admin's username and one-time
+password to stdout. The package log capture in `journalctl` shows it
+only on the first start of the service. If you missed it, run:
+
+```sh
+sudo -u nebula-mgmt -E nebula-mgmt user create --username admin --role admin
+```
+
+to mint a new admin operator (the existing seed user keeps its TOTP
+binding, if any).
+
+### `permission denied` on `/var/lib/nebula-mgmt`
+
+The package sets `0750 nebula-mgmt:nebula-mgmt` on the data dir. If a
+previous install left it as root-owned, fix it:
+
+```sh
+sudo chown -R nebula-mgmt:nebula-mgmt /var/lib/nebula-mgmt
+sudo chmod 0750                       /var/lib/nebula-mgmt
+```


### PR DESCRIPTION
## Summary

- Extend `.goreleaser.yml` so every release publishes `nebula-mgmt_<v>_linux_{amd64,arm64}.{deb,rpm}` next to the existing agent packages, with `/usr/bin/nebula-mgmt`, the systemd unit, an example config, the doc set, and the reverse-proxy snippets all laid down by the package.
- Lifecycle scripts (`postinstall-mgmt.sh`, `preremove-mgmt.sh`, `postremove-mgmt.sh`) mirror the agent contract: install creates the system user + data dir at `0750` and prints bootstrap hints, removal stops/disables the service, purge drops the user only — **never** the data dir or config.
- Reverse-proxy snippets under `deploy/reverse-proxy/` for nginx, Caddy, and Traefik. All three preserve `X-Forwarded-For` (pairs with `rate_limit.trust_proxy_header: true`), disable buffering on `/ui/events` for live SSE, and set HSTS + the usual security headers.
- New `docs/server.md` walks operators through install, bootstrap, reverse proxy, upgrade, removal, backups, and a few common troubleshooting cases.

Closes #51.

## Test plan

- [x] `go test -race ./... && golangci-lint run ./...` — no Go side changes, suite green, 0 lint issues.
- [ ] `goreleaser release --snapshot --clean --skip=publish` to verify the new nfpms entry produces the expected artifacts — couldn't run inside this environment, please confirm in CI / first release tag.
EOF
