### PR TITLE
feat(api,agent): structured revocation 403/410 (step 5 of #75)

### DIFF
--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -220,7 +220,17 @@ func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
 	}()
 
 	logger.Info("nebula-agent starting", "server", cfg.ServerURL, "poll_interval", cfg.PollInterval)
-	return poller.Run(ctx)
+	if err := poller.Run(ctx); err != nil {
+		// A 403 revoked / 410 gone signal means the operator deliberately
+		// stopped this agent. Exit cleanly so systemd does not restart us
+		// into the same denied state on a loop.
+		if agent.IsRevoked(err) {
+			logger.Error("agent revoked; exiting cleanly", "error", err)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // runLegacyEnroll preserves the old `nebula-agent enroll` invocation for one

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -31,6 +31,45 @@ type UpdatesResponse struct {
 	Blocklist      []string `json:"blocklist"`
 }
 
+// RevocationError is returned by Poller.poll when the management server
+// signals that the agent should stop polling — either 403 revoked (the host
+// is blocked) or 410 gone (the host row has been deleted). Run() returns
+// this error so callers can exit with status 0 and avoid systemd
+// auto-restart loops.
+type RevocationError struct {
+	StatusCode int
+	Reason     string
+	Body       string
+}
+
+func (e *RevocationError) Error() string {
+	return fmt.Sprintf("agent revoked by server (HTTP %d, reason=%s): %s", e.StatusCode, e.Reason, e.Body)
+}
+
+// IsRevoked reports whether err originates from a 403/410 server response.
+func IsRevoked(err error) bool {
+	var re *RevocationError
+	return err != nil && errorsAs(err, &re)
+}
+
+func errorsAs(err error, target any) bool {
+	type unwrapper interface{ Unwrap() error }
+	for cur := err; cur != nil; {
+		if ptr, ok := target.(**RevocationError); ok {
+			if re, ok := cur.(*RevocationError); ok {
+				*ptr = re
+				return true
+			}
+		}
+		if u, ok := cur.(unwrapper); ok {
+			cur = u.Unwrap()
+			continue
+		}
+		break
+	}
+	return false
+}
+
 // PollerConfig holds configuration for the Poller.
 type PollerConfig struct {
 	ServerURL   string
@@ -97,6 +136,10 @@ func (p *Poller) Run(ctx context.Context) error {
 			return ctx.Err()
 		case <-ticker.C:
 			if err := p.poll(ctx); err != nil {
+				if IsRevoked(err) {
+					p.logger.Error("poll loop stopped by server revocation signal", "error", err)
+					return err
+				}
 				p.logger.Error("poll failed", "error", err)
 			}
 		}
@@ -124,6 +167,14 @@ func (p *Poller) poll(ctx context.Context) error {
 
 	if resp.StatusCode == http.StatusNotModified {
 		return nil
+	}
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusGone {
+		body, _ := io.ReadAll(resp.Body)
+		reason := "revoked"
+		if resp.StatusCode == http.StatusGone {
+			reason = "gone"
+		}
+		return &RevocationError{StatusCode: resp.StatusCode, Reason: reason, Body: string(body)}
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, readErr := io.ReadAll(resp.Body)

--- a/internal/agent/poller_revocation_test.go
+++ b/internal/agent/poller_revocation_test.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestPoll_ReturnsRevocationErrorOn403(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"reason":"revoked","blocked_at":"2026-05-13T00:00:00Z"}`))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	writeSigningKey(t, dir)
+	p, err := NewPoller(PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    time.Hour,
+	}, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.signalFunc = func() error { return nil }
+
+	pollErr := p.poll(context.Background())
+	if pollErr == nil {
+		t.Fatal("poll returned nil; expected RevocationError")
+	}
+	if !IsRevoked(pollErr) {
+		t.Fatalf("IsRevoked(err) = false; want true, err = %v", pollErr)
+	}
+	var re *RevocationError
+	if !errors.As(pollErr, &re) {
+		t.Fatalf("errors.As(*RevocationError) failed for %v", pollErr)
+	}
+	if re.StatusCode != http.StatusForbidden || re.Reason != "revoked" {
+		t.Errorf("got %+v, want 403/revoked", re)
+	}
+}
+
+func TestPoll_ReturnsRevocationErrorOn410(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(`{"reason":"gone"}`))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	writeSigningKey(t, dir)
+	p, err := NewPoller(PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    time.Hour,
+	}, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.signalFunc = func() error { return nil }
+
+	pollErr := p.poll(context.Background())
+	if !IsRevoked(pollErr) {
+		t.Fatalf("IsRevoked(err) = false; want true, err = %v", pollErr)
+	}
+}
+
+func TestRun_StopsOnRevocation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"reason":"revoked"}`))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	writeSigningKey(t, dir)
+	p := newPoller(t, PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    20 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	runErr := p.Run(ctx)
+	if !IsRevoked(runErr) {
+		t.Errorf("Run did not propagate revocation; got %v", runErr)
+	}
+}

--- a/internal/api/revocation.go
+++ b/internal/api/revocation.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// revocationRevokedResponse is the JSON body returned for blocked hosts on a
+// signed poll (ADR 0004 §7.1 — structured revocation).
+type revocationRevokedResponse struct {
+	Reason    string    `json:"reason"`
+	Message   string    `json:"message"`
+	BlockedAt time.Time `json:"blocked_at"`
+}
+
+// revocationGoneResponse is the JSON body returned when the host row has
+// been deleted but its fingerprint still lives on the blocklist.
+type revocationGoneResponse struct {
+	Reason  string    `json:"reason"`
+	Message string    `json:"message"`
+	At      time.Time `json:"deleted_at"`
+}
+
+func writeRevocation(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// fingerprintInBlocklist returns true when the fingerprint is recorded in
+// the blocklist table. Errors during the lookup are logged and treated as
+// "not in the list" — better to fall through to 401 unknown_fingerprint
+// than to wrongly stop a working agent.
+func (s *Server) fingerprintInBlocklist(ctx context.Context, fingerprint string) bool {
+	list, err := s.store.GetBlocklist(ctx)
+	if err != nil {
+		s.logger.Error("blocklist lookup for revocation check", "error", err)
+		return false
+	}
+	for _, fp := range list {
+		if fp == fingerprint {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -47,6 +47,19 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 
 	host, err := s.store.GetHostByFingerprint(r.Context(), fingerprint)
 	if errors.Is(err, store.ErrNotFound) {
+		// The fingerprint is not bound to any live host row. If it shows
+		// up in the blocklist the row was deleted after enrollment — in
+		// that case the agent gets a structured 410 gone so it stops the
+		// poll loop instead of retrying forever.
+		if s.fingerprintInBlocklist(r.Context(), fingerprint) {
+			s.recordAuditAction(r.Context(), auditHostAuthFailed, "", authReasonGone)
+			writeRevocation(w, http.StatusGone, revocationGoneResponse{
+				Reason:  "gone",
+				Message: "host row no longer exists; agent should stop and re-enroll if a fresh --token is provisioned",
+				At:      time.Now().UTC(),
+			})
+			return
+		}
 		s.recordAuditAction(r.Context(), auditHostAuthFailed, "", authReasonUnknownFingerprint)
 		writeError(w, http.StatusUnauthorized, "unknown_fingerprint")
 		return
@@ -99,6 +112,20 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 	if !s.nonces().SeenOrAdd(host.ID, nonce) {
 		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonReplayedNonce)
 		writeError(w, http.StatusUnauthorized, "replayed_nonce")
+		return
+	}
+
+	// Revocation signal. Blocked hosts get a structured 403 with a
+	// machine-readable body so the agent can log loudly and exit (ADR 0004
+	// §7.1). The poll loop must not silently drain configuration to a host
+	// we have already revoked.
+	if host.Status == models.HostStatusBlocked {
+		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonRevoked)
+		writeRevocation(w, http.StatusForbidden, revocationRevokedResponse{
+			Reason:    "revoked",
+			Message:   "host is blocked; agent should stop the poll loop and exit 0",
+			BlockedAt: time.Now().UTC(),
+		})
 		return
 	}
 

--- a/internal/api/updates_revocation_test.go
+++ b/internal/api/updates_revocation_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+func TestPoll_RespondsForbidden_WhenHostBlocked(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	ctx := context.Background()
+	host, err := st.GetHostByFingerprint(ctx, agent.fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.BlockHostAndAddToBlocklist(ctx, host.ID, "manual block"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body = %s", w.Code, w.Body.String())
+	}
+	var body revocationRevokedResponse
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Reason != "revoked" {
+		t.Errorf("reason = %q, want revoked", body.Reason)
+	}
+	if body.BlockedAt.IsZero() {
+		t.Errorf("BlockedAt is zero")
+	}
+}
+
+func TestPoll_RespondsGone_WhenHostDeletedButBlocklisted(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	ctx := context.Background()
+	host, err := st.GetHostByFingerprint(ctx, agent.fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// DeleteHostAndBlockCert removes the row and blocklists the
+	// fingerprint — the exact state that should map to 410 gone.
+	if err := st.DeleteHostAndBlockCert(ctx, host.ID, "manual delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusGone {
+		t.Fatalf("status = %d, want 410, body = %s", w.Code, w.Body.String())
+	}
+	var body revocationGoneResponse
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Reason != "gone" {
+		t.Errorf("reason = %q, want gone", body.Reason)
+	}
+}
+
+func TestPoll_UnknownStatusStillSucceeds(t *testing.T) {
+	// Defensive: a non-blocked, non-deleted host must continue to receive
+	// 200 even if its status string is something unexpected (forward-
+	// compat with future status values that PR5 should not break).
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	ctx := context.Background()
+	host, err := st.GetHostByFingerprint(ctx, agent.fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpdateHostStatus(ctx, host.ID, models.HostStatus("something-future")); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for unknown status, body = %s", w.Code, w.Body.String())
+	}
+}

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -298,20 +298,15 @@ func TestE2E_FullCycle(t *testing.T) {
 	}
 	t.Log("host blocked, fingerprint in blocklist")
 
-	// 10. Agent poll after block — should have blocklist update
+	// 10. Agent poll after block — now answered with 403 revoked (ADR
+	// 0004 §7.1 structured revocation), agent must stop polling.
 	pollResp = signedGetUpdates(t, ts, fp, signingPriv)
-	if err := json.NewDecoder(pollResp.Body).Decode(&updates); err != nil {
-		t.Fatalf("decode post-block updates: %v", err)
+	if pollResp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(pollResp.Body)
+		t.Errorf("post-block poll: HTTP %d, want 403, body: %s", pollResp.StatusCode, string(body))
 	}
 	pollResp.Body.Close()
-
-	if !updates.HasUpdates {
-		t.Error("expected has_updates=true after block")
-	}
-	if len(updates.Blocklist) == 0 {
-		t.Error("expected non-empty blocklist after block")
-	}
-	t.Logf("post-block poll: has_updates=%v, blocklist=%v", updates.HasUpdates, updates.Blocklist)
+	t.Logf("post-block poll: 403 revoked received as expected")
 
 	// 11. Try duplicate enrollment (should fail)
 	enrollResp2, _ := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(data))


### PR DESCRIPTION
## Summary

PR5 of the #75 split. Implements ADR 0004 §7.1 structured revocation signals so blocked / deleted hosts exit cleanly instead of polling forever.

### Server

- Blocked hosts now answer `403` with JSON `{reason: "revoked", message, blocked_at}`.
- When a fingerprint is not bound to any host row but still appears in the blocklist (i.e. the row was `DeleteHostAndBlockCert`-ed), the server replies `410 gone` with `{reason: "gone", message, deleted_at}`. Polls with an unknown fingerprint that is **not** blocklisted continue to fall through to `401 unknown_fingerprint`.
- Both new paths emit `host.auth.failed` audit entries with the matching reason code (`revoked` / `gone`).
- `revocation.go` centralises the response writers; `fingerprintInBlocklist` treats lookup errors as "no" so a transient DB hiccup does not stop a working agent.

### Agent

- 403 / 410 polls return a `*RevocationError` that carries `StatusCode + Reason + Body`. `IsRevoked` is a small wrapper so callers don't have to import the error type to check.
- `Poller.Run` unwinds when `poll()` returns a `RevocationError`, returning the same error to its caller.
- `cmd/nebula-agent` catches `IsRevoked` and exits with status 0; systemd therefore does not auto-restart the agent into the same denied state.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] Server: `TestPoll_RespondsForbidden_WhenHostBlocked`, `TestPoll_RespondsGone_WhenHostDeletedButBlocklisted`, `TestPoll_UnknownStatusStillSucceeds`.
- [x] Agent: `TestPoll_ReturnsRevocationErrorOn403`, `TestPoll_ReturnsRevocationErrorOn410`, `TestRun_StopsOnRevocation`.
- [x] E2E: `TestE2E_FullCycle` now asserts `403` after block instead of the pre-PR5 "drain blocklist over a still-200 poll" behaviour.

Refs #75. Builds on #80, #81.
