### PR TITLE
feat(api): configurable enrollment-token TTL + regenerate endpoint (step 2 of #75)

### DIFF
--- a/configs/server.example.yml
+++ b/configs/server.example.yml
@@ -77,6 +77,12 @@ allow_self_registration: false
 # Settings UI (#47) can flip it without a restart.
 # enforce_2fa: false
 
+# Default lifetime applied to freshly minted enrollment tokens (ADR 0004 / #75).
+# A per-network override can be set at runtime via the `network_config` table
+# under the `enrollment_token_ttl` key. Empty / unparseable value falls back
+# to 24h.
+# enrollment_token_ttl: "24h"
+
 # Optional OpenID Connect identity provider for operator login. When enabled,
 # the Web UI offers a "Sign in with SSO" button on top of the local password
 # form. Local logins keep working alongside OIDC.

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -100,7 +100,7 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		ID:        uuid.New().String(),
 		HostID:    host.ID,
 		Token:     uuid.New().String(),
-		ExpiresAt: now.Add(24 * time.Hour),
+		ExpiresAt: now.Add(s.tokenTTLFor(r.Context(), host.NetworkID)),
 		CreatedAt: now,
 	}
 	if err := s.store.CreateHostAndToken(r.Context(), host, token); err != nil {
@@ -211,4 +211,42 @@ func (s *Server) handleGetBlocklist(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, list)
+}
+
+type regenerateEnrollmentTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// handleRegenerateEnrollmentToken mints a fresh single-use enrollment token
+// bound to an existing host row (ADR 0004 §7.1 — "regenerates the token
+// without churning the row"). Previous active tokens for the same host are
+// invalidated atomically. The host row, its IP allocation, group membership,
+// and audit history are preserved.
+func (s *Server) handleRegenerateEnrollmentToken(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	host, err := s.store.GetHost(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "host not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get host", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get host")
+		return
+	}
+
+	tokenStr := uuid.New().String()
+	expiresAt := time.Now().Add(s.tokenTTLFor(r.Context(), host.NetworkID))
+	if err := s.store.CreateTokenForHost(r.Context(), host.ID, tokenStr, expiresAt); err != nil {
+		s.logger.Error("create enrollment token", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to mint token")
+		return
+	}
+	s.recordAuditAction(r.Context(), auditHostReenrollRequested, host.ID, host.Name)
+
+	writeJSON(w, http.StatusCreated, regenerateEnrollmentTokenResponse{
+		Token:     tokenStr,
+		ExpiresAt: expiresAt,
+	})
 }

--- a/internal/api/hosts_token_ttl_test.go
+++ b/internal/api/hosts_token_ttl_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestCreateHost_UsesServerDefaultTTL — when no per-network override exists,
+// the freshly minted token expires at now + server-default (24h by default).
+// Bumping `WithEnrollmentTokenTTL` to a distinctive value lets the test see
+// the override was applied without relying on the default.
+func TestCreateHost_UsesServerDefaultTTL(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.WithEnrollmentTokenTTL(2 * time.Hour)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID,
+		Name:      "h1",
+		NebulaIP:  "192.168.100.10",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	before := time.Now()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body: %s", w.Code, w.Body.String())
+	}
+
+	var resp createHostResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// We don't return ExpiresAt on the host, but we can read the token row
+	// from the store. Pull the host from the store and re-fetch through the
+	// API to make sure it exists.
+	hostID := resp.Host.ID
+	if hostID == "" {
+		t.Fatal("host id empty")
+	}
+	// ConsumeToken would mark it used — instead, validate by trying to mint
+	// a fresh one and observing the same TTL.
+	expectedMinExpiry := before.Add(2 * time.Hour).Add(-1 * time.Minute)
+	expectedMaxExpiry := time.Now().Add(2 * time.Hour).Add(1 * time.Minute)
+
+	regReq := httptest.NewRequest("POST", "/api/v1/hosts/"+hostID+"/enrollment-token", nil)
+	authRequest(regReq)
+	w2 := httptest.NewRecorder()
+	srv.ServeHTTP(w2, regReq)
+	if w2.Code != http.StatusCreated {
+		t.Fatalf("regen status = %d, want 201, body: %s", w2.Code, w2.Body.String())
+	}
+	var reg regenerateEnrollmentTokenResponse
+	if err := json.NewDecoder(w2.Body).Decode(&reg); err != nil {
+		t.Fatalf("decode regen: %v", err)
+	}
+	if reg.ExpiresAt.Before(expectedMinExpiry) || reg.ExpiresAt.After(expectedMaxExpiry) {
+		t.Errorf("ExpiresAt = %v, want within [%v, %v]", reg.ExpiresAt, expectedMinExpiry, expectedMaxExpiry)
+	}
+}
+
+// TestCreateHost_UsesNetworkOverride — per-network value in network_config
+// overrides the server-level default.
+func TestCreateHost_UsesNetworkOverride(t *testing.T) {
+	srv, st := newTestServer(t)
+	srv.WithEnrollmentTokenTTL(24 * time.Hour)
+	netID := createNetwork(t, srv)
+
+	if err := st.SetNetworkConfig(context.Background(), netID, "enrollment_token_ttl", "30m"); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID,
+		Name:      "h2",
+		NebulaIP:  "192.168.100.11",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	before := time.Now()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", w.Code)
+	}
+	var resp createHostResponse
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+
+	regReq := httptest.NewRequest("POST", "/api/v1/hosts/"+resp.Host.ID+"/enrollment-token", nil)
+	authRequest(regReq)
+	w2 := httptest.NewRecorder()
+	srv.ServeHTTP(w2, regReq)
+	if w2.Code != http.StatusCreated {
+		t.Fatalf("regen status = %d", w2.Code)
+	}
+	var reg regenerateEnrollmentTokenResponse
+	_ = json.NewDecoder(w2.Body).Decode(&reg)
+
+	expectedMin := before.Add(30 * time.Minute).Add(-1 * time.Minute)
+	expectedMax := time.Now().Add(30 * time.Minute).Add(1 * time.Minute)
+	if reg.ExpiresAt.Before(expectedMin) || reg.ExpiresAt.After(expectedMax) {
+		t.Errorf("ExpiresAt = %v, want within [%v, %v]", reg.ExpiresAt, expectedMin, expectedMax)
+	}
+}
+
+// TestRegenerateEnrollmentToken_InvalidatesPrevious confirms the old token
+// can no longer be consumed after regeneration, while the new one works.
+func TestRegenerateEnrollmentToken_InvalidatesPrevious(t *testing.T) {
+	srv, st := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID,
+		Name:      "h3",
+		NebulaIP:  "192.168.100.12",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create status = %d", w.Code)
+	}
+	var initial createHostResponse
+	_ = json.NewDecoder(w.Body).Decode(&initial)
+
+	regReq := httptest.NewRequest("POST", "/api/v1/hosts/"+initial.Host.ID+"/enrollment-token", nil)
+	authRequest(regReq)
+	w2 := httptest.NewRecorder()
+	srv.ServeHTTP(w2, regReq)
+	if w2.Code != http.StatusCreated {
+		t.Fatalf("regen status = %d", w2.Code)
+	}
+	var reg regenerateEnrollmentTokenResponse
+	_ = json.NewDecoder(w2.Body).Decode(&reg)
+	if reg.Token == "" || reg.Token == initial.EnrollmentToken {
+		t.Fatalf("regenerated token must differ from initial: initial=%q new=%q", initial.EnrollmentToken, reg.Token)
+	}
+
+	// Old token must be wiped from the store.
+	if _, err := st.ConsumeToken(context.Background(), initial.EnrollmentToken); err == nil {
+		t.Error("old token still consumable after regenerate")
+	}
+	// New token must be consumable exactly once.
+	if _, err := st.ConsumeToken(context.Background(), reg.Token); err != nil {
+		t.Errorf("new token not consumable: %v", err)
+	}
+}
+
+// TestRegenerateEnrollmentToken_RequiresAuth — endpoint sits behind bearer
+// auth, like every other host-CRUD route.
+func TestRegenerateEnrollmentToken_RequiresAuth(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/v1/hosts/anything/enrollment-token", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+// TestRegenerateEnrollmentToken_HostNotFound — 404 for a non-existent host id.
+func TestRegenerateEnrollmentToken_HostNotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/v1/hosts/missing-host/enrollment-token", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404, body: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -41,25 +41,53 @@ type Server struct {
 	apiKey         string
 	metrics        *metrics
 	metricsEnabled bool
-	hostSeen       HostSeenEmitter
-	limiter        *ratelimit.Limiter
-	passwordPolicy auth.Policy
+	hostSeen           HostSeenEmitter
+	limiter            *ratelimit.Limiter
+	passwordPolicy     auth.Policy
+	enrollmentTokenTTL time.Duration
 }
 
 // NewServer creates a new API server.
 func NewServer(s store.Store, ca *pki.CAManager, apiKey string, logger *slog.Logger, caCfg CAConfig) *Server {
 	srv := &Server{
-		store:          s,
-		ca:             ca,
-		caConfig:       caCfg,
-		logger:         logger,
-		apiKey:         apiKey,
-		metrics:        newMetrics(s),
-		metricsEnabled: true,
-		passwordPolicy: auth.Default(),
+		store:              s,
+		ca:                 ca,
+		caConfig:           caCfg,
+		logger:             logger,
+		apiKey:             apiKey,
+		metrics:            newMetrics(s),
+		metricsEnabled:     true,
+		passwordPolicy:     auth.Default(),
+		enrollmentTokenTTL: 24 * time.Hour,
 	}
 	srv.setupRoutes()
 	return srv
+}
+
+// WithEnrollmentTokenTTL sets the default enrollment-token TTL applied when
+// the per-network override is unset. Default is 24h (ADR 0004 §7.1).
+func (s *Server) WithEnrollmentTokenTTL(ttl time.Duration) {
+	if ttl > 0 {
+		s.enrollmentTokenTTL = ttl
+	}
+}
+
+// tokenTTLFor resolves the enrollment-token TTL for the network. Order of
+// precedence: per-network `enrollment_token_ttl` value in `network_config`,
+// then the server-level default, then 24h.
+func (s *Server) tokenTTLFor(ctx context.Context, networkID string) time.Duration {
+	if networkID != "" {
+		v, err := s.store.GetNetworkConfig(ctx, networkID, "enrollment_token_ttl")
+		if err == nil && v != "" {
+			if d, perr := time.ParseDuration(v); perr == nil && d > 0 {
+				return d
+			}
+		}
+	}
+	if s.enrollmentTokenTTL > 0 {
+		return s.enrollmentTokenTTL
+	}
+	return 24 * time.Hour
 }
 
 // WithCAResolver attaches a CAResolver. Must be called before ServeHTTP.
@@ -158,6 +186,7 @@ func (s *Server) setupRoutes() {
 		r.Delete("/api/v1/hosts/{id}", s.handleDeleteHost)
 		r.Post("/api/v1/hosts/{id}/block", s.handleBlockHost)
 		r.Post("/api/v1/hosts/{id}/unblock", s.handleUnblockHost)
+		r.Post("/api/v1/hosts/{id}/enrollment-token", s.handleRegenerateEnrollmentToken)
 		r.Get("/api/v1/blocklist", s.handleGetBlocklist)
 		r.Get("/api/v1/ca", s.handleGetCA)
 		r.Post("/api/v1/ca/rotate", s.handleRotateCA)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -179,6 +179,7 @@ func Serve(configPath string) error {
 		Passphrase: passphrase,
 	})
 	apiSrv.WithMetricsEnabled(cfg.Metrics.PrometheusEnabled())
+	apiSrv.WithEnrollmentTokenTTL(cfg.EnrollmentTokenTTLDuration())
 
 	// Build a single rate limiter shared by API and Web. The Web UI runs
 	// auth/ui groups; the API server runs api/enroll/agent_poll groups.

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -59,6 +59,26 @@ type ServerConfig struct {
 	// the DB value alone — the future Settings UI (#47) will edit the
 	// same row at runtime.
 	EnforceTOTP *bool `yaml:"enforce_2fa,omitempty"`
+
+	// EnrollmentTokenTTL is the default lifetime applied to freshly minted
+	// enrollment tokens (ADR 0004 / #75). Per-network overrides live in
+	// the `network_config` table under the `enrollment_token_ttl` key.
+	// Empty / unparseable value falls back to 24h.
+	EnrollmentTokenTTL string `yaml:"enrollment_token_ttl,omitempty"`
+}
+
+// EnrollmentTokenTTLDuration returns the configured default token TTL parsed
+// as a Go duration. Falls back to 24h when unset or invalid so the server
+// always has a sane default.
+func (c ServerConfig) EnrollmentTokenTTLDuration() time.Duration {
+	if c.EnrollmentTokenTTL == "" {
+		return 24 * time.Hour
+	}
+	d, err := time.ParseDuration(c.EnrollmentTokenTTL)
+	if err != nil || d <= 0 {
+		return 24 * time.Hour
+	}
+	return d
 }
 
 // PasswordConfig overrides the password policy defaults.

--- a/internal/config/server_enrollment_ttl_test.go
+++ b/internal/config/server_enrollment_ttl_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEnrollmentTokenTTLDuration(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want time.Duration
+	}{
+		{"empty falls back to 24h", "", 24 * time.Hour},
+		{"valid hours", "2h", 2 * time.Hour},
+		{"valid mixed", "1h30m", 90 * time.Minute},
+		{"invalid syntax falls back", "nonsense", 24 * time.Hour},
+		{"zero falls back", "0s", 24 * time.Hour},
+		{"negative falls back", "-1h", 24 * time.Hour},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ServerConfig{EnrollmentTokenTTL: c.in}.EnrollmentTokenTTLDuration()
+			if got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

PR2 of the #75 split. Implements ADR 0004 §7.1 token-policy section.

- `ServerConfig` gains `enrollment_token_ttl` (Go duration string). Default 24h; helper falls back to 24h on empty/invalid/<=0.
- `api.Server.WithEnrollmentTokenTTL` + internal `tokenTTLFor` helper. Resolution order: per-network override (`network_config["enrollment_token_ttl"]`) → server default → 24h.
- `handleCreateHost` replaces the hardcoded `24 * time.Hour` with the resolved value.
- New endpoint `POST /api/v1/hosts/{id}/enrollment-token` mints a fresh single-use token bound to the existing host row. Previous active tokens are wiped atomically via `CreateTokenForHost`. Emits the `host.reenroll.requested` audit action; returns `{token, expires_at}`.
- `cmd` wiring in `internal/cli/serve.go` pipes the config default into the API server.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] `TestCreateHost_UsesServerDefaultTTL`, `TestCreateHost_UsesNetworkOverride` — TTL resolution.
- [x] `TestRegenerateEnrollmentToken_InvalidatesPrevious`, `_RequiresAuth`, `_HostNotFound` — endpoint behaviour.
- [x] `TestEnrollmentTokenTTLDuration` — config helper edge cases (empty / valid / invalid / zero / negative).

Refs #75. Builds on #78.
