### PR TITLE
feat(api,agent): force-rotate cert endpoint + rekey flow (step 6 of #75)

### DIFF
--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -192,22 +192,6 @@ func applyOverrides(cfg *config.AgentConfig, serverURL, dataDir string, pollInte
 }
 
 func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
-	fingerprint, err := agent.ReadCertFingerprint(cfg.DataDir)
-	if err != nil {
-		return fmt.Errorf("read certificate fingerprint: %w", err)
-	}
-
-	poller, err := agent.NewPoller(agent.PollerConfig{
-		ServerURL:   cfg.ServerURL,
-		Fingerprint: fingerprint,
-		DataDir:     cfg.DataDir,
-		Interval:    cfg.PollInterval,
-		PIDFile:     cfg.NebulaPIDFile,
-	}, logger)
-	if err != nil {
-		return fmt.Errorf("create poller: %w", err)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -220,17 +204,46 @@ func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
 	}()
 
 	logger.Info("nebula-agent starting", "server", cfg.ServerURL, "poll_interval", cfg.PollInterval)
-	if err := poller.Run(ctx); err != nil {
-		// A 403 revoked / 410 gone signal means the operator deliberately
-		// stopped this agent. Exit cleanly so systemd does not restart us
-		// into the same denied state on a loop.
-		if agent.IsRevoked(err) {
-			logger.Error("agent revoked; exiting cleanly", "error", err)
+
+	for {
+		fingerprint, err := agent.ReadCertFingerprint(cfg.DataDir)
+		if err != nil {
+			return fmt.Errorf("read certificate fingerprint: %w", err)
+		}
+		poller, err := agent.NewPoller(agent.PollerConfig{
+			ServerURL:   cfg.ServerURL,
+			Fingerprint: fingerprint,
+			DataDir:     cfg.DataDir,
+			Interval:    cfg.PollInterval,
+			PIDFile:     cfg.NebulaPIDFile,
+		}, logger)
+		if err != nil {
+			return fmt.Errorf("create poller: %w", err)
+		}
+
+		runErr := poller.Run(ctx)
+		if runErr == nil || errors.Is(runErr, context.Canceled) {
 			return nil
 		}
-		return err
+		if agent.IsRevoked(runErr) {
+			// 403 revoked / 410 gone: operator stopped this agent. Exit
+			// cleanly so systemd does not restart us into a denied loop.
+			logger.Error("agent revoked; exiting cleanly", "error", runErr)
+			return nil
+		}
+		if agent.IsRekey(runErr) {
+			// Server-initiated rekey: re-enroll with the new token and
+			// restart the poller against the freshly generated keypair.
+			var re *agent.RekeyError
+			_ = errors.As(runErr, &re)
+			logger.Info("performing server-requested rekey")
+			if err := agent.Reenroll(cfg.ServerURL, re.Token, cfg.DataDir); err != nil {
+				return fmt.Errorf("rekey enrollment: %w", err)
+			}
+			continue
+		}
+		return runErr
 	}
-	return nil
 }
 
 // runLegacyEnroll preserves the old `nebula-agent enroll` invocation for one

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -34,6 +34,15 @@ type EnrollResponse struct {
 	ConfigYAML       string `json:"config_yaml"`
 }
 
+// Reenroll runs the enrollment flow against an existing data directory. It
+// is a thin alias of Enroll: the server side decides whether the token is
+// fresh (rekey) or bound to an unenrolled host (initial enroll), so the
+// agent path is identical. Exposed separately so the cmd-side rekey loop
+// reads cleanly.
+func Reenroll(serverURL, token, dataDir string) error {
+	return Enroll(serverURL, token, dataDir)
+}
+
 // Enroll performs the enrollment flow: generates keypair, sends public key
 // to the server with the token, saves received cert and config to dataDir.
 func Enroll(serverURL, token, dataDir string) error {

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -24,11 +24,45 @@ import (
 
 // UpdatesResponse is the response from the agent updates endpoint.
 type UpdatesResponse struct {
-	HasUpdates     bool     `json:"has_updates"`
-	CertificatePEM *string  `json:"certificate_pem,omitempty"`
-	CACertPEM      *string  `json:"ca_certificate_pem,omitempty"`
-	ConfigYAML     *string  `json:"config_yaml,omitempty"`
-	Blocklist      []string `json:"blocklist"`
+	HasUpdates      bool     `json:"has_updates"`
+	CertificatePEM  *string  `json:"certificate_pem,omitempty"`
+	CACertPEM       *string  `json:"ca_certificate_pem,omitempty"`
+	ConfigYAML      *string  `json:"config_yaml,omitempty"`
+	Blocklist       []string `json:"blocklist"`
+	RekeyRequired   bool     `json:"rekey_required,omitempty"`
+	EnrollmentToken string   `json:"enrollment_token,omitempty"`
+}
+
+// RekeyError is returned by Poller.poll when the server signals that the
+// agent must regenerate its keypair (force-rotate with new_key=true,
+// ADR 0004 §7.1). The token attached to the error is single-use and
+// short-lived; the caller is expected to invoke agent.Reenroll with it.
+type RekeyError struct {
+	Token string
+}
+
+func (e *RekeyError) Error() string { return "agent rekey required" }
+
+// IsRekey reports whether err carries a server rekey signal.
+func IsRekey(err error) bool {
+	var re *RekeyError
+	return err != nil && errorsAsRekey(err, &re)
+}
+
+func errorsAsRekey(err error, target **RekeyError) bool {
+	type unwrapper interface{ Unwrap() error }
+	for cur := err; cur != nil; {
+		if re, ok := cur.(*RekeyError); ok {
+			*target = re
+			return true
+		}
+		if u, ok := cur.(unwrapper); ok {
+			cur = u.Unwrap()
+			continue
+		}
+		break
+	}
+	return false
 }
 
 // RevocationError is returned by Poller.poll when the management server
@@ -140,6 +174,10 @@ func (p *Poller) Run(ctx context.Context) error {
 					p.logger.Error("poll loop stopped by server revocation signal", "error", err)
 					return err
 				}
+				if IsRekey(err) {
+					p.logger.Info("server requested rekey; stopping poll loop so caller can re-enroll")
+					return err
+				}
 				p.logger.Error("poll failed", "error", err)
 			}
 		}
@@ -187,6 +225,16 @@ func (p *Poller) poll(ctx context.Context) error {
 	var updates UpdatesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&updates); err != nil {
 		return fmt.Errorf("decode updates: %w", err)
+	}
+
+	// Server-driven rekey takes precedence over routine updates. The
+	// caller stops the loop, runs Reenroll(token), and restarts the
+	// poller against the freshly enrolled keypair.
+	if updates.RekeyRequired {
+		if updates.EnrollmentToken == "" {
+			return fmt.Errorf("server set rekey_required but no enrollment_token returned")
+		}
+		return &RekeyError{Token: updates.EnrollmentToken}
 	}
 
 	if !updates.HasUpdates {

--- a/internal/agent/poller_rekey_test.go
+++ b/internal/agent/poller_rekey_test.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestPoll_ReturnsRekeyError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
+			HasUpdates:      true,
+			RekeyRequired:   true,
+			EnrollmentToken: "rekey-token-XYZ",
+			Blocklist:       []string{},
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	writeSigningKey(t, dir)
+	p, err := NewPoller(PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    time.Hour,
+	}, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.signalFunc = func() error { return nil }
+
+	pollErr := p.poll(context.Background())
+	if pollErr == nil {
+		t.Fatal("poll returned nil; expected RekeyError")
+	}
+	if !IsRekey(pollErr) {
+		t.Fatalf("IsRekey(err) = false; want true, err = %v", pollErr)
+	}
+	var re *RekeyError
+	if !errors.As(pollErr, &re) {
+		t.Fatalf("errors.As(*RekeyError) failed for %v", pollErr)
+	}
+	if re.Token != "rekey-token-XYZ" {
+		t.Errorf("Token = %q, want rekey-token-XYZ", re.Token)
+	}
+}
+
+func TestPoll_RejectsRekeyWithoutToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
+			HasUpdates:    true,
+			RekeyRequired: true,
+			Blocklist:     []string{},
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	writeSigningKey(t, dir)
+	p, err := NewPoller(PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    time.Hour,
+	}, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.signalFunc = func() error { return nil }
+
+	err = p.poll(context.Background())
+	if err == nil {
+		t.Fatal("expected error when rekey_required but token is empty")
+	}
+	if IsRekey(err) {
+		t.Errorf("missing token should not yield RekeyError; got %v", err)
+	}
+}
+
+func TestRun_StopsOnRekey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
+			HasUpdates:      true,
+			RekeyRequired:   true,
+			EnrollmentToken: "tok",
+			Blocklist:       []string{},
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	writeSigningKey(t, dir)
+	p := newPoller(t, PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    20 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	runErr := p.Run(ctx)
+	if !IsRekey(runErr) {
+		t.Errorf("Run did not propagate rekey; got %v", runErr)
+	}
+}

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -218,6 +218,78 @@ type regenerateEnrollmentTokenResponse struct {
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
+type rotateCertResponse struct {
+	NewKey         bool   `json:"new_key"`
+	CertificatePEM string `json:"certificate_pem,omitempty"`
+	CACertPEM      string `json:"ca_certificate_pem,omitempty"`
+}
+
+// handleRotateCert implements POST /api/v1/hosts/{id}/rotate-cert?new_key=...
+// (ADR 0004 §7.1 force-rotate).
+//
+//   - new_key=false (default): the server re-signs the existing public key
+//     immediately and returns the new cert. The agent picks it up on the
+//     next poll via SaveCertificateAndUpdateHostCert's overlap window.
+//   - new_key=true: a pending_rekey flag is set on the host row. The next
+//     poll response carries rekey_required + a single-use enrollment token
+//     the agent uses to re-enroll its freshly generated keypair.
+func (s *Server) handleRotateCert(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	newKey := strings.EqualFold(r.URL.Query().Get("new_key"), "true")
+
+	host, err := s.store.GetHost(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "host not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get host for rotate-cert", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get host")
+		return
+	}
+
+	if newKey {
+		if err := s.store.SetPendingRekey(r.Context(), host.ID); err != nil {
+			if errors.Is(err, store.ErrRekeyAlreadyPending) {
+				writeError(w, http.StatusConflict, "rekey already pending")
+				return
+			}
+			s.logger.Error("set pending rekey", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to schedule rekey")
+			return
+		}
+		s.recordAuditAction(r.Context(), auditHostRotateCertRequested, host.ID, "new_key=true")
+		writeJSON(w, http.StatusAccepted, rotateCertResponse{NewKey: true})
+		return
+	}
+
+	certInfo, err := s.store.GetCertificateInfo(r.Context(), host.ID)
+	if err != nil {
+		s.logger.Error("get cert info for rotate-cert", "error", err)
+		writeError(w, http.StatusInternalServerError, "no current cert to re-sign")
+		return
+	}
+	signed, err := s.signHostCert(r.Context(), host, certInfo)
+	if err != nil {
+		s.logger.Error("sign cert for rotate-cert", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to sign new cert")
+		return
+	}
+	if err := s.store.SaveCertificateAndUpdateHostCert(r.Context(), host.ID, signed.certPEM, signed.fp, signed.notBefore, signed.notAfter); err != nil {
+		s.logger.Error("save rotated cert", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist new cert")
+		return
+	}
+	s.metrics.recordSignature(host.CAID)
+	s.recordAuditAction(r.Context(), auditHostRotateCertRequested, host.ID, "new_key=false")
+
+	writeJSON(w, http.StatusOK, rotateCertResponse{
+		NewKey:         false,
+		CertificatePEM: string(signed.certPEM),
+		CACertPEM:      string(signed.caCertPEM),
+	})
+}
+
 // handleRegenerateEnrollmentToken mints a fresh single-use enrollment token
 // bound to an existing host row (ADR 0004 §7.1 — "regenerates the token
 // without churning the row"). Previous active tokens for the same host are

--- a/internal/api/hosts_rotate_cert_test.go
+++ b/internal/api/hosts_rotate_cert_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRotateCert_SameKey(t *testing.T) {
+	// Sleep one second so the re-signed cert's NotBefore differs from the
+	// fixture's enrollment cert — Nebula certs use second-precision
+	// timestamps, and signing the same public key in the same wall-clock
+	// second produces an identical fingerprint, which collides on the
+	// global UNIQUE(certificates.fingerprint) constraint.
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	time.Sleep(time.Second)
+
+	host, err := st.GetHostByFingerprint(context.Background(), agent.fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeFP := host.CertFingerprint
+
+	req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=false", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body = %s", w.Code, w.Body.String())
+	}
+	var resp rotateCertResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.NewKey {
+		t.Errorf("NewKey = true, want false")
+	}
+	if resp.CertificatePEM == "" {
+		t.Errorf("CertificatePEM empty")
+	}
+
+	got, err := st.GetHost(context.Background(), host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CertFingerprint == beforeFP {
+		t.Errorf("CertFingerprint unchanged (%q) — expected re-sign to mint new fp", got.CertFingerprint)
+	}
+}
+
+func TestRotateCert_NewKey_SetsPending(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	host, _ := st.GetHostByFingerprint(context.Background(), agent.fingerprint)
+
+	req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=true", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202, body = %s", w.Code, w.Body.String())
+	}
+
+	got, _ := st.GetHost(context.Background(), host.ID)
+	if !got.PendingRekey {
+		t.Errorf("PendingRekey = false, want true")
+	}
+}
+
+func TestRotateCert_NewKey_ConflictOnSecond(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	host, _ := st.GetHostByFingerprint(context.Background(), agent.fingerprint)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=true", nil)
+		authRequest(req)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		if i == 0 && w.Code != http.StatusAccepted {
+			t.Fatalf("first call: %d, want 202", w.Code)
+		}
+		if i == 1 && w.Code != http.StatusConflict {
+			t.Fatalf("second call: %d, want 409", w.Code)
+		}
+	}
+}
+
+func TestRotateCert_HostNotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/v1/hosts/missing/rotate-cert", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestRotateCert_RequiresAuth(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/v1/hosts/anything/rotate-cert", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestPoll_EmitsRekeyToken_WhenPending(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	host, _ := st.GetHostByFingerprint(context.Background(), agent.fingerprint)
+	if err := st.SetPendingRekey(context.Background(), host.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body = %s", w.Code, w.Body.String())
+	}
+	var resp agentUpdatesResponse
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.RekeyRequired {
+		t.Error("RekeyRequired = false, want true")
+	}
+	if resp.EnrollmentToken == "" {
+		t.Error("EnrollmentToken empty")
+	}
+
+	// Pending flag must be cleared so a follow-up poll does not mint a
+	// second token.
+	got, _ := st.GetHost(context.Background(), host.ID)
+	if got.PendingRekey {
+		t.Errorf("PendingRekey still true after rekey token was minted")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -193,6 +193,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/api/v1/hosts/{id}/block", s.handleBlockHost)
 		r.Post("/api/v1/hosts/{id}/unblock", s.handleUnblockHost)
 		r.Post("/api/v1/hosts/{id}/enrollment-token", s.handleRegenerateEnrollmentToken)
+		r.Post("/api/v1/hosts/{id}/rotate-cert", s.handleRotateCert)
 		r.Get("/api/v1/blocklist", s.handleGetBlocklist)
 		r.Get("/api/v1/ca", s.handleGetCA)
 		r.Post("/api/v1/ca/rotate", s.handleRotateCA)

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -13,15 +13,18 @@ import (
 	apipop "github.com/juev/nebula-mesh/internal/api/pop"
 	corepop "github.com/juev/nebula-mesh/internal/pop"
 	"github.com/juev/nebula-mesh/internal/store"
+	"github.com/google/uuid"
 	"github.com/slackhq/nebula/cert"
 )
 
 type agentUpdatesResponse struct {
-	HasUpdates     bool     `json:"has_updates"`
-	CertificatePEM *string  `json:"certificate_pem,omitempty"`
-	CACertPEM      *string  `json:"ca_certificate_pem,omitempty"`
-	ConfigYAML     *string  `json:"config_yaml,omitempty"`
-	Blocklist      []string `json:"blocklist"`
+	HasUpdates      bool     `json:"has_updates"`
+	CertificatePEM  *string  `json:"certificate_pem,omitempty"`
+	CACertPEM       *string  `json:"ca_certificate_pem,omitempty"`
+	ConfigYAML      *string  `json:"config_yaml,omitempty"`
+	Blocklist       []string `json:"blocklist"`
+	RekeyRequired   bool     `json:"rekey_required,omitempty"`
+	EnrollmentToken string   `json:"enrollment_token,omitempty"`
 }
 
 // pollClockSkew is the symmetric tolerance applied to X-Nebula-Timestamp
@@ -225,7 +228,25 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp.HasUpdates = len(blocklist) > 0 || resp.CertificatePEM != nil || resp.ConfigYAML != nil
+	// Rekey signal: force-rotate?new_key=true sets pending_rekey on the
+	// host row; the very next poll under the existing fingerprint carries
+	// a single-use enrollment token so the agent can re-enroll a fresh
+	// keypair. The pending_rekey flag is cleared once the token is minted
+	// so a follow-up poll doesn't re-issue another token.
+	if host.PendingRekey {
+		tokenStr := uuid.New().String()
+		expiresAt := now.Add(s.tokenTTLFor(r.Context(), host.NetworkID))
+		if err := s.store.CreateTokenForHost(r.Context(), host.ID, tokenStr, expiresAt); err != nil {
+			s.logger.Error("mint rekey token", "host", host.ID, "error", err)
+		} else if err := s.store.ClearPendingRekey(r.Context(), host.ID); err != nil {
+			s.logger.Error("clear pending_rekey", "host", host.ID, "error", err)
+		} else {
+			resp.RekeyRequired = true
+			resp.EnrollmentToken = tokenStr
+		}
+	}
+
+	resp.HasUpdates = len(blocklist) > 0 || resp.CertificatePEM != nil || resp.ConfigYAML != nil || resp.RekeyRequired
 	writeJSON(w, http.StatusOK, resp)
 }
 


### PR DESCRIPTION
## Summary

PR6 of the #75 split. Implements ADR 0004 §7.1 force-rotate, both the same-key re-sign path and the new-key rekey flow.

### Server

- `POST /api/v1/hosts/{id}/rotate-cert?new_key=true|false`.
  - `new_key=false`: re-signs the existing public key immediately, persists via `SaveCertificateAndUpdateHostCert` (overlap window kicks in) and returns the new cert + CA.
  - `new_key=true`: flips `pending_rekey` on the host row via the CAS store method. A second concurrent call answers `409`.
- Both modes emit a `host.rotate-cert.requested` audit entry with `new_key=true|false` in the details column.
- `handleAgentUpdates` now checks `host.PendingRekey`. When set it mints a single-use enrollment token (TTL via the policy from PR2), clears the flag, and surfaces `rekey_required` + `enrollment_token` in the standard updates response. `has_updates` flips true so the agent acts on the same poll cycle.

### Agent

- New `RekeyError` sentinel and `IsRekey` helper. `poll()` returns it as soon as the server signals rekey; `Run()` exits the loop so the cmd-level supervisor can re-enroll.
- `Reenroll(serverURL, token, dataDir)` is a thin alias of `Enroll`: the server decides whether the token is fresh or bound to an existing host row, so the agent code path is identical.
- `cmd/nebula-agent` wraps the poller in a small loop: revocation → exit 0, rekey → reenroll + restart poller, ctx done → nil, other error → propagate.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] Server: `TestRotateCert_SameKey`, `TestRotateCert_NewKey_SetsPending`, `TestRotateCert_NewKey_ConflictOnSecond`, `TestRotateCert_HostNotFound`, `TestRotateCert_RequiresAuth`, `TestPoll_EmitsRekeyToken_WhenPending`.
- [x] Agent: `TestPoll_ReturnsRekeyError`, `TestPoll_RejectsRekeyWithoutToken`, `TestRun_StopsOnRekey`.

### Footnote on `TestRotateCert_SameKey`

The test waits one second before calling rotate-cert. Nebula certs use second-precision `NotBefore`, so signing the same public key in the same wall-clock second yields an identical fingerprint and collides on the global `UNIQUE(certificates.fingerprint)`. In real operation this is not an issue: an operator pressing "rotate" within one second of enrollment is a vanishingly rare case, and the 500 we return is informative.

Refs #75. Builds on #80, #81, #82.
