### PR TITLE
feat(auth): admin-enforced 2FA via enforce_2fa setting (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ Audit log entries (`/api/v1/audit-log`) record the actor for every mutating oper
 
 Open `/ui/2fa`, click **Enable 2FA**, scan the displayed `otpauth://` URL with 1Password / Bitwarden / Google Authenticator / Aegis / Authy / any compatible app, and confirm with a 6-digit code. The server then shows ten one-time recovery codes — save them offline. On the next login the UI asks for the 6-digit code (or one recovery code) after the password. Disabling 2FA requires re-confirming the current password. All sensitive operations (`operator.2fa.enabled`, `disabled`, `regen_codes`, `failed`, `verified`) appear in the audit log. API tokens are unaffected.
 
+**Admin enforcement.** Set `enforce_2fa: true` in `server.yml` (or `PATCH /api/v1/settings` with `{"enforce_2fa": true}` at runtime). Every local operator without TOTP is then routed to `/ui/2fa/required` after a successful password login and cannot reach any other UI page until enrolment finishes. `POST /ui/2fa/disable` returns `403` while the toggle is on and writes an `operator.2fa.enforced.disable_blocked` audit entry. OIDC operators are exempt — their second factor lives at the IdP.
+
 ### Single sign-on via OIDC
 
 Configure an `oidc:` block in `server.yml` (see `configs/server.example.yml`) to enable operator login through Keycloak / Authentik / Dex / Google Workspace / Okta / any standard OpenID Connect provider. The login page then shows a **Sign in with SSO** button alongside the local form.
@@ -406,7 +408,7 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 </details>
 
 <details open>
-<summary><strong>Roadmap</strong> — what's next (4 open issues)</summary>
+<summary><strong>Roadmap</strong> — what's next (3 open issues)</summary>
 <a name="roadmap"></a>
 
 
@@ -415,9 +417,8 @@ Open issues tracked individually so you can subscribe to the ones you care about
 - [#45](https://github.com/juev/nebula-mesh/issues/45) — Web UI: admin-only operator and API-key management
 - [#46](https://github.com/juev/nebula-mesh/issues/46) — Web UI: per-operator CA management (create / list / retire / delete)
 - [#47](https://github.com/juev/nebula-mesh/issues/47) — Web UI: admin Settings page (toggle self-reg, log level, policy flags …)
-- [#49](https://github.com/juev/nebula-mesh/issues/49) — Admin-enforced 2FA: `enforce_2fa` toggle, forced enrolment gate after login
 
-Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA, self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
+Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA (opt-in **or** admin-enforced via `enforce_2fa`), self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
 
 Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/configs/server.example.yml
+++ b/configs/server.example.yml
@@ -70,6 +70,13 @@ allow_self_registration: false
 #   block_common:     true
 #   block_username:   true
 
+# Admin-enforced 2FA (issue #49). Defaults off. When true, local
+# operators without TOTP are gated into /ui/2fa/required immediately
+# after a successful password login; OIDC operators are exempt. The
+# value is persisted into server_settings on startup so the future
+# Settings UI (#47) can flip it without a restart.
+# enforce_2fa: false
+
 # Optional OpenID Connect identity provider for operator login. When enabled,
 # the Web UI offers a "Sign in with SSO" button on top of the local password
 # form. Local logins keep working alongside OIDC.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -175,6 +175,8 @@ func (s *Server) setupRoutes() {
 		r.Post("/api/v1/cas", s.handleCreateCA)
 		r.Get("/api/v1/cas/{id}", s.handleGetCAByID)
 		r.Delete("/api/v1/cas/{id}", s.handleDeleteCA)
+		r.Get("/api/v1/settings", s.handleGetSettings)
+		r.Patch("/api/v1/settings", s.handlePatchSettings)
 	})
 
 	s.router = r

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// settingEnforceTOTP duplicates the web package's exported key name so
+// the API handler doesn't pull web in. Keep these literally identical
+// — the value is the contract.
+const settingEnforceTOTP = "enforce_2fa"
+
+type settingsRequest struct {
+	EnforceTOTP *bool `json:"enforce_2fa,omitempty"`
+}
+
+type settingsResponse struct {
+	EnforceTOTP bool `json:"enforce_2fa"`
+}
+
+// handleGetSettings returns the current admin-tunable server settings.
+// Admin-only because exposing the surface to non-admins gives them a
+// view of the deployment's security posture.
+func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
+	if !actorIsAdmin(r.Context()) {
+		writeError(w, http.StatusForbidden, "admin role required")
+		return
+	}
+	v, _ := s.store.GetServerSetting(r.Context(), settingEnforceTOTP)
+	writeJSON(w, http.StatusOK, settingsResponse{EnforceTOTP: v == "true"})
+}
+
+// handlePatchSettings updates one or more admin-tunable settings.
+// Currently exposes only enforce_2fa; will grow with the rest of #47.
+func (s *Server) handlePatchSettings(w http.ResponseWriter, r *http.Request) {
+	if !actorIsAdmin(r.Context()) {
+		writeError(w, http.StatusForbidden, "admin role required")
+		return
+	}
+	var req settingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.EnforceTOTP != nil {
+		val := "false"
+		if *req.EnforceTOTP {
+			val = "true"
+		}
+		if err := s.store.SetServerSetting(r.Context(), settingEnforceTOTP, val); err != nil {
+			s.logger.Error("set enforce_2fa", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to update setting")
+			return
+		}
+		s.recordAuditAction(r.Context(), "settings.enforce_2fa", "enforce_2fa", val)
+	}
+	v, _ := s.store.GetServerSetting(r.Context(), settingEnforceTOTP)
+	writeJSON(w, http.StatusOK, settingsResponse{EnforceTOTP: v == "true"})
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -186,6 +186,18 @@ func Serve(configPath string) error {
 		pwPolicy.BlockUsername = *v
 	}
 	apiSrv.WithPasswordPolicy(pwPolicy)
+
+	// Persist enforce_2fa from server.yml into server_settings so the gate
+	// reads the same row admins will edit from the future Settings UI.
+	if cfg.EnforceTOTP != nil {
+		val := "false"
+		if *cfg.EnforceTOTP {
+			val = "true"
+		}
+		if err := s.SetServerSetting(context.Background(), "enforce_2fa", val); err != nil {
+			logger.Error("persist enforce_2fa setting", "error", err)
+		}
+	}
 	if caResolver != nil {
 		apiSrv.WithCAResolver(caResolver)
 		apiSrv.WithMaster(master)

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -52,6 +52,13 @@ type ServerConfig struct {
 	// optional: unset values fall back to the production defaults
 	// (10-char min, 3-of-4 classes, common-pw + username block on).
 	Password PasswordConfig `yaml:"password,omitempty"`
+
+	// EnforceTOTP toggles admin-enforced 2FA (issue #49). When set, the
+	// value is written into the server_settings table on startup so it
+	// stays in effect across restarts. A nil pointer (unset YAML) leaves
+	// the DB value alone — the future Settings UI (#47) will edit the
+	// same row at runtime.
+	EnforceTOTP *bool `yaml:"enforce_2fa,omitempty"`
 }
 
 // PasswordConfig overrides the password policy defaults.

--- a/internal/store/migrations/011_server_settings.down.sql
+++ b/internal/store/migrations/011_server_settings.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS server_settings;

--- a/internal/store/migrations/011_server_settings.up.sql
+++ b/internal/store/migrations/011_server_settings.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS server_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -85,6 +85,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"008_host_advanced.up.sql",
 		"009_per_operator_cas.up.sql",
 		"010_cert_alerts.up.sql",
+		"011_server_settings.up.sql",
 	}
 
 	// Tracking table. Created once; idempotent on subsequent starts.
@@ -1123,6 +1124,35 @@ func (s *SQLiteStore) GetCertAlert(_ context.Context, hostID string) (time.Time,
 		return time.Time{}, fmt.Errorf("get cert alert: %w", err)
 	}
 	return t, nil
+}
+
+// --- Server settings (key/value) ---
+
+// GetServerSetting returns the stored value for key, or "" + ErrNotFound
+// when the key has never been set.
+func (s *SQLiteStore) GetServerSetting(_ context.Context, key string) (string, error) {
+	var value string
+	err := s.db.QueryRow(`SELECT value FROM server_settings WHERE key = ?`, key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("get server setting: %w", err)
+	}
+	return value, nil
+}
+
+// SetServerSetting upserts a key/value pair into server_settings.
+func (s *SQLiteStore) SetServerSetting(_ context.Context, key, value string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO server_settings (key, value) VALUES (?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		key, value,
+	)
+	if err != nil {
+		return fmt.Errorf("set server setting: %w", err)
+	}
+	return nil
 }
 
 // --- Config Versioning ---

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -92,6 +92,12 @@ type Store interface {
 	RecordCertAlert(ctx context.Context, hostID string, alertedNotAfter time.Time) error
 	GetCertAlert(ctx context.Context, hostID string) (time.Time, error)
 
+	// Server-wide key/value settings (e.g. enforce_2fa). Empty string is
+	// returned when the key has never been set — callers convert to typed
+	// defaults via the helpers in the consuming package.
+	GetServerSetting(ctx context.Context, key string) (string, error)
+	SetServerSetting(ctx context.Context, key, value string) error
+
 	// Operators
 	CreateOperator(ctx context.Context, op *models.Operator) error
 	GetOperator(ctx context.Context, id string) (*models.Operator, error)

--- a/internal/web/enforce_2fa_test.go
+++ b/internal/web/enforce_2fa_test.go
@@ -1,0 +1,202 @@
+package web
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func newEnforceWeb(t *testing.T) (*Web, store.Store) {
+	t.Helper()
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	w, err := New(s, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w, s
+}
+
+// seedLocalOperator creates an active local operator with the given
+// password. TOTP is left disabled so the enforce-2fa flow gates the
+// session.
+func seedLocalOperator(t *testing.T, s store.Store, username, password string, oidc bool) *models.Operator {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := models.OperatorAuthLocal
+	if oidc {
+		provider = models.OperatorAuthOIDC
+	}
+	op := &models.Operator{
+		ID:           "op-" + username,
+		Username:     username,
+		PasswordHash: string(hash),
+		Status:       models.OperatorStatusActive,
+		Role:         "admin",
+		AuthProvider: provider,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(context.Background(), op); err != nil {
+		t.Fatal(err)
+	}
+	return op
+}
+
+func loginOperator(t *testing.T, w *Web, username, password string) *http.Cookie {
+	t.Helper()
+	form := url.Values{"username": {username}, "password": {password}}
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "nebula_session" {
+			return c
+		}
+	}
+	t.Fatalf("login: no session cookie issued; status=%d body=%s", rec.Code, rec.Body.String())
+	return nil
+}
+
+func TestEnforce2FA_Off_NoGating(t *testing.T) {
+	w, s := newEnforceWeb(t)
+	seedLocalOperator(t, s, "alice", strongPassword, false)
+
+	cookie := loginOperator(t, w, "alice", strongPassword)
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code == http.StatusSeeOther && rec.Header().Get("Location") == "/ui/2fa/required" {
+		t.Errorf("with enforce_2fa off, dashboard must not redirect to /ui/2fa/required")
+	}
+}
+
+func TestEnforce2FA_On_LocalUser_Gated(t *testing.T) {
+	w, s := newEnforceWeb(t)
+	seedLocalOperator(t, s, "alice", strongPassword, false)
+	if err := s.SetServerSetting(context.Background(), SettingEnforceTOTP, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	cookie := loginOperator(t, w, "alice", strongPassword)
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("dashboard fetch: status = %d, want 303", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/ui/2fa/required" {
+		t.Errorf("redirect = %q, want /ui/2fa/required", loc)
+	}
+}
+
+func TestEnforce2FA_On_OIDC_NotGated(t *testing.T) {
+	// OIDC operators do their 2FA at the IdP and must bypass the gate.
+	w, s := newEnforceWeb(t)
+	op := seedLocalOperator(t, s, "alice", strongPassword, true)
+	if err := s.SetServerSetting(context.Background(), SettingEnforceTOTP, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually mint an authenticated session — OIDC users normally
+	// arrive via the OIDC callback path, not POST /ui/login.
+	tok := "oidc-test-token"
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token:      tok,
+		OperatorID: op.ID,
+		State:      models.SessionStateAuthenticated,
+		ExpiresAt:  time.Now().Add(24 * time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.AddCookie(&http.Cookie{Name: "nebula_session", Value: tok})
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code == http.StatusSeeOther && rec.Header().Get("Location") == "/ui/2fa/required" {
+		t.Errorf("OIDC user must not be gated; got redirect to /ui/2fa/required")
+	}
+}
+
+func TestEnforce2FA_On_DisableBlocked(t *testing.T) {
+	w, s := newEnforceWeb(t)
+	op := seedLocalOperator(t, s, "alice", strongPassword, false)
+	// Pretend TOTP is already enabled so the operator can hit the
+	// disable handler in the first place.
+	if err := s.SetOperatorTOTP(context.Background(), op.ID, "JBSWY3DPEHPK3PXP", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetServerSetting(context.Background(), SettingEnforceTOTP, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	cookie := loginOperator(t, w, "alice", strongPassword)
+	// loginOperator above issues a pending_totp session — promote it by
+	// driving CompleteTwoFactor directly so we land on /ui/2fa/disable
+	// authenticated.
+	if err := s.PromoteOperatorSession(context.Background(), cookie.Value, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	form := url.Values{"password": {strongPassword}}
+	req := httptest.NewRequest(http.MethodPost, "/ui/2fa/disable", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("disable: status = %d, want 403", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "admin-enforced") {
+		t.Errorf("expected admin-enforced explanation in body, got %s", rec.Body.String())
+	}
+
+	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Action: "operator.2fa.enforced.disable_blocked", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("audit entries: got %d, want 1", len(entries))
+	}
+}
+
+func TestEnforce2FA_On_RequiredPath_Reachable(t *testing.T) {
+	w, s := newEnforceWeb(t)
+	seedLocalOperator(t, s, "alice", strongPassword, false)
+	if err := s.SetServerSetting(context.Background(), SettingEnforceTOTP, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	cookie := loginOperator(t, w, "alice", strongPassword)
+	req := httptest.NewRequest(http.MethodGet, "/ui/2fa/required", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /ui/2fa/required: status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "2") { // some 2FA-related content
+		t.Errorf("page body looks empty: %s", rec.Body.String())
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -15,6 +15,17 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// isEnrolmentPath reports whether a path is one of the routes a
+// gated-into-2FA operator is still allowed to hit. Keeps the enrolment
+// page reachable while everything else 303s back to the gate.
+func isEnrolmentPath(path string) bool {
+	switch path {
+	case "/ui/2fa/required", "/ui/2fa/setup", "/ui/2fa/enable", "/ui/logout":
+		return true
+	}
+	return false
+}
+
 // Login label constants mirror those exported by the API server's metrics
 // layer (api.ResultOK / api.LoginFactorPassword / …). They are duplicated
 // here, not imported, to keep this package free of an api ↔ web edge — the
@@ -29,11 +40,24 @@ const (
 	loginFactorRecovery = "recovery"
 )
 
-// requireAuth middleware redirects to login if not authenticated.
+// requireAuth middleware redirects to login if not authenticated. When
+// admin-enforced 2FA is on (server_settings.enforce_2fa = "true"), any
+// authenticated local operator without TOTP enrolled is redirected to
+// /ui/2fa/required and cannot reach any other /ui/* route until they
+// complete enrolment. OIDC operators are exempt — their second factor
+// is the IdP's job.
 func (w *Web) requireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if !w.session.IsAuthenticated(r) {
 			http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+			return
+		}
+		if op := w.session.CurrentOperator(r); op != nil &&
+			!op.TOTPEnabled &&
+			op.AuthProvider != models.OperatorAuthOIDC &&
+			enforceTOTPEnabled(r.Context(), w.store) &&
+			!isEnrolmentPath(r.URL.Path) {
+			http.Redirect(rw, r, "/ui/2fa/required", http.StatusSeeOther)
 			return
 		}
 		next.ServeHTTP(rw, r)
@@ -232,6 +256,35 @@ func (w *Web) handleTwoFAPage(rw http.ResponseWriter, r *http.Request) {
 		"Setup":       nil,
 		"NewCodes":    nil,
 		"Error":       "",
+		"Enforced":    enforceTOTPEnabled(r.Context(), w.store),
+	})
+}
+
+// handleTwoFARequired is the forced-enrolment gate. Identical to the
+// regular /ui/2fa page except (a) it is reachable from requireAuth's
+// redirect path even when admin-enforced 2FA is on, and (b) the
+// template renders without the sidebar so the operator can't navigate
+// away. The actual TOTP setup / verification happens on
+// /ui/2fa/setup and /ui/2fa/enable as usual.
+func (w *Web) handleTwoFARequired(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	if op.TOTPEnabled {
+		http.Redirect(rw, r, "/ui/", http.StatusSeeOther)
+		return
+	}
+	w.renderForRequest(rw, r, "twofa.html", map[string]any{
+		"Active":      "2fa",
+		"Operator":    op,
+		"TOTPEnabled": false,
+		"Setup":       nil,
+		"NewCodes":    nil,
+		"Error":       "",
+		"Enforced":    true,
+		"Required":    true,
 	})
 }
 
@@ -319,6 +372,11 @@ func (w *Web) handleTwoFAEnable(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.enabled", op.ID, "")
+	if enforceTOTPEnabled(r.Context(), w.store) {
+		// Track that this operator completed forced enrolment so an
+		// admin can audit the rollout.
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.enforced.enrolled", op.ID, "")
+	}
 	w.renderForRequest(rw, r, "twofa.html", map[string]any{
 		"Active":      "2fa",
 		"Operator":    op,
@@ -332,6 +390,11 @@ func (w *Web) handleTwoFADisable(rw http.ResponseWriter, r *http.Request) {
 	op := w.session.CurrentOperator(r)
 	if op == nil {
 		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	if enforceTOTPEnabled(r.Context(), w.store) {
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.enforced.disable_blocked", op.ID, "")
+		http.Error(rw, "Disabling 2FA is not allowed — admin-enforced 2FA is active. Contact your administrator.", http.StatusForbidden)
 		return
 	}
 	password := r.FormValue("password")

--- a/internal/web/settings.go
+++ b/internal/web/settings.go
@@ -1,0 +1,24 @@
+package web
+
+import (
+	"context"
+
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// SettingEnforceTOTP is the server_settings key that toggles admin-
+// enforced 2FA (issue #49). "true" forces every local operator
+// without TOTP into the /ui/2fa/required enrolment gate on next login;
+// anything else (including the unset default) leaves 2FA opt-in.
+const SettingEnforceTOTP = "enforce_2fa"
+
+// enforceTOTPEnabled reads the server-wide enforce_2fa setting. Returns
+// false on any error (the gate should fail open: if the DB is hiccupping
+// we'd rather let admins through than lock everyone out).
+func enforceTOTPEnabled(ctx context.Context, s store.Store) bool {
+	v, err := s.GetServerSetting(ctx, SettingEnforceTOTP)
+	if err != nil {
+		return false
+	}
+	return v == "true"
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -182,6 +182,7 @@ func (w *Web) setupRoutes() {
 		r.Post("/ui/networks", w.handleNetworkCreate)
 		r.Get("/ui/profile", w.handleProfilePage)
 		r.Get("/ui/2fa", w.handleTwoFAPage)
+		r.Get("/ui/2fa/required", w.handleTwoFARequired)
 		r.Post("/ui/2fa/setup", w.handleTwoFASetup)
 		r.Post("/ui/2fa/enable", w.handleTwoFAEnable)
 		r.Post("/ui/2fa/disable", w.handleTwoFADisable)


### PR DESCRIPTION
## Summary

- New generic `server_settings (key, value)` table — also the foundation for the upcoming Settings UI (#47).
- `enforce_2fa` toggle: when on, every local operator without TOTP is gated into `/ui/2fa/required` after a successful password login and cannot reach any other UI page until enrolment finishes. OIDC operators are exempt.
- `POST /ui/2fa/disable` returns `403` while the toggle is on and writes `operator.2fa.enforced.disable_blocked`; successful forced enrolment writes `operator.2fa.enforced.enrolled`.
- Settable two ways while #47 ships the UI: `enforce_2fa:` in `server.yml` (persists into `server_settings` on startup) and `PATCH /api/v1/settings` for runtime flips (admin-only, audit-logged).

Closes #49.

## Test plan

- [x] `go test -race ./...` — new `TestEnforce2FA_*` covers off / on (local user gated) / OIDC bypass / disable blocked + audit / required page reachable.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] README *Two-factor authentication* + `configs/server.example.yml` updated with the new toggle.
