### PR TITLE
feat(api,agent): HTTP-signed agent polls (step 3 of #75)

### DIFF
--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -197,13 +197,16 @@ func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
 		return fmt.Errorf("read certificate fingerprint: %w", err)
 	}
 
-	poller := agent.NewPoller(agent.PollerConfig{
+	poller, err := agent.NewPoller(agent.PollerConfig{
 		ServerURL:   cfg.ServerURL,
 		Fingerprint: fingerprint,
 		DataDir:     cfg.DataDir,
 		Interval:    cfg.PollInterval,
 		PIDFile:     cfg.NebulaPIDFile,
 	}, logger)
+	if err != nil {
+		return fmt.Errorf("create poller: %w", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,6 +17,16 @@ import (
 	"golang.org/x/crypto/curve25519"
 )
 
+// SigningPublicKeyPEMType is the PEM block type used by the agent for its
+// Ed25519 poll-signature public key (ADR 0004 §7.1).
+const SigningPublicKeyPEMType = "NEBULA ED25519 PUBLIC KEY"
+
+// SigningPrivateKeyPEMType is the PEM block type used to persist the Ed25519
+// signing private key on disk (mode 0600). The block bytes contain the full
+// 64-byte ed25519.PrivateKey (seed + public-key half), so SignerFromDisk can
+// reconstruct the keypair without re-deriving from a seed.
+const SigningPrivateKeyPEMType = "NEBULA ED25519 PRIVATE KEY"
+
 // EnrollResponse is the response from the enrollment endpoint.
 type EnrollResponse struct {
 	CertificatePEM   string `json:"certificate_pem"`
@@ -25,7 +37,7 @@ type EnrollResponse struct {
 // Enroll performs the enrollment flow: generates keypair, sends public key
 // to the server with the token, saves received cert and config to dataDir.
 func Enroll(serverURL, token, dataDir string) error {
-	// Generate X25519 keypair
+	// Generate X25519 keypair (for the Nebula handshake cert).
 	privKey := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, privKey); err != nil {
 		return fmt.Errorf("generate private key: %w", err)
@@ -35,13 +47,21 @@ func Enroll(serverURL, token, dataDir string) error {
 		return fmt.Errorf("derive public key: %w", err)
 	}
 
-	// Encode public key to PEM
+	// Generate Ed25519 signing keypair (for poll proof-of-possession, ADR 0004).
+	signingPub, signingPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate signing keypair: %w", err)
+	}
+
+	// Encode keys to PEM.
 	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pubKey)
+	signingPubPEM := pem.EncodeToMemory(&pem.Block{Type: SigningPublicKeyPEMType, Bytes: signingPub})
 
 	// Send enrollment request
 	reqBody, err := json.Marshal(map[string]string{
-		"token":          token,
-		"public_key_pem": string(pubKeyPEM),
+		"token":                  token,
+		"public_key_pem":         string(pubKeyPEM),
+		"signing_public_key_pem": string(signingPubPEM),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
@@ -79,6 +99,12 @@ func Enroll(serverURL, token, dataDir string) error {
 	privKeyPEM := cert.MarshalPrivateKeyToPEM(cert.Curve_CURVE25519, privKey)
 	if err := os.WriteFile(filepath.Join(dataDir, "host.key"), privKeyPEM, 0o600); err != nil {
 		return fmt.Errorf("write host key: %w", err)
+	}
+
+	// Save signing private key (ADR 0004 — used to sign poll requests).
+	signingPrivPEM := pem.EncodeToMemory(&pem.Block{Type: SigningPrivateKeyPEMType, Bytes: signingPriv})
+	if err := os.WriteFile(filepath.Join(dataDir, "host.signing.key"), signingPrivPEM, 0o600); err != nil {
+		return fmt.Errorf("write signing key: %w", err)
 	}
 
 	// Save certificate

--- a/internal/agent/enroll_test.go
+++ b/internal/agent/enroll_test.go
@@ -21,8 +21,9 @@ func TestEnroll_Success(t *testing.T) {
 		}
 
 		var req struct {
-			Token        string `json:"token"`
-			PublicKeyPEM string `json:"public_key_pem"`
+			Token         string `json:"token"`
+			PublicKeyPEM  string `json:"public_key_pem"`
+			SigningPubPEM string `json:"signing_public_key_pem"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Errorf("decode enroll request: %v", err)
@@ -35,6 +36,9 @@ func TestEnroll_Success(t *testing.T) {
 		}
 		if req.PublicKeyPEM == "" {
 			t.Error("empty public key in request")
+		}
+		if req.SigningPubPEM == "" {
+			t.Error("empty signing public key in request")
 		}
 
 		resp := EnrollResponse{
@@ -53,7 +57,7 @@ func TestEnroll_Success(t *testing.T) {
 	}
 
 	// Verify files
-	for _, name := range []string{"ca.crt", "host.crt", "host.key", "config.yml"} {
+	for _, name := range []string{"ca.crt", "host.crt", "host.key", "host.signing.key", "config.yml"} {
 		path := filepath.Join(dir, name)
 		info, err := os.Stat(path)
 		if err != nil {
@@ -66,9 +70,11 @@ func TestEnroll_Success(t *testing.T) {
 	}
 
 	// Check key permissions
-	info, _ := os.Stat(filepath.Join(dir, "host.key"))
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("host.key permissions = %o, want 0600", info.Mode().Perm())
+	for _, secret := range []string{"host.key", "host.signing.key"} {
+		info, _ := os.Stat(filepath.Join(dir, secret))
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("%s permissions = %o, want 0600", secret, info.Mode().Perm())
+		}
 	}
 }
 

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -2,18 +2,24 @@ package agent
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
+
+	agentpop "github.com/juev/nebula-mesh/internal/agent/pop"
+	corepop "github.com/juev/nebula-mesh/internal/pop"
 )
 
 // UpdatesResponse is the response from the agent updates endpoint.
@@ -39,18 +45,42 @@ type Poller struct {
 	config     PollerConfig
 	logger     *slog.Logger
 	signalFunc func() error // for testing: override SIGHUP sending
+	signingKey ed25519.PrivateKey
 }
 
-// NewPoller creates a new Poller.
-func NewPoller(cfg PollerConfig, logger *slog.Logger) *Poller {
+// NewPoller creates a new Poller and loads the Ed25519 signing key needed to
+// sign poll requests (ADR 0004 §7.1). If the key cannot be loaded the
+// returned error is propagated to the caller; the agent must re-enroll
+// before polling can resume.
+func NewPoller(cfg PollerConfig, logger *slog.Logger) (*Poller, error) {
+	priv, err := loadSigningKey(filepath.Join(cfg.DataDir, "host.signing.key"))
+	if err != nil {
+		return nil, fmt.Errorf("load signing key: %w", err)
+	}
 	p := &Poller{
-		config: cfg,
-		logger: logger,
+		config:     cfg,
+		logger:     logger,
+		signingKey: priv,
 	}
 	p.signalFunc = func() error {
 		return signalNebulaFromPID(cfg.PIDFile)
 	}
-	return p
+	return p, nil
+}
+
+func loadSigningKey(path string) (ed25519.PrivateKey, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil || block.Type != SigningPrivateKeyPEMType {
+		return nil, fmt.Errorf("signing key PEM at %s has wrong block type", path)
+	}
+	if len(block.Bytes) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("signing key has length %d, want %d", len(block.Bytes), ed25519.PrivateKeySize)
+	}
+	return ed25519.PrivateKey(block.Bytes), nil
 }
 
 // Run starts the poll loop, blocking until ctx is cancelled.
@@ -74,10 +104,13 @@ func (p *Poller) Run(ctx context.Context) error {
 }
 
 func (p *Poller) poll(ctx context.Context) error {
-	u := fmt.Sprintf("%s/api/v1/agent/updates?fingerprint=%s", p.config.ServerURL, url.QueryEscape(p.config.Fingerprint))
+	u := p.config.ServerURL + "/api/v1/agent/updates"
 	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return fmt.Errorf("create poll request: %w", err)
+	}
+	if err := p.signRequest(req); err != nil {
+		return fmt.Errorf("sign poll request: %w", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -143,6 +176,32 @@ func (p *Poller) poll(ctx context.Context) error {
 		}
 	}
 
+	return nil
+}
+
+// signRequest attaches the four ADR 0004 PoP headers to req: fingerprint,
+// timestamp, nonce, signature over the canonical string.
+func (p *Poller) signRequest(req *http.Request) error {
+	ts := time.Now().UTC().Format(time.RFC3339)
+	nonceBytes := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, nonceBytes); err != nil {
+		return fmt.Errorf("read nonce bytes: %w", err)
+	}
+	nonce := base64.StdEncoding.EncodeToString(nonceBytes)
+
+	host := req.URL.Host
+	if host == "" {
+		host = req.Host
+	}
+	canonical := corepop.CanonicalString(req.Method, req.URL.Path, host, ts, nonce)
+	sig, err := agentpop.Sign(p.signingKey, canonical)
+	if err != nil {
+		return fmt.Errorf("sign canonical: %w", err)
+	}
+	req.Header.Set(corepop.HeaderFingerprint, p.config.Fingerprint)
+	req.Header.Set(corepop.HeaderTimestamp, ts)
+	req.Header.Set(corepop.HeaderNonce, nonce)
+	req.Header.Set(corepop.HeaderSignature, agentpop.EncodeSignature(sig))
 	return nil
 }
 

--- a/internal/agent/poller_test.go
+++ b/internal/agent/poller_test.go
@@ -2,7 +2,10 @@ package agent
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
+	"encoding/pem"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,14 +14,42 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	corepop "github.com/juev/nebula-mesh/internal/pop"
 )
+
+// writeSigningKey seeds a temp data dir with a freshly generated Ed25519
+// signing private key in the on-disk PEM format the poller expects. Returns
+// the matching public key so tests can verify signatures.
+func writeSigningKey(t *testing.T, dir string) ed25519.PublicKey {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: SigningPrivateKeyPEMType, Bytes: priv})
+	if err := os.WriteFile(filepath.Join(dir, "host.signing.key"), pemBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return pub
+}
+
+func newPoller(t *testing.T, cfg PollerConfig) *Poller {
+	t.Helper()
+	p, err := NewPoller(cfg, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.signalFunc = func() error { return nil }
+	return p
+}
 
 func TestPoller_NoUpdates(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("fingerprint") == "" {
-			t.Error("missing fingerprint")
+		if r.Header.Get(corepop.HeaderFingerprint) == "" {
+			t.Error("missing fingerprint header")
 		}
-		json.NewEncoder(w).Encode(UpdatesResponse{
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
 			HasUpdates: false,
 			Blocklist:  []string{},
 		})
@@ -26,12 +57,13 @@ func TestPoller_NoUpdates(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	p := NewPoller(PollerConfig{
+	writeSigningKey(t, dir)
+	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
 		Interval:    50 * time.Millisecond,
-	}, slog.Default())
+	})
 
 	var signalled atomic.Bool
 	p.signalFunc = func() error {
@@ -41,7 +73,7 @@ func TestPoller_NoUpdates(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	p.Run(ctx)
+	_ = p.Run(ctx)
 
 	if signalled.Load() {
 		t.Error("should not signal nebula when no updates")
@@ -51,7 +83,7 @@ func TestPoller_NoUpdates(t *testing.T) {
 func TestPoller_WithCertUpdate(t *testing.T) {
 	certPEM := "-----BEGIN NEBULA CERTIFICATE-----\nupdated-cert\n-----END NEBULA CERTIFICATE-----"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		json.NewEncoder(w).Encode(UpdatesResponse{
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
 			HasUpdates:     true,
 			CertificatePEM: &certPEM,
 			Blocklist:      []string{},
@@ -60,12 +92,13 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	p := NewPoller(PollerConfig{
+	writeSigningKey(t, dir)
+	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
 		Interval:    50 * time.Millisecond,
-	}, slog.Default())
+	})
 
 	var signalled atomic.Bool
 	p.signalFunc = func() error {
@@ -75,9 +108,8 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	p.Run(ctx)
+	_ = p.Run(ctx)
 
-	// Verify cert file was written
 	data, err := os.ReadFile(filepath.Join(dir, "host.crt"))
 	if err != nil {
 		t.Fatalf("read cert: %v", err)
@@ -94,7 +126,7 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 func TestPoller_WithConfigUpdate(t *testing.T) {
 	configYAML := "pki:\n  ca: /etc/nebula/ca.crt\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		json.NewEncoder(w).Encode(UpdatesResponse{
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
 			HasUpdates: true,
 			ConfigYAML: &configYAML,
 			Blocklist:  []string{},
@@ -103,17 +135,17 @@ func TestPoller_WithConfigUpdate(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	p := NewPoller(PollerConfig{
+	writeSigningKey(t, dir)
+	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
 		Interval:    50 * time.Millisecond,
-	}, slog.Default())
-	p.signalFunc = func() error { return nil }
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	p.Run(ctx)
+	_ = p.Run(ctx)
 
 	data, err := os.ReadFile(filepath.Join(dir, "config.yml"))
 	if err != nil {
@@ -124,49 +156,70 @@ func TestPoller_WithConfigUpdate(t *testing.T) {
 	}
 }
 
-func TestPoller_FingerprintEscaped(t *testing.T) {
-	var receivedFP atomic.Value
+func TestPoller_SignsRequest(t *testing.T) {
+	var (
+		seenFP        atomic.Value
+		seenTimestamp atomic.Value
+		seenNonces    [2]atomic.Value
+		call          atomic.Int32
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedFP.Store(r.URL.Query().Get("fingerprint"))
-		json.NewEncoder(w).Encode(UpdatesResponse{HasUpdates: false, Blocklist: []string{}})
+		seenFP.Store(r.Header.Get(corepop.HeaderFingerprint))
+		seenTimestamp.Store(r.Header.Get(corepop.HeaderTimestamp))
+		idx := call.Add(1) - 1
+		if idx < int32(len(seenNonces)) {
+			seenNonces[idx].Store(r.Header.Get(corepop.HeaderNonce))
+		}
+		if r.Header.Get(corepop.HeaderSignature) == "" {
+			t.Error("missing signature header")
+		}
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{HasUpdates: false, Blocklist: []string{}})
 	}))
 	defer server.Close()
 
-	p := NewPoller(PollerConfig{
+	dir := t.TempDir()
+	writeSigningKey(t, dir)
+	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
-		Fingerprint: "fp with spaces&special=chars",
-		DataDir:     t.TempDir(),
-		Interval:    50 * time.Millisecond,
-	}, slog.Default())
-	p.signalFunc = func() error { return nil }
+		Fingerprint: "fp-123",
+		DataDir:     dir,
+		Interval:    20 * time.Millisecond,
+	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
 	defer cancel()
-	p.Run(ctx)
+	_ = p.Run(ctx)
 
-	got, _ := receivedFP.Load().(string)
-	if got != "fp with spaces&special=chars" {
-		t.Errorf("fingerprint = %q, want %q", got, "fp with spaces&special=chars")
+	if call.Load() < 2 {
+		t.Fatalf("expected at least 2 polls, got %d", call.Load())
+	}
+	if seenFP.Load().(string) != "fp-123" {
+		t.Errorf("fingerprint header = %q, want fp-123", seenFP.Load())
+	}
+	if seenTimestamp.Load().(string) == "" {
+		t.Error("missing timestamp")
+	}
+	if seenNonces[0].Load() == seenNonces[1].Load() {
+		t.Errorf("expected distinct nonces, got %v twice", seenNonces[0].Load())
 	}
 }
 
 func TestPoll_RespectsContext(t *testing.T) {
-	// Server that blocks until request is cancelled
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
 	}))
 	defer server.Close()
 
-	p := NewPoller(PollerConfig{
+	dir := t.TempDir()
+	writeSigningKey(t, dir)
+	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
-		DataDir:     t.TempDir(),
-		Interval:    time.Hour, // won't tick — we call poll directly
-	}, slog.Default())
-	p.signalFunc = func() error { return nil }
+		DataDir:     dir,
+		Interval:    time.Hour,
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel context after a short delay
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		cancel()
@@ -182,7 +235,6 @@ func TestAtomicWriteFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.txt")
 
-	// Write initial content
 	if err := atomicWriteFile(path, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +246,6 @@ func TestAtomicWriteFile(t *testing.T) {
 		t.Errorf("content = %q, want hello", data)
 	}
 
-	// Overwrite
 	if err := atomicWriteFile(path, []byte("world"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +257,6 @@ func TestAtomicWriteFile(t *testing.T) {
 		t.Errorf("content = %q, want world", data)
 	}
 
-	// Verify no temp files left
 	entries, _ := os.ReadDir(dir)
 	if len(entries) != 1 {
 		t.Errorf("expected 1 file in dir, got %d", len(entries))
@@ -222,13 +272,11 @@ func TestAtomicWriteFile_InvalidDir(t *testing.T) {
 
 func TestSignalNebula_ReadsPIDFile(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "nebula.pid")
-	// Write current process PID — signal to self is safe (SIGHUP is handled)
 	if err := os.WriteFile(pidFile, []byte("99999999"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	err := signalNebulaFromPID(pidFile)
-	// Should fail because PID 99999999 doesn't exist — but it should parse correctly
 	if err == nil {
 		t.Error("expected error signaling nonexistent process")
 	}
@@ -245,5 +293,11 @@ func TestSignalNebula_NoPIDFile(t *testing.T) {
 	err := signalNebulaFromPID("")
 	if err == nil {
 		t.Error("expected error when PID file not configured")
+	}
+}
+
+func TestNewPoller_MissingSigningKey(t *testing.T) {
+	if _, err := NewPoller(PollerConfig{DataDir: t.TempDir()}, slog.Default()); err == nil {
+		t.Fatal("expected error when host.signing.key missing")
 	}
 }

--- a/internal/agent/pop/sign.go
+++ b/internal/agent/pop/sign.go
@@ -1,0 +1,37 @@
+// Package pop is the agent-side proof-of-possession helper for ADR 0004
+// (#75): it owns the Ed25519 signing private key, knows how to load it from
+// disk, and signs poll-request canonical strings.
+package pop
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+)
+
+// Sign returns the Ed25519 signature over the canonical string. The caller
+// is responsible for constructing the canonical string via the shared
+// internal/pop.CanonicalString helper.
+func Sign(privateKey ed25519.PrivateKey, canonical string) ([]byte, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("private key length = %d, want %d", len(privateKey), ed25519.PrivateKeySize)
+	}
+	return ed25519.Sign(privateKey, []byte(canonical)), nil
+}
+
+// EncodeSignature returns the base64 (standard, no-padding-stripped) form of
+// the signature, suitable for the X-Nebula-Signature header.
+func EncodeSignature(sig []byte) string {
+	return base64.StdEncoding.EncodeToString(sig)
+}
+
+// DecodeSignature is the inverse of EncodeSignature. Reuses the same
+// standard encoding; mismatched padding or non-base64 bytes return an
+// error so the verifier can answer 400/401 instead of panicking.
+func DecodeSignature(s string) ([]byte, error) {
+	if s == "" {
+		return nil, errors.New("signature is empty")
+	}
+	return base64.StdEncoding.DecodeString(s)
+}

--- a/internal/agent/pop/sign_test.go
+++ b/internal/agent/pop/sign_test.go
@@ -1,0 +1,68 @@
+package pop
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	corepop "github.com/juev/nebula-mesh/internal/pop"
+)
+
+func TestSign_RoundTrip(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical := corepop.CanonicalString("GET", "/p", "h", "2026-05-13T08:30:00Z", "n")
+	sig, err := Sign(priv, canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ed25519.Verify(pub, []byte(canonical), sig) {
+		t.Fatal("Verify failed for round-trip")
+	}
+}
+
+func TestSign_WrongKeyDoesNotVerify(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	canonical := corepop.CanonicalString("GET", "/p", "h", "ts", "n")
+	sig, err := Sign(priv, canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ed25519.Verify(otherPub, []byte(canonical), sig) {
+		t.Fatal("Verify accepted signature under the wrong public key")
+	}
+}
+
+func TestSign_BadPrivateKeyLength(t *testing.T) {
+	if _, err := Sign(make([]byte, 10), "anything"); err == nil {
+		t.Fatal("expected error for short private key")
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	sig, err := Sign(priv, "msg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := EncodeSignature(sig)
+	if encoded == "" {
+		t.Fatal("encoded empty")
+	}
+	decoded, err := DecodeSignature(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decoded) != string(sig) {
+		t.Fatal("round-trip mismatch")
+	}
+}
+
+func TestDecodeSignature_RejectsBase64Garbage(t *testing.T) {
+	if _, err := DecodeSignature("!!!not base64!!!"); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -17,8 +17,9 @@ import (
 )
 
 type enrollRequest struct {
-	Token        string `json:"token"`
-	PublicKeyPEM string `json:"public_key_pem"`
+	Token         string `json:"token"`
+	PublicKeyPEM  string `json:"public_key_pem"`
+	SigningPubPEM string `json:"signing_public_key_pem"`
 }
 
 type enrollResponse struct {
@@ -36,6 +37,11 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 
 	if req.Token == "" || req.PublicKeyPEM == "" {
 		writeError(w, http.StatusBadRequest, "token and public_key_pem are required")
+		return
+	}
+	if _, err := decodeSigningPublicKeyPEM(req.SigningPubPEM); err != nil {
+		s.metrics.recordEnrollment(resultDenied)
+		writeError(w, http.StatusBadRequest, "signing_public_key_pem is required and must be Ed25519")
 		return
 	}
 
@@ -164,6 +170,15 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 	if err := s.store.SaveCertificateAndEnrollHost(r.Context(), host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
 		s.metrics.recordEnrollment(resultError)
 		s.logger.Error("save certificate and enroll host", "error", err)
+		writeError(w, http.StatusInternalServerError, "enrollment failed")
+		return
+	}
+
+	// Bind the Ed25519 signing public key to the host so subsequent poll
+	// signatures verify against it (ADR 0004 §7.1).
+	if err := s.store.UpdateHostSigningPub(r.Context(), host.ID, req.SigningPubPEM); err != nil {
+		s.metrics.recordEnrollment(resultError)
+		s.logger.Error("update host signing pub", "error", err)
 		writeError(w, http.StatusInternalServerError, "enrollment failed")
 		return
 	}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -119,9 +119,11 @@ func TestMetricsEndpoint_EnrollmentIncrementsCounter(t *testing.T) {
 	}
 	pubPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pub)
 
+	_, _, signingPEM := generateSigningKeypair(t)
 	enrollBody, _ := json.Marshal(enrollRequest{
-		Token:        created.EnrollmentToken,
-		PublicKeyPEM: string(pubPEM),
+		Token:         created.EnrollmentToken,
+		PublicKeyPEM:  string(pubPEM),
+		SigningPubPEM: signingPEM,
 	})
 	req = httptest.NewRequest("POST", "/api/v1/enroll", bytes.NewBuffer(enrollBody))
 	w = httptest.NewRecorder()

--- a/internal/api/pop/nonce.go
+++ b/internal/api/pop/nonce.go
@@ -1,0 +1,96 @@
+package pop
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// NonceCacheConfig configures NonceCache. Zero-valued IdleTTL falls back to
+// 10 minutes; zero Capacity falls back to 65536 (ADR 0004 §7.1 specifics).
+type NonceCacheConfig struct {
+	Capacity int
+	IdleTTL  time.Duration
+	// Now is injectable for tests. Defaults to time.Now when nil.
+	Now func() time.Time
+}
+
+// NonceCache tracks recently observed (host_id, nonce) pairs to defeat
+// poll-request replays inside the timestamp window (ADR 0004 §7.1).
+//
+// Implementation: a doubly linked list + map guarded by a single mutex.
+// Each entry is evicted either when the LRU exceeds Capacity or when its
+// idle age exceeds IdleTTL. Both bounds are required because real traffic
+// is dominated by many short-lived hosts.
+type NonceCache struct {
+	mu      sync.Mutex
+	cap     int
+	idleTTL time.Duration
+	now     func() time.Time
+	order   *list.List // front = newest, back = oldest
+	items   map[string]*list.Element
+}
+
+type nonceEntry struct {
+	key      string
+	lastSeen time.Time
+}
+
+// NewNonceCache constructs a NonceCache with sensible defaults.
+func NewNonceCache(cfg NonceCacheConfig) *NonceCache {
+	if cfg.Capacity <= 0 {
+		cfg.Capacity = 65536
+	}
+	if cfg.IdleTTL <= 0 {
+		cfg.IdleTTL = 10 * time.Minute
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &NonceCache{
+		cap:     cfg.Capacity,
+		idleTTL: cfg.IdleTTL,
+		now:     now,
+		order:   list.New(),
+		items:   make(map[string]*list.Element),
+	}
+}
+
+// SeenOrAdd records the (hostID, nonce) pair if it has not been observed
+// within the active window. Returns true when the pair is freshly inserted
+// (caller may proceed) and false when it duplicates an existing live entry
+// (caller must reject with reason=replayed_nonce).
+func (c *NonceCache) SeenOrAdd(hostID, nonce string) bool {
+	key := hostID + "\x00" + nonce
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	if el, ok := c.items[key]; ok {
+		entry := el.Value.(*nonceEntry)
+		if now.Sub(entry.lastSeen) >= c.idleTTL {
+			c.removeEl(el)
+		} else {
+			// Live duplicate: replay. Bump recency to defeat
+			// flood-then-replay tactics.
+			entry.lastSeen = now
+			c.order.MoveToFront(el)
+			return false
+		}
+	}
+
+	entry := &nonceEntry{key: key, lastSeen: now}
+	el := c.order.PushFront(entry)
+	c.items[key] = el
+	for c.order.Len() > c.cap {
+		c.removeEl(c.order.Back())
+	}
+	return true
+}
+
+func (c *NonceCache) removeEl(el *list.Element) {
+	entry := el.Value.(*nonceEntry)
+	delete(c.items, entry.key)
+	c.order.Remove(el)
+}

--- a/internal/api/pop/verify.go
+++ b/internal/api/pop/verify.go
@@ -1,0 +1,29 @@
+// Package pop holds the server-side proof-of-possession verifier and the
+// per-(host, nonce) replay cache used by the signed-poll handler (ADR 0004).
+package pop
+
+import (
+	"crypto/ed25519"
+	"errors"
+)
+
+// ErrBadSignature is returned when the signature does not verify, either
+// because the canonical message was tampered, the public key does not match
+// the host, or the key/signature length is wrong. The poll handler maps it
+// to a 401 with reason=bad_signature.
+var ErrBadSignature = errors.New("bad signature")
+
+// Verify checks the Ed25519 signature over the canonical string. All length
+// validation happens here so the handler can call Verify uniformly.
+func Verify(publicKey ed25519.PublicKey, canonical string, sig []byte) error {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return ErrBadSignature
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return ErrBadSignature
+	}
+	if !ed25519.Verify(publicKey, []byte(canonical), sig) {
+		return ErrBadSignature
+	}
+	return nil
+}

--- a/internal/api/pop/verify_test.go
+++ b/internal/api/pop/verify_test.go
@@ -1,0 +1,90 @@
+package pop
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+	"time"
+
+	agentpop "github.com/juev/nebula-mesh/internal/agent/pop"
+	corepop "github.com/juev/nebula-mesh/internal/pop"
+)
+
+func TestVerify_RoundTrip(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	canonical := corepop.CanonicalString("GET", "/p", "h", "ts", "n")
+	sig, err := agentpop.Sign(priv, canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(pub, canonical, sig); err != nil {
+		t.Errorf("Verify: %v", err)
+	}
+}
+
+func TestVerify_TamperedCanonical(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	canonical := corepop.CanonicalString("GET", "/p", "h", "ts", "n")
+	sig, _ := agentpop.Sign(priv, canonical)
+	if err := Verify(pub, canonical+"x", sig); !errors.Is(err, ErrBadSignature) {
+		t.Errorf("err = %v, want ErrBadSignature", err)
+	}
+}
+
+func TestVerify_WrongKey(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	canonical := corepop.CanonicalString("GET", "/p", "h", "ts", "n")
+	sig, _ := agentpop.Sign(priv, canonical)
+	if err := Verify(otherPub, canonical, sig); !errors.Is(err, ErrBadSignature) {
+		t.Errorf("err = %v, want ErrBadSignature", err)
+	}
+}
+
+func TestVerify_BadKeyLength(t *testing.T) {
+	if err := Verify(make([]byte, 5), "msg", []byte("sig")); !errors.Is(err, ErrBadSignature) {
+		t.Errorf("err = %v, want ErrBadSignature", err)
+	}
+}
+
+func TestVerify_BadSignatureLength(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	if err := Verify(pub, "msg", []byte("short")); !errors.Is(err, ErrBadSignature) {
+		t.Errorf("err = %v, want ErrBadSignature", err)
+	}
+}
+
+func TestNonceCache_AcceptsOnce(t *testing.T) {
+	c := NewNonceCache(NonceCacheConfig{Capacity: 16, IdleTTL: time.Minute, Now: time.Now})
+	if !c.SeenOrAdd("host1", "nonceA") {
+		t.Error("first SeenOrAdd returned false (must be true = added)")
+	}
+	if c.SeenOrAdd("host1", "nonceA") {
+		t.Error("replay returned true (must be false = already seen)")
+	}
+	// Different host + same nonce is still independent (we key by both).
+	if !c.SeenOrAdd("host2", "nonceA") {
+		t.Error("different host nonceA must be accepted")
+	}
+}
+
+func TestNonceCache_EvictsBySize(t *testing.T) {
+	c := NewNonceCache(NonceCacheConfig{Capacity: 2, IdleTTL: time.Hour, Now: time.Now})
+	c.SeenOrAdd("h", "a")
+	c.SeenOrAdd("h", "b")
+	c.SeenOrAdd("h", "c") // evicts "a"
+	if !c.SeenOrAdd("h", "a") {
+		t.Error("nonce a should have been evicted and acceptable again")
+	}
+}
+
+func TestNonceCache_EvictsByIdle(t *testing.T) {
+	now := time.Unix(0, 0)
+	c := NewNonceCache(NonceCacheConfig{Capacity: 16, IdleTTL: 10 * time.Minute, Now: func() time.Time { return now }})
+	c.SeenOrAdd("h", "a")
+	now = now.Add(11 * time.Minute)
+	if !c.SeenOrAdd("h", "a") {
+		t.Error("nonce should have been evicted after idle TTL")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	poppkg "github.com/juev/nebula-mesh/internal/api/pop"
 	"github.com/juev/nebula-mesh/internal/auth"
 	"github.com/juev/nebula-mesh/internal/configgen"
 	"github.com/juev/nebula-mesh/internal/keystore"
@@ -45,6 +46,7 @@ type Server struct {
 	limiter            *ratelimit.Limiter
 	passwordPolicy     auth.Policy
 	enrollmentTokenTTL time.Duration
+	nonceCache         *poppkg.NonceCache
 }
 
 // NewServer creates a new API server.
@@ -59,10 +61,14 @@ func NewServer(s store.Store, ca *pki.CAManager, apiKey string, logger *slog.Log
 		metricsEnabled:     true,
 		passwordPolicy:     auth.Default(),
 		enrollmentTokenTTL: 24 * time.Hour,
+		nonceCache:         poppkg.NewNonceCache(poppkg.NonceCacheConfig{}),
 	}
 	srv.setupRoutes()
 	return srv
 }
+
+// nonces returns the per-server replay-protection cache.
+func (s *Server) nonces() *poppkg.NonceCache { return s.nonceCache }
 
 // WithEnrollmentTokenTTL sets the default enrollment-token TTL applied when
 // the per-network override is unset. Default is 24h (ADR 0004 §7.1).

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -849,9 +849,11 @@ func TestEnroll_HostDeletedAfterTokenCreated(t *testing.T) {
 	}
 
 	// Try enrollment — token is consumed OK, but GetHost returns ErrNotFound
+	_, _, signingPEM := generateSigningKeypair(t)
 	enrollBody, _ := json.Marshal(enrollRequest{
-		Token:        resp.EnrollmentToken,
-		PublicKeyPEM: "dummy-key",
+		Token:         resp.EnrollmentToken,
+		PublicKeyPEM:  "dummy-key",
+		SigningPubPEM: signingPEM,
 	})
 	req = httptest.NewRequest("POST", "/api/v1/enroll", bytes.NewBuffer(enrollBody))
 	w = httptest.NewRecorder()

--- a/internal/api/signed_poll_helpers_test.go
+++ b/internal/api/signed_poll_helpers_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"testing"
+)
+
+// generateSigningKeypair returns a fresh Ed25519 keypair and its PEM-encoded
+// public key in the format the server expects on /api/v1/enroll.
+func generateSigningKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  SigningPublicKeyPEMType,
+		Bytes: pub,
+	})
+	return pub, priv, string(pemBytes)
+}

--- a/internal/api/signing_pem.go
+++ b/internal/api/signing_pem.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+)
+
+// decodeSigBase64 is the inverse of agent-side EncodeSignature; standard
+// base64 with required padding.
+func decodeSigBase64(s string) ([]byte, error) {
+	if s == "" {
+		return nil, errors.New("empty signature")
+	}
+	return base64.StdEncoding.DecodeString(s)
+}
+
+// SigningPublicKeyPEMType is the PEM block type used by the agent for its
+// Ed25519 poll-signature public key (ADR 0004 §7.1). Distinct from the X25519
+// `NEBULA X25519 PRIVATE KEY` / `NEBULA X25519 PUBLIC KEY` banners that
+// slackhq/nebula/cert owns.
+const SigningPublicKeyPEMType = "NEBULA ED25519 PUBLIC KEY"
+
+// decodeSigningPublicKeyPEM parses an Ed25519 public key from its PEM-wrapped
+// raw 32-byte representation. Returns ErrBadSigningPEM on shape mismatch so
+// callers map it to 400.
+func decodeSigningPublicKeyPEM(pemStr string) (ed25519.PublicKey, error) {
+	if pemStr == "" {
+		return nil, ErrBadSigningPEM
+	}
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil || block.Type != SigningPublicKeyPEMType {
+		return nil, ErrBadSigningPEM
+	}
+	if len(block.Bytes) != ed25519.PublicKeySize {
+		return nil, ErrBadSigningPEM
+	}
+	return ed25519.PublicKey(block.Bytes), nil
+}
+
+// ErrBadSigningPEM is returned when an Ed25519 signing public key PEM is
+// missing, the wrong block type, or the wrong byte length.
+var ErrBadSigningPEM = errors.New("bad signing public key PEM")

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
+	apipop "github.com/juev/nebula-mesh/internal/api/pop"
+	corepop "github.com/juev/nebula-mesh/internal/pop"
 	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/slackhq/nebula/cert"
 )
@@ -22,16 +24,25 @@ type agentUpdatesResponse struct {
 	Blocklist      []string `json:"blocklist"`
 }
 
+// pollClockSkew is the symmetric tolerance applied to X-Nebula-Timestamp
+// (ADR 0004 §7.1).
+const pollClockSkew = 5 * time.Minute
+
 func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
-	fingerprint := r.URL.Query().Get("fingerprint")
-	if fingerprint == "" {
-		writeError(w, http.StatusBadRequest, "fingerprint query parameter is required")
+	fingerprint := r.Header.Get(corepop.HeaderFingerprint)
+	timestamp := r.Header.Get(corepop.HeaderTimestamp)
+	nonce := r.Header.Get(corepop.HeaderNonce)
+	signatureB64 := r.Header.Get(corepop.HeaderSignature)
+	if fingerprint == "" || timestamp == "" || nonce == "" || signatureB64 == "" {
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, "", authReasonBadSignature)
+		writeError(w, http.StatusBadRequest, "missing_signature")
 		return
 	}
 
 	host, err := s.store.GetHostByFingerprint(r.Context(), fingerprint)
 	if errors.Is(err, store.ErrNotFound) {
-		writeError(w, http.StatusNotFound, "host not found")
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, "", authReasonUnknownFingerprint)
+		writeError(w, http.StatusUnauthorized, "unknown_fingerprint")
 		return
 	}
 	if err != nil {
@@ -40,8 +51,52 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// non-critical: log and continue — last_seen is informational
+	// Verify the proof-of-possession signature against the stored Ed25519
+	// signing public key. host.SigningPubPEM is empty for legacy host rows
+	// that pre-date the ADR 0004 enrollment, in which case verification is
+	// impossible — answer 401 with reason=bad_signature so the operator can
+	// re-enroll the host via POST /hosts/{id}/reenroll.
+	signingPub, err := decodeSigningPublicKeyPEM(host.SigningPubPEM)
+	if err != nil {
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonBadSignature)
+		writeError(w, http.StatusUnauthorized, "bad_signature")
+		return
+	}
+	sigBytes, err := decodeSigBase64(signatureB64)
+	if err != nil {
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonBadSignature)
+		writeError(w, http.StatusUnauthorized, "bad_signature")
+		return
+	}
+	canonical := corepop.CanonicalString(r.Method, r.URL.Path, r.Host, timestamp, nonce)
+	if err := apipop.Verify(signingPub, canonical, sigBytes); err != nil {
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonBadSignature)
+		writeError(w, http.StatusUnauthorized, "bad_signature")
+		return
+	}
+
+	// Timestamp window.
+	ts, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonTimestampSkew)
+		writeError(w, http.StatusUnauthorized, "timestamp_skew")
+		return
+	}
 	now := time.Now()
+	if diff := now.Sub(ts); diff > pollClockSkew || diff < -pollClockSkew {
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonTimestampSkew)
+		writeError(w, http.StatusUnauthorized, "timestamp_skew")
+		return
+	}
+
+	// Replay protection.
+	if !s.nonces().SeenOrAdd(host.ID, nonce) {
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonReplayedNonce)
+		writeError(w, http.StatusUnauthorized, "replayed_nonce")
+		return
+	}
+
+	// non-critical: log and continue — last_seen is informational
 	if err := s.store.UpdateHostLastSeen(r.Context(), host.ID, now); err != nil {
 		s.logger.Error("update last seen", "error", err)
 	} else if s.hostSeen != nil {

--- a/internal/api/updates_signed_poll_test.go
+++ b/internal/api/updates_signed_poll_test.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	corepop "github.com/juev/nebula-mesh/internal/pop"
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+)
+
+// enrolledAgent represents a fully enrolled host fixture in the
+// signed-poll test suite: cert fingerprint + Ed25519 signing keypair.
+type enrolledAgent struct {
+	fingerprint string
+	signingPub  ed25519.PublicKey
+	signingPriv ed25519.PrivateKey
+}
+
+// enrolledFixture creates a network + host and runs the full enrollment
+// handshake (X25519 + Ed25519). The host row ends up with both
+// `cert_fingerprint` and `signing_pub_pem` populated, so signed polls can
+// be exercised end-to-end.
+func enrolledFixture(t *testing.T, srv *Server) enrolledAgent {
+	t.Helper()
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID,
+		Name:      "signed-host",
+		NebulaIP:  "192.168.100.30",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create host: %d / %s", w.Code, w.Body.String())
+	}
+	var created createHostResponse
+	_ = json.NewDecoder(w.Body).Decode(&created)
+
+	// X25519 for the cert.
+	x25519Priv := make([]byte, 32)
+	if _, err := rand.Read(x25519Priv); err != nil {
+		t.Fatal(err)
+	}
+	x25519Pub, err := curve25519.X25519(x25519Priv, curve25519.Basepoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, x25519Pub)
+
+	// Ed25519 for signed polls.
+	edPub, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signingPubPEM := pem.EncodeToMemory(&pem.Block{Type: SigningPublicKeyPEMType, Bytes: edPub})
+
+	enrollBody, _ := json.Marshal(enrollRequest{
+		Token:         created.EnrollmentToken,
+		PublicKeyPEM:  string(pubKeyPEM),
+		SigningPubPEM: string(signingPubPEM),
+	})
+	er := httptest.NewRequest("POST", "/api/v1/enroll", bytes.NewBuffer(enrollBody))
+	ew := httptest.NewRecorder()
+	srv.ServeHTTP(ew, er)
+	if ew.Code != http.StatusOK {
+		t.Fatalf("enroll: %d / %s", ew.Code, ew.Body.String())
+	}
+	var enrolled struct {
+		CertificatePEM string `json:"certificate_pem"`
+	}
+	_ = json.NewDecoder(ew.Body).Decode(&enrolled)
+	hostCert, _, err := cert.UnmarshalCertificateFromPEM([]byte(enrolled.CertificatePEM))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp, err := hostCert.Fingerprint()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return enrolledAgent{fingerprint: fp, signingPub: edPub, signingPriv: edPriv}
+}
+
+// signPoll mutates the request, attaching the four ADR 0004 headers.
+func signPoll(t *testing.T, req *http.Request, agent enrolledAgent, opts ...func(*signOpts)) {
+	t.Helper()
+	o := signOpts{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	for _, f := range opts {
+		f(&o)
+	}
+	if o.Nonce == "" {
+		nb := make([]byte, 16)
+		if _, err := rand.Read(nb); err != nil {
+			t.Fatal(err)
+		}
+		o.Nonce = base64.StdEncoding.EncodeToString(nb)
+	}
+	host := req.URL.Host
+	if host == "" {
+		host = req.Host
+	}
+	canonical := corepop.CanonicalString(req.Method, req.URL.Path, host, o.Timestamp, o.Nonce)
+	if o.CanonicalOverride != "" {
+		canonical = o.CanonicalOverride
+	}
+	priv := agent.signingPriv
+	if o.PrivateKey != nil {
+		priv = o.PrivateKey
+	}
+	sig := ed25519.Sign(priv, []byte(canonical))
+	encoded := base64.StdEncoding.EncodeToString(sig)
+	if o.SignatureOverride != "" {
+		encoded = o.SignatureOverride
+	}
+	req.Header.Set(corepop.HeaderFingerprint, agent.fingerprint)
+	req.Header.Set(corepop.HeaderTimestamp, o.Timestamp)
+	req.Header.Set(corepop.HeaderNonce, o.Nonce)
+	req.Header.Set(corepop.HeaderSignature, encoded)
+}
+
+type signOpts struct {
+	Timestamp         string
+	Nonce             string
+	PrivateKey        ed25519.PrivateKey
+	CanonicalOverride string
+	SignatureOverride string
+}
+
+func withTimestamp(ts string) func(*signOpts) { return func(o *signOpts) { o.Timestamp = ts } }
+func withNonce(n string) func(*signOpts)      { return func(o *signOpts) { o.Nonce = n } }
+func withPrivateKey(k ed25519.PrivateKey) func(*signOpts) {
+	return func(o *signOpts) { o.PrivateKey = k }
+}
+
+func errBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return string(b)
+}
+
+func TestPoll_RejectsMissingHeaders(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "missing_signature") {
+		t.Errorf("body = %q, want missing_signature", w.Body.String())
+	}
+}
+
+func TestPoll_RejectsUnknownFingerprint(t *testing.T) {
+	srv, _ := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	// Swap fingerprint to an unknown value.
+	bogus := enrolledAgent{fingerprint: "deadbeef", signingPub: agent.signingPub, signingPriv: agent.signingPriv}
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, bogus)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "unknown_fingerprint") {
+		t.Errorf("body = %q, want unknown_fingerprint", w.Body.String())
+	}
+}
+
+func TestPoll_RejectsBadSignature(t *testing.T) {
+	srv, _ := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	// Sign with a different keypair.
+	_, otherPriv, _ := ed25519.GenerateKey(rand.Reader)
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent, withPrivateKey(otherPriv))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "bad_signature") {
+		t.Errorf("body = %q, want bad_signature", w.Body.String())
+	}
+}
+
+func TestPoll_RejectsSkewedTimestamp(t *testing.T) {
+	srv, _ := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	// 10 minutes in the past — outside ±5 min window.
+	past := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent, withTimestamp(past))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "timestamp_skew") {
+		t.Errorf("body = %q, want timestamp_skew", w.Body.String())
+	}
+}
+
+func TestPoll_RejectsReplayedNonce(t *testing.T) {
+	srv, _ := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	nonce := "fixed-nonce-12345678"
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+		signPoll(t, req, agent, withNonce(nonce))
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		if i == 0 && w.Code != http.StatusOK {
+			t.Fatalf("first poll status = %d, want 200, body = %s", w.Code, w.Body.String())
+		}
+		if i == 1 {
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("second poll status = %d, want 401, body = %s", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "replayed_nonce") {
+				t.Errorf("body = %q, want replayed_nonce", w.Body.String())
+			}
+		}
+	}
+}
+
+func TestPoll_HappyPath(t *testing.T) {
+	srv, _ := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200, body = %s", w.Code, w.Body.String())
+	}
+	var resp agentUpdatesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Blocklist == nil {
+		t.Error("blocklist nil; expected at least empty slice")
+	}
+}
+
+// keep models import meaningful — used elsewhere by future PRs.
+var _ = models.HostStatusEnrolled
+var _ = errBody

--- a/internal/pop/canonical.go
+++ b/internal/pop/canonical.go
@@ -1,0 +1,30 @@
+// Package pop holds the proof-of-possession primitives shared by the agent
+// (signer) and the management server (verifier) for ADR 0004 #75 polls.
+//
+// The canonical string is signed by the agent's Ed25519 signing key and
+// transported in the X-Nebula-Signature header alongside the fingerprint,
+// timestamp, and nonce. The format is intentionally rigid — four "\n"
+// separators between five trusted server-shaped fields — so a single
+// implementation works for sign and verify and a golden test can pin it.
+package pop
+
+// Header names used in the signed-poll protocol (ADR 0004 §7.1).
+const (
+	HeaderFingerprint = "X-Nebula-Fingerprint"
+	HeaderTimestamp   = "X-Nebula-Timestamp"
+	HeaderNonce       = "X-Nebula-Nonce"
+	HeaderSignature   = "X-Nebula-Signature"
+)
+
+// CanonicalString returns the bytes that the agent signs and the server
+// verifies for every poll request. Format:
+//
+//	METHOD\nPATH\nHOST_HEADER\nTIMESTAMP\nNONCE
+//
+// All inputs are caller-trusted: METHOD and PATH come from the chi router,
+// HOST_HEADER from the Host header, and TIMESTAMP / NONCE from the request
+// headers (already syntactically validated by the verifier before this is
+// computed on the server side).
+func CanonicalString(method, path, host, timestamp, nonce string) string {
+	return method + "\n" + path + "\n" + host + "\n" + timestamp + "\n" + nonce
+}

--- a/internal/pop/canonical_test.go
+++ b/internal/pop/canonical_test.go
@@ -1,0 +1,45 @@
+package pop
+
+import "testing"
+
+func TestCanonicalString_Format(t *testing.T) {
+	got := CanonicalString("GET", "/api/v1/agent/updates", "mgmt.example.com", "2026-05-13T08:30:00Z", "abc-nonce")
+	want := "GET\n/api/v1/agent/updates\nmgmt.example.com\n2026-05-13T08:30:00Z\nabc-nonce"
+	if got != want {
+		t.Errorf("canonical mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestCanonicalString_FieldsAreLineSeparated(t *testing.T) {
+	// Embedded newlines in any field would let an attacker hide bytes from
+	// the verifier. We don't sanitise the input here — the API layer feeds
+	// trusted, fixed-shape values — but the canonical helper must still
+	// produce exactly four \n separators.
+	got := CanonicalString("GET", "/p", "h", "t", "n")
+	count := 0
+	for _, c := range got {
+		if c == '\n' {
+			count++
+		}
+	}
+	if count != 4 {
+		t.Errorf("got %d newlines, want 4 in %q", count, got)
+	}
+}
+
+func TestHeaderConstants(t *testing.T) {
+	cases := []struct {
+		got  string
+		want string
+	}{
+		{HeaderFingerprint, "X-Nebula-Fingerprint"},
+		{HeaderTimestamp, "X-Nebula-Timestamp"},
+		{HeaderNonce, "X-Nebula-Nonce"},
+		{HeaderSignature, "X-Nebula-Signature"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("header constant = %q, want %q", c.got, c.want)
+		}
+	}
+}

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -3,8 +3,11 @@ package integration
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"io"
 	"log/slog"
 	"net/http"
@@ -14,12 +17,57 @@ import (
 	"time"
 
 	"github.com/juev/nebula-mesh/internal/api"
+	agentpop "github.com/juev/nebula-mesh/internal/agent/pop"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
+	corepop "github.com/juev/nebula-mesh/internal/pop"
 	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
 )
+
+// signingKeypair returns a fresh Ed25519 keypair and its PEM-encoded public
+// key — the same shape an agent would send to /api/v1/enroll under ADR 0004.
+func signingKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "NEBULA ED25519 PUBLIC KEY", Bytes: pub})
+	return pub, priv, string(pemBytes)
+}
+
+// signedGetUpdates issues an authenticated GET /api/v1/agent/updates poll on
+// behalf of an enrolled host. The four PoP headers are filled in identically
+// to what internal/agent.Poller produces.
+func signedGetUpdates(t *testing.T, ts *httptest.Server, fingerprint string, signingPriv ed25519.PrivateKey) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("GET", ts.URL+"/api/v1/agent/updates", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts2 := time.Now().UTC().Format(time.RFC3339)
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		t.Fatal(err)
+	}
+	nonce := base64.StdEncoding.EncodeToString(nonceBytes)
+	canonical := corepop.CanonicalString(req.Method, req.URL.Path, req.URL.Host, ts2, nonce)
+	sig, err := agentpop.Sign(signingPriv, canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set(corepop.HeaderFingerprint, fingerprint)
+	req.Header.Set(corepop.HeaderTimestamp, ts2)
+	req.Header.Set(corepop.HeaderNonce, nonce)
+	req.Header.Set(corepop.HeaderSignature, agentpop.EncodeSignature(sig))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
 
 const testAPIKey = "e2e-test-api-key"
 
@@ -138,10 +186,12 @@ func TestE2E_FullCycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pubKey)
+	_, signingPriv, signingPubPEM := signingKeypair(t)
 
 	enrollReq := map[string]string{
-		"token":          hostResp.EnrollmentToken,
-		"public_key_pem": string(pubKeyPEM),
+		"token":                  hostResp.EnrollmentToken,
+		"public_key_pem":         string(pubKeyPEM),
+		"signing_public_key_pem": signingPubPEM,
 	}
 	data, _ := json.Marshal(enrollReq)
 	enrollResp, err := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(data))
@@ -209,10 +259,7 @@ func TestE2E_FullCycle(t *testing.T) {
 
 	// 7. Agent poll — should get updates (at least blocklist)
 	fp, _ := hostCert.Fingerprint()
-	pollResp, err := http.Get(ts.URL + "/api/v1/agent/updates?fingerprint=" + fp)
-	if err != nil {
-		t.Fatal(err)
-	}
+	pollResp := signedGetUpdates(t, ts, fp, signingPriv)
 	var updates struct {
 		HasUpdates bool     `json:"has_updates"`
 		Blocklist  []string `json:"blocklist"`
@@ -252,10 +299,7 @@ func TestE2E_FullCycle(t *testing.T) {
 	t.Log("host blocked, fingerprint in blocklist")
 
 	// 10. Agent poll after block — should have blocklist update
-	pollResp, err = http.Get(ts.URL + "/api/v1/agent/updates?fingerprint=" + fp)
-	if err != nil {
-		t.Fatal(err)
-	}
+	pollResp = signedGetUpdates(t, ts, fp, signingPriv)
 	if err := json.NewDecoder(pollResp.Body).Decode(&updates); err != nil {
 		t.Fatalf("decode post-block updates: %v", err)
 	}
@@ -322,9 +366,11 @@ func TestAgentUpdates_CertSaveFailure(t *testing.T) {
 	pubKey, _ := curve25519.X25519(privKey, curve25519.Basepoint)
 	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pubKey)
 
+	_, signingPriv, signingPubPEM := signingKeypair(t)
 	enrollReq := map[string]string{
-		"token":          hostResp.EnrollmentToken,
-		"public_key_pem": string(pubKeyPEM),
+		"token":                  hostResp.EnrollmentToken,
+		"public_key_pem":         string(pubKeyPEM),
+		"signing_public_key_pem": signingPubPEM,
 	}
 	data, _ := json.Marshal(enrollReq)
 	enrollResp, _ := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(data))
@@ -357,10 +403,7 @@ func TestAgentUpdates_CertSaveFailure(t *testing.T) {
 	}
 
 	// 5. Agent poll — renewal triggered, save fails → expect 500
-	pollResp, err := http.Get(ts.URL + "/api/v1/agent/updates?fingerprint=" + fp)
-	if err != nil {
-		t.Fatal(err)
-	}
+	pollResp := signedGetUpdates(t, ts, fp, signingPriv)
 	defer pollResp.Body.Close()
 
 	if pollResp.StatusCode != http.StatusInternalServerError {
@@ -371,8 +414,9 @@ func TestAgentUpdates_CertSaveFailure(t *testing.T) {
 
 // enrollHost is a small helper used by the lighthouse auto-assignment tests
 // below: it creates a host, runs the full enrollment handshake, and returns
-// the host record plus its cert fingerprint (needed for agent polls).
-func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP string, extra map[string]any) (*models.Host, string, string) {
+// the host record, its cert fingerprint, its rendered config, and the
+// Ed25519 signing private key needed to issue signed polls afterwards.
+func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP string, extra map[string]any) (*models.Host, string, string, ed25519.PrivateKey) {
 	t.Helper()
 	payload := map[string]any{
 		"network_id": networkID,
@@ -405,10 +449,12 @@ func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP str
 		t.Fatal(err)
 	}
 	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pubKey)
+	_, signingPriv, signingPubPEM := signingKeypair(t)
 
 	enrollData, _ := json.Marshal(map[string]string{
-		"token":          created.EnrollmentToken,
-		"public_key_pem": string(pubKeyPEM),
+		"token":                  created.EnrollmentToken,
+		"public_key_pem":         string(pubKeyPEM),
+		"signing_public_key_pem": signingPubPEM,
 	})
 	enrollResp, err := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(enrollData))
 	if err != nil {
@@ -436,21 +482,18 @@ func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP str
 		t.Fatalf("fingerprint %s: %v", name, err)
 	}
 
-	return created.Host, fp, enrolled.ConfigYAML
+	return created.Host, fp, enrolled.ConfigYAML, signingPriv
 }
 
-// pollAgent runs a single agent updates poll for the given fingerprint and
-// returns the decoded response.
-func pollAgent(t *testing.T, ts *httptest.Server, fingerprint string) struct {
+// pollAgent runs a single signed agent updates poll for the given fingerprint
+// and returns the decoded response.
+func pollAgent(t *testing.T, ts *httptest.Server, fingerprint string, signingPriv ed25519.PrivateKey) struct {
 	HasUpdates bool     `json:"has_updates"`
 	ConfigYAML *string  `json:"config_yaml,omitempty"`
 	Blocklist  []string `json:"blocklist"`
 } {
 	t.Helper()
-	resp, err := http.Get(ts.URL + "/api/v1/agent/updates?fingerprint=" + fingerprint)
-	if err != nil {
-		t.Fatal(err)
-	}
+	resp := signedGetUpdates(t, ts, fingerprint, signingPriv)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -485,21 +528,21 @@ func TestE2E_LighthouseAutoAssignment(t *testing.T) {
 
 	// 1. Enroll a peer host first, *before* any lighthouse exists. Its
 	// enrollment-time config must contain zero lighthouses.
-	_, peerFP, peerInitialCfg := enrollHost(t, ts, network.ID, "peer-1", "192.168.50.10", nil)
+	_, peerFP, peerInitialCfg, peerSigning := enrollHost(t, ts, network.ID, "peer-1", "192.168.50.10", nil)
 	if strings.Contains(peerInitialCfg, "203.0.113.") {
 		t.Fatalf("initial peer config unexpectedly references a lighthouse public IP:\n%s", peerInitialCfg)
 	}
 
 	// 2. Initial poll immediately after enrollment — no version drift, no
 	// config redelivery.
-	updates := pollAgent(t, ts, peerFP)
+	updates := pollAgent(t, ts, peerFP, peerSigning)
 	if updates.ConfigYAML != nil {
 		t.Errorf("first poll: ConfigYAML must be nil (no version drift), got non-nil")
 	}
 
 	// 3. Now create and enroll a lighthouse. Enrolling a lighthouse must bump
 	// the network config_version.
-	_, _, _ = enrollHost(t, ts, network.ID, "lh-1", "192.168.50.1", map[string]any{
+	_, _, _, _ = enrollHost(t, ts, network.ID, "lh-1", "192.168.50.1", map[string]any{
 		"role":        "lighthouse",
 		"public_ip":   "203.0.113.10",
 		"listen_port": 4242,
@@ -507,7 +550,7 @@ func TestE2E_LighthouseAutoAssignment(t *testing.T) {
 
 	// 4. Peer poll — the agent must now receive a config_yaml that lists the
 	// newly enrolled lighthouse.
-	updates = pollAgent(t, ts, peerFP)
+	updates = pollAgent(t, ts, peerFP, peerSigning)
 	if updates.ConfigYAML == nil {
 		t.Fatal("peer poll after lighthouse promotion: ConfigYAML is nil, expected fresh config")
 	}
@@ -517,18 +560,18 @@ func TestE2E_LighthouseAutoAssignment(t *testing.T) {
 
 	// 5. Subsequent poll with no further changes — version is back in sync,
 	// no config is pushed.
-	updates = pollAgent(t, ts, peerFP)
+	updates = pollAgent(t, ts, peerFP, peerSigning)
 	if updates.ConfigYAML != nil {
 		t.Errorf("second poll: expected ConfigYAML=nil, got %q", *updates.ConfigYAML)
 	}
 
 	// 6. Add a second lighthouse — peer must pick up both on the next poll.
-	_, _, _ = enrollHost(t, ts, network.ID, "lh-2", "192.168.50.2", map[string]any{
+	_, _, _, _ = enrollHost(t, ts, network.ID, "lh-2", "192.168.50.2", map[string]any{
 		"role":        "lighthouse",
 		"public_ip":   "203.0.113.20",
 		"listen_port": 4242,
 	})
-	updates = pollAgent(t, ts, peerFP)
+	updates = pollAgent(t, ts, peerFP, peerSigning)
 	if updates.ConfigYAML == nil {
 		t.Fatal("peer poll after second lighthouse: ConfigYAML is nil")
 	}
@@ -562,7 +605,7 @@ func TestE2E_LighthouseAutoAssignment(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	updates = pollAgent(t, ts, peerFP)
+	updates = pollAgent(t, ts, peerFP, peerSigning)
 	if updates.ConfigYAML == nil {
 		t.Fatal("peer poll after lighthouse block: ConfigYAML is nil")
 	}


### PR DESCRIPTION
## Summary

PR3 of the #75 split. Implements ADR 0004 §7.1 poll proof-of-possession.

**Breaking change.** Per the issue Scope deviation the old `?fingerprint=` poll path is removed in the same change set. There is no legacy compatibility flag — the server rejects unsigned polls from day one. No fleet exists, so this is safe.

### Shared primitives (`internal/pop`)

- `CanonicalString(method, path, host, ts, nonce)` — the bytes signed by the agent and verified by the server.
- `HeaderFingerprint` / `HeaderTimestamp` / `HeaderNonce` / `HeaderSignature` constants reused by both sides.

### Agent (`internal/agent`, `internal/agent/pop`)

- `Enroll()` generates an Ed25519 signing keypair alongside the existing X25519 cert keypair, registers the Ed25519 public key with the server (`signing_public_key_pem`), and writes `host.signing.key` (PEM, mode 0600) next to `host.key`.
- `Poller` loads `host.signing.key` at construction; every poll request carries the four `X-Nebula-*` headers with a fresh nonce and a signature over the canonical string.

### Server (`internal/api`, `internal/api/pop`)

- `/api/v1/enroll` requires `signing_public_key_pem` (Ed25519 PEM); the key is bound to the host row via `store.UpdateHostSigningPub`.
- `handleAgentUpdates` parses the four headers, verifies the signature against `host.signing_pub_pem`, enforces ±5 min timestamp skew, and replays through an in-process `NonceCache` (cap 65536, idle 10m). Every failure path writes a `host.auth.failed` audit entry with the matching reason code (`missing_signature` / `unknown_fingerprint` / `bad_signature` / `timestamp_skew` / `replayed_nonce`).

### E2E (`tests/integration`)

- Helpers now produce a signing keypair per enrolled host and issue signed polls; the full-cycle and lighthouse-auto-assignment scenarios run against the new protocol end-to-end.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] `TestCanonicalString_Format` + `TestHeaderConstants` — shared canonical contract.
- [x] `internal/agent/pop`: `TestSign_RoundTrip`, `TestSign_WrongKeyDoesNotVerify`, `TestEncodeDecodeRoundTrip`.
- [x] `internal/api/pop`: `TestVerify_*`, `TestNonceCache_AcceptsOnce`, `TestNonceCache_EvictsBySize`, `TestNonceCache_EvictsByIdle`.
- [x] `internal/api`: `TestPoll_RejectsMissingHeaders`, `TestPoll_RejectsUnknownFingerprint`, `TestPoll_RejectsBadSignature`, `TestPoll_RejectsSkewedTimestamp`, `TestPoll_RejectsReplayedNonce`, `TestPoll_HappyPath`.
- [x] `internal/agent`: `TestPoller_SignsRequest`, `TestNewPoller_MissingSigningKey`, all pre-existing tests updated to header-based polls.
- [x] `tests/integration`: `TestE2E_FullCycle`, `TestAgentUpdates_CertSaveFailure`, `TestE2E_LighthouseAutoAssignment` running with signed polls.

Refs #75. Builds on #77, #78, #79.
