### PR TITLE
feat(server): cert rotation overlap window (step 4 of #75)

### DIFF
--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -28,6 +28,12 @@ type agentUpdatesResponse struct {
 // (ADR 0004 §7.1).
 const pollClockSkew = 5 * time.Minute
 
+// overlapWindow returns how long the previous cert fingerprint is accepted
+// after auto-renew lands. ADR 0004 §7.1 specifies "2 × poll_interval"; the
+// server does not see the agent's poll cadence directly, so we pick a
+// conservative two minutes — that covers the 30s default plus retries.
+func overlapWindow() time.Duration { return 2 * time.Minute }
+
 func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 	fingerprint := r.Header.Get(corepop.HeaderFingerprint)
 	timestamp := r.Header.Get(corepop.HeaderTimestamp)
@@ -94,6 +100,31 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonReplayedNonce)
 		writeError(w, http.StatusUnauthorized, "replayed_nonce")
 		return
+	}
+
+	// Cert-rotation overlap window (ADR 0004 §7.1).
+	//
+	// If the agent polled with the *current* cert fingerprint and the row
+	// still has a parked previous fingerprint, clear it — the rotation
+	// completed successfully and we no longer need the dual-accept window.
+	// If the agent polled with the previous fingerprint and the wall-clock
+	// window has expired (2 × poll interval, lower-bounded at one minute),
+	// clear it too so a forever-stale agent does not keep the slot.
+	if host.PrevCertFingerprint != "" {
+		if fingerprint == host.CertFingerprint {
+			if err := s.store.ClearPrevFingerprint(r.Context(), host.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+				s.logger.Error("clear prev fingerprint", "error", err)
+			}
+		} else if host.CertRotatedAt != nil && now.Sub(*host.CertRotatedAt) > overlapWindow() {
+			if err := s.store.ClearPrevFingerprint(r.Context(), host.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+				s.logger.Error("clear prev fingerprint (timeout)", "error", err)
+			}
+			// Window expired: this old fingerprint should no longer be
+			// accepted. Treat as unknown so the agent re-enrolls.
+			s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonUnknownFingerprint)
+			writeError(w, http.StatusUnauthorized, "unknown_fingerprint")
+			return
+		}
 	}
 
 	// non-critical: log and continue — last_seen is informational

--- a/internal/api/updates_rotation_overlap_test.go
+++ b/internal/api/updates_rotation_overlap_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// TestPoll_AcceptsPrevFingerprintDuringOverlap simulates auto-renew: the
+// host row now has prev_cert_fingerprint pointing at the agent's on-disk
+// cert. The server must accept the old fingerprint until either (a) the
+// agent comes back with the new one or (b) the overlap window expires.
+func TestPoll_AcceptsPrevFingerprintDuringOverlap(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	// Park the agent's actual fingerprint as the *previous* one and rotate
+	// to a synthetic "new-fp" value. The agent has not yet observed the
+	// rotation, so its next poll still uses the old fp.
+	if err := st.SetPrevFingerprint(context.Background(), hostByFingerprint(t, st, agent.fingerprint).ID, agent.fingerprint, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().Exec(`UPDATE hosts SET cert_fingerprint = ? WHERE prev_cert_fingerprint = ?`, "new-fp-XYZ", agent.fingerprint); err != nil {
+		t.Fatal(err)
+	}
+
+	// Agent still polls under the old fingerprint — must succeed.
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("old-fp poll during overlap: status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+// TestPoll_ClearsPrevFingerprintAfterAgentUpgrades — once the agent comes
+// back with the new fingerprint, the previous slot is cleared so a leaked
+// old cert cannot keep haunting the host row.
+func TestPoll_ClearsPrevFingerprintAfterAgentUpgrades(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	ctx := context.Background()
+	host := hostByFingerprint(t, st, agent.fingerprint)
+	if err := st.SetPrevFingerprint(ctx, host.ID, "old-fp", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Poll under the *current* fingerprint with prev still populated.
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("poll: status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	got, err := st.GetHost(ctx, host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PrevCertFingerprint != "" {
+		t.Errorf("PrevCertFingerprint = %q, want empty after current-fp poll", got.PrevCertFingerprint)
+	}
+	if got.CertRotatedAt != nil {
+		t.Errorf("CertRotatedAt = %v, want nil after current-fp poll", got.CertRotatedAt)
+	}
+}
+
+// TestPoll_RejectsStalePrevFingerprintAfterTimeout — once 2×poll_interval
+// elapses without the agent upgrading, the slot is cleared and the old
+// fingerprint is no longer accepted.
+func TestPoll_RejectsStalePrevFingerprintAfterTimeout(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	ctx := context.Background()
+	host := hostByFingerprint(t, st, agent.fingerprint)
+	// Park the agent's fingerprint as previous, rotate to a different
+	// current, and backdate the rotation past the overlap window.
+	rotatedAt := time.Now().Add(-1 * time.Hour)
+	if err := st.SetPrevFingerprint(ctx, host.ID, agent.fingerprint, rotatedAt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().Exec(`UPDATE hosts SET cert_fingerprint = ? WHERE id = ?`, "new-fp-XYZ", host.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("stale prev-fp poll: status = %d, want 401, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "unknown_fingerprint") {
+		t.Errorf("body = %q, want unknown_fingerprint", w.Body.String())
+	}
+
+	got, err := st.GetHost(ctx, host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PrevCertFingerprint != "" {
+		t.Errorf("PrevCertFingerprint = %q, want empty after timeout-clear", got.PrevCertFingerprint)
+	}
+}
+
+// hostByFingerprint is a small test convenience that resolves the host row
+// (regardless of current vs previous fingerprint) through the store.
+func hostByFingerprint(t *testing.T, st *store.SQLiteStore, fp string) *struct{ ID string } {
+	t.Helper()
+	h, err := st.GetHostByFingerprint(context.Background(), fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &struct{ ID string }{ID: h.ID}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -414,8 +414,19 @@ func (s *SQLiteStore) GetHost(_ context.Context, id string) (*models.Host, error
 	return h, nil
 }
 
+// GetHostByFingerprint resolves the host by either its current or previous
+// cert fingerprint. The previous-fingerprint match window exists so cert
+// auto-rotation does not lock the agent out between server-side cert update
+// and on-disk cert write (ADR 0004 §7.1 cert rotation overlap).
+//
+// The returned host's CertFingerprint always reflects the row's current
+// value; callers that need to know which fingerprint matched can compare
+// against the input.
 func (s *SQLiteStore) GetHostByFingerprint(_ context.Context, fingerprint string) (*models.Host, error) {
-	row := s.db.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE cert_fingerprint = ?`, fingerprint)
+	row := s.db.QueryRow(
+		`SELECT `+hostColumns+` FROM hosts WHERE cert_fingerprint = ? OR prev_cert_fingerprint = ?`,
+		fingerprint, fingerprint,
+	)
 	h, err := s.scanHost(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -1094,7 +1105,11 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID str
 	return nil
 }
 
-// SaveCertificateAndUpdateHostCert atomically saves a certificate and updates the host's cert metadata.
+// SaveCertificateAndUpdateHostCert atomically saves a certificate and
+// updates the host's cert metadata. The previous fingerprint (if non-empty)
+// is parked in prev_cert_fingerprint with cert_rotated_at = now() so the
+// poll handler can accept either fingerprint during the rotation overlap
+// window (ADR 0004 §7.1).
 func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(_ context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -1110,10 +1125,26 @@ func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(_ context.Context, hostID
 		return err
 	}
 
-	// Update host cert metadata only
+	now := time.Now()
+	// Park the prior fingerprint (only when it actually differs from the
+	// new one). Same-key rotation handing back the same fingerprint should
+	// not populate prev_cert_fingerprint; the agent's poll continues to
+	// match on cert_fingerprint.
 	result, err := tx.Exec(
-		`UPDATE hosts SET cert_fingerprint=?, cert_expires_at=?, updated_at=? WHERE id=?`,
-		fp, notAfter, time.Now(), hostID,
+		`UPDATE hosts SET
+			prev_cert_fingerprint = CASE
+				WHEN cert_fingerprint IS NULL OR cert_fingerprint = '' OR cert_fingerprint = ? THEN prev_cert_fingerprint
+				ELSE cert_fingerprint
+			END,
+			cert_rotated_at = CASE
+				WHEN cert_fingerprint IS NULL OR cert_fingerprint = '' OR cert_fingerprint = ? THEN cert_rotated_at
+				ELSE ?
+			END,
+			cert_fingerprint = ?,
+			cert_expires_at  = ?,
+			updated_at       = ?
+		 WHERE id = ?`,
+		fp, fp, now, fp, notAfter, now, hostID,
 	)
 	if err != nil {
 		return fmt.Errorf("update host cert: %w", err)


### PR DESCRIPTION
## Summary

PR4 of the #75 split. Implements ADR 0004 §7.1 cert rotation overlap.

- `GetHostByFingerprint` now accepts either the current `cert_fingerprint` or the parked `prev_cert_fingerprint`. The returned host's `CertFingerprint` always reflects the current row value, so callers detect "matched on prev" via direct comparison.
- `SaveCertificateAndUpdateHostCert` parks the previous fingerprint and stamps `cert_rotated_at` in the same transaction it writes the new one. Same-fingerprint (same-key) rotations leave the prev slot untouched.
- `handleAgentUpdates` clears `prev_cert_fingerprint` on the first poll under the new fingerprint and, after 2 minutes (server-side proxy for ADR's "2 × poll_interval"), evicts any old-fingerprint poll with a fresh `401 unknown_fingerprint` + audit entry. Bookkeeping errors are logged but do not fail the poll.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] `TestPoll_AcceptsPrevFingerprintDuringOverlap` — agent still on old cert during overlap window.
- [x] `TestPoll_ClearsPrevFingerprintAfterAgentUpgrades` — current-fp poll clears the parked prev slot.
- [x] `TestPoll_RejectsStalePrevFingerprintAfterTimeout` — beyond 2-minute window, old fp → 401.

Refs #75. Builds on #80.
