### PR TITLE
feat(store): foundation for ADR 0004 agent auth (step 1 of #75)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	golang.org/x/crypto v0.47.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.41.0
+	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.48.0
 )
@@ -33,7 +34,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/api/agent_auth_constants_test.go
+++ b/internal/api/agent_auth_constants_test.go
@@ -1,0 +1,30 @@
+package api
+
+import "testing"
+
+// TestAgentAuthAuditConstants pins the audit action labels and reason codes
+// introduced for ADR 0004 (#75). The strings are part of the public API of
+// the audit log — UIs and external log aggregators key off them — so flipping
+// a string here is a breaking change that needs a deliberate test update.
+func TestAgentAuthAuditConstants(t *testing.T) {
+	cases := []struct {
+		got  string
+		want string
+	}{
+		{auditHostAuthFailed, "host.auth.failed"},
+		{auditHostRotateCertRequested, "host.rotate-cert.requested"},
+		{auditHostReenrollRequested, "host.reenroll.requested"},
+		{auditHostRekeyCompleted, "host.rekey.completed"},
+		{authReasonUnknownFingerprint, "unknown_fingerprint"},
+		{authReasonBadSignature, "bad_signature"},
+		{authReasonTimestampSkew, "timestamp_skew"},
+		{authReasonReplayedNonce, "replayed_nonce"},
+		{authReasonRevoked, "revoked"},
+		{authReasonGone, "gone"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("constant = %q, want %q", c.got, c.want)
+		}
+	}
+}

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -49,17 +49,33 @@ const (
 // future RBAC tooling can share the same vocabulary instead of duplicating
 // string literals.
 const (
-	auditHostCreate           = "host.create"
-	auditHostDelete           = "host.delete"
-	auditHostBlock            = "host.block"
-	auditHostUnblock          = "host.unblock"
-	auditCACreated            = "ca.created"
-	auditCADeleted            = "ca.deleted"
-	auditOperatorCreate       = "operator.create"
-	auditOperatorDisable      = "operator.disable"
-	auditOperatorEnable       = "operator.enable"
-	auditOperatorAPIKeyCreate = "operator.api_key.create"
-	auditOperatorAPIKeyRevoke = "operator.api_key.revoke"
+	auditHostCreate              = "host.create"
+	auditHostDelete              = "host.delete"
+	auditHostBlock               = "host.block"
+	auditHostUnblock             = "host.unblock"
+	auditHostAuthFailed          = "host.auth.failed"
+	auditHostRotateCertRequested = "host.rotate-cert.requested"
+	auditHostReenrollRequested   = "host.reenroll.requested"
+	auditHostRekeyCompleted      = "host.rekey.completed"
+	auditCACreated               = "ca.created"
+	auditCADeleted               = "ca.deleted"
+	auditOperatorCreate          = "operator.create"
+	auditOperatorDisable         = "operator.disable"
+	auditOperatorEnable          = "operator.enable"
+	auditOperatorAPIKeyCreate    = "operator.api_key.create"
+	auditOperatorAPIKeyRevoke    = "operator.api_key.revoke"
+)
+
+// Audit reason codes used in the `details` field of host.auth.failed audit
+// entries (ADR 0004 §8 — telemetry). Surfaced as constants so server-side and
+// test code share one source of truth.
+const (
+	authReasonUnknownFingerprint = "unknown_fingerprint"
+	authReasonBadSignature       = "bad_signature"
+	authReasonTimestampSkew      = "timestamp_skew"
+	authReasonReplayedNonce      = "replayed_nonce"
+	authReasonRevoked            = "revoked"
+	authReasonGone               = "gone"
 )
 
 // caIDFallback is the label value used when a CA signing event happens on

--- a/internal/models/host.go
+++ b/internal/models/host.go
@@ -29,24 +29,28 @@ func ValidRole(r HostRole) bool {
 }
 
 type Host struct {
-	ID              string         `json:"id"`
-	NetworkID       string         `json:"network_id"`
-	CAID            string         `json:"ca_id,omitempty"`
-	Name            string         `json:"name"`
-	NebulaIP        string         `json:"nebula_ip"`
-	Groups          []string       `json:"groups"`
-	Role            HostRole       `json:"role"`
-	IsLighthouse    bool           `json:"is_lighthouse"`
-	IsRelay         bool           `json:"is_relay"`
-	PublicIP        string         `json:"public_ip,omitempty"`
-	ListenPort      int            `json:"listen_port,omitempty"`
-	Status          HostStatus     `json:"status"`
-	CertFingerprint string         `json:"cert_fingerprint,omitempty"`
-	CertExpiresAt   *time.Time     `json:"cert_expires_at,omitempty"`
-	LastSeenAt      *time.Time     `json:"last_seen_at,omitempty"`
-	Advanced        *HostAdvanced  `json:"advanced,omitempty"`
-	CreatedAt       time.Time      `json:"created_at"`
-	UpdatedAt       time.Time      `json:"updated_at"`
+	ID                  string        `json:"id"`
+	NetworkID           string        `json:"network_id"`
+	CAID                string        `json:"ca_id,omitempty"`
+	Name                string        `json:"name"`
+	NebulaIP            string        `json:"nebula_ip"`
+	Groups              []string      `json:"groups"`
+	Role                HostRole      `json:"role"`
+	IsLighthouse        bool          `json:"is_lighthouse"`
+	IsRelay             bool          `json:"is_relay"`
+	PublicIP            string        `json:"public_ip,omitempty"`
+	ListenPort          int           `json:"listen_port,omitempty"`
+	Status              HostStatus    `json:"status"`
+	CertFingerprint     string        `json:"cert_fingerprint,omitempty"`
+	PrevCertFingerprint string        `json:"prev_cert_fingerprint,omitempty"`
+	CertExpiresAt       *time.Time    `json:"cert_expires_at,omitempty"`
+	CertRotatedAt       *time.Time    `json:"cert_rotated_at,omitempty"`
+	PendingRekey        bool          `json:"pending_rekey,omitempty"`
+	SigningPubPEM       string        `json:"signing_pub_pem,omitempty"`
+	LastSeenAt          *time.Time    `json:"last_seen_at,omitempty"`
+	Advanced            *HostAdvanced `json:"advanced,omitempty"`
+	CreatedAt           time.Time     `json:"created_at"`
+	UpdatedAt           time.Time     `json:"updated_at"`
 }
 
 // UnsafeRoute is a single "unsafe route" entry: traffic for `Route` is sent

--- a/internal/store/migration_012_test.go
+++ b/internal/store/migration_012_test.go
@@ -1,0 +1,21 @@
+package store
+
+import "testing"
+
+// TestMigration012_AddsAgentAuthColumns verifies migration 012 added the
+// per-host columns required by ADR 0004 implementation (#75): the previous
+// cert fingerprint window, the rotation timestamp, the pending-rekey flag,
+// and the host's Ed25519 signing public key.
+func TestMigration012_AddsAgentAuthColumns(t *testing.T) {
+	s := newTestStore(t)
+	for _, col := range []string{
+		"prev_cert_fingerprint",
+		"cert_rotated_at",
+		"pending_rekey",
+		"signing_pub_pem",
+	} {
+		if !columnExists(t, s, "hosts", col) {
+			t.Errorf("hosts is missing the %s column after Migrate()", col)
+		}
+	}
+}

--- a/internal/store/migrations/012_agent_auth.down.sql
+++ b/internal/store/migrations/012_agent_auth.down.sql
@@ -1,0 +1,3 @@
+-- SQLite before 3.35 cannot drop columns cleanly; the agent-auth columns are
+-- left in place on rollback and simply unused.
+DROP INDEX IF EXISTS idx_hosts_prev_fingerprint;

--- a/internal/store/migrations/012_agent_auth.up.sql
+++ b/internal/store/migrations/012_agent_auth.up.sql
@@ -1,0 +1,10 @@
+-- ADR 0004 (#75) — agent authorization model.
+-- Adds the per-host fields needed for HTTP-signed polls, cert rotation overlap,
+-- force-rotate (rekey) flow, and the Ed25519 signing public key registered at
+-- enrollment.
+ALTER TABLE hosts ADD COLUMN prev_cert_fingerprint TEXT;
+ALTER TABLE hosts ADD COLUMN cert_rotated_at       DATETIME;
+ALTER TABLE hosts ADD COLUMN pending_rekey         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE hosts ADD COLUMN signing_pub_pem       TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_hosts_prev_fingerprint ON hosts(prev_cert_fingerprint);

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -17,10 +17,11 @@ import (
 )
 
 var (
-	ErrNotFound       = errors.New("not found")
-	ErrTokenUsed      = errors.New("token already used")
-	ErrTokenExpired   = errors.New("token expired")
-	ErrDuplicateEntry = errors.New("duplicate entry")
+	ErrNotFound            = errors.New("not found")
+	ErrTokenUsed           = errors.New("token already used")
+	ErrTokenExpired        = errors.New("token expired")
+	ErrDuplicateEntry      = errors.New("duplicate entry")
+	ErrRekeyAlreadyPending = errors.New("rekey already pending")
 )
 
 // SQLiteStore implements Store using SQLite.
@@ -86,6 +87,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"009_per_operator_cas.up.sql",
 		"010_cert_alerts.up.sql",
 		"011_server_settings.up.sql",
+		"012_agent_auth.up.sql",
 	}
 
 	// Tracking table. Created once; idempotent on subsequent starts.
@@ -346,14 +348,18 @@ func (s *SQLiteStore) scanHost(scanner interface {
 	var advancedJSON string
 	var publicIP sql.NullString
 	var certFP sql.NullString
+	var prevCertFP sql.NullString
 	var certExpires sql.NullTime
+	var certRotatedAt sql.NullTime
 	var lastSeen sql.NullTime
+	var signingPub sql.NullString
 
 	err := scanner.Scan(
 		&h.ID, &h.NetworkID, &h.Name, &h.NebulaIP, &groupsJSON,
 		&h.Role, &h.IsLighthouse, &h.IsRelay, &publicIP, &h.ListenPort,
 		&h.Status, &certFP, &certExpires, &lastSeen,
 		&h.CreatedAt, &h.UpdatedAt, &advancedJSON, &h.CAID,
+		&prevCertFP, &certRotatedAt, &h.PendingRekey, &signingPub,
 	)
 	if err != nil {
 		return nil, err
@@ -375,17 +381,26 @@ func (s *SQLiteStore) scanHost(scanner interface {
 	if certFP.Valid {
 		h.CertFingerprint = certFP.String
 	}
+	if prevCertFP.Valid {
+		h.PrevCertFingerprint = prevCertFP.String
+	}
 	if certExpires.Valid {
 		h.CertExpiresAt = &certExpires.Time
 	}
+	if certRotatedAt.Valid {
+		h.CertRotatedAt = &certRotatedAt.Time
+	}
 	if lastSeen.Valid {
 		h.LastSeenAt = &lastSeen.Time
+	}
+	if signingPub.Valid {
+		h.SigningPubPEM = signingPub.String
 	}
 
 	return h, nil
 }
 
-const hostColumns = `id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, cert_fingerprint, cert_expires_at, last_seen_at, created_at, updated_at, advanced_json, ca_id`
+const hostColumns = `id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, cert_fingerprint, cert_expires_at, last_seen_at, created_at, updated_at, advanced_json, ca_id, prev_cert_fingerprint, cert_rotated_at, pending_rekey, signing_pub_pem`
 
 func (s *SQLiteStore) GetHost(_ context.Context, id string) (*models.Host, error) {
 	row := s.db.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
@@ -744,6 +759,122 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason strin
 	return nil
 }
 
+// --- Agent authorization (ADR 0004) ---
+
+// SetPrevFingerprint records the previous cert fingerprint and the rotation
+// timestamp on the host row. Called from SaveCertificateAndUpdateHostCert
+// before the new fingerprint is written so the overlap window is preserved.
+func (s *SQLiteStore) SetPrevFingerprint(_ context.Context, hostID, prev string, rotatedAt time.Time) error {
+	res, err := s.db.Exec(
+		`UPDATE hosts SET prev_cert_fingerprint = ?, cert_rotated_at = ?, updated_at = ? WHERE id = ?`,
+		prev, rotatedAt, time.Now(), hostID,
+	)
+	if err != nil {
+		return fmt.Errorf("set prev fingerprint: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("set prev fingerprint rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ClearPrevFingerprint drops the rotation overlap state once the agent has
+// successfully polled under the new fingerprint or the wall-clock window
+// expired.
+func (s *SQLiteStore) ClearPrevFingerprint(_ context.Context, hostID string) error {
+	res, err := s.db.Exec(
+		`UPDATE hosts SET prev_cert_fingerprint = NULL, cert_rotated_at = NULL, updated_at = ? WHERE id = ?`,
+		time.Now(), hostID,
+	)
+	if err != nil {
+		return fmt.Errorf("clear prev fingerprint: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("clear prev fingerprint rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// SetPendingRekey flips the pending_rekey flag atomically. If the flag is
+// already set on this host the call returns ErrRekeyAlreadyPending so a
+// duplicate force-rotate request can be rejected with 409.
+func (s *SQLiteStore) SetPendingRekey(_ context.Context, hostID string) error {
+	res, err := s.db.Exec(
+		`UPDATE hosts SET pending_rekey = 1, updated_at = ? WHERE id = ? AND pending_rekey = 0`,
+		time.Now(), hostID,
+	)
+	if err != nil {
+		return fmt.Errorf("set pending rekey: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("set pending rekey rows affected: %w", err)
+	}
+	if n == 0 {
+		// Either the host does not exist or pending_rekey is already 1.
+		// Distinguish by re-reading the row.
+		var exists int
+		row := s.db.QueryRow(`SELECT 1 FROM hosts WHERE id = ?`, hostID)
+		if err := row.Scan(&exists); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("scan host existence: %w", err)
+		}
+		return ErrRekeyAlreadyPending
+	}
+	return nil
+}
+
+// ClearPendingRekey resets the pending_rekey flag, typically after the agent
+// has redeemed the rekey token and the new keypair has been bound to the
+// existing host row.
+func (s *SQLiteStore) ClearPendingRekey(_ context.Context, hostID string) error {
+	res, err := s.db.Exec(
+		`UPDATE hosts SET pending_rekey = 0, updated_at = ? WHERE id = ?`,
+		time.Now(), hostID,
+	)
+	if err != nil {
+		return fmt.Errorf("clear pending rekey: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("clear pending rekey rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateHostSigningPub stores the Ed25519 PEM public key bound to the host's
+// signing identity at enrollment / re-enrollment time.
+func (s *SQLiteStore) UpdateHostSigningPub(_ context.Context, hostID, signingPubPEM string) error {
+	res, err := s.db.Exec(
+		`UPDATE hosts SET signing_pub_pem = ?, updated_at = ? WHERE id = ?`,
+		signingPubPEM, time.Now(), hostID,
+	)
+	if err != nil {
+		return fmt.Errorf("update signing pub: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update signing pub rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // --- Enrollment Tokens ---
 
 // CreateHostAndToken atomically creates a host and its enrollment token.
@@ -799,6 +930,37 @@ func (s *SQLiteStore) CreateToken(_ context.Context, t *models.EnrollmentToken) 
 	)
 	if err != nil {
 		return fmt.Errorf("insert token: %w", err)
+	}
+	return nil
+}
+
+// CreateTokenForHost atomically invalidates any active enrollment tokens for
+// the host and writes a fresh single-use one. Used by the regenerate-token,
+// reenroll, and rekey flows (ADR 0004) where the host row must be preserved.
+func (s *SQLiteStore) CreateTokenForHost(_ context.Context, hostID, token string, expiresAt time.Time) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Error("rollback", "error", err)
+		}
+	}()
+
+	if _, err := tx.Exec(`DELETE FROM enrollment_tokens WHERE host_id = ? AND used = 0`, hostID); err != nil {
+		return fmt.Errorf("delete previous tokens: %w", err)
+	}
+	now := time.Now()
+	id := fmt.Sprintf("etok_%d", now.UnixNano())
+	if _, err := tx.Exec(
+		`INSERT INTO enrollment_tokens (id, host_id, token, used, expires_at, created_at) VALUES (?, ?, ?, 0, ?, ?)`,
+		id, hostID, token, expiresAt, now,
+	); err != nil {
+		return fmt.Errorf("insert token: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit create token: %w", err)
 	}
 	return nil
 }

--- a/internal/store/sqlite_agent_auth_test.go
+++ b/internal/store/sqlite_agent_auth_test.go
@@ -1,0 +1,175 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+func newHostFixture(t *testing.T, s *SQLiteStore, id string) *models.Host {
+	t.Helper()
+	net := createTestNetwork(t, s)
+	h := &models.Host{
+		ID:        id,
+		NetworkID: net.ID,
+		Name:      "host-" + id,
+		NebulaIP:  "192.168.100.10",
+		Groups:    []string{"g"},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func TestSetPrevFingerprint_RoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "h1")
+
+	rotatedAt := time.Now().UTC().Truncate(time.Second)
+	if err := s.SetPrevFingerprint(ctx, h.ID, "old-fp", rotatedAt); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PrevCertFingerprint != "old-fp" {
+		t.Errorf("prev fingerprint = %q, want %q", got.PrevCertFingerprint, "old-fp")
+	}
+	if got.CertRotatedAt == nil || !got.CertRotatedAt.UTC().Equal(rotatedAt) {
+		t.Errorf("cert_rotated_at = %v, want %v", got.CertRotatedAt, rotatedAt)
+	}
+}
+
+func TestSetPrevFingerprint_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.SetPrevFingerprint(context.Background(), "missing", "fp", time.Now()); !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestClearPrevFingerprint_RoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "h1")
+
+	if err := s.SetPrevFingerprint(ctx, h.ID, "old-fp", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ClearPrevFingerprint(ctx, h.ID); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PrevCertFingerprint != "" {
+		t.Errorf("prev fingerprint = %q, want empty", got.PrevCertFingerprint)
+	}
+	if got.CertRotatedAt != nil {
+		t.Errorf("cert_rotated_at = %v, want nil", got.CertRotatedAt)
+	}
+}
+
+func TestSetPendingRekey_CAS(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "h1")
+
+	if err := s.SetPendingRekey(ctx, h.ID); err != nil {
+		t.Fatalf("first SetPendingRekey: %v", err)
+	}
+	if err := s.SetPendingRekey(ctx, h.ID); !errors.Is(err, ErrRekeyAlreadyPending) {
+		t.Fatalf("second SetPendingRekey err = %v, want ErrRekeyAlreadyPending", err)
+	}
+	got, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.PendingRekey {
+		t.Error("pending_rekey = false, want true")
+	}
+}
+
+func TestSetPendingRekey_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.SetPendingRekey(context.Background(), "missing"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestClearPendingRekey(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "h1")
+
+	if err := s.SetPendingRekey(ctx, h.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ClearPendingRekey(ctx, h.ID); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PendingRekey {
+		t.Error("pending_rekey = true after clear")
+	}
+}
+
+func TestUpdateHostSigningPub(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "h1")
+
+	pem := "-----BEGIN NEBULA ED25519 PUBLIC KEY-----\nbase64...\n-----END NEBULA ED25519 PUBLIC KEY-----\n"
+	if err := s.UpdateHostSigningPub(ctx, h.ID, pem); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SigningPubPEM != pem {
+		t.Errorf("signing_pub_pem mismatch")
+	}
+}
+
+func TestCreateTokenForHost_InvalidatesPrevious(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "h1")
+
+	// Seed an initial token.
+	first := &models.EnrollmentToken{
+		ID: "tok_first", HostID: h.ID, Token: "old-token",
+		ExpiresAt: time.Now().Add(time.Hour), CreatedAt: time.Now(),
+	}
+	if err := s.CreateToken(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	// Regenerate; old token must be wiped.
+	if err := s.CreateTokenForHost(ctx, h.ID, "new-token", time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ConsumeToken(ctx, "old-token"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("old token err = %v, want ErrNotFound", err)
+	}
+	got, err := s.ConsumeToken(ctx, "new-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.HostID != h.ID {
+		t.Errorf("new token host_id = %q, want %q", got.HostID, h.ID)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -52,9 +52,26 @@ type Store interface {
 	UnblockHostAndRemoveFromBlocklist(ctx context.Context, id string) (*models.Host, error)
 	DeleteHostAndBlockCert(ctx context.Context, id, reason string) error
 
+	// Agent authorization (ADR 0004 / #75).
+	//
+	// SetPrevFingerprint records the prior cert fingerprint and the time of
+	// rotation; SaveCertificateAndUpdateHostCert is the natural caller.
+	// ClearPrevFingerprint drops the overlap window once the agent has
+	// successfully polled under the new fingerprint.
+	//
+	// SetPendingRekey is a compare-and-swap that succeeds only when the host
+	// is not already mid-rekey; the second concurrent call returns
+	// ErrRekeyAlreadyPending so the API layer can answer 409.
+	SetPrevFingerprint(ctx context.Context, hostID, prev string, rotatedAt time.Time) error
+	ClearPrevFingerprint(ctx context.Context, hostID string) error
+	SetPendingRekey(ctx context.Context, hostID string) error
+	ClearPendingRekey(ctx context.Context, hostID string) error
+	UpdateHostSigningPub(ctx context.Context, hostID, signingPubPEM string) error
+
 	// Enrollment tokens
 	CreateHostAndToken(ctx context.Context, h *models.Host, t *models.EnrollmentToken) error
 	CreateToken(ctx context.Context, t *models.EnrollmentToken) error
+	CreateTokenForHost(ctx context.Context, hostID, token string, expiresAt time.Time) error
 	ConsumeToken(ctx context.Context, token string) (*models.EnrollmentToken, error)
 
 	// Certificates


### PR DESCRIPTION
## Summary

PR1 of the #75 split. Pure plumbing — no behaviour change in the poll handler yet. Sets up the schema, models, store methods, and audit vocabulary that the next PRs will use.

- Migration 012 adds `hosts.{prev_cert_fingerprint, cert_rotated_at, pending_rekey, signing_pub_pem}` + an index on `prev_cert_fingerprint`.
- `models.Host` gains the matching fields; `scanHost` / `hostColumns` updated.
- `store` gains `SetPrevFingerprint`, `ClearPrevFingerprint`, `SetPendingRekey` (CAS), `ClearPendingRekey`, `UpdateHostSigningPub`, `CreateTokenForHost`, and the `ErrRekeyAlreadyPending` sentinel.
- `internal/api` gains audit action labels and reason codes (`host.auth.failed`, `host.rotate-cert.requested`, `host.reenroll.requested`, `host.rekey.completed` + six reason codes).

The `signing_pub_pem` column is new because X25519 (the curve of `host.crt`) is a DH scheme that cannot sign arbitrary messages; the amended ADR 0004 (PR #77) introduces a separate Ed25519 keypair used solely for poll signatures.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] `TestMigration012_AddsAgentAuthColumns` covers schema.
- [x] `TestSetPrevFingerprint_*`, `TestClearPrevFingerprint_*`, `TestSetPendingRekey_CAS`, `TestClearPendingRekey`, `TestUpdateHostSigningPub`, `TestCreateTokenForHost_InvalidatesPrevious` cover every new store method.
- [x] `TestAgentAuthAuditConstants` pins audit strings as public contract.

Refs #75. Builds on #77 (ADR amendment).
