### PR TITLE
feat(web): per-operator CA management UI (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ By default only administrators can create operator accounts. Set `allow_self_reg
 
 ### Per-operator CAs
 
-With `NEBULA_MGMT_MASTER_KEY` configured, operators can run their networks under isolated CAs:
+With `NEBULA_MGMT_MASTER_KEY` configured, operators can run their networks under isolated CAs. Mint, browse, retire, and delete CAs from the CLI (below), the REST API (`/api/v1/cas*`), or the Web UI at `/ui/cas` — every flow shares the same ownership check, so a non-admin operator only sees the CAs they own.
 
 ```sh
 # Create a CA scoped to a real operator (the legacy config key is denied)
@@ -411,16 +411,14 @@ Full route list in [`internal/api/server.go`](internal/api/server.go).
 
 </details>
 
-<details open>
-<summary><strong>Roadmap</strong> — what's next (1 open issue)</summary>
+<details>
+<summary><strong>Roadmap</strong> — no open issues right now</summary>
 <a name="roadmap"></a>
 
 
-Open issues tracked individually so you can subscribe to the ones you care about:
+All originally-tracked roadmap items (issues #39–#53) have shipped. New ideas welcome — open an issue.
 
-- [#46](https://github.com/juev/nebula-mesh/issues/46) — Web UI: per-operator CA management (create / list / retire / delete)
-
-Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA (opt-in **or** admin-enforced via `enforce_2fa`), self-registration, per-operator CAs, advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, admin Settings page (toggle self-reg, log level, policy flags, …) at `/ui/settings`, admin operator + API-key management Web UI at `/ui/operators`, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
+Already delivered: multi-operator auth, OIDC SSO, TOTP 2FA (opt-in **or** admin-enforced via `enforce_2fa`), self-registration, per-operator CAs (manage from CLI **or** `/ui/cas`), advanced per-host overrides, automatic lighthouse assignment by host role, Prometheus exporter, built-in cert-expiry alerter, Terraform / Ansible / cloud-init bootstrap recipes ([`docs/deployment.md`](docs/deployment.md)), live host status in the Web UI via SSE (`/ui/events`), per-IP rate limiting on auth + enrolment, configurable password policy with embedded common-password block, admin Settings page (toggle self-reg, log level, policy flags, …) at `/ui/settings`, admin operator + API-key management Web UI at `/ui/operators`, deb/rpm packages for both server and agent, reverse-proxy snippets for nginx / Caddy / Traefik ([`deploy/reverse-proxy/`](deploy/reverse-proxy/)), and the cross-platform agent build matrix.
 
 Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -213,6 +213,9 @@ func Serve(configPath string) error {
 	webUI.WithLoginRecorder(apiSrv.RecordLogin)
 	webUI.WithRateLimiter(limiter)
 	webUI.WithPasswordPolicy(pwPolicy)
+	if master != nil {
+		webUI.WithMaster(master)
+	}
 
 	// Live host-status SSE: API server fires HostSeenEmitter on each agent
 	// poll, EventBus fans out to subscribed browser tabs.

--- a/internal/web/cas.go
+++ b/internal/web/cas.go
@@ -1,0 +1,232 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/juev/nebula-mesh/internal/keystore"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// CAMaster is the slim interface the Web UI needs from the keystore to
+// wrap a freshly-generated CA key for storage. Mirrors the methods the
+// API server uses; supplied by the same *keystore.Master singleton.
+type CAMaster interface {
+	GenerateDEK() (dek []byte, wrapped keystore.WrappedKey, err error)
+}
+
+// WithMaster wires the keystore master the CA-create handler needs.
+// Without it, /ui/cas/new renders an inline error pointing at the
+// NEBULA_MGMT_MASTER_KEY docs instead of failing with a 500.
+func (w *Web) WithMaster(m CAMaster) { w.caMaster = m }
+
+func (w *Web) handleCAsList(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	var (
+		cas []*models.CA
+		err error
+	)
+	if op.Role == "admin" {
+		cas, err = w.store.ListCAs(r.Context())
+	} else {
+		cas, err = w.store.ListCAsByOwner(r.Context(), op.ID)
+	}
+	if err != nil {
+		w.logger.Error("list cas", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.renderForRequest(rw, r, "cas_list.html", map[string]any{
+		"Active":  "cas",
+		"CAs":     cas,
+		"IsAdmin": op.Role == "admin",
+	})
+}
+
+func (w *Web) handleCANewPage(rw http.ResponseWriter, r *http.Request) {
+	w.renderForRequest(rw, r, "ca_new.html", map[string]any{
+		"Active":      "cas",
+		"Error":       "",
+		"MasterReady": w.caMaster != nil,
+	})
+}
+
+func (w *Web) handleCACreate(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	if w.caMaster == nil {
+		w.renderForRequest(rw, r, "ca_new.html", map[string]any{
+			"Active":      "cas",
+			"Error":       "CA creation requires NEBULA_MGMT_MASTER_KEY to be configured. See docs/adr/0002-per-operator-cas.md.",
+			"MasterReady": false,
+		})
+		return
+	}
+	name := strings.TrimSpace(r.FormValue("name"))
+	if name == "" {
+		w.renderForRequest(rw, r, "ca_new.html", map[string]any{
+			"Active":      "cas",
+			"Error":       "Name is required",
+			"MasterReady": true,
+		})
+		return
+	}
+	dur := 365 * 24 * time.Hour
+	if d := strings.TrimSpace(r.FormValue("duration")); d != "" {
+		parsed, err := time.ParseDuration(d)
+		if err != nil || parsed <= 0 {
+			w.renderForRequest(rw, r, "ca_new.html", map[string]any{
+				"Active":      "cas",
+				"Error":       "Invalid duration (try e.g. 8760h)",
+				"MasterReady": true,
+			})
+			return
+		}
+		dur = parsed
+	}
+
+	mgr, _, err := pki.NewCA(name, dur)
+	if err != nil {
+		w.logger.Error("generate ca", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	rawKey := mgr.RawKey()
+	defer keystore.Zeroize(rawKey)
+
+	dek, wrappedDEK, err := w.caMaster.GenerateDEK()
+	if err != nil {
+		w.logger.Error("generate dek", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	defer keystore.Zeroize(dek)
+	wrappedKey, err := keystore.SealWithDEK(dek, rawKey)
+	if err != nil {
+		w.logger.Error("seal ca key", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	certPEM, err := mgr.CACertPEM()
+	if err != nil {
+		w.logger.Error("marshal ca cert", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	fp, err := mgr.CACertFingerprint()
+	if err != nil {
+		w.logger.Error("fingerprint ca cert", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	now := time.Now()
+	c := &models.CA{
+		ID:                   uuid.New().String(),
+		Name:                 name,
+		OwnerOperatorID:      op.ID,
+		CertPEM:              string(certPEM),
+		Fingerprint:          fp,
+		NotBefore:            mgr.CACert().NotBefore(),
+		NotAfter:             mgr.CACert().NotAfter(),
+		Status:               models.CAStatusActive,
+		EncryptedKeyDEK:      wrappedDEK.Ciphertext,
+		NonceDEK:             wrappedDEK.Nonce,
+		EncryptedKeyMaterial: wrappedKey.Ciphertext,
+		NonceKey:             wrappedKey.Nonce,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	if err := w.store.CreateCA(r.Context(), c); err != nil {
+		w.logger.Error("create ca", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	_ = w.store.AddAuditEntry(r.Context(), op.Username, "ca.created", c.ID, c.Name)
+	http.Redirect(rw, r, "/ui/cas/"+c.ID, http.StatusSeeOther)
+}
+
+func (w *Web) handleCADetail(rw http.ResponseWriter, r *http.Request) {
+	c, ok := w.loadAccessibleCA(rw, r)
+	if !ok {
+		return
+	}
+	w.renderForRequest(rw, r, "ca_detail.html", map[string]any{
+		"Active": "cas",
+		"CA":     c,
+		"Error":  r.URL.Query().Get("error"),
+	})
+}
+
+func (w *Web) handleCARetire(rw http.ResponseWriter, r *http.Request) {
+	c, ok := w.loadAccessibleCA(rw, r)
+	if !ok {
+		return
+	}
+	if err := w.store.UpdateCAStatus(r.Context(), c.ID, models.CAStatusRetired); err != nil {
+		w.logger.Error("retire ca", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if op := w.session.CurrentOperator(r); op != nil {
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "ca.retired", c.ID, c.Name)
+	}
+	http.Redirect(rw, r, "/ui/cas/"+c.ID, http.StatusSeeOther)
+}
+
+func (w *Web) handleCADelete(rw http.ResponseWriter, r *http.Request) {
+	c, ok := w.loadAccessibleCA(rw, r)
+	if !ok {
+		return
+	}
+	if err := w.store.DeleteCA(r.Context(), c.ID); err != nil {
+		// Common case: still attached to one or more networks. Surface
+		// the store-layer message inline rather than a generic 500.
+		http.Redirect(rw, r, "/ui/cas/"+c.ID+"?error="+
+			http.StatusText(http.StatusConflict)+": "+err.Error(), http.StatusSeeOther)
+		return
+	}
+	if op := w.session.CurrentOperator(r); op != nil {
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "ca.deleted", c.ID, c.Name)
+	}
+	http.Redirect(rw, r, "/ui/cas", http.StatusSeeOther)
+}
+
+// loadAccessibleCA wraps the GetCA + ownership check used by every
+// detail / mutating handler. Writes the appropriate response (404 /
+// 403) directly and returns ok=false on failure.
+func (w *Web) loadAccessibleCA(rw http.ResponseWriter, r *http.Request) (*models.CA, bool) {
+	id := chi.URLParam(r, "id")
+	c, err := w.store.GetCA(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		http.Error(rw, "CA not found", http.StatusNotFound)
+		return nil, false
+	}
+	if err != nil {
+		w.logger.Error("get ca", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return nil, false
+	}
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return nil, false
+	}
+	if op.Role != "admin" && c.OwnerOperatorID != op.ID {
+		http.Error(rw, "you do not own this CA", http.StatusForbidden)
+		return nil, false
+	}
+	return c, true
+}

--- a/internal/web/cas_test.go
+++ b/internal/web/cas_test.go
@@ -1,0 +1,145 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+func TestCAs_NonOwner_Forbidden(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	aliceCookie := mintSession(t, s, "alice", "user")
+	bobCookie := mintSession(t, s, "bob", "user")
+
+	// Bob mints a CA via the store directly so the test stays focused on
+	// the ownership check, not on the master-key plumbing.
+	ca := &models.CA{
+		ID:              "ca-bob",
+		Name:            "bob-ca",
+		OwnerOperatorID: "op-bob",
+		CertPEM:         "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint:     "fp-bob",
+		NotBefore:       time.Now(),
+		NotAfter:        time.Now().Add(time.Hour),
+		Status:               models.CAStatusActive,
+		EncryptedKeyDEK:      []byte("dek"),
+		NonceDEK:             []byte("ndek"),
+		EncryptedKeyMaterial: []byte("key"),
+		NonceKey:             []byte("nkey"),
+		CreatedAt:            time.Now(),
+		UpdatedAt:            time.Now(),
+	}
+	if err := s.CreateCA(context.Background(), ca); err != nil {
+		t.Fatal(err)
+	}
+
+	// Alice (not the owner, not admin) gets 403.
+	req := httptest.NewRequest(http.MethodGet, "/ui/cas/"+ca.ID, nil)
+	req.AddCookie(aliceCookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("alice GET ca: status = %d, want 403", rec.Code)
+	}
+
+	// Bob (owner) gets 200.
+	req = httptest.NewRequest(http.MethodGet, "/ui/cas/"+ca.ID, nil)
+	req.AddCookie(bobCookie)
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("bob GET own ca: status = %d, want 200", rec.Code)
+	}
+}
+
+func TestCAs_List_FiltersByOwnership(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	aliceCookie := mintSession(t, s, "alice", "user")
+	adminCookie := mintSession(t, s, "root", "admin")
+	mintSession(t, s, "bob", "user") // FK target for the CA below
+
+	for _, c := range []models.CA{
+		{ID: "ca1", Name: "alice-ca", OwnerOperatorID: "op-alice", Fingerprint: "fp-alice", NotAfter: time.Now().Add(time.Hour), Status: models.CAStatusActive, EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"), EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: "ca2", Name: "bob-ca",   OwnerOperatorID: "op-bob",   Fingerprint: "fp-bob",   NotAfter: time.Now().Add(time.Hour), Status: models.CAStatusActive, EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"), EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	} {
+		if err := s.CreateCA(context.Background(), &c); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/cas", nil)
+	req.AddCookie(aliceCookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	body := rec.Body.String()
+	if !strings.Contains(body, "alice-ca") {
+		t.Errorf("alice list: own CA missing\n%s", body)
+	}
+	if strings.Contains(body, "bob-ca") {
+		t.Errorf("alice list: must not see bob's CA")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/ui/cas", nil)
+	req.AddCookie(adminCookie)
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	body = rec.Body.String()
+	if !strings.Contains(body, "alice-ca") || !strings.Contains(body, "bob-ca") {
+		t.Errorf("admin list should show both CAs\n%s", body)
+	}
+}
+
+func TestCAs_Retire_FlipsStatus(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "bob", "user")
+
+	ca := &models.CA{
+		ID: "ca-r", Name: "to-retire", OwnerOperatorID: "op-bob",
+		Fingerprint: "fp-r", NotAfter: time.Now().Add(time.Hour),
+		Status: models.CAStatusActive, EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"), EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"), CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateCA(context.Background(), ca); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/cas/"+ca.ID+"/retire", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("retire: status = %d, want 303", rec.Code)
+	}
+
+	got, err := s.GetCA(context.Background(), ca.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.CAStatusRetired {
+		t.Errorf("status = %q, want retired", got.Status)
+	}
+}
+
+func TestCAs_New_WithoutMaster_InlineError(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "bob", "user")
+
+	form := url.Values{"name": {"new-ca"}, "duration": {"8760h"}}
+	req := httptest.NewRequest(http.MethodPost, "/ui/cas", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create without master: status = %d, want 200 (inline error)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "NEBULA_MGMT_MASTER_KEY") {
+		t.Errorf("expected master-key hint in body, got %s", rec.Body.String())
+	}
+}

--- a/internal/web/templates/ca_detail.html
+++ b/internal/web/templates/ca_detail.html
@@ -1,0 +1,39 @@
+{{define "title"}}{{.CA.Name}} — CAs — Nebula Mesh{{end}}
+
+{{define "content"}}
+<div class="header-actions">
+    <h1>{{.CA.Name}}</h1>
+    <a href="/ui/cas">← Back to CAs</a>
+</div>
+
+{{if .Error}}<div class="card error">{{.Error}}</div>{{end}}
+
+<div class="card">
+    <dl>
+        <dt>Status</dt>         <dd><span class="badge badge-{{.CA.Status}}">{{.CA.Status}}</span></dd>
+        <dt>Fingerprint</dt>    <dd><code>{{.CA.Fingerprint}}</code></dd>
+        <dt>Owner</dt>          <dd>{{.CA.OwnerOperatorID}}</dd>
+        <dt>Valid from</dt>     <dd>{{.CA.NotBefore.Format "2006-01-02 15:04 MST"}}</dd>
+        <dt>Valid until</dt>    <dd>{{.CA.NotAfter.Format "2006-01-02 15:04 MST"}}</dd>
+        <dt>Created</dt>        <dd>{{.CA.CreatedAt.Format "2006-01-02 15:04"}}</dd>
+    </dl>
+
+    <details>
+        <summary>Certificate PEM</summary>
+        <pre><code>{{.CA.CertPEM}}</code></pre>
+    </details>
+
+    <div class="row" style="margin-top:1em">
+        {{if eq (printf "%s" .CA.Status) "active"}}
+        <form method="POST" action="/ui/cas/{{.CA.ID}}/retire" style="display:inline">
+            <button type="submit" class="btn btn-warning"
+                    onclick="return confirm('Retire {{.CA.Name}}? Retired CAs can no longer sign new certificates; existing host certs keep working until they expire.')">Retire</button>
+        </form>
+        {{end}}
+        <form method="POST" action="/ui/cas/{{.CA.ID}}/delete" style="display:inline">
+            <button type="submit" class="btn btn-danger"
+                    onclick="return confirm('Delete {{.CA.Name}}? This is permanent.')">Delete</button>
+        </form>
+    </div>
+</div>
+{{end}}

--- a/internal/web/templates/ca_new.html
+++ b/internal/web/templates/ca_new.html
@@ -1,0 +1,22 @@
+{{define "title"}}New CA — Nebula Mesh{{end}}
+
+{{define "content"}}
+<div class="header-actions">
+    <h1>New CA</h1>
+    <a href="/ui/cas">← Back to CAs</a>
+</div>
+
+<form method="POST" action="/ui/cas" class="card">
+    {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+    {{if not .MasterReady}}
+    <div class="error">
+        CA creation requires <code>NEBULA_MGMT_MASTER_KEY</code> to be set at startup.
+        See <a href="docs/adr/0002-per-operator-cas.md">ADR&nbsp;0002</a> for the
+        master-key handling.
+    </div>
+    {{end}}
+    <label>Name <input type="text" name="name" required></label>
+    <label>Duration <input type="text" name="duration" value="8760h"></label>
+    <button type="submit" class="btn btn-primary" {{if not .MasterReady}}disabled{{end}}>Create</button>
+</form>
+{{end}}

--- a/internal/web/templates/cas_list.html
+++ b/internal/web/templates/cas_list.html
@@ -1,0 +1,37 @@
+{{define "title"}}CAs — Nebula Mesh{{end}}
+
+{{define "content"}}
+<div class="header-actions">
+    <h1>CAs</h1>
+    <a href="/ui/cas/new" class="btn btn-primary">+ New CA</a>
+</div>
+
+{{if .CAs}}
+<div class="card">
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Fingerprint</th>
+                {{if .IsAdmin}}<th>Owner</th>{{end}}
+                <th>Status</th>
+                <th>Expires</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .CAs}}
+        <tr>
+            <td><a href="/ui/cas/{{.ID}}">{{.Name}}</a></td>
+            <td><code>{{.Fingerprint}}</code></td>
+            {{if $.IsAdmin}}<td>{{.OwnerOperatorID}}</td>{{end}}
+            <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
+            <td>{{.NotAfter.Format "2006-01-02"}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="card empty">No CAs visible to you yet.</div>
+{{end}}
+{{end}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -213,6 +213,7 @@
                 <a href="/ui/" {{if eq .Active "dashboard"}}class="active"{{end}}>Dashboard</a>
                 <a href="/ui/networks" {{if eq .Active "networks"}}class="active"{{end}}>Networks</a>
                 <a href="/ui/hosts" {{if eq .Active "hosts"}}class="active"{{end}}>Hosts</a>
+                <a href="/ui/cas"   {{if eq .Active "cas"}}class="active"{{end}}>CAs</a>
                 {{if and .CurrentUser (eq .CurrentUser.Role "admin")}}
                 <a href="/ui/operators" {{if eq .Active "operators"}}class="active"{{end}}>Operators</a>
                 <a href="/ui/settings"  {{if eq .Active "settings"}}class="active"{{end}}>Settings</a>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -40,6 +40,7 @@ type Web struct {
 	events                *EventBus
 	limiter               *ratelimit.Limiter
 	passwordPolicy        auth.Policy
+	caMaster              CAMaster
 }
 
 // WithPasswordPolicy installs the password policy used by registration
@@ -129,6 +130,9 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		"operators_list.html",
 		"operator_new.html",
 		"operator_detail.html",
+		"cas_list.html",
+		"ca_new.html",
+		"ca_detail.html",
 	}
 	for _, page := range pages {
 		tmpl, err := template.ParseFS(templateFS, "templates/layout.html", "templates/"+page)
@@ -203,6 +207,16 @@ func (w *Web) setupRoutes() {
 			r.Post("/ui/operators/{id}/api-keys", w.handleOperatorCreateAPIKey)
 			r.Post("/ui/operators/{id}/api-keys/{kid}/revoke", w.handleOperatorRevokeAPIKey)
 		})
+
+		// Per-operator CA management (issue #46). Available to every
+		// authenticated operator; non-admins only see / act on the CAs
+		// they own — enforced server-side by loadAccessibleCA.
+		r.Get("/ui/cas", w.handleCAsList)
+		r.Get("/ui/cas/new", w.handleCANewPage)
+		r.Post("/ui/cas", w.handleCACreate)
+		r.Get("/ui/cas/{id}", w.handleCADetail)
+		r.Post("/ui/cas/{id}/retire", w.handleCARetire)
+		r.Post("/ui/cas/{id}/delete", w.handleCADelete)
 		r.Post("/ui/2fa/setup", w.handleTwoFASetup)
 		r.Post("/ui/2fa/enable", w.handleTwoFAEnable)
 		r.Post("/ui/2fa/disable", w.handleTwoFADisable)


### PR DESCRIPTION
## Summary

- New `/ui/cas` surface lets operators mint, browse, retire, and delete CAs from the Web UI. Non-admins only see / act on CAs they own; admins see them all — enforced by `loadAccessibleCA` so toggling the sidebar is purely cosmetic.
- `/ui/cas/new` renders an inline error when `NEBULA_MGMT_MASTER_KEY` is unset instead of a generic 500 (matches the REST behaviour).
- `cli/serve.go` plumbs the existing `*keystore.Master` into the Web UI so the create-CA flow works out of the box once the master key is set.

Closes #46.

## Test plan

- [x] `go test -race ./...` — new `TestCAs_*`: non-owner 403 on detail, list filtered by ownership, retire flips status, master-less create returns inline error.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] README *Per-operator CAs* mentions `/ui/cas`; *Already delivered* updated.
