### PR TITLE
feat(api): re-enroll endpoint (step 7 of #75)

### DIFF
--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -290,12 +290,29 @@ func (s *Server) handleRotateCert(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleReenroll is the explicit re-enrollment endpoint (ADR 0004 §7.1).
+// It delegates to mintEnrollmentTokenForHost — identical mechanics to
+// handleRegenerateEnrollmentToken — but exists as a separate route so
+// operator UIs can present "re-enroll" as a discrete action (e.g. when a
+// host has lost its key material), distinct from the "regenerate token"
+// fix-up that handleRegenerateEnrollmentToken serves.
+func (s *Server) handleReenroll(w http.ResponseWriter, r *http.Request) {
+	s.mintEnrollmentTokenForHost(w, r, "reenroll")
+}
+
 // handleRegenerateEnrollmentToken mints a fresh single-use enrollment token
 // bound to an existing host row (ADR 0004 §7.1 — "regenerates the token
 // without churning the row"). Previous active tokens for the same host are
 // invalidated atomically. The host row, its IP allocation, group membership,
 // and audit history are preserved.
 func (s *Server) handleRegenerateEnrollmentToken(w http.ResponseWriter, r *http.Request) {
+	s.mintEnrollmentTokenForHost(w, r, "regenerate-token")
+}
+
+// mintEnrollmentTokenForHost is the shared implementation of the
+// regenerate-token and reenroll endpoints. The reason argument flows into
+// the audit details column so the timeline distinguishes the two.
+func (s *Server) mintEnrollmentTokenForHost(w http.ResponseWriter, r *http.Request, reason string) {
 	id := chi.URLParam(r, "id")
 	host, err := s.store.GetHost(r.Context(), id)
 	if errors.Is(err, store.ErrNotFound) {
@@ -315,7 +332,11 @@ func (s *Server) handleRegenerateEnrollmentToken(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusInternalServerError, "failed to mint token")
 		return
 	}
-	s.recordAuditAction(r.Context(), auditHostReenrollRequested, host.ID, host.Name)
+	details := host.Name
+	if reason != "" {
+		details = reason + ": " + host.Name
+	}
+	s.recordAuditAction(r.Context(), auditHostReenrollRequested, host.ID, details)
 
 	writeJSON(w, http.StatusCreated, regenerateEnrollmentTokenResponse{
 		Token:     tokenStr,

--- a/internal/api/hosts_reenroll_test.go
+++ b/internal/api/hosts_reenroll_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+func TestReenroll_MintsTokenAndPreservesHost(t *testing.T) {
+	srv, st := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID,
+		Name:      "reenroll-host",
+		NebulaIP:  "192.168.100.42",
+		Groups:    []string{"g1"},
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create host: %d", w.Code)
+	}
+	var initial createHostResponse
+	_ = json.NewDecoder(w.Body).Decode(&initial)
+
+	// Force the host into enrolled state so we can confirm the row
+	// survives across reenroll.
+	if err := st.UpdateHostStatus(context.Background(), initial.Host.ID, models.HostStatusEnrolled); err != nil {
+		t.Fatal(err)
+	}
+
+	req = httptest.NewRequest("POST", "/api/v1/hosts/"+initial.Host.ID+"/reenroll", nil)
+	authRequest(req)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("reenroll: status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp regenerateEnrollmentTokenResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Token == "" || resp.Token == initial.EnrollmentToken {
+		t.Errorf("reenroll token must be fresh; got %q", resp.Token)
+	}
+
+	// Host row survives — ID, IP, groups, status unchanged.
+	got, err := st.GetHost(context.Background(), initial.Host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != initial.Host.ID || got.NebulaIP != initial.Host.NebulaIP {
+		t.Errorf("host row mutated; got %+v", got)
+	}
+	if len(got.Groups) != 1 || got.Groups[0] != "g1" {
+		t.Errorf("groups changed; got %v", got.Groups)
+	}
+}
+
+func TestReenroll_HostNotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/v1/hosts/missing/reenroll", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestReenroll_RequiresAuth(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/v1/hosts/anything/reenroll", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -194,6 +194,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/api/v1/hosts/{id}/unblock", s.handleUnblockHost)
 		r.Post("/api/v1/hosts/{id}/enrollment-token", s.handleRegenerateEnrollmentToken)
 		r.Post("/api/v1/hosts/{id}/rotate-cert", s.handleRotateCert)
+		r.Post("/api/v1/hosts/{id}/reenroll", s.handleReenroll)
 		r.Get("/api/v1/blocklist", s.handleGetBlocklist)
 		r.Get("/api/v1/ca", s.handleGetCA)
 		r.Post("/api/v1/ca/rotate", s.handleRotateCA)


### PR DESCRIPTION
## Summary

PR7 of the #75 split. Implements ADR 0004 §7.1 re-enroll.

- New `POST /api/v1/hosts/{id}/reenroll` endpoint mints a fresh single-use enrollment token bound to the existing host row.
- Identical mechanics to `POST /api/v1/hosts/{id}/enrollment-token` from PR2 — they share `mintEnrollmentTokenForHost` — but exposed as a discrete route so operator UIs can present "re-enroll" as a separate intent (the host has lost its key material) distinct from the routine "regenerate token" fix-up.
- Audit entry: `host.reenroll.requested` with reason (`reenroll` vs `regenerate-token`) prefixed into the `details` column so the timeline disambiguates the two flows.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] `TestReenroll_MintsTokenAndPreservesHost` — happy path: fresh token + host row (ID, IP, groups) untouched.
- [x] `TestReenroll_HostNotFound` — 404.
- [x] `TestReenroll_RequiresAuth` — 401.

Refs #75. Builds on #79, #83.
