### PR TITLE
feat(web): admin Settings page at /ui/settings (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,11 @@ The first successful login for an unknown subject creates a local operator recor
 
 ### Configurable self-registration
 
-By default only administrators can create operator accounts. Set `allow_self_registration: true` in `server.yml` to let unauthenticated visitors sign up via `/ui/register`. Server-side checks gate the endpoint independently of the UI, so flipping the flag is enough to block self-registration. Self-registered operators get the `user` role; the operator-management API (`POST /api/v1/operators`, `disable`, etc) requires `role: admin`.
+By default only administrators can create operator accounts. Set `allow_self_registration: true` in `server.yml`, or flip it from **Settings → Allow self-registration** in the Web UI, to let unauthenticated visitors sign up via `/ui/register`. Server-side checks gate the endpoint independently of the UI, so flipping the flag is enough to block self-registration. Self-registered operators get the `user` role; the operator-management API (`POST /api/v1/operators`, `disable`, etc) requires `role: admin`.
+
+### Settings page
+
+`/ui/settings` (admin-only — non-admins are 403'd, and the sidebar entry is hidden) exposes the runtime knobs administrators can flip without restarting the server: admin-enforced 2FA, self-registration, password policy (min length, required character classes, common-password blocklist, username block), and log level. Saved values land in the `server_settings` table; every save writes a `settings.update` audit-log entry. `server.yml` becomes the bootstrap snapshot — `allow_self_registration:` and `enforce_2fa:` are seeded once and then the DB row wins. Secrets (`master_key`, OIDC client secret, TLS file paths) stay in `server.yml` only.
 
 ### Per-operator CAs
 
@@ -408,7 +412,7 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 </details>
 
 <details open>
-<summary><strong>Roadmap</strong> — what's next (3 open issues)</summary>
+<summary><strong>Roadmap</strong> — what's next (2 open issues)</summary>
 <a name="roadmap"></a>
 
 
@@ -416,9 +420,8 @@ Open issues tracked individually so you can subscribe to the ones you care about
 
 - [#45](https://github.com/juev/nebula-mesh/issues/45) — Web UI: admin-only operator and API-key management
 - [#46](https://github.com/juev/nebula-mesh/issues/46) — Web UI: per-operator CA management (create / list / retire / delete)
-- [#47](https://github.com/juev/nebula-mesh/issues/47) — Web UI: admin Settings page (toggle self-reg, log level, policy flags …)
 
-Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA (opt-in **or** admin-enforced via `enforce_2fa`), self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
+Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA (opt-in **or** admin-enforced via `enforce_2fa`), self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, admin Settings page (toggle self-reg, log level, policy flags, …) at `/ui/settings`, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
 
 Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -68,7 +68,7 @@ func (w *Web) handleLoginPage(rw http.ResponseWriter, r *http.Request) {
 	w.renderForRequest(rw, r, "login.html", map[string]any{
 		"Error":                "",
 		"OIDCEnabled":          w.oidc.Enabled(),
-		"AllowSelfRegistration": w.allowSelfRegistration,
+		"AllowSelfRegistration": w.allowSelfRegistrationEffective(r.Context()),
 	})
 }
 
@@ -90,7 +90,7 @@ func (w *Web) handleLogin(rw http.ResponseWriter, r *http.Request) {
 		w.renderForRequest(rw, r, "login.html", map[string]any{
 			"Error":                 "Invalid username or password",
 			"OIDCEnabled":           w.oidc.Enabled(),
-			"AllowSelfRegistration": w.allowSelfRegistration,
+			"AllowSelfRegistration": w.allowSelfRegistrationEffective(r.Context()),
 		})
 		return
 	}
@@ -166,7 +166,7 @@ func (w *Web) handleLogout(rw http.ResponseWriter, r *http.Request) {
 // --- Self-registration ---
 
 func (w *Web) handleRegisterPage(rw http.ResponseWriter, r *http.Request) {
-	if !w.allowSelfRegistration {
+	if !w.allowSelfRegistrationEffective(r.Context()) {
 		http.Error(rw, "self-registration is disabled", http.StatusForbidden)
 		return
 	}
@@ -174,7 +174,7 @@ func (w *Web) handleRegisterPage(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (w *Web) handleRegister(rw http.ResponseWriter, r *http.Request) {
-	if !w.allowSelfRegistration {
+	if !w.allowSelfRegistrationEffective(r.Context()) {
 		http.Error(rw, "self-registration is disabled", http.StatusForbidden)
 		return
 	}

--- a/internal/web/settings.go
+++ b/internal/web/settings.go
@@ -2,23 +2,72 @@ package web
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/juev/nebula-mesh/internal/store"
 )
 
-// SettingEnforceTOTP is the server_settings key that toggles admin-
-// enforced 2FA (issue #49). "true" forces every local operator
-// without TOTP into the /ui/2fa/required enrolment gate on next login;
-// anything else (including the unset default) leaves 2FA opt-in.
-const SettingEnforceTOTP = "enforce_2fa"
+// Server-wide setting keys, mirrored as exported constants so callers
+// (other packages, tests) can use the same canonical strings.
+const (
+	SettingEnforceTOTP            = "enforce_2fa"
+	SettingAllowSelfRegistration  = "allow_self_registration"
+	SettingPasswordMinLength      = "password_min_length"
+	SettingPasswordRequireClasses = "password_require_classes"
+	SettingPasswordBlockCommon    = "password_block_common"
+	SettingPasswordBlockUsername  = "password_block_username"
+	SettingLogLevel               = "log_level"
+)
 
-// enforceTOTPEnabled reads the server-wide enforce_2fa setting. Returns
-// false on any error (the gate should fail open: if the DB is hiccupping
-// we'd rather let admins through than lock everyone out).
-func enforceTOTPEnabled(ctx context.Context, s store.Store) bool {
-	v, err := s.GetServerSetting(ctx, SettingEnforceTOTP)
+// boolSetting reads a boolean DB setting. dflt is returned when the key
+// is unset or the DB call fails (fail-open for non-critical paths).
+func boolSetting(ctx context.Context, s store.Store, key string, dflt bool) bool {
+	v, err := s.GetServerSetting(ctx, key)
 	if err != nil {
-		return false
+		return dflt
 	}
-	return v == "true"
+	switch v {
+	case "true":
+		return true
+	case "false":
+		return false
+	default:
+		return dflt
+	}
+}
+
+// stringSetting reads a string DB setting. Empty / error → dflt.
+func stringSetting(ctx context.Context, s store.Store, key, dflt string) string {
+	v, err := s.GetServerSetting(ctx, key)
+	if err != nil || v == "" {
+		return dflt
+	}
+	return v
+}
+
+// intSetting reads an int DB setting. Unset / unparseable → dflt.
+func intSetting(ctx context.Context, s store.Store, key string, dflt int) int {
+	v, err := s.GetServerSetting(ctx, key)
+	if err != nil {
+		return dflt
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return dflt
+	}
+	return n
+}
+
+// enforceTOTPEnabled is the canonical reader for the enforce_2fa toggle
+// used by the requireAuth middleware (issue #49). Fail-open: a DB hiccup
+// should not lock everyone out.
+func enforceTOTPEnabled(ctx context.Context, s store.Store) bool {
+	return boolSetting(ctx, s, SettingEnforceTOTP, false)
+}
+
+// allowSelfRegistrationEffective is the read-through helper for
+// /ui/register: DB row wins over the YAML default so admins can flip
+// registration via the Settings UI without a restart.
+func (w *Web) allowSelfRegistrationEffective(ctx context.Context) bool {
+	return boolSetting(ctx, w.store, SettingAllowSelfRegistration, w.allowSelfRegistration)
 }

--- a/internal/web/settings_handler.go
+++ b/internal/web/settings_handler.go
@@ -1,0 +1,132 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// settingsView is the view-model the settings template renders. Each
+// field carries both the current value and a "source" tag so admins can
+// see whether a value comes from the database or the YAML defaults.
+type settingsView struct {
+	EnforceTOTP             bool
+	AllowSelfRegistration   bool
+	PasswordMinLength       int
+	PasswordRequireClasses  int
+	PasswordBlockCommon     bool
+	PasswordBlockUsername   bool
+	LogLevel                string
+	OIDCEnabled             bool
+	Saved                   bool
+	Error                   string
+}
+
+func (w *Web) currentSettings(ctx context.Context) settingsView {
+	return settingsView{
+		EnforceTOTP:            enforceTOTPEnabled(ctx, w.store),
+		AllowSelfRegistration:  boolSetting(ctx, w.store, SettingAllowSelfRegistration, w.allowSelfRegistration),
+		PasswordMinLength:      intSetting(ctx, w.store, SettingPasswordMinLength, w.passwordPolicy.MinLength),
+		PasswordRequireClasses: intSetting(ctx, w.store, SettingPasswordRequireClasses, w.passwordPolicy.RequireClasses),
+		PasswordBlockCommon:    boolSetting(ctx, w.store, SettingPasswordBlockCommon, w.passwordPolicy.BlockCommon),
+		PasswordBlockUsername:  boolSetting(ctx, w.store, SettingPasswordBlockUsername, w.passwordPolicy.BlockUsername),
+		LogLevel:               stringSetting(ctx, w.store, SettingLogLevel, "info"),
+		OIDCEnabled:            w.oidc.Enabled(),
+	}
+}
+
+func (w *Web) handleSettingsPage(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil || op.Role != "admin" {
+		http.Error(rw, "admin role required", http.StatusForbidden)
+		return
+	}
+	view := w.currentSettings(r.Context())
+	w.renderForRequest(rw, r, "settings.html", map[string]any{
+		"Active":   "settings",
+		"Settings": view,
+	})
+}
+
+// handleSettingsSave persists every boolean / int / string knob the
+// settings form exposed. Each diff against the previous value emits a
+// settings.update audit entry so admins can audit who flipped what.
+func (w *Web) handleSettingsSave(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil || op.Role != "admin" {
+		http.Error(rw, "admin role required", http.StatusForbidden)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(rw, "invalid form", http.StatusBadRequest)
+		return
+	}
+	before := w.currentSettings(r.Context())
+
+	type knob struct {
+		key   string
+		val   string
+		human string
+	}
+	knobs := []knob{
+		{SettingEnforceTOTP, boolFromForm(r, "enforce_2fa"), "enforce_2fa"},
+		{SettingAllowSelfRegistration, boolFromForm(r, "allow_self_registration"), "allow_self_registration"},
+		{SettingPasswordBlockCommon, boolFromForm(r, "password_block_common"), "password_block_common"},
+		{SettingPasswordBlockUsername, boolFromForm(r, "password_block_username"), "password_block_username"},
+	}
+	for _, k := range knobs {
+		if err := w.store.SetServerSetting(r.Context(), k.key, k.val); err != nil {
+			w.renderSettingsError(rw, r, fmt.Sprintf("failed to save %s: %v", k.human, err))
+			return
+		}
+	}
+
+	if v := r.FormValue("password_min_length"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 && n <= 256 {
+			_ = w.store.SetServerSetting(r.Context(), SettingPasswordMinLength, strconv.Itoa(n))
+		}
+	}
+	if v := r.FormValue("password_require_classes"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 && n <= 4 {
+			_ = w.store.SetServerSetting(r.Context(), SettingPasswordRequireClasses, strconv.Itoa(n))
+		}
+	}
+	if v := r.FormValue("log_level"); v != "" {
+		switch v {
+		case "debug", "info", "warn", "error":
+			_ = w.store.SetServerSetting(r.Context(), SettingLogLevel, v)
+		}
+	}
+
+	// One audit-log line summarising the change set — easier to grep
+	// than one per knob and still captures who pressed Save.
+	after := w.currentSettings(r.Context())
+	_ = w.store.AddAuditEntry(r.Context(), op.Username, "settings.update", "settings",
+		fmt.Sprintf("before=%+v after=%+v", before, after))
+
+	view := after
+	view.Saved = true
+	w.renderForRequest(rw, r, "settings.html", map[string]any{
+		"Active":   "settings",
+		"Settings": view,
+	})
+}
+
+func (w *Web) renderSettingsError(rw http.ResponseWriter, r *http.Request, msg string) {
+	v := w.currentSettings(r.Context())
+	v.Error = msg
+	w.renderForRequest(rw, r, "settings.html", map[string]any{
+		"Active":   "settings",
+		"Settings": v,
+	})
+}
+
+// boolFromForm normalises a checkbox to "true" / "false". HTML
+// checkboxes only send a value when ticked, so absent ⇒ false.
+func boolFromForm(r *http.Request, name string) string {
+	if r.FormValue(name) == "" {
+		return "false"
+	}
+	return "true"
+}

--- a/internal/web/settings_handler_test.go
+++ b/internal/web/settings_handler_test.go
@@ -1,0 +1,165 @@
+package web
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+func newSettingsWeb(t *testing.T) (*Web, store.Store) {
+	t.Helper()
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	w, err := New(s, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w, s
+}
+
+// authedSession mints an authenticated session for the given role and
+// returns a cookie callers can attach to subsequent requests.
+func authedSession(t *testing.T, s store.Store, username, role string) *http.Cookie {
+	t.Helper()
+	op := &models.Operator{
+		ID:           "op-" + username,
+		Username:     username,
+		PasswordHash: "x",
+		Status:       models.OperatorStatusActive,
+		Role:         role,
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(context.Background(), op); err != nil {
+		t.Fatal(err)
+	}
+	tok := "session-" + username
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token:      tok,
+		OperatorID: op.ID,
+		State:      models.SessionStateAuthenticated,
+		ExpiresAt:  time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return &http.Cookie{Name: "nebula_session", Value: tok}
+}
+
+func TestSettings_NonAdmin_403(t *testing.T) {
+	w, s := newSettingsWeb(t)
+	cookie := authedSession(t, s, "alice", "user")
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/settings", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestSettings_Admin_FlipsAndPersists(t *testing.T) {
+	w, s := newSettingsWeb(t)
+	cookie := authedSession(t, s, "root", "admin")
+
+	form := url.Values{
+		"enforce_2fa":              {"1"},
+		"allow_self_registration":  {"1"},
+		"password_block_common":    {"1"},
+		"password_block_username":  {"1"},
+		"password_min_length":      {"16"},
+		"password_require_classes": {"4"},
+		"log_level":                {"warn"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("save: status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Settings saved") {
+		t.Errorf("expected 'Settings saved' banner; body=%s", rec.Body.String())
+	}
+
+	// DB-backed reads should now return the new values.
+	ctx := context.Background()
+	if !enforceTOTPEnabled(ctx, s) {
+		t.Error("enforce_2fa was not persisted")
+	}
+	if v, _ := s.GetServerSetting(ctx, SettingPasswordMinLength); v != "16" {
+		t.Errorf("password_min_length = %q, want 16", v)
+	}
+	if v, _ := s.GetServerSetting(ctx, SettingLogLevel); v != "warn" {
+		t.Errorf("log_level = %q, want warn", v)
+	}
+
+	// Audit entry recorded.
+	entries, err := s.ListAuditEntries(ctx, store.AuditFilter{Action: "settings.update", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("audit entries: got %d, want 1", len(entries))
+	}
+}
+
+func TestSettings_Unchecked_CheckboxSetsFalse(t *testing.T) {
+	w, s := newSettingsWeb(t)
+	// Seed allow_self_registration=true; an empty POST must flip it back
+	// to false because HTML checkboxes only send a value when ticked.
+	if err := s.SetServerSetting(context.Background(), SettingAllowSelfRegistration, "true"); err != nil {
+		t.Fatal(err)
+	}
+	cookie := authedSession(t, s, "root", "admin")
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/settings", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	if boolSetting(context.Background(), s, SettingAllowSelfRegistration, false) {
+		t.Error("unchecked checkbox should have set allow_self_registration back to false")
+	}
+}
+
+func TestSettings_NonAdmin_PostForbidden(t *testing.T) {
+	w, s := newSettingsWeb(t)
+	cookie := authedSession(t, s, "alice", "user")
+
+	form := url.Values{"enforce_2fa": {"1"}}
+	req := httptest.NewRequest(http.MethodPost, "/ui/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+
+	// And the setting should not have moved.
+	if enforceTOTPEnabled(context.Background(), s) {
+		t.Error("non-admin POST should not change enforce_2fa")
+	}
+}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -213,6 +213,9 @@
                 <a href="/ui/" {{if eq .Active "dashboard"}}class="active"{{end}}>Dashboard</a>
                 <a href="/ui/networks" {{if eq .Active "networks"}}class="active"{{end}}>Networks</a>
                 <a href="/ui/hosts" {{if eq .Active "hosts"}}class="active"{{end}}>Hosts</a>
+                {{if and .CurrentUser (eq .CurrentUser.Role "admin")}}
+                <a href="/ui/settings" {{if eq .Active "settings"}}class="active"{{end}}>Settings</a>
+                {{end}}
             </div>
         </nav>
         <main class="main">

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -1,0 +1,78 @@
+{{define "title"}}Settings — Nebula Mesh{{end}}
+
+{{define "content"}}
+<div class="header-actions">
+    <h1>Settings</h1>
+</div>
+
+{{if .Settings.Saved}}
+<div class="card success">Settings saved. Changes take effect on the next request — no restart required.</div>
+{{end}}
+
+{{if .Settings.Error}}
+<div class="card error">{{.Settings.Error}}</div>
+{{end}}
+
+<form method="POST" action="/ui/settings" class="card">
+    <h2>Authentication</h2>
+
+    <label class="row">
+        <input type="checkbox" name="enforce_2fa" value="1" {{if .Settings.EnforceTOTP}}checked{{end}}>
+        <span>
+            <strong>Enforce 2FA for local operators.</strong>
+            When on, every local operator without TOTP is routed to <code>/ui/2fa/required</code>
+            after a successful password login. OIDC operators are exempt.
+        </span>
+    </label>
+
+    <label class="row">
+        <input type="checkbox" name="allow_self_registration" value="1" {{if .Settings.AllowSelfRegistration}}checked{{end}}>
+        <span>
+            <strong>Allow self-registration.</strong>
+            Unauthenticated visitors can create their own operator account at <code>/ui/register</code>.
+        </span>
+    </label>
+
+    <p class="muted">
+        OIDC SSO is currently
+        {{if .Settings.OIDCEnabled}}<strong>enabled</strong>{{else}}<strong>not configured</strong>{{end}}.
+        OIDC issuer / client credentials are managed in <code>server.yml</code> and are not editable here.
+    </p>
+
+    <h2>Password policy</h2>
+
+    <label>
+        Minimum length
+        <input type="number" name="password_min_length" min="0" max="256" value="{{.Settings.PasswordMinLength}}">
+    </label>
+
+    <label>
+        Required character classes (0–4: lower, upper, digit, symbol)
+        <input type="number" name="password_require_classes" min="0" max="4" value="{{.Settings.PasswordRequireClasses}}">
+    </label>
+
+    <label class="row">
+        <input type="checkbox" name="password_block_common" value="1" {{if .Settings.PasswordBlockCommon}}checked{{end}}>
+        <span>Reject passwords on the embedded common-passwords list.</span>
+    </label>
+
+    <label class="row">
+        <input type="checkbox" name="password_block_username" value="1" {{if .Settings.PasswordBlockUsername}}checked{{end}}>
+        <span>Reject passwords equal to or containing the username.</span>
+    </label>
+
+    <h2>Logging</h2>
+
+    <label>
+        Log level
+        <select name="log_level">
+            <option value="debug" {{if eq .Settings.LogLevel "debug"}}selected{{end}}>debug</option>
+            <option value="info"  {{if eq .Settings.LogLevel "info"}}selected{{end}}>info</option>
+            <option value="warn"  {{if eq .Settings.LogLevel "warn"}}selected{{end}}>warn</option>
+            <option value="error" {{if eq .Settings.LogLevel "error"}}selected{{end}}>error</option>
+        </select>
+    </label>
+
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{{end}}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -125,6 +125,7 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		"networks.html",
 		"twofa.html",
 		"profile.html",
+		"settings.html",
 	}
 	for _, page := range pages {
 		tmpl, err := template.ParseFS(templateFS, "templates/layout.html", "templates/"+page)
@@ -183,6 +184,8 @@ func (w *Web) setupRoutes() {
 		r.Get("/ui/profile", w.handleProfilePage)
 		r.Get("/ui/2fa", w.handleTwoFAPage)
 		r.Get("/ui/2fa/required", w.handleTwoFARequired)
+		r.Get("/ui/settings", w.handleSettingsPage)
+		r.Post("/ui/settings", w.handleSettingsSave)
 		r.Post("/ui/2fa/setup", w.handleTwoFASetup)
 		r.Post("/ui/2fa/enable", w.handleTwoFAEnable)
 		r.Post("/ui/2fa/disable", w.handleTwoFADisable)


### PR DESCRIPTION
## Summary

- New `/ui/settings` page (admin-only — sidebar link hidden for non-admins, GET + POST return 403).
- Knobs exposed: `enforce_2fa`, `allow_self_registration`, `password_min_length`, `password_require_classes`, `password_block_common`, `password_block_username`, `log_level`. All landed via boolean / number / select inputs in `templates/settings.html`.
- Storage routed through the `server_settings` table introduced in #49. `boolSetting` / `intSetting` / `stringSetting` helpers in `web/settings.go` read DB → fall back to YAML defaults so changes take effect on the next request without a restart. `allow_self_registration` now flows through the helper too.
- Every save writes a single `settings.update` audit entry that captures the before / after view-model so admins can grep who flipped what.

Closes #47.

## Test plan

- [x] `go test -race ./...` — new `TestSettings_*` covers non-admin 403 on GET + POST, admin flip persisting each knob + audit entry, unchecked-checkbox round-trip to false.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] README *Configurable self-registration* + new *Settings page* paragraph updated.
