### PR TITLE
feat(agent): unify enroll/run into a single command (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ sudo rpm -i "https://github.com/juev/nebula-mesh/releases/download/v${VERSION}/n
 sudo rpm -i "https://github.com/juev/nebula-mesh/releases/download/v${VERSION}/nebula-agent_${VERSION}_linux_${ARCH}.rpm"
 ```
 
-**What the package does.** Installs the binary to `/usr/bin/`, the systemd unit to `/lib/systemd/system/`, and an example config at `/etc/nebula-{mgmt,agent}/`. The service is **not** auto-started — run `nebula-mgmt init` (server) or `nebula-agent enroll` (agent) first, then `sudo systemctl enable --now nebula-{mgmt,agent}`. Configs are marked `noreplace`, so upgrades preserve your edits. `apt purge` / `dnf remove --purge` keeps `/etc/nebula-agent` and `/etc/nebula` so host keys survive accidental removal.
+**What the package does.** Installs the binary to `/usr/bin/`, the systemd unit to `/lib/systemd/system/`, and an example config at `/etc/nebula-{mgmt,agent}/`. The service is **not** auto-started — run `nebula-mgmt init` (server) or `nebula-agent --server URL --token TOK` (agent) first, then `sudo systemctl enable --now nebula-{mgmt,agent}`. Configs are marked `noreplace`, so upgrades preserve your edits. `apt purge` / `dnf remove --purge` keeps `/etc/nebula-agent` and `/etc/nebula` so host keys survive accidental removal.
 
 ### Prebuilt binaries (other Linux, macOS, FreeBSD, Windows)
 
@@ -242,14 +242,16 @@ nebula-mgmt host create \
   --name web-1 --ip 192.168.100.10
 # → prints an enrollment token
 
-# On the host — one-time enrollment + start the polling agent:
-sudo cp configs/agent.example.yml /etc/nebula-agent/agent.yml
-sudo nebula-agent enroll \
+# On the host — single command on first run: enrolls, writes config, starts polling.
+sudo nebula-agent \
   --server https://mgmt.example.com:8080 \
-  --token "$ENROLL_TOKEN" \
-  --data-dir /etc/nebula
-sudo nebula-agent run --config /etc/nebula-agent/agent.yml
+  --token "$ENROLL_TOKEN"
+
+# Every subsequent run (e.g. under systemd):
+sudo nebula-agent
 ```
+
+The first invocation writes `/etc/nebula-agent/agent.yml` (mode 0600) from the supplied flags. Subsequent runs need no arguments — the agent reads its config, finds `host.crt`, and starts polling. The enrollment token is single-use and is never persisted. The legacy `nebula-agent enroll` / `nebula-agent run` subcommands still work for one release and emit a deprecation warning.
 
 The agent keeps `host.crt` / `host.key` / `ca.crt` / `config.yml` in sync and signals Nebula on changes.
 

--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/juev/nebula-mesh/internal/agent"
 	"github.com/juev/nebula-mesh/internal/config"
@@ -21,75 +25,176 @@ var (
 	date       = "unknown"
 )
 
+const defaultConfigPath = "/etc/nebula-agent/agent.yml"
+
 func main() {
-	if err := run(); err != nil {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run() error {
-	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: nebula-agent <command> [flags]")
-		fmt.Fprintln(os.Stderr, "commands: enroll, run, version")
-		return fmt.Errorf("no command specified")
+func run(args []string, stdout, stderr io.Writer) error {
+	// Dispatch deprecated subcommands first so the unified flag set does not
+	// need to understand "enroll" / "run" as positional arguments.
+	if len(args) > 0 {
+		switch args[0] {
+		case "enroll":
+			_, _ = fmt.Fprintln(stderr, "warning: `nebula-agent enroll` is deprecated; pass --token and --server to `nebula-agent` instead")
+			return runLegacyEnroll(args[1:], stderr)
+		case "run":
+			_, _ = fmt.Fprintln(stderr, "warning: `nebula-agent run` is deprecated; invoke `nebula-agent` without a subcommand")
+			return runLegacyRun(args[1:], stderr)
+		case "version", "--version", "-v":
+			version.Print(stdout, "nebula-agent", versionStr, commit, date)
+			return nil
+		case "-h", "--help", "help":
+			printUsage(stderr)
+			return nil
+		}
 	}
 
-	switch os.Args[1] {
-	case "enroll":
-		return runEnroll(os.Args[2:])
-	case "run":
-		return runAgent(os.Args[2:])
-	case "version", "--version", "-v":
-		version.Print(os.Stdout, "nebula-agent", versionStr, commit, date)
-		return nil
-	default:
-		return fmt.Errorf("unknown command: %s", os.Args[1])
-	}
+	return runUnified(args, stderr)
 }
 
-func runEnroll(args []string) error {
-	fs := flag.NewFlagSet("enroll", flag.ExitOnError)
-	token := fs.String("token", "", "enrollment token")
-	serverURL := fs.String("server", "", "management server URL")
-	dataDir := fs.String("data-dir", "/etc/nebula", "data directory")
+func printUsage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "Usage: nebula-agent [--config PATH] [--token TOK --server URL] [--data-dir DIR] [--update-config]")
+	_, _ = fmt.Fprintln(w, "       nebula-agent version")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "First run on a fresh host: nebula-agent --token TOK --server URL")
+	_, _ = fmt.Fprintln(w, "Every subsequent run    : nebula-agent")
+}
+
+// runUnified is the single-command entrypoint described in issue #67.
+//
+// Startup algorithm:
+//  1. Resolve config path (--config PATH or defaultConfigPath).
+//  2. If config exists → load it; warn when CLI flags conflict; --update-config
+//     overwrites fields with CLI values before starting.
+//  3. If config missing → build AgentConfig from defaults + CLI flags, write
+//     it atomically. --server is required for first run.
+//  4. After config is in place:
+//     a. cert exists → start poller.
+//     b. cert missing and --token set → enroll, then start poller.
+//     c. cert missing and no --token → fatal with hint.
+//
+// The enrollment token is never written to disk.
+func runUnified(args []string, stderr io.Writer) error {
+	fs := flag.NewFlagSet("nebula-agent", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configPath := fs.String("config", defaultConfigPath, "config file path")
+	serverURL := fs.String("server", "", "management server URL (first run only)")
+	token := fs.String("token", "", "enrollment token (first run only, never written to disk)")
+	dataDir := fs.String("data-dir", "", "override data directory (first run only)")
+	pollInterval := fs.Duration("poll-interval", 0, "override poll interval (first run only)")
+	updateConfig := fs.Bool("update-config", false, "overwrite on-disk config with CLI flags")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	if *token == "" || *serverURL == "" {
-		return fmt.Errorf("--token and --server are required")
-	}
-
-	fmt.Printf("enrolling with server %s...\n", *serverURL)
-	if err := agent.Enroll(*serverURL, *token, *dataDir); err != nil {
-		return fmt.Errorf("enrollment failed: %w", err)
-	}
-
-	fmt.Println("enrollment successful")
-	return nil
-}
-
-func runAgent(args []string) error {
-	fs := flag.NewFlagSet("run", flag.ExitOnError)
-	configPath := fs.String("config", "/etc/nebula-agent/agent.yml", "config file path")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-
-	cfg, err := config.LoadAgentConfig(*configPath)
+	cfg, err := resolveConfig(*configPath, *serverURL, *dataDir, *pollInterval, *updateConfig, stderr)
 	if err != nil {
-		return fmt.Errorf("load config: %w", err)
+		return err
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
 
-	// Read current fingerprint from certificate
+	certPath := filepath.Join(cfg.DataDir, "host.crt")
+	switch _, err := os.Stat(certPath); {
+	case err == nil:
+		// Already enrolled — fall through to poller.
+	case errors.Is(err, os.ErrNotExist):
+		if *token == "" {
+			return fmt.Errorf("no host certificate at %s and no --token to enroll with; pass --token TOK to enroll", certPath)
+		}
+		logger.Info("enrolling host", "server", cfg.ServerURL, "data_dir", cfg.DataDir)
+		if err := agent.Enroll(cfg.ServerURL, *token, cfg.DataDir); err != nil {
+			return fmt.Errorf("enrollment failed: %w", err)
+		}
+		logger.Info("enrollment successful")
+	default:
+		return fmt.Errorf("stat host certificate: %w", err)
+	}
+
+	return startPoller(cfg, logger)
+}
+
+// resolveConfig loads the on-disk config or creates one from CLI flags.
+// CLI flags conflicting with an existing config are warned about unless
+// --update-config is set, in which case they overwrite the file.
+func resolveConfig(path, serverURL, dataDir string, pollInterval time.Duration, updateConfig bool, stderr io.Writer) (*config.AgentConfig, error) {
+	if _, err := os.Stat(path); err == nil {
+		cfg, err := config.LoadAgentConfig(path)
+		if err != nil {
+			return nil, fmt.Errorf("load config: %w", err)
+		}
+		applied := applyOverrides(cfg, serverURL, dataDir, pollInterval, updateConfig, stderr)
+		if updateConfig && applied {
+			if err := config.SaveAgentConfig(path, cfg); err != nil {
+				return nil, fmt.Errorf("update config: %w", err)
+			}
+			_, _ = fmt.Fprintf(stderr, "config updated: %s\n", path)
+		}
+		return cfg, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat config: %w", err)
+	}
+
+	if serverURL == "" {
+		return nil, fmt.Errorf("config %s not found and --server not set; pass --server URL on first run", path)
+	}
+	cfg := config.DefaultAgentConfig()
+	cfg.ServerURL = serverURL
+	if dataDir != "" {
+		cfg.DataDir = dataDir
+	}
+	if pollInterval > 0 {
+		cfg.PollInterval = pollInterval
+	}
+	if err := config.SaveAgentConfig(path, cfg); err != nil {
+		return nil, fmt.Errorf("write config: %w", err)
+	}
+	_, _ = fmt.Fprintf(stderr, "wrote config: %s\n", path)
+	return cfg, nil
+}
+
+// applyOverrides compares CLI overrides with the on-disk config and either
+// warns (default) or overwrites (when updateConfig is true). Returns true when
+// any field actually changed.
+func applyOverrides(cfg *config.AgentConfig, serverURL, dataDir string, pollInterval time.Duration, updateConfig bool, stderr io.Writer) bool {
+	changed := false
+	maybeApply := func(field, current, override string) string {
+		if override == "" || override == current {
+			return current
+		}
+		if updateConfig {
+			_, _ = fmt.Fprintf(stderr, "overwriting %s: %q -> %q\n", field, current, override)
+			changed = true
+			return override
+		}
+		_, _ = fmt.Fprintf(stderr, "warning: --%s=%q ignored (config has %q); use --update-config to overwrite\n", field, override, current)
+		return current
+	}
+	cfg.ServerURL = maybeApply("server", cfg.ServerURL, serverURL)
+	cfg.DataDir = maybeApply("data-dir", cfg.DataDir, dataDir)
+	if pollInterval > 0 && pollInterval != cfg.PollInterval {
+		if updateConfig {
+			_, _ = fmt.Fprintf(stderr, "overwriting poll-interval: %v -> %v\n", cfg.PollInterval, pollInterval)
+			cfg.PollInterval = pollInterval
+			changed = true
+		} else {
+			_, _ = fmt.Fprintf(stderr, "warning: --poll-interval=%v ignored (config has %v); use --update-config to overwrite\n", pollInterval, cfg.PollInterval)
+		}
+	}
+	return changed
+}
+
+func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
 	fingerprint, err := agent.ReadCertFingerprint(cfg.DataDir)
 	if err != nil {
-		return fmt.Errorf("read certificate fingerprint: %w (did you run 'enroll' first?)", err)
+		return fmt.Errorf("read certificate fingerprint: %w", err)
 	}
 
 	poller := agent.NewPoller(agent.PollerConfig{
@@ -100,13 +205,11 @@ func runAgent(args []string) error {
 		PIDFile:     cfg.NebulaPIDFile,
 	}, logger)
 
-	// Graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-
 	go func() {
 		sig := <-sigCh
 		logger.Info("received signal, shutting down", "signal", sig)
@@ -115,4 +218,42 @@ func runAgent(args []string) error {
 
 	logger.Info("nebula-agent starting", "server", cfg.ServerURL, "poll_interval", cfg.PollInterval)
 	return poller.Run(ctx)
+}
+
+// runLegacyEnroll preserves the old `nebula-agent enroll` invocation for one
+// release. It does not persist any config — operators get the unified flow
+// the next time they invoke the agent.
+func runLegacyEnroll(args []string, stderr io.Writer) error {
+	fs := flag.NewFlagSet("enroll", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	token := fs.String("token", "", "enrollment token")
+	serverURL := fs.String("server", "", "management server URL")
+	dataDir := fs.String("data-dir", "/etc/nebula", "data directory")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *token == "" || *serverURL == "" {
+		return fmt.Errorf("--token and --server are required")
+	}
+	_, _ = fmt.Fprintf(stderr, "enrolling with server %s...\n", *serverURL)
+	if err := agent.Enroll(*serverURL, *token, *dataDir); err != nil {
+		return fmt.Errorf("enrollment failed: %w", err)
+	}
+	_, _ = fmt.Fprintln(stderr, "enrollment successful")
+	return nil
+}
+
+func runLegacyRun(args []string, stderr io.Writer) error {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configPath := fs.String("config", defaultConfigPath, "config file path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cfg, err := config.LoadAgentConfig(*configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	return startPoller(cfg, logger)
 }

--- a/cmd/nebula-agent/main_test.go
+++ b/cmd/nebula-agent/main_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/config"
+)
+
+func TestResolveConfig_FileExists_FlagsIgnored(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	initial := config.DefaultAgentConfig()
+	initial.ServerURL = "https://on-disk.example.com"
+	if err := config.SaveAgentConfig(cfgPath, initial); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	cfg, err := resolveConfig(cfgPath, "https://cli.example.com", "", 0, false, &stderr)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if cfg.ServerURL != initial.ServerURL {
+		t.Errorf("ServerURL = %q, want on-disk %q", cfg.ServerURL, initial.ServerURL)
+	}
+	if !strings.Contains(stderr.String(), "warning") {
+		t.Errorf("expected warning about ignored flag in stderr; got %q", stderr.String())
+	}
+
+	// File on disk must not have been rewritten.
+	loaded, err := config.LoadAgentConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if loaded.ServerURL != initial.ServerURL {
+		t.Errorf("on-disk ServerURL changed to %q", loaded.ServerURL)
+	}
+}
+
+func TestResolveConfig_FileExists_UpdateConfigOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	initial := config.DefaultAgentConfig()
+	initial.ServerURL = "https://old.example.com"
+	if err := config.SaveAgentConfig(cfgPath, initial); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	cfg, err := resolveConfig(cfgPath, "https://new.example.com", "", 0, true, &stderr)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if cfg.ServerURL != "https://new.example.com" {
+		t.Errorf("ServerURL = %q, want new", cfg.ServerURL)
+	}
+
+	loaded, err := config.LoadAgentConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if loaded.ServerURL != "https://new.example.com" {
+		t.Errorf("on-disk ServerURL = %q, want overwritten", loaded.ServerURL)
+	}
+}
+
+func TestResolveConfig_FileMissing_WritesFromFlags(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "sub", "agent.yml")
+
+	var stderr bytes.Buffer
+	cfg, err := resolveConfig(cfgPath, "https://fresh.example.com", filepath.Join(dir, "nebula"), 15*time.Second, false, &stderr)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if cfg.ServerURL != "https://fresh.example.com" {
+		t.Errorf("ServerURL = %q", cfg.ServerURL)
+	}
+	if cfg.DataDir != filepath.Join(dir, "nebula") {
+		t.Errorf("DataDir = %q", cfg.DataDir)
+	}
+	if cfg.PollInterval != 15*time.Second {
+		t.Errorf("PollInterval = %v", cfg.PollInterval)
+	}
+
+	info, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("config mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestResolveConfig_FileMissing_NoServer_Errors(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	var stderr bytes.Buffer
+	_, err := resolveConfig(cfgPath, "", "", 0, false, &stderr)
+	if err == nil {
+		t.Fatal("expected error when config missing and --server unset")
+	}
+	if _, statErr := os.Stat(cfgPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("config file was created on error path: %v", statErr)
+	}
+}
+
+func TestResolveConfig_DoesNotPersistToken(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	var stderr bytes.Buffer
+	// We never pass token into resolveConfig — but assert the file content
+	// contains nothing token-shaped to lock the invariant from issue #67.
+	_, err := resolveConfig(cfgPath, "https://srv.example.com", "", 0, false, &stderr)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(strings.ToLower(string(data)), "token") {
+		t.Errorf("config file contains token-shaped data: %s", data)
+	}
+}
+
+func TestRun_FreshHost_NoTokenNoCert_Errors(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+	dataDir := filepath.Join(dir, "nebula")
+
+	// Seed an enrolled-but-cert-missing state: config exists, host.crt does not.
+	cfg := config.DefaultAgentConfig()
+	cfg.ServerURL = "https://srv.example.com"
+	cfg.DataDir = dataDir
+	if err := config.SaveAgentConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	err := run([]string{"--config", cfgPath}, &stderr, &stderr)
+	if err == nil {
+		t.Fatal("expected error: missing cert + no token")
+	}
+	if !strings.Contains(err.Error(), "--token") {
+		t.Errorf("error message should mention --token hint; got %v", err)
+	}
+}
+
+func TestRun_DeprecatedSubcommandWarning(t *testing.T) {
+	var stderr bytes.Buffer
+	// Both deprecated commands fail fast (missing flags), but the warning
+	// must hit stderr regardless.
+	_ = run([]string{"enroll"}, &stderr, &stderr)
+	if !strings.Contains(stderr.String(), "deprecated") {
+		t.Errorf("expected deprecation warning for enroll; got %q", stderr.String())
+	}
+
+	stderr.Reset()
+	_ = run([]string{"run", "--config", "/nonexistent"}, &stderr, &stderr)
+	if !strings.Contains(stderr.String(), "deprecated") {
+		t.Errorf("expected deprecation warning for run; got %q", stderr.String())
+	}
+}

--- a/deploy/ansible/roles/nebula_agent/tasks/main.yml
+++ b/deploy/ansible/roles/nebula_agent/tasks/main.yml
@@ -71,6 +71,10 @@
   register: nebula_agent_fp_stat
 
 - name: Enroll (run once)
+  # We use the deprecated `enroll` subcommand here because it is the only
+  # one-shot form: the unified `nebula-agent --token …` starts the poller
+  # after enrolling, which would block this task forever. See issue #67 for
+  # the unified UX; this subcommand is supported for one release.
   when: not nebula_agent_fp_stat.stat.exists
   ansible.builtin.command:
     cmd: >

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -31,13 +31,13 @@ The service reads `NEBULA_MGMT_CA_PASSPHRASE` from `passphrase.env` and unlocks 
 
 ```sh
 sudo install -m 0755 bin/nebula-agent /usr/local/bin/nebula-agent
-sudo install -d -m 0755 /etc/nebula-agent
-sudo install -m 0644 configs/agent.example.yml /etc/nebula-agent/agent.yml
 
-# Edit /etc/nebula-agent/agent.yml: set server_url, data_dir, nebula_pid_file.
-# Then enroll once (writes host.crt/key and config.yml to data_dir):
-sudo nebula-agent enroll --server https://mgmt.example.com:8080 \
-                        --token "$ENROLL_TOKEN" --data-dir /etc/nebula
+# First run: enrolls the host and writes /etc/nebula-agent/agent.yml (mode 0600).
+sudo nebula-agent \
+  --server https://mgmt.example.com:8080 \
+  --token "$ENROLL_TOKEN"
+
+# The default data_dir is /etc/nebula; pass --data-dir on the first run to change it.
 
 sudo install -m 0644 deploy/systemd/nebula-agent.service /etc/systemd/system/
 sudo systemctl daemon-reload

--- a/deploy/systemd/nebula-agent.service
+++ b/deploy/systemd/nebula-agent.service
@@ -12,7 +12,7 @@ Type=simple
 User=root
 Group=root
 
-ExecStart=/usr/local/bin/nebula-agent run --config /etc/nebula-agent/agent.yml
+ExecStart=/usr/local/bin/nebula-agent --config /etc/nebula-agent/agent.yml
 Restart=on-failure
 RestartSec=5s
 

--- a/details.md
+++ b/details.md
@@ -440,8 +440,10 @@ Chi router с middleware chain:
 4. При ошибке → логировать, retry с backoff
 
 **CLI:**
-- `nebula-agent enroll --token=<TOKEN> --server=<URL> [--config=<path>]`
-- `nebula-agent run [--config=<path>]`
+- `nebula-agent --server=<URL> --token=<TOKEN> [--config=<path>] [--data-dir=<dir>]` — первый запуск: enroll, запись `agent.yml` (0600), старт поллера
+- `nebula-agent [--config=<path>]` — последующие запуски (token не нужен)
+- `nebula-agent --update-config --server=<URL>` — атомарно переписать поле в `agent.yml`
+- Legacy (deprecated, поддерживается один релиз): `nebula-agent enroll …` / `nebula-agent run …`
 
 ### 1.8 Server CLI
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -90,7 +90,7 @@ The package:
 - installs `/usr/bin/nebula-agent` and `/lib/systemd/system/nebula-agent.service`;
 - ships an example config at `/etc/nebula-agent/agent.example.yml`;
 - creates the `nebula-agent` system user/group for future hardening;
-- **does not** create `/etc/nebula-agent/agent.yml`, start, or enable the service — you must copy the example, edit it, run `nebula-agent enroll`, then `systemctl enable --now nebula-agent`;
+- **does not** create `/etc/nebula-agent/agent.yml`, start, or enable the service — run `nebula-agent --server URL --token TOK` once to write the config + enroll, then `systemctl enable --now nebula-agent`;
 - on upgrade, leaves `/etc/nebula-agent/agent.yml` and `/etc/nebula/{host.crt,host.key,ca.crt,config.yml}` untouched;
 - on removal, stops and disables the service but keeps `/etc/nebula-agent` and `/etc/nebula` intact (so host keys survive accidental removals). `apt purge` / `dnf remove --purge` will additionally delete the system user.
 
@@ -123,9 +123,8 @@ on the host key and for sending `SIGHUP` to Nebula), and is hardened with the us
 
 ```sh
 sudo install -m 0644 deploy/systemd/nebula-agent.service /etc/systemd/system/
-sudo mkdir -p /etc/nebula-agent
-sudo install -m 0640 configs/agent.example.yml /etc/nebula-agent/agent.yml
-# edit /etc/nebula-agent/agent.yml first — see "Configuration"
+# First run enrolls the host and writes /etc/nebula-agent/agent.yml (mode 0600):
+sudo nebula-agent --server https://mgmt.example.com:8080 --token "$ENROLL_TOKEN"
 sudo systemctl daemon-reload
 sudo systemctl enable --now nebula-agent.service
 journalctl -u nebula-agent.service -f
@@ -151,7 +150,7 @@ services:
   nebula-agent:
     image: ghcr.io/juev/nebula-mesh:latest
     entrypoint: ["/usr/local/bin/nebula-agent"]
-    command: ["run", "--config", "/etc/nebula-agent/agent.yml"]
+    command: ["--config", "/etc/nebula-agent/agent.yml"]
     volumes:
       - nebula-conf:/etc/nebula
       - ./agent.yml:/etc/nebula-agent/agent.yml:ro
@@ -244,10 +243,14 @@ it through `POST /api/v1/hosts/{id}/enrollment-token` (or via the UI).
 ### 2. On the host
 
 ```sh
-sudo nebula-agent enroll \
+# First run: enrolls, writes config to /etc/nebula-agent/agent.yml (0600),
+# starts the poller. The token is single-use and is never written to disk.
+sudo nebula-agent \
   --server https://mgmt.example.com:8080 \
-  --token "$ENROLL_TOKEN" \
-  --data-dir /etc/nebula
+  --token "$ENROLL_TOKEN"
+
+# Optional: pick a non-default data dir on first run.
+sudo nebula-agent --server ... --token ... --data-dir /etc/nebula
 ```
 
 After a successful enrollment the agent writes the following to `data_dir`:
@@ -265,14 +268,40 @@ token returns `409 Conflict`.
 
 ### 3. Starting the run loop
 
-Once the host has been enrolled, the agent runs in a long-lived `run` loop:
+Once the host has been enrolled, subsequent invocations need no arguments — the
+agent reads `/etc/nebula-agent/agent.yml`, finds `host.crt`, and starts polling:
 
 ```sh
+sudo nebula-agent                                # default config path
+sudo nebula-agent --config /path/to/agent.yml    # non-default location
+```
+
+To change a setting later, edit the YAML file (preferred) or pass
+`--update-config` together with the override flag to overwrite a single field
+atomically:
+
+```sh
+sudo nebula-agent --update-config --poll-interval 60s
+```
+
+CLI overrides without `--update-config` are ignored on subsequent runs (a
+warning is logged) so a one-shot flag never silently rewrites persisted state.
+
+The agent exits non-zero if the host's certificate is missing and no `--token`
+is supplied — the error message tells you to pass `--token TOK` to enroll.
+
+### Legacy subcommands (deprecated)
+
+The previous two-step ceremony still works for one release for backward
+compatibility with existing scripts:
+
+```sh
+sudo nebula-agent enroll --server ... --token ... --data-dir /etc/nebula
 sudo nebula-agent run --config /etc/nebula-agent/agent.yml
 ```
 
-`nebula-agent run` exits with a non-zero status if the host's certificate file or
-fingerprint is missing — make sure `enroll` ran first.
+Both print a deprecation warning on stderr; switch to the unified form when
+convenient.
 
 ## How updates work
 
@@ -317,8 +346,8 @@ that `data_dir/host.crt` exists and is readable, then try removing
 
 ### `cannot read certificate fingerprint`
 
-`nebula-agent run` was launched before `nebula-agent enroll` succeeded. Run
-`enroll` first.
+`nebula-agent` was launched on a host with no `host.crt`. Pass `--token TOK`
+to enroll, or check that `data_dir/host.crt` exists (the path in `agent.yml`).
 
 ### Nebula keeps using the old config
 
@@ -363,7 +392,7 @@ delete` the old record and create a new one; on the host:
 ```sh
 sudo systemctl stop nebula-agent nebula
 sudo rm /etc/nebula/{host.crt,host.key,ca.crt,config.yml,.fingerprint}
-sudo nebula-agent enroll --server <url> --token <new-token> --data-dir /etc/nebula
+sudo nebula-agent --server <url> --token <new-token>
 sudo systemctl start nebula nebula-agent
 ```
 

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -17,18 +18,23 @@ type AgentConfig struct {
 	NebulaPIDFile    string        `yaml:"nebula_pid_file"`
 }
 
+// DefaultAgentConfig returns a config populated with the defaults the agent
+// applies when fields are missing.
+func DefaultAgentConfig() *AgentConfig {
+	return &AgentConfig{
+		DataDir:          "/etc/nebula",
+		PollInterval:     30 * time.Second,
+		NebulaConfigPath: "/etc/nebula/config.yml",
+	}
+}
+
 func LoadAgentConfig(path string) (*AgentConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
 
-	cfg := &AgentConfig{
-		DataDir:          "/etc/nebula",
-		PollInterval:     30 * time.Second,
-		NebulaConfigPath: "/etc/nebula/config.yml",
-	}
-
+	cfg := DefaultAgentConfig()
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
@@ -38,4 +44,57 @@ func LoadAgentConfig(path string) (*AgentConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+// SaveAgentConfig writes cfg to path atomically (tmp + fsync + rename) with
+// mode 0600. The parent directory is created with mode 0755 if missing.
+func SaveAgentConfig(path string, cfg *AgentConfig) error {
+	if cfg == nil {
+		return errors.New("nil config")
+	}
+	if cfg.ServerURL == "" {
+		return errors.New("server_url is required")
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".agent.yml.*")
+	if err != nil {
+		return fmt.Errorf("create temp config: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write temp config: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp config: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("sync temp config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp config: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename temp config: %w", err)
+	}
+	return nil
 }

--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -98,3 +98,83 @@ func TestLoadAgentConfig_InvalidYAML(t *testing.T) {
 		t.Fatal("expected error for invalid YAML, got nil")
 	}
 }
+
+func TestSaveAgentConfig_AtomicWriteAndMode(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "sub", "agent.yml")
+
+	cfg := DefaultAgentConfig()
+	cfg.ServerURL = "https://mgmt.example.com:8080"
+	cfg.PollInterval = 45 * time.Second
+	cfg.NebulaPIDFile = "/run/nebula.pid"
+
+	if err := SaveAgentConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("SaveAgentConfig: %v", err)
+	}
+
+	info, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat saved config: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("config mode = %v, want 0600", mode)
+	}
+
+	loaded, err := LoadAgentConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadAgentConfig: %v", err)
+	}
+	if loaded.ServerURL != cfg.ServerURL {
+		t.Errorf("ServerURL = %q, want %q", loaded.ServerURL, cfg.ServerURL)
+	}
+	if loaded.PollInterval != cfg.PollInterval {
+		t.Errorf("PollInterval = %v, want %v", loaded.PollInterval, cfg.PollInterval)
+	}
+	if loaded.NebulaPIDFile != cfg.NebulaPIDFile {
+		t.Errorf("NebulaPIDFile = %q, want %q", loaded.NebulaPIDFile, cfg.NebulaPIDFile)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(cfgPath))
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "agent.yml" {
+			t.Errorf("leftover file in config dir: %s", e.Name())
+		}
+	}
+}
+
+func TestSaveAgentConfig_Overwrite(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	cfg := DefaultAgentConfig()
+	cfg.ServerURL = "https://first.example.com"
+	if err := SaveAgentConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	cfg.ServerURL = "https://second.example.com"
+	if err := SaveAgentConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	loaded, err := LoadAgentConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadAgentConfig: %v", err)
+	}
+	if loaded.ServerURL != "https://second.example.com" {
+		t.Errorf("ServerURL = %q, want second", loaded.ServerURL)
+	}
+}
+
+func TestSaveAgentConfig_RejectsEmpty(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "agent.yml")
+	if err := SaveAgentConfig(cfgPath, nil); err == nil {
+		t.Fatal("expected error for nil cfg")
+	}
+	if err := SaveAgentConfig(cfgPath, &AgentConfig{}); err == nil {
+		t.Fatal("expected error for missing server_url")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #67.

- First run on a fresh host: `nebula-agent --server URL --token TOK` enrolls, persists `/etc/nebula-agent/agent.yml` (mode 0600), and starts the poller — no second command, no `--config` ceremony.
- Subsequent runs: bare `nebula-agent` — config is loaded, fingerprint is read from `host.crt`, poller starts.
- The enrollment token is consumed by `Enroll` and is **never** written to the config file.
- Conflicting CLI flags on an already-configured host emit a warning and do not silently overwrite the file. Pass `--update-config` to overwrite a field atomically.
- `enroll` and `run` subcommands remain for one release as deprecated aliases (deprecation warning on stderr) so existing Ansible / systemd / scripted setups keep working.
- `SaveAgentConfig` writes the file atomically (tmp + chmod 0600 + fsync + rename).

Touch-points (per #67 code-touch-points list):
- `cmd/nebula-agent/main.go` — flag parsing and dispatch (unified path + legacy subcommands).
- `internal/config/agent.go` — adds `SaveAgentConfig` and `DefaultAgentConfig`.
- `deploy/systemd/nebula-agent.service` — `ExecStart` drops the `run` subcommand.
- README + `docs/agent.md` + `deploy/systemd/README.md` + Ansible role docs updated.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`
- [x] Unit tests cover the four startup branches: config exists (flags ignored), config exists + `--update-config` (rewritten), config missing + flags (created), missing cert + no token (errors with hint).
- [x] `SaveAgentConfig` writes mode 0600, atomically, no leftover tmp files.
- [x] Deprecated `enroll` / `run` subcommands print a deprecation warning.
