### PR TITLE
feat(web): route / to UI, /api to API; document UI-only mTLS via proxy (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,20 +376,40 @@ Keep `NEBULA_MGMT_MASTER_KEY` in your secret manager — both the DB and the mas
 <a name="endpoints"></a>
 ## Endpoints
 
-Public, agent, and admin routes at a glance:
+The router (issue #69) splits the listener three ways: `/api/` for the API surface, root + `/ui/` for the Web UI, and a fixed list of ops paths kept at the root for monitoring scrapes. The bare `/` redirects browsers to `/ui/`.
 
-| Path | Auth | Purpose |
+| Prefix | Path | Auth | Purpose |
+|---|---|---|---|
+| UI | `/` | (redirect) | 302 to `/ui/` so first-time visitors land on the dashboard. |
+| UI | `/ui/` | session cookie | web UI (rate-limited, see below). |
+| UI | `/static/*`, `/favicon.ico` | none | UI assets. |
+| API | `/api/v1/enroll` | enrollment token | agent first-contact. |
+| API | `/api/v1/agent/updates` | host cert fingerprint | agent poll. |
+| API | `/api/v1/...` | `Bearer <api_key>` | admin REST API. |
+| Ops | `/healthz` | none | liveness. |
+| Ops | `/readyz` | none | readiness (DB reachable). |
+| Ops | `/metrics` | none | Prometheus exposition (see [`internal/api/metrics.go`](internal/api/metrics.go)). Disable via `metrics.prometheus: false`. |
+| Ops | `/debug/vars`, `/debug/pprof/*` | none | Go `expvar` / pprof. |
+| Ops | `/health` | none | legacy alias for `/healthz`. |
+
+Full route list in [`internal/api/server.go`](internal/api/server.go) and [`internal/web/web.go`](internal/web/web.go).
+
+### Per-endpoint rate-limit groups
+
+On by default; configurable in `server.yml`. Each group is a separate per-IP token bucket:
+
+| Group | Default (req/s / burst) | Endpoints |
 |---|---|---|
-| `/healthz` | none | liveness |
-| `/readyz` | none | readiness (DB reachable) |
-| `/metrics` | none | Prometheus exposition (counters, histograms, gauges — see [`internal/api/metrics.go`](internal/api/metrics.go)). Disable via `metrics.prometheus: false` for air-gapped installs. |
-| `/debug/vars` | none | Go `expvar` runtime stats (kept for backward compatibility). |
-| `/ui/` | session cookie | web UI |
-| `/api/v1/enroll` | enrollment token | agent first-contact |
-| `/api/v1/agent/updates` | host cert | agent poll |
-| `/api/v1/...` | `Bearer <api_key>` | admin REST API |
+| `auth` | 5 / 10 | `POST /ui/login`, `POST /ui/login/totp`, `POST /ui/register` |
+| `ui` | 30 / 60 | every other `/ui/...` page + the admin REST API under `/api/v1/...` |
+| `enroll` | 2 / 5 | `POST /api/v1/enroll` |
+| `agent_poll` | 60 / 120 | `GET /api/v1/agent/updates` |
 
-Full route list in [`internal/api/server.go`](internal/api/server.go).
+Ops endpoints (`/healthz`, `/readyz`, `/metrics`, `/debug/`, `/favicon.ico`, `/static/*`) are exempt so scrapes never get 429s. Behind a reverse proxy, set `rate_limit.trust_proxy_header: true` to key the buckets on `X-Forwarded-For` instead of the proxy's loopback connection.
+
+### Optional: mTLS on the UI only
+
+`crypto/tls.ClientAuth` is a listener-level setting, so per-route client-cert verification lives in the reverse proxy rather than in `nebula-mgmt` itself. Each snippet in [`deploy/reverse-proxy/`](deploy/reverse-proxy/) ships a commented-out block that gates `/ui/` (and `/`) behind a client cert while leaving `/api/` and the ops endpoints reachable without one — agents and Prometheus do not present operator certificates.
 
 <a name="status"></a>
 ## Status

--- a/deploy/reverse-proxy/README.md
+++ b/deploy/reverse-proxy/README.md
@@ -24,3 +24,23 @@ All three:
 The agent endpoints (`/api/v1/enroll`, `/api/v1/agent/updates`) carry
 their own bearer / token authentication — do **not** stack HTTP basic
 auth in the proxy on top of them.
+
+## Optional: mTLS on the UI only (issue #69)
+
+Each of the three snippets ships a commented-out block that gates the
+**UI surface only** behind a client certificate, leaving `/api/`,
+`/healthz`, `/readyz`, `/metrics`, and `/debug/` reachable without one.
+Why split the surfaces:
+
+- Browsers can present a client cert (per-operator, issued from your
+  internal PKI), giving an extra factor on top of the password / 2FA.
+- Agents authenticate with an enrollment token or their host cert at
+  the application layer — they have no operator-cert chain to present.
+- Prometheus / monitoring rarely scrapes through mTLS, and the ops
+  endpoints have no secrets in their responses.
+
+In-binary mTLS would require a second `net.Listener` per route, which
+expands the operational surface — keeping `crypto/tls.ClientAuth` in
+the reverse proxy is the cleaner lever. To enable on your setup,
+uncomment the marked block in the file for your proxy and supply the
+operator-CA bundle (the CA that signs operator client certs).

--- a/deploy/reverse-proxy/caddy/Caddyfile
+++ b/deploy/reverse-proxy/caddy/Caddyfile
@@ -36,4 +36,50 @@ mgmt.example.com {
     # headers; nothing extra to configure for the rate limiter to see the
     # real client IP.
     reverse_proxy 127.0.0.1:8080
+
+    # ------------------------------------------------------------------
+    # Optional: mTLS on the UI only (issue #69).
+    #
+    # Require a client certificate from any browser hitting /ui/ or /,
+    # while leaving /api/ (admin API + agent endpoints) and the
+    # operations endpoints (/healthz, /readyz, /metrics, /debug/)
+    # reachable without one. Agents and Prometheus rarely speak mTLS.
+    #
+    # To enable:
+    #   1. Drop the operator-CA bundle into /etc/caddy/ui-clients-ca.pem.
+    #   2. Uncomment the tls block and the @ui matcher below.
+    #   3. systemctl reload caddy
+    #
+    # tls {
+    #     client_auth {
+    #         mode             require_and_verify
+    #         trusted_ca_cert_file /etc/caddy/ui-clients-ca.pem
+    #     }
+    # }
+    # @ui {
+    #     path /ui/* /
+    # }
+    # # Caddy applies the listener-level client_auth above to every
+    # # request; to keep /api, /healthz, /readyz, /metrics, /debug
+    # # client-cert-free, prefer the second-listener / second-site
+    # # approach below.
 }
+
+# Alternative: a second site (different hostname) that fronts the
+# Web UI with mTLS, while the public hostname above keeps the API and
+# ops endpoints anonymous. Browsers visit https://ui.mgmt.example.com,
+# agents and Prometheus visit https://mgmt.example.com.
+#
+# ui.mgmt.example.com {
+#     tls {
+#         client_auth {
+#             mode require_and_verify
+#             trusted_ca_cert_file /etc/caddy/ui-clients-ca.pem
+#         }
+#     }
+#     @api path /api/* /healthz /readyz /metrics /debug/*
+#     handle @api {
+#         respond 404
+#     }
+#     reverse_proxy 127.0.0.1:8080
+# }

--- a/deploy/reverse-proxy/nginx/nebula-mgmt.conf
+++ b/deploy/reverse-proxy/nginx/nebula-mgmt.conf
@@ -93,4 +93,33 @@ server {
         proxy_read_timeout 24h;
         chunked_transfer_encoding off;
     }
+
+    # --------------------------------------------------------------------
+    # Optional: mTLS on the UI only (issue #69).
+    #
+    # Require a client certificate from any browser hitting /ui/ or /,
+    # while leaving /api/ (admin API + agent endpoints) and the operations
+    # endpoints (/healthz, /readyz, /metrics, /debug/) reachable without a
+    # client cert. Agents authenticate via enrollment token / host cert at
+    # the application layer; monitoring tooling is rarely able to present
+    # a client cert.
+    #
+    # To enable:
+    #   1. Distribute a CA + per-user client cert to the operators who
+    #      need UI access (e.g. via your existing internal PKI).
+    #   2. Uncomment the four lines below and the per-location overrides.
+    #   3. nginx -t && systemctl reload nginx
+    #
+    # ssl_client_certificate /etc/ssl/ui-clients-ca.pem; # CA that signed
+    #                                                   # operator client certs
+    # ssl_verify_client       optional;                  # checked per-location
+    # ssl_verify_depth        2;
+    #
+    # location /ui/      { ssl_verify_client on;  proxy_pass http://127.0.0.1:8080; }
+    # location = /       { ssl_verify_client on;  proxy_pass http://127.0.0.1:8080; }
+    # location /api/     { ssl_verify_client off; proxy_pass http://127.0.0.1:8080; }
+    # location /healthz  { ssl_verify_client off; proxy_pass http://127.0.0.1:8080; }
+    # location /readyz   { ssl_verify_client off; proxy_pass http://127.0.0.1:8080; }
+    # location /metrics  { ssl_verify_client off; proxy_pass http://127.0.0.1:8080; }
+    # location /debug/   { ssl_verify_client off; proxy_pass http://127.0.0.1:8080; }
 }

--- a/deploy/reverse-proxy/traefik/dynamic.yml
+++ b/deploy/reverse-proxy/traefik/dynamic.yml
@@ -60,3 +60,37 @@ http:
         contentTypeNosniff: true
         frameDeny: true
         referrerPolicy: "no-referrer"
+
+# --------------------------------------------------------------------
+# Optional: mTLS on the UI only (issue #69).
+#
+# Traefik client-cert verification is a per-router setting via a named
+# tls.options entry. Define an options block requiring a client cert,
+# then attach it to a router that matches only `/ui/*` and `/`. Leave
+# the main `nebula-mgmt` router above untouched so agents (/api/v1/...)
+# and Prometheus (/healthz, /readyz, /metrics, /debug/) keep working.
+#
+# Uncomment everything below to enable. Replace the CA bundle path with
+# the operator client-cert CA you control.
+#
+# tls:
+#   options:
+#     nebula-mgmt-ui-mtls:
+#       clientAuth:
+#         caFiles:
+#           - /etc/traefik/ui-clients-ca.pem
+#         clientAuthType: RequireAndVerifyClientCert
+#       minVersion: VersionTLS12
+#
+# http:
+#   routers:
+#     nebula-mgmt-ui:
+#       # Higher priority than the catch-all so /ui/* and "/" land here first.
+#       priority: 100
+#       rule: "Host(`mgmt.example.com`) && (PathPrefix(`/ui`) || Path(`/`) || PathPrefix(`/static`) || Path(`/favicon.ico`))"
+#       entryPoints: [websecure]
+#       service: nebula-mgmt
+#       middlewares: [nebula-mgmt-headers]
+#       tls:
+#         certResolver: letsencrypt
+#         options: nebula-mgmt-ui-mtls

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -26,6 +26,29 @@ import (
 // caPassphraseEnv is read by readCAPassphrase before falling back to TTY prompt.
 const caPassphraseEnv = "NEBULA_MGMT_CA_PASSPHRASE"
 
+// buildMux assembles the top-level routing per issue #69.
+//
+//   - /api/                  → API server (admin REST API, agent endpoints)
+//   - /healthz, /readyz      → API server (kept at root for monitoring scrapes)
+//   - /metrics, /debug/      → API server (kept at root for Prometheus / pprof)
+//   - /health                → API server (legacy alias)
+//   - / (everything else)    → Web UI (which 302s "/" to "/ui/")
+//
+// API endpoints under /api/ that are not registered in api.Server return 404
+// from the API surface (not from the UI router). Static assets and the
+// favicon are still served by the UI handler.
+func buildMux(webUI, apiSrv http.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/api/", apiSrv)
+	mux.Handle("/healthz", apiSrv)
+	mux.Handle("/readyz", apiSrv)
+	mux.Handle("/metrics", apiSrv)
+	mux.Handle("/debug/", apiSrv)
+	mux.Handle("/health", apiSrv) // legacy alias
+	mux.Handle("/", webUI)
+	return mux
+}
+
 // readCAPassphrase reads the CA passphrase from $NEBULA_MGMT_CA_PASSPHRASE if set,
 // otherwise prompts on the controlling terminal. Returns an error when stdin
 // is not a TTY and the env var is not set (typical of systemd / Docker without -i).
@@ -241,11 +264,7 @@ func Serve(configPath string) error {
 		logger.Info("oidc enabled", "issuer", cfg.OIDC.Issuer)
 	}
 
-	// Combine: Web UI + API
-	mux := http.NewServeMux()
-	mux.Handle("/ui/", webUI)
-	mux.Handle("/static/", webUI)
-	mux.Handle("/", apiSrv)
+	mux := buildMux(webUI, apiSrv)
 
 	httpServer := &http.Server{
 		Addr:         cfg.Listen,

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildMux_RoutesPerIssue69 verifies the acceptance criteria from #69:
+//
+//   - GET /                → UI handler
+//   - GET /ui/...          → UI handler
+//   - GET /static/...      → UI handler
+//   - GET /favicon.ico     → UI handler
+//   - GET /api/v1/enroll   → API handler
+//   - GET /healthz         → API handler
+//   - GET /readyz          → API handler
+//   - GET /metrics         → API handler
+//   - GET /debug/vars      → API handler
+//   - GET /health          → API handler (legacy alias)
+//   - GET /api/unknown     → API handler (lets it 404, not UI)
+func TestBuildMux_RoutesPerIssue69(t *testing.T) {
+	apiSrv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Handler", "api")
+		w.WriteHeader(http.StatusOK)
+	})
+	uiSrv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Handler", "ui")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux := buildMux(uiSrv, apiSrv)
+
+	cases := []struct {
+		path    string
+		handler string
+	}{
+		{"/", "ui"},
+		{"/ui/", "ui"},
+		{"/ui/hosts", "ui"},
+		{"/static/app.css", "ui"},
+		{"/favicon.ico", "ui"},
+		{"/api/", "api"},
+		{"/api/v1/enroll", "api"},
+		{"/api/v1/agent/updates", "api"},
+		{"/api/unknown-endpoint", "api"},
+		{"/healthz", "api"},
+		{"/readyz", "api"},
+		{"/metrics", "api"},
+		{"/debug/vars", "api"},
+		{"/debug/pprof/", "api"},
+		{"/health", "api"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			mux.ServeHTTP(rr, req)
+			if got := rr.Header().Get("X-Handler"); got != tc.handler {
+				t.Errorf("path %s routed to %q, want %q", tc.path, got, tc.handler)
+			}
+		})
+	}
+}
+
+func TestBuildMux_UnknownApiPathDoesNotFallThroughToUI(t *testing.T) {
+	// API stub mimics chi's NotFound behaviour: returns 404 with a distinctive body.
+	apiSrv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("api-not-found"))
+	})
+	uiSrv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If the UI ever sees /api/... we've regressed.
+		t.Fatalf("UI should not handle %s", r.URL.Path)
+	})
+	mux := buildMux(uiSrv, apiSrv)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/does-not-exist", nil)
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "api-not-found") {
+		t.Errorf("body = %q, want API-generated 404", rr.Body.String())
+	}
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -165,6 +165,14 @@ func (w *Web) setupRoutes() {
 	// Favicon (public, served from embedded SVG)
 	r.Get("/favicon.ico", w.handleFavicon)
 
+	// Bare root redirects to the dashboard so first-time visitors land on /ui/
+	// instead of a 404. Per issue #69, the catch-all mux now sends "/" to the
+	// Web UI; this redirect keeps existing /ui/ links and bookmarks canonical
+	// instead of switching every UI URL to bare root in one go.
+	r.Get("/", func(rw http.ResponseWriter, req *http.Request) {
+		http.Redirect(rw, req, "/ui/", http.StatusFound)
+	})
+
 	// Login (public). Auth-group rate limit only on the form submissions
 	// — GET pages render the form and a 429 there would just confuse
 	// legitimate users who haven't yet pressed Submit.


### PR DESCRIPTION
## Summary

Closes #69.

- `internal/cli/serve.go` — new `buildMux` helper. `/api/` and the ops endpoints (`/healthz`, `/readyz`, `/metrics`, `/debug/`, `/health`) go to the API server; everything else (`/`, `/ui/...`, `/static/*`, `/favicon.ico`) goes to the Web UI.
- `internal/web/web.go` — `GET /` returns `302 → /ui/` so first-time visitors land on the dashboard. Existing `/ui/...` URLs and bookmarks stay canonical.
- `internal/cli/serve_test.go` — unit tests cover the routing matrix and the "unknown `/api/...` returns 404 from the API, not the UI" guarantee.
- `deploy/reverse-proxy/{nginx,caddy,traefik}` — commented-out **UI-only mTLS** blocks. Agents and Prometheus rarely present operator certs, and `crypto/tls.ClientAuth` is a listener-level setting — keeping the per-route split in the proxy avoids adding a second listener inside the binary.
- README — new endpoints table grouped by prefix; rate-limit groups (`auth`, `ui`, `enroll`, `agent_poll`) promoted out of `configs/server.example.yml` comments.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`
- [x] `TestBuildMux_RoutesPerIssue69` checks every path in the acceptance list: `/`, `/ui/`, `/static/...`, `/favicon.ico`, `/api/v1/enroll`, `/api/v1/agent/updates`, `/api/unknown`, `/healthz`, `/readyz`, `/metrics`, `/debug/vars`, `/debug/pprof/`, `/health`.
- [x] `TestBuildMux_UnknownApiPathDoesNotFallThroughToUI` asserts that an unknown `/api/...` path is served by the API handler (404 from the API), not by the UI.
