### PR TITLE
feat(web): admin operator + API-key management UI (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,16 +412,15 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 </details>
 
 <details open>
-<summary><strong>Roadmap</strong> — what's next (2 open issues)</summary>
+<summary><strong>Roadmap</strong> — what's next (1 open issue)</summary>
 <a name="roadmap"></a>
 
 
 Open issues tracked individually so you can subscribe to the ones you care about:
 
-- [#45](https://github.com/juev/nebula-mesh/issues/45) — Web UI: admin-only operator and API-key management
 - [#46](https://github.com/juev/nebula-mesh/issues/46) — Web UI: per-operator CA management (create / list / retire / delete)
 
-Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA (opt-in **or** admin-enforced via `enforce_2fa`), self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, admin Settings page (toggle self-reg, log level, policy flags, …) at `/ui/settings`, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
+Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA (opt-in **or** admin-enforced via `enforce_2fa`), self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, admin Settings page (toggle self-reg, log level, policy flags, …) at `/ui/settings`, admin operator + API-key management Web UI at `/ui/operators`, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
 
 Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/internal/web/operators.go
+++ b/internal/web/operators.go
@@ -1,0 +1,278 @@
+package web
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// requireAdmin gates a route group to admins only — non-admin sessions
+// get a 403. Sits *after* requireAuth so an unauthenticated user
+// already redirects to /ui/login.
+func (w *Web) requireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		op := w.session.CurrentOperator(r)
+		if op == nil || op.Role != "admin" {
+			http.Error(rw, "admin role required", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(rw, r)
+	})
+}
+
+func (w *Web) handleOperatorsList(rw http.ResponseWriter, r *http.Request) {
+	ops, err := w.store.ListOperators(r.Context())
+	if err != nil {
+		w.logger.Error("list operators", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.renderForRequest(rw, r, "operators_list.html", map[string]any{
+		"Active":    "operators",
+		"Operators": ops,
+	})
+}
+
+func (w *Web) handleOperatorNewPage(rw http.ResponseWriter, r *http.Request) {
+	w.renderForRequest(rw, r, "operator_new.html", map[string]any{
+		"Active": "operators",
+		"Error":  "",
+	})
+}
+
+func (w *Web) handleOperatorCreate(rw http.ResponseWriter, r *http.Request) {
+	username := strings.TrimSpace(r.FormValue("username"))
+	displayName := strings.TrimSpace(r.FormValue("display_name"))
+	password := r.FormValue("password")
+	confirm := r.FormValue("password_confirm")
+	role := strings.TrimSpace(r.FormValue("role"))
+	if role == "" {
+		role = "user"
+	}
+
+	if username == "" || password == "" {
+		w.renderForRequest(rw, r, "operator_new.html", map[string]any{
+			"Active": "operators",
+			"Error":  "Username and password are required",
+		})
+		return
+	}
+	if password != confirm {
+		w.renderForRequest(rw, r, "operator_new.html", map[string]any{
+			"Active": "operators",
+			"Error":  "Password confirmation does not match",
+		})
+		return
+	}
+	if err := w.passwordPolicy.Validate(password, strings.ToLower(username)); err != nil {
+		w.renderForRequest(rw, r, "operator_new.html", map[string]any{
+			"Active": "operators",
+			"Error":  err.Error(),
+		})
+		return
+	}
+	if _, err := w.store.GetOperatorByUsername(r.Context(), username); err == nil {
+		w.renderForRequest(rw, r, "operator_new.html", map[string]any{
+			"Active": "operators",
+			"Error":  "Username already taken",
+		})
+		return
+	} else if !errors.Is(err, store.ErrNotFound) {
+		w.logger.Error("operator lookup", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		w.logger.Error("hash password", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	op := &models.Operator{
+		ID:           uuid.New().String(),
+		Username:     username,
+		DisplayName:  displayName,
+		PasswordHash: string(hash),
+		Status:       models.OperatorStatusActive,
+		Role:         role,
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := w.store.CreateOperator(r.Context(), op); err != nil {
+		w.logger.Error("create operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	actor := actorUsername(r, w.session)
+	_ = w.store.AddAuditEntry(r.Context(), actor, "operator.create", op.ID, op.Username)
+
+	http.Redirect(rw, r, "/ui/operators/"+op.ID, http.StatusSeeOther)
+}
+
+func (w *Web) handleOperatorDetail(rw http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	op, err := w.store.GetOperator(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		http.Error(rw, "operator not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		w.logger.Error("get operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	keys, err := w.store.ListOperatorAPIKeys(r.Context(), id)
+	if err != nil {
+		w.logger.Error("list api keys", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.renderForRequest(rw, r, "operator_detail.html", map[string]any{
+		"Active":     "operators",
+		"Operator":   op,
+		"APIKeys":    keys,
+		"NewAPIKey":  r.URL.Query().Get("new_key"),
+		"KeyName":    r.URL.Query().Get("key_name"),
+	})
+}
+
+func (w *Web) handleOperatorDisable(rw http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := w.store.DisableOperator(r.Context(), id); err != nil && !errors.Is(err, store.ErrNotFound) {
+		w.logger.Error("disable operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	actor := actorUsername(r, w.session)
+	_ = w.store.AddAuditEntry(r.Context(), actor, "operator.disable", id, "")
+	http.Redirect(rw, r, "/ui/operators/"+id, http.StatusSeeOther)
+}
+
+func (w *Web) handleOperatorEnable(rw http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := w.store.EnableOperator(r.Context(), id); err != nil && !errors.Is(err, store.ErrNotFound) {
+		w.logger.Error("enable operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	actor := actorUsername(r, w.session)
+	_ = w.store.AddAuditEntry(r.Context(), actor, "operator.enable", id, "")
+	http.Redirect(rw, r, "/ui/operators/"+id, http.StatusSeeOther)
+}
+
+func (w *Web) handleOperatorResetPassword(rw http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	op, err := w.store.GetOperator(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		http.Error(rw, "operator not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		w.logger.Error("get operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	password := r.FormValue("password")
+	if err := w.passwordPolicy.Validate(password, strings.ToLower(op.Username)); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		w.logger.Error("hash password", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := w.store.UpdateOperatorPassword(r.Context(), id, string(hash)); err != nil {
+		w.logger.Error("update password", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	actor := actorUsername(r, w.session)
+	_ = w.store.AddAuditEntry(r.Context(), actor, "operator.reset_password", id, op.Username)
+	http.Redirect(rw, r, "/ui/operators/"+id, http.StatusSeeOther)
+}
+
+func (w *Web) handleOperatorCreateAPIKey(rw http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := w.store.GetOperator(r.Context(), id); err != nil {
+		http.Error(rw, "operator not found", http.StatusNotFound)
+		return
+	}
+	name := strings.TrimSpace(r.FormValue("name"))
+	if name == "" {
+		name = "ui-created"
+	}
+	raw, err := newAPIKeyToken()
+	if err != nil {
+		w.logger.Error("generate api key", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	sum := sha256.Sum256([]byte(raw))
+	hash := hex.EncodeToString(sum[:])
+	key := &models.OperatorAPIKey{
+		ID:         uuid.New().String(),
+		OperatorID: id,
+		Name:       name,
+		KeyHash:    hash,
+		CreatedAt:  time.Now(),
+	}
+	if err := w.store.CreateOperatorAPIKey(r.Context(), key); err != nil {
+		w.logger.Error("create api key", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	actor := actorUsername(r, w.session)
+	_ = w.store.AddAuditEntry(r.Context(), actor, "operator.api_key.create", id, key.ID)
+	http.Redirect(rw, r, "/ui/operators/"+id+"?new_key="+raw+"&key_name="+name, http.StatusSeeOther)
+}
+
+func (w *Web) handleOperatorRevokeAPIKey(rw http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	kid := chi.URLParam(r, "kid")
+	err := w.store.RevokeOperatorAPIKey(r.Context(), kid)
+	switch {
+	case err == nil:
+		actor := actorUsername(r, w.session)
+		_ = w.store.AddAuditEntry(r.Context(), actor, "operator.api_key.revoke", id, kid)
+	case errors.Is(err, store.ErrNotFound):
+		// Already revoked (DisableOperator auto-revokes every key in the
+		// same transaction). UI stays idempotent — just redirect back.
+	default:
+		w.logger.Error("revoke api key", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(rw, r, "/ui/operators/"+id, http.StatusSeeOther)
+}
+
+// newAPIKeyToken returns the plaintext key shown once to the operator.
+// 32 random bytes hex-encoded — 64 chars, indistinguishable from the
+// CLI-generated token shape.
+func newAPIKeyToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func actorUsername(r *http.Request, sm *SessionManager) string {
+	if op := sm.CurrentOperator(r); op != nil {
+		return op.Username
+	}
+	return "anonymous"
+}

--- a/internal/web/operators_test.go
+++ b/internal/web/operators_test.go
@@ -1,0 +1,186 @@
+package web
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+func newOperatorsWeb(t *testing.T) (*Web, store.Store) {
+	t.Helper()
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	w, err := New(s, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w, s
+}
+
+func mintSession(t *testing.T, s store.Store, username, role string) *http.Cookie {
+	t.Helper()
+	op := &models.Operator{
+		ID:           "op-" + username,
+		Username:     username,
+		PasswordHash: "x",
+		Status:       models.OperatorStatusActive,
+		Role:         role,
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(context.Background(), op); err != nil {
+		t.Fatal(err)
+	}
+	tok := "session-" + username
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token:      tok,
+		OperatorID: op.ID,
+		State:      models.SessionStateAuthenticated,
+		ExpiresAt:  time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return &http.Cookie{Name: "nebula_session", Value: tok}
+}
+
+func TestOperators_NonAdmin_403(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "alice", "user")
+
+	for _, path := range []string{
+		"/ui/operators",
+		"/ui/operators/new",
+		"/ui/operators/op-someone",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.AddCookie(cookie)
+		rec := httptest.NewRecorder()
+		w.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s: status = %d, want 403", path, rec.Code)
+		}
+	}
+}
+
+func TestOperators_AdminLifecycle(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	// 1. Create.
+	form := url.Values{
+		"username":         {"bob"},
+		"display_name":     {"Bob"},
+		"password":         {strongPassword},
+		"password_confirm": {strongPassword},
+		"role":             {"user"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("create: status = %d, want 303; body=%s", rec.Code, rec.Body.String())
+	}
+
+	op, err := s.GetOperatorByUsername(context.Background(), "bob")
+	if err != nil {
+		t.Fatalf("bob not created: %v", err)
+	}
+
+	// 2. Detail page lists no keys yet.
+	req = httptest.NewRequest(http.MethodGet, "/ui/operators/"+op.ID, nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("detail: status = %d, want 200", rec.Code)
+	}
+
+	// 3. Create an API key.
+	form = url.Values{"name": {"ci-token"}}
+	req = httptest.NewRequest(http.MethodPost, "/ui/operators/"+op.ID+"/api-keys", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("create key: status = %d, want 303; body=%s", rec.Code, rec.Body.String())
+	}
+	keys, err := s.ListOperatorAPIKeys(context.Background(), op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 1 || keys[0].Name != "ci-token" {
+		t.Fatalf("expected 1 key named ci-token, got %+v", keys)
+	}
+
+	// 4. Reset password.
+	form = url.Values{"password": {strongPassword + "X"}}
+	req = httptest.NewRequest(http.MethodPost, "/ui/operators/"+op.ID+"/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("reset password: status = %d, want 303; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// 5. Disable.
+	req = httptest.NewRequest(http.MethodPost, "/ui/operators/"+op.ID+"/disable", nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("disable: status = %d, want 303", rec.Code)
+	}
+	got, _ := s.GetOperator(context.Background(), op.ID)
+	if got.Status != models.OperatorStatusDisabled {
+		t.Errorf("status = %q, want disabled", got.Status)
+	}
+
+	// 6. Revoke API key.
+	req = httptest.NewRequest(http.MethodPost,
+		"/ui/operators/"+op.ID+"/api-keys/"+keys[0].ID+"/revoke", nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("revoke: status = %d, want 303", rec.Code)
+	}
+}
+
+func TestOperators_CreateRejectsWeakPassword(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	form := url.Values{
+		"username":         {"bob"},
+		"password":         {"short"},
+		"password_confirm": {"short"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "at least 10") {
+		t.Errorf("expected password policy error, got %s", rec.Body.String())
+	}
+}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -214,7 +214,8 @@
                 <a href="/ui/networks" {{if eq .Active "networks"}}class="active"{{end}}>Networks</a>
                 <a href="/ui/hosts" {{if eq .Active "hosts"}}class="active"{{end}}>Hosts</a>
                 {{if and .CurrentUser (eq .CurrentUser.Role "admin")}}
-                <a href="/ui/settings" {{if eq .Active "settings"}}class="active"{{end}}>Settings</a>
+                <a href="/ui/operators" {{if eq .Active "operators"}}class="active"{{end}}>Operators</a>
+                <a href="/ui/settings"  {{if eq .Active "settings"}}class="active"{{end}}>Settings</a>
                 {{end}}
             </div>
         </nav>

--- a/internal/web/templates/operator_detail.html
+++ b/internal/web/templates/operator_detail.html
@@ -1,0 +1,78 @@
+{{define "title"}}{{.Operator.Username}} — Operators — Nebula Mesh{{end}}
+
+{{define "content"}}
+<div class="header-actions">
+    <h1>{{.Operator.Username}}</h1>
+    <a href="/ui/operators">← Back to operators</a>
+</div>
+
+{{if .NewAPIKey}}
+<div class="card success">
+    <strong>New API key</strong> ({{.KeyName}}) — copy it now, it will not be shown again:
+    <pre><code>{{.NewAPIKey}}</code></pre>
+</div>
+{{end}}
+
+<div class="card">
+    <dl>
+        <dt>Display name</dt><dd>{{.Operator.DisplayName}}</dd>
+        <dt>Role</dt>        <dd>{{.Operator.Role}}</dd>
+        <dt>Auth provider</dt><dd>{{.Operator.AuthProvider}}</dd>
+        <dt>Status</dt>      <dd>{{.Operator.Status}}</dd>
+        <dt>2FA</dt>         <dd>{{if .Operator.TOTPEnabled}}on{{else}}off{{end}}</dd>
+        <dt>Created</dt>     <dd>{{.Operator.CreatedAt.Format "2006-01-02 15:04"}}</dd>
+        <dt>Last login</dt>  <dd>{{if .Operator.LastLoginAt}}{{.Operator.LastLoginAt.Format "2006-01-02 15:04"}}{{else}}—{{end}}</dd>
+    </dl>
+
+    <form method="POST" action="/ui/operators/{{.Operator.ID}}/reset-password" class="row" style="margin-top:1em">
+        <input type="password" name="password" placeholder="New password" required>
+        <button type="submit" class="btn btn-warning"
+                onclick="return confirm('Set a new password for {{.Operator.Username}}?')">Reset password</button>
+    </form>
+
+    {{if eq (printf "%s" .Operator.Status) "active"}}
+    <form method="POST" action="/ui/operators/{{.Operator.ID}}/disable" style="display:inline-block">
+        <button type="submit" class="btn btn-danger"
+                onclick="return confirm('Disable {{.Operator.Username}}? Their sessions and API keys are invalidated.')">Disable</button>
+    </form>
+    {{else}}
+    <form method="POST" action="/ui/operators/{{.Operator.ID}}/enable" style="display:inline-block">
+        <button type="submit" class="btn btn-primary">Enable</button>
+    </form>
+    {{end}}
+</div>
+
+<div class="card">
+    <h2>API keys</h2>
+    {{if .APIKeys}}
+    <table>
+        <thead><tr><th>Name</th><th>Created</th><th>Last used</th><th>Revoked</th><th></th></tr></thead>
+        <tbody>
+        {{range .APIKeys}}
+        <tr>
+            <td>{{.Name}}</td>
+            <td>{{.CreatedAt.Format "2006-01-02 15:04"}}</td>
+            <td>{{if .LastUsedAt}}{{.LastUsedAt.Format "2006-01-02 15:04"}}{{else}}—{{end}}</td>
+            <td>{{if .RevokedAt}}{{.RevokedAt.Format "2006-01-02 15:04"}}{{else}}—{{end}}</td>
+            <td>
+                {{if not .RevokedAt}}
+                <form method="POST" action="/ui/operators/{{$.Operator.ID}}/api-keys/{{.ID}}/revoke" style="display:inline">
+                    <button type="submit" class="btn btn-sm btn-danger"
+                            onclick="return confirm('Revoke this key?')">Revoke</button>
+                </form>
+                {{end}}
+            </td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    {{else}}
+    <p class="muted">No API keys yet.</p>
+    {{end}}
+
+    <form method="POST" action="/ui/operators/{{.Operator.ID}}/api-keys" class="row">
+        <input type="text" name="name" placeholder="Key name" required>
+        <button type="submit" class="btn btn-primary">Create key</button>
+    </form>
+</div>
+{{end}}

--- a/internal/web/templates/operator_new.html
+++ b/internal/web/templates/operator_new.html
@@ -1,0 +1,24 @@
+{{define "title"}}New operator — Nebula Mesh{{end}}
+
+{{define "content"}}
+<div class="header-actions">
+    <h1>New operator</h1>
+    <a href="/ui/operators">← Back to operators</a>
+</div>
+
+<form method="POST" action="/ui/operators" class="card">
+    {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+    <label>Username <input type="text" name="username" required></label>
+    <label>Display name <input type="text" name="display_name"></label>
+    <label>Password <input type="password" name="password" required></label>
+    <label>Confirm password <input type="password" name="password_confirm" required></label>
+    <label>
+        Role
+        <select name="role">
+            <option value="user">user</option>
+            <option value="admin">admin</option>
+        </select>
+    </label>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>
+{{end}}

--- a/internal/web/templates/operators_list.html
+++ b/internal/web/templates/operators_list.html
@@ -1,0 +1,36 @@
+{{define "title"}}Operators — Nebula Mesh{{end}}
+
+{{define "content"}}
+<div class="header-actions">
+    <h1>Operators</h1>
+    <a href="/ui/operators/new" class="btn btn-primary">+ New Operator</a>
+</div>
+
+{{if .Operators}}
+<div class="card">
+    <table>
+        <thead>
+            <tr>
+                <th>Username</th><th>Display name</th><th>Role</th>
+                <th>Auth</th><th>Status</th><th>2FA</th><th>Last login</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Operators}}
+        <tr>
+            <td><a href="/ui/operators/{{.ID}}">{{.Username}}</a></td>
+            <td>{{.DisplayName}}</td>
+            <td>{{.Role}}</td>
+            <td>{{.AuthProvider}}</td>
+            <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
+            <td>{{if .TOTPEnabled}}on{{else}}off{{end}}</td>
+            <td>{{if .LastLoginAt}}{{.LastLoginAt.Format "2006-01-02 15:04"}}{{else}}—{{end}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="card empty">No operators yet.</div>
+{{end}}
+{{end}}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -126,6 +126,9 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		"twofa.html",
 		"profile.html",
 		"settings.html",
+		"operators_list.html",
+		"operator_new.html",
+		"operator_detail.html",
 	}
 	for _, page := range pages {
 		tmpl, err := template.ParseFS(templateFS, "templates/layout.html", "templates/"+page)
@@ -186,6 +189,20 @@ func (w *Web) setupRoutes() {
 		r.Get("/ui/2fa/required", w.handleTwoFARequired)
 		r.Get("/ui/settings", w.handleSettingsPage)
 		r.Post("/ui/settings", w.handleSettingsSave)
+
+		// Admin-only operator + API-key management (issue #45).
+		r.Group(func(r chi.Router) {
+			r.Use(w.requireAdmin)
+			r.Get("/ui/operators", w.handleOperatorsList)
+			r.Get("/ui/operators/new", w.handleOperatorNewPage)
+			r.Post("/ui/operators", w.handleOperatorCreate)
+			r.Get("/ui/operators/{id}", w.handleOperatorDetail)
+			r.Post("/ui/operators/{id}/disable", w.handleOperatorDisable)
+			r.Post("/ui/operators/{id}/enable", w.handleOperatorEnable)
+			r.Post("/ui/operators/{id}/reset-password", w.handleOperatorResetPassword)
+			r.Post("/ui/operators/{id}/api-keys", w.handleOperatorCreateAPIKey)
+			r.Post("/ui/operators/{id}/api-keys/{kid}/revoke", w.handleOperatorRevokeAPIKey)
+		})
 		r.Post("/ui/2fa/setup", w.handleTwoFASetup)
 		r.Post("/ui/2fa/enable", w.handleTwoFAEnable)
 		r.Post("/ui/2fa/disable", w.handleTwoFADisable)


### PR DESCRIPTION
## Summary

- Admin-only operator + API-key management surface in the Web UI: list, create, detail, disable / enable, password reset, mint key (plaintext shown once), revoke key.
- New `requireAdmin` middleware gates every `/ui/operators*` route; the sidebar entry is rendered only for admins (cosmetic — server check is authoritative).
- All actions delegate to the existing store methods so the audit log keeps firing `operator.create / disable / enable / api_key.create / api_key.revoke` with `actor=<admin>`.

Closes #45.

## Test plan

- [x] `go test -race ./...` — new `TestOperators_*`: non-admin 403 on every route, full admin lifecycle, password-policy enforced on create.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] README *Roadmap* + *Already delivered* updated.
