### PR TITLE
feat(agent): idle-standby + first-class enroll subcommand (closes #88)

### DIFF
--- a/cmd/nebula-agent/enroll_test.go
+++ b/cmd/nebula-agent/enroll_test.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// syncedBuffer is a tiny mutex-guarded byte buffer used by tests that read
+// stderr concurrently with the daemon writing to it. bytes.Buffer alone is
+// not safe for concurrent Write+String, which trips the race detector.
+type syncedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncedBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncedBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// enrollMockServer answers POST /api/v1/enroll with a synthetic cert+CA+config
+// payload and GET /api/v1/agent/updates with an empty signed-poll response.
+// callsByPath records how often each endpoint was hit so tests can assert
+// the confirmation poll fired.
+type enrollMockServer struct {
+	ts           *httptest.Server
+	enrollCalls  atomic.Int32
+	updatesCalls atomic.Int32
+	updatesCode  atomic.Int32 // override status code for /agent/updates
+	signingPub   ed25519.PublicKey
+}
+
+func newEnrollMockServer(t *testing.T) *enrollMockServer {
+	t.Helper()
+	srv := &enrollMockServer{}
+	srv.updatesCode.Store(int32(http.StatusOK))
+	srv.ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/enroll":
+			srv.enrollCalls.Add(1)
+			// Capture the signing public key the agent sent so we don't
+			// need a fresh fingerprint match in the updates branch.
+			var body struct {
+				SigningPubPEM string `json:"signing_public_key_pem"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if block, _ := pem.Decode([]byte(body.SigningPubPEM)); block != nil {
+				srv.signingPub = ed25519.PublicKey(block.Bytes)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"certificate_pem":    pemBlock("NEBULA CERTIFICATE", "cert-bytes"),
+				"ca_certificate_pem": pemBlock("NEBULA CERTIFICATE", "ca-bytes"),
+				"config_yaml":        "pki:\n  ca: /etc/nebula/ca.crt\n",
+			})
+		case "/api/v1/agent/updates":
+			srv.updatesCalls.Add(1)
+			code := int(srv.updatesCode.Load())
+			w.WriteHeader(code)
+			if code == http.StatusOK {
+				_, _ = io.WriteString(w, `{"has_updates":false,"blocklist":[]}`)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.ts.Close)
+	return srv
+}
+
+func pemBlock(kind, body string) string {
+	return "-----BEGIN " + kind + "-----\n" + body + "\n-----END " + kind + "-----\n"
+}
+
+// TestEnrollSubcommand_WritesFiles — happy path. enroll subcommand hits
+// both the enroll and updates endpoints, writes agent.yml + the five
+// enrollment files with the right modes, and exits 0.
+func TestEnrollSubcommand_WritesFiles(t *testing.T) {
+	srv := newEnrollMockServer(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+	dataDir := filepath.Join(dir, "nebula")
+	signingKeyPath := filepath.Join(dir, "agent", "host.signing.key")
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := run(ctx, []string{
+		"enroll",
+		"--config", cfgPath,
+		"--server", srv.ts.URL,
+		"--token", "tok",
+		"--data-dir", dataDir,
+		"--signing-key-path", signingKeyPath,
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("enroll: %v\nstderr=%s", err, stderr.String())
+	}
+	if srv.enrollCalls.Load() != 1 {
+		t.Errorf("enroll endpoint hit %d times, want 1", srv.enrollCalls.Load())
+	}
+
+	// Cert won't actually parse (we don't generate a real Nebula cert in
+	// the mock), so confirmation poll may emit "warning: cannot read fresh
+	// cert fingerprint" and skip the updates call. We accept either branch
+	// here — the file contract is what we lock down.
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Errorf("agent.yml missing: %v", err)
+	}
+	for _, p := range []string{
+		filepath.Join(dataDir, "host.key"),
+		filepath.Join(dataDir, "host.crt"),
+		filepath.Join(dataDir, "ca.crt"),
+		filepath.Join(dataDir, "config.yml"),
+		signingKeyPath,
+	} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Errorf("%s missing: %v", p, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("%s is empty", p)
+		}
+	}
+	// Private keys must be 0600.
+	for _, p := range []string{filepath.Join(dataDir, "host.key"), signingKeyPath} {
+		info, _ := os.Stat(p)
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("%s mode = %o, want 0600", p, info.Mode().Perm())
+		}
+	}
+	// agent.yml is also 0600.
+	info, _ := os.Stat(cfgPath)
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("agent.yml mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+// TestEnrollSubcommand_FirstPollFailureIsNonFatal — mock returns 500 on
+// /agent/updates. enroll still exits 0; the on-disk artefacts are intact;
+// stderr carries the warning.
+func TestEnrollSubcommand_FirstPollFailureIsNonFatal(t *testing.T) {
+	srv := newEnrollMockServer(t)
+	srv.updatesCode.Store(int32(http.StatusInternalServerError))
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+	dataDir := filepath.Join(dir, "nebula")
+	signingKeyPath := filepath.Join(dir, "agent", "host.signing.key")
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := run(ctx, []string{
+		"enroll",
+		"--config", cfgPath,
+		"--server", srv.ts.URL,
+		"--token", "tok",
+		"--data-dir", dataDir,
+		"--signing-key-path", signingKeyPath,
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("enroll should not fail when first poll errors: %v\nstderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "warning") {
+		// Allow either "first poll failed" or "cannot read fresh cert
+		// fingerprint" — both qualify; the contract is that enroll keeps
+		// exit 0 and surfaces a warning.
+		t.Errorf("expected warning on stderr; got %q", stderr.String())
+	}
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Errorf("agent.yml must still be written on first-poll failure: %v", err)
+	}
+}
+
+// TestEnrollSubcommand_RefusesWhenAlreadyEnrolled — pre-seed host.crt;
+// enroll without --force is rejected; the second call with --force succeeds.
+func TestEnrollSubcommand_RefusesWhenAlreadyEnrolled(t *testing.T) {
+	srv := newEnrollMockServer(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+	dataDir := filepath.Join(dir, "nebula")
+	signingKeyPath := filepath.Join(dir, "agent", "host.signing.key")
+
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "host.crt"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	err := run(ctx, []string{
+		"enroll",
+		"--config", cfgPath,
+		"--server", srv.ts.URL,
+		"--token", "tok",
+		"--data-dir", dataDir,
+		"--signing-key-path", signingKeyPath,
+	}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error; pre-seeded host.crt should block enroll without --force")
+	}
+	if !strings.Contains(err.Error(), "already enrolled") {
+		t.Errorf("error message should mention 'already enrolled'; got %v", err)
+	}
+
+	// With --force, the same command succeeds.
+	stdout.Reset()
+	stderr.Reset()
+	err = run(ctx, []string{
+		"enroll",
+		"--config", cfgPath,
+		"--server", srv.ts.URL,
+		"--token", "tok",
+		"--data-dir", dataDir,
+		"--signing-key-path", signingKeyPath,
+		"--force",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("enroll --force: %v\nstderr=%s", err, stderr.String())
+	}
+}
+
+// TestEnrollSubcommand_RequiresServerAndToken — both flags are required.
+func TestEnrollSubcommand_RequiresServerAndToken(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	err := run(ctx, []string{"enroll", "--config", cfgPath, "--token", "tok"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Errorf("missing --server: err = %v", err)
+	}
+	stderr.Reset()
+	err = run(ctx, []string{"enroll", "--config", cfgPath, "--server", "https://srv"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Errorf("missing --token: err = %v", err)
+	}
+}
+
+// TestRun_LeavesStandbyAfterFilesAppear — start runUnified in idle, then
+// from a goroutine drop the enrollment artefacts into place and confirm
+// the daemon transitions to the poll loop (mock server records a signed
+// updates call). Uses a shorter standby tick for test latency — the real
+// tick is hard-coded but the helper drops files BEFORE the first tick to
+// keep the test under one second.
+func TestRun_LeavesStandbyAfterFilesAppear(t *testing.T) {
+	// Shorten the standby tick so the test runs in <1s. Restore on exit.
+	orig := standbyTick
+	standbyTick = 50 * time.Millisecond
+	t.Cleanup(func() { standbyTick = orig })
+
+	srv := newEnrollMockServer(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+	dataDir := filepath.Join(dir, "nebula")
+	signingKeyPath := filepath.Join(dir, "agent", "host.signing.key")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(signingKeyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use the real enroll subcommand to lay down the artefacts — that
+	// exercises the same code path operators will use.
+	enrollDone := make(chan struct{})
+	go func() {
+		// Small delay so the daemon goroutine below has time to enter
+		// standby first.
+		time.Sleep(50 * time.Millisecond)
+		var b bytes.Buffer
+		_ = run(context.Background(), []string{
+			"enroll",
+			"--config", cfgPath,
+			"--server", srv.ts.URL,
+			"--token", "tok",
+			"--data-dir", dataDir,
+			"--signing-key-path", signingKeyPath,
+		}, &b, &b)
+		close(enrollDone)
+	}()
+
+	// Daemon goroutine — runs runUnified, expects to leave standby and
+	// poll the mock server at least once.
+	daemonCtx, cancelDaemon := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDaemon()
+	daemonDone := make(chan error, 1)
+	stderrW := &syncedBuffer{}
+	go func() {
+		daemonDone <- run(daemonCtx, []string{"--config", cfgPath}, io.Discard, stderrW)
+	}()
+
+	// Wait for enroll subcommand to write files. Then poll the mock
+	// server's updates-counter until the daemon catches up.
+	select {
+	case <-enrollDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("enroll subcommand did not finish")
+	}
+
+	// Watch stderr for the transition log message. We assert that the
+	// daemon left standby and entered the poll loop — that proves
+	// awaitEnrollment unblocked, which is what #88 is about. We don't
+	// assert on updates_calls because the production poll_interval (30s)
+	// is far longer than the test timeout; the standby → poll transition
+	// itself is the contract.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(stderrW.String(), "leaving standby") {
+			cancelDaemon()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !strings.Contains(stderrW.String(), "leaving standby") {
+		t.Errorf("daemon did not leave standby; stderr = %s", stderrW.String())
+	}
+
+	// Drain the daemon goroutine; we don't care about its error value as
+	// long as it stopped (it returns ctx.Err() once we cancel).
+	select {
+	case err := <-daemonDone:
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			// Confirmation poll inside the daemon will fail to parse the
+			// fake cert in the response and return a poll error — that's
+			// expected with this mock.
+			_ = err
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("daemon did not exit within 5s after cancel")
+	}
+}
+

--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -28,23 +28,28 @@ var (
 const defaultConfigPath = "/etc/nebula-agent/agent.yml"
 
 func main() {
-	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	err := run(ctx, os.Args[1:], os.Stdout, os.Stderr)
+	stop() // release signal handler before any os.Exit to avoid gocritic exitAfterDefer.
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(args []string, stdout, stderr io.Writer) error {
-	// Dispatch deprecated subcommands first so the unified flag set does not
-	// need to understand "enroll" / "run" as positional arguments.
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	// Dispatch subcommands first so the unified flag set does not need to
+	// understand "enroll" / "run" as positional arguments. `enroll` is
+	// first-class (#88) and does NOT warn; `run` is still a deprecated alias.
 	if len(args) > 0 {
 		switch args[0] {
 		case "enroll":
-			_, _ = fmt.Fprintln(stderr, "warning: `nebula-agent enroll` is deprecated; pass --token and --server to `nebula-agent` instead")
-			return runLegacyEnroll(args[1:], stderr)
+			// First-class subcommand (#88). No deprecation warning — this
+			// is now the recommended way to enroll a host.
+			return runEnroll(ctx, args[1:], stdout, stderr)
 		case "run":
 			_, _ = fmt.Fprintln(stderr, "warning: `nebula-agent run` is deprecated; invoke `nebula-agent` without a subcommand")
-			return runLegacyRun(args[1:], stderr)
+			return runLegacyRun(ctx, args[1:], stderr)
 		case "version", "--version", "-v":
 			version.Print(stdout, "nebula-agent", versionStr, commit, date)
 			return nil
@@ -54,7 +59,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		}
 	}
 
-	return runUnified(args, stderr)
+	return runUnified(ctx, args, stderr)
 }
 
 func printUsage(w io.Writer) {
@@ -65,60 +70,115 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "Every subsequent run    : nebula-agent")
 }
 
-// runUnified is the single-command entrypoint described in issue #67.
+// standbyTick is how often the daemon re-checks the filesystem for a
+// freshly written enrollment while in standby (#88). Exposed as a var
+// rather than const so tests can shorten it; production callers must
+// not mutate it at runtime.
+var standbyTick = 10 * time.Second
+
+// runUnified is the daemon entrypoint. After #88 it never fails fast on a
+// missing config or missing enrollment; instead it parks in standby and
+// re-checks every standbyTick until the operator runs `nebula-agent enroll`
+// (or systemd is told to stop the process).
 //
-// Startup algorithm:
-//  1. Resolve config path (--config PATH or defaultConfigPath).
-//  2. If config exists → load it; warn when CLI flags conflict; --update-config
-//     overwrites fields with CLI values before starting.
-//  3. If config missing → build AgentConfig from defaults + CLI flags, write
-//     it atomically. --server is required for first run.
-//  4. After config is in place:
-//     a. cert exists → start poller.
-//     b. cert missing and --token set → enroll, then start poller.
-//     c. cert missing and no --token → fatal with hint.
-//
-// The enrollment token is never written to disk.
-func runUnified(args []string, stderr io.Writer) error {
+// The legacy one-shot flow (`nebula-agent --server URL --token TOK`) still
+// works: when both flags are set the agent enrolls and immediately starts
+// the poll loop, just like before. That branch is used by Docker / non-
+// systemd setups and by `nebula-agent enroll` itself for its confirmation
+// poll.
+func runUnified(ctx context.Context, args []string, stderr io.Writer) error {
 	fs := flag.NewFlagSet("nebula-agent", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	configPath := fs.String("config", defaultConfigPath, "config file path")
-	serverURL := fs.String("server", "", "management server URL (first run only)")
-	token := fs.String("token", "", "enrollment token (first run only, never written to disk)")
-	dataDir := fs.String("data-dir", "", "override data directory (first run only)")
-	pollInterval := fs.Duration("poll-interval", 0, "override poll interval (first run only)")
+	serverURL := fs.String("server", "", "management server URL (one-shot enroll+poll)")
+	token := fs.String("token", "", "enrollment token (one-shot enroll+poll; never persisted)")
+	dataDir := fs.String("data-dir", "", "override data directory (one-shot flow only)")
+	pollInterval := fs.Duration("poll-interval", 0, "override poll interval (one-shot flow only)")
 	updateConfig := fs.Bool("update-config", false, "overwrite on-disk config with CLI flags")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	cfg, err := resolveConfig(*configPath, *serverURL, *dataDir, *pollInterval, *updateConfig, stderr)
+	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	// One-shot enroll+poll path — explicit operator intent on the command
+	// line. Preserves the pre-#88 behaviour.
+	if *token != "" && *serverURL != "" {
+		cfg, err := resolveConfig(*configPath, *serverURL, *dataDir, *pollInterval, *updateConfig, stderr)
+		if err != nil {
+			return err
+		}
+		certPath := filepath.Join(cfg.DataDir, "host.crt")
+		if _, err := os.Stat(certPath); errors.Is(err, os.ErrNotExist) {
+			logger.Info("enrolling host", "server", cfg.ServerURL, "data_dir", cfg.DataDir, "signing_key", cfg.SigningKeyPath)
+			if err := agent.Enroll(cfg.ServerURL, *token, cfg.DataDir, cfg.SigningKeyPath); err != nil {
+				return fmt.Errorf("enrollment failed: %w", err)
+			}
+			logger.Info("enrollment successful")
+		} else if err != nil {
+			return fmt.Errorf("stat host certificate: %w", err)
+		}
+		return startPoller(ctx, cfg, logger)
+	}
+
+	// Daemon path — block in standby until the operator runs
+	// `nebula-agent enroll`, then transition to the poll loop.
+	cfg, err := awaitEnrollment(ctx, logger, *configPath)
 	if err != nil {
 		return err
 	}
+	return startPoller(ctx, cfg, logger)
+}
 
-	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
-
-	certPath := filepath.Join(cfg.DataDir, "host.crt")
-	switch _, err := os.Stat(certPath); {
-	case err == nil:
-		// Already enrolled — fall through to poller.
-	case errors.Is(err, os.ErrNotExist):
-		if *token == "" {
-			return fmt.Errorf("no host certificate at %s and no --token to enroll with; pass --token TOK to enroll", certPath)
-		}
-		logger.Info("enrolling host", "server", cfg.ServerURL, "data_dir", cfg.DataDir)
-		if err := agent.Enroll(cfg.ServerURL, *token, cfg.DataDir); err != nil {
-			return fmt.Errorf("enrollment failed: %w", err)
-		}
-		logger.Info("enrollment successful")
-	default:
-		return fmt.Errorf("stat host certificate: %w", err)
+// awaitEnrollment blocks until the agent has a usable config and the three
+// on-disk artefacts the poller needs (agent.yml, host.crt, signing key).
+// Returns ctx.Err() when the context is cancelled. The standby hint is
+// logged exactly once per process lifetime, even across multiple reasons,
+// to keep journals readable.
+func awaitEnrollment(ctx context.Context, logger *slog.Logger, configPath string) (*config.AgentConfig, error) {
+	cfg, reason := checkEnrollment(configPath)
+	if cfg != nil {
+		return cfg, nil
 	}
+	logger.Info("nebula-agent standby — run `nebula-agent enroll --server URL --token TOK` to bind", "reason", reason, "config", configPath, "tick", standbyTick)
+	ticker := time.NewTicker(standbyTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			cfg, reason = checkEnrollment(configPath)
+			if cfg != nil {
+				logger.Info("enrollment detected; leaving standby", "config", configPath)
+				return cfg, nil
+			}
+			// Suppress per-tick log noise; the one-time hint above is
+			// enough. reason is recomputed for the next iteration only.
+			_ = reason
+		}
+	}
+}
 
-	return startPoller(cfg, logger)
+// checkEnrollment returns the loaded config when every required on-disk
+// artefact is present, and a short human-readable reason string otherwise.
+// All errors map to "missing" — the standby loop only cares whether the
+// agent is ready to poll, not why a previous attempt failed.
+func checkEnrollment(configPath string) (*config.AgentConfig, string) {
+	if _, err := os.Stat(configPath); err != nil {
+		return nil, "config missing: " + configPath
+	}
+	cfg, err := config.LoadAgentConfig(configPath)
+	if err != nil {
+		return nil, "config invalid: " + err.Error()
+	}
+	if _, err := os.Stat(filepath.Join(cfg.DataDir, "host.crt")); err != nil {
+		return nil, "host.crt missing in " + cfg.DataDir
+	}
+	if _, err := os.Stat(cfg.SigningKeyPath); err != nil {
+		return nil, "signing key missing: " + cfg.SigningKeyPath
+	}
+	return cfg, ""
 }
 
 // resolveConfig loads the on-disk config or creates one from CLI flags.
@@ -191,18 +251,7 @@ func applyOverrides(cfg *config.AgentConfig, serverURL, dataDir string, pollInte
 	return changed
 }
 
-func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		sig := <-sigCh
-		logger.Info("received signal, shutting down", "signal", sig)
-		cancel()
-	}()
-
+func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logger) error {
 	logger.Info("nebula-agent starting", "server", cfg.ServerURL, "poll_interval", cfg.PollInterval)
 
 	for {
@@ -211,11 +260,12 @@ func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
 			return fmt.Errorf("read certificate fingerprint: %w", err)
 		}
 		poller, err := agent.NewPoller(agent.PollerConfig{
-			ServerURL:   cfg.ServerURL,
-			Fingerprint: fingerprint,
-			DataDir:     cfg.DataDir,
-			Interval:    cfg.PollInterval,
-			PIDFile:     cfg.NebulaPIDFile,
+			ServerURL:      cfg.ServerURL,
+			Fingerprint:    fingerprint,
+			DataDir:        cfg.DataDir,
+			SigningKeyPath: cfg.SigningKeyPath,
+			Interval:       cfg.PollInterval,
+			PIDFile:        cfg.NebulaPIDFile,
 		}, logger)
 		if err != nil {
 			return fmt.Errorf("create poller: %w", err)
@@ -237,7 +287,7 @@ func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
 			var re *agent.RekeyError
 			_ = errors.As(runErr, &re)
 			logger.Info("performing server-requested rekey")
-			if err := agent.Reenroll(cfg.ServerURL, re.Token, cfg.DataDir); err != nil {
+			if err := agent.Reenroll(cfg.ServerURL, re.Token, cfg.DataDir, cfg.SigningKeyPath); err != nil {
 				return fmt.Errorf("rekey enrollment: %w", err)
 			}
 			continue
@@ -246,30 +296,96 @@ func startPoller(cfg *config.AgentConfig, logger *slog.Logger) error {
 	}
 }
 
-// runLegacyEnroll preserves the old `nebula-agent enroll` invocation for one
-// release. It does not persist any config — operators get the unified flow
-// the next time they invoke the agent.
-func runLegacyEnroll(args []string, stderr io.Writer) error {
+// runEnroll is the first-class `nebula-agent enroll` subcommand (#88). It
+// performs the enrollment side-effects (generate keypairs, hit
+// /api/v1/enroll, atomically persist agent.yml + the five enrollment files,
+// run one confirmation poll) and exits. It is designed to be called by an
+// operator from a shell — the long-running poll loop belongs to the
+// systemd-managed daemon, which picks up the freshly written files on its
+// next idle tick.
+func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("enroll", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	token := fs.String("token", "", "enrollment token")
-	serverURL := fs.String("server", "", "management server URL")
-	dataDir := fs.String("data-dir", "/etc/nebula", "data directory")
+	configPath := fs.String("config", defaultConfigPath, "agent config file path")
+	serverURL := fs.String("server", "", "management server URL (required)")
+	token := fs.String("token", "", "enrollment token (required; never persisted)")
+	dataDir := fs.String("data-dir", "/etc/nebula", "Nebula data directory")
+	signingKeyPath := fs.String("signing-key-path", "", "Ed25519 PoP signing key path; defaults to <config-dir>/host.signing.key")
+	pollInterval := fs.Duration("poll-interval", 30*time.Second, "poll interval written to agent.yml")
+	force := fs.Bool("force", false, "overwrite an existing enrollment")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *token == "" || *serverURL == "" {
-		return fmt.Errorf("--token and --server are required")
+	if *serverURL == "" || *token == "" {
+		return fmt.Errorf("--server and --token are required")
 	}
-	_, _ = fmt.Fprintf(stderr, "enrolling with server %s...\n", *serverURL)
-	if err := agent.Enroll(*serverURL, *token, *dataDir); err != nil {
+	if *signingKeyPath == "" {
+		*signingKeyPath = filepath.Join(filepath.Dir(*configPath), "host.signing.key")
+	}
+
+	// Refuse to overwrite an existing enrollment unless --force.
+	if !*force {
+		for _, p := range []string{
+			*configPath,
+			filepath.Join(*dataDir, "host.crt"),
+			*signingKeyPath,
+		} {
+			if _, err := os.Stat(p); err == nil {
+				return fmt.Errorf("already enrolled (found %s); pass --force to overwrite", p)
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("stat %s: %w", p, err)
+			}
+		}
+	}
+
+	_, _ = fmt.Fprintf(stdout, "enrolling with %s...\n", *serverURL)
+	if err := agent.Enroll(*serverURL, *token, *dataDir, *signingKeyPath); err != nil {
 		return fmt.Errorf("enrollment failed: %w", err)
 	}
-	_, _ = fmt.Fprintln(stderr, "enrollment successful")
+
+	cfg := config.DefaultAgentConfig()
+	cfg.ServerURL = *serverURL
+	cfg.DataDir = *dataDir
+	cfg.SigningKeyPath = *signingKeyPath
+	cfg.PollInterval = *pollInterval
+	cfg.NebulaConfigPath = filepath.Join(*dataDir, "config.yml")
+	if err := config.SaveAgentConfig(*configPath, cfg); err != nil {
+		return fmt.Errorf("write %s: %w", *configPath, err)
+	}
+	_, _ = fmt.Fprintf(stdout, "wrote %s\n", *configPath)
+
+	// One confirmation poll so the operator sees "enrollment + first poll
+	// succeeded" in the same command. Failures here are informational —
+	// the on-disk state is good; the idle daemon will retry.
+	fingerprint, err := agent.ReadCertFingerprint(*dataDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "warning: cannot read fresh cert fingerprint: %v\n", err)
+		_, _ = fmt.Fprintln(stdout, "enrollment successful (confirmation poll skipped)")
+		return nil
+	}
+	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	poller, err := agent.NewPoller(agent.PollerConfig{
+		ServerURL:      cfg.ServerURL,
+		Fingerprint:    fingerprint,
+		DataDir:        cfg.DataDir,
+		SigningKeyPath: cfg.SigningKeyPath,
+		Interval:       cfg.PollInterval,
+	}, logger)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "warning: poller init failed: %v\n", err)
+		_, _ = fmt.Fprintln(stdout, "enrollment successful (confirmation poll skipped)")
+		return nil
+	}
+	if err := poller.PollOnce(ctx); err != nil {
+		_, _ = fmt.Fprintf(stderr, "warning: first poll failed (enrollment files are valid; daemon will retry): %v\n", err)
+		_, _ = fmt.Fprintln(stdout, "enrollment successful")
+		return nil
+	}
+	_, _ = fmt.Fprintln(stdout, "enrollment successful (confirmation poll OK)")
 	return nil
 }
 
-func runLegacyRun(args []string, stderr io.Writer) error {
+func runLegacyRun(ctx context.Context, args []string, stderr io.Writer) error {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	configPath := fs.String("config", defaultConfigPath, "config file path")
@@ -281,5 +397,5 @@ func runLegacyRun(args []string, stderr io.Writer) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	return startPoller(cfg, logger)
+	return startPoller(ctx, cfg, logger)
 }

--- a/cmd/nebula-agent/main_test.go
+++ b/cmd/nebula-agent/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -134,41 +135,110 @@ func TestResolveConfig_DoesNotPersistToken(t *testing.T) {
 	}
 }
 
-func TestRun_FreshHost_NoTokenNoCert_Errors(t *testing.T) {
+// TestRun_StandbyWhenConfigMissing — daemon launched with no flags and no
+// existing config sits in standby instead of failing fast. Context-cancel
+// (the SIGTERM analog under test) must return ctx.Err(), not a wrapped
+// error.
+func TestRun_StandbyWhenConfigMissing(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	var stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := run(ctx, []string{"--config", cfgPath}, &stderr, &stderr)
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded or Canceled", err)
+	}
+	if !strings.Contains(stderr.String(), "standby") {
+		t.Errorf("stderr should mention standby; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "nebula-agent enroll") {
+		t.Errorf("stderr should hint at `nebula-agent enroll`; got %q", stderr.String())
+	}
+}
+
+// TestRun_StandbyWhenCertMissing — config exists, but host.crt/signing-key
+// are not on disk yet. Same standby behaviour as TestRun_StandbyWhenConfigMissing.
+func TestRun_StandbyWhenCertMissing(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "agent.yml")
 	dataDir := filepath.Join(dir, "nebula")
 
-	// Seed an enrolled-but-cert-missing state: config exists, host.crt does not.
 	cfg := config.DefaultAgentConfig()
 	cfg.ServerURL = "https://srv.example.com"
 	cfg.DataDir = dataDir
+	cfg.SigningKeyPath = filepath.Join(dir, "agent", "host.signing.key")
 	if err := config.SaveAgentConfig(cfgPath, cfg); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
 	var stderr bytes.Buffer
-	err := run([]string{"--config", cfgPath}, &stderr, &stderr)
-	if err == nil {
-		t.Fatal("expected error: missing cert + no token")
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := run(ctx, []string{"--config", cfgPath}, &stderr, &stderr)
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded or Canceled", err)
 	}
-	if !strings.Contains(err.Error(), "--token") {
-		t.Errorf("error message should mention --token hint; got %v", err)
+	if !strings.Contains(stderr.String(), "standby") {
+		t.Errorf("stderr should mention standby; got %q", stderr.String())
 	}
 }
 
-func TestRun_DeprecatedSubcommandWarning(t *testing.T) {
-	var stderr bytes.Buffer
-	// Both deprecated commands fail fast (missing flags), but the warning
-	// must hit stderr regardless.
-	_ = run([]string{"enroll"}, &stderr, &stderr)
-	if !strings.Contains(stderr.String(), "deprecated") {
-		t.Errorf("expected deprecation warning for enroll; got %q", stderr.String())
+// TestCheckEnrollment_ReturnsCfgWhenReady — unit-level coverage of the
+// state-machine helper. When config + cert + signing key are all present,
+// it returns the loaded config and an empty reason.
+func TestCheckEnrollment_ReturnsCfgWhenReady(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+	dataDir := filepath.Join(dir, "nebula")
+	skPath := filepath.Join(dir, "agent", "host.signing.key")
+
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(skPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "host.crt"), []byte("cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skPath, []byte("sk"), 0o600); err != nil {
+		t.Fatal(err)
 	}
 
-	stderr.Reset()
-	_ = run([]string{"run", "--config", "/nonexistent"}, &stderr, &stderr)
+	cfg := config.DefaultAgentConfig()
+	cfg.ServerURL = "https://srv.example.com"
+	cfg.DataDir = dataDir
+	cfg.SigningKeyPath = skPath
+	if err := config.SaveAgentConfig(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	got, reason := checkEnrollment(cfgPath)
+	if got == nil {
+		t.Fatalf("got nil cfg with reason %q", reason)
+	}
+	if reason != "" {
+		t.Errorf("reason = %q, want empty", reason)
+	}
+	if got.ServerURL != "https://srv.example.com" {
+		t.Errorf("ServerURL = %q", got.ServerURL)
+	}
+}
+
+// TestRun_DeprecatedSubcommand_Run pins the deprecation warning on the
+// remaining legacy subcommand. `enroll` is no longer deprecated after #88,
+// so its branch is exercised separately (see TestEnrollSubcommand_* below).
+func TestRun_DeprecatedSubcommand_Run(t *testing.T) {
+	var stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_ = run(ctx, []string{"run", "--config", "/nonexistent"}, &stderr, &stderr)
 	if !strings.Contains(stderr.String(), "deprecated") {
 		t.Errorf("expected deprecation warning for run; got %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "`nebula-agent enroll` is deprecated") {
+		t.Errorf("enroll subcommand should NOT print deprecation warning; got %q", stderr.String())
 	}
 }

--- a/deploy/packaging/postinstall.sh
+++ b/deploy/packaging/postinstall.sh
@@ -12,26 +12,39 @@ if ! getent passwd nebula-agent >/dev/null 2>&1; then
         --shell /usr/sbin/nologin --comment "nebula-agent" nebula-agent
 fi
 
-# /etc/nebula-agent/agent.yml is intentionally NOT created automatically —
-# operators copy from the shipped example and edit before first run.
+# /etc/nebula-agent/agent.yml is created by `nebula-agent enroll` (#88) and
+# is intentionally NOT created here. The daemon happily sits in idle-standby
+# without it; the operator binds the host with one command.
 if [ ! -f /etc/nebula-agent/agent.yml ]; then
-    cat <<EOF >&2
+    cat <<'EOF' >&2
 
-  nebula-agent: configuration not yet present.
-  Copy the example and edit before starting the service:
+  nebula-agent: not yet enrolled — service will start in idle-standby.
+  Bind the host with one command:
 
-    sudo cp /etc/nebula-agent/agent.example.yml /etc/nebula-agent/agent.yml
-    sudoedit /etc/nebula-agent/agent.yml
-    sudo nebula-agent enroll --server <url> --token <token> --data-dir /etc/nebula
-    sudo systemctl enable --now nebula-agent.service
+    sudo nebula-agent enroll --server <url> --token <token>
+
+  The running daemon will pick up the fresh enrollment within ~10s
+  without a restart.
 
 EOF
 fi
 
-# Reload systemd so the new unit is visible, but never enable/start
-# automatically — operators must enroll first.
-if command -v systemctl >/dev/null 2>&1; then
+# Reload systemd so the new unit is visible. On a fresh install (DEB:
+# $1=configure with no $2; RPM: $1=1) enable and start the service so the
+# daemon is up immediately — it sits idle until the operator enrolls,
+# which is now a safe default thanks to #88. On upgrade ($1=2 for RPM,
+# $1=configure with $2 set for DEB) leave the current enable-state alone.
+if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload || true
+    fresh_install=0
+    case "${1:-}" in
+        "")           fresh_install=1 ;;
+        configure)    if [ -z "${2:-}" ]; then fresh_install=1; fi ;;
+        1)            fresh_install=1 ;;
+    esac
+    if [ "${fresh_install}" = "1" ]; then
+        systemctl enable --now nebula-agent.service >/dev/null 2>&1 || true
+    fi
 fi
 
 exit 0

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -90,9 +90,17 @@ The package:
 - installs `/usr/bin/nebula-agent` and `/lib/systemd/system/nebula-agent.service`;
 - ships an example config at `/etc/nebula-agent/agent.example.yml`;
 - creates the `nebula-agent` system user/group for future hardening;
-- **does not** create `/etc/nebula-agent/agent.yml`, start, or enable the service — run `nebula-agent --server URL --token TOK` once to write the config + enroll, then `systemctl enable --now nebula-agent`;
-- on upgrade, leaves `/etc/nebula-agent/agent.yml` and `/etc/nebula/{host.crt,host.key,ca.crt,config.yml}` untouched;
-- on removal, stops and disables the service but keeps `/etc/nebula-agent` and `/etc/nebula` intact (so host keys survive accidental removals). `apt purge` / `dnf remove --purge` will additionally delete the system user.
+- on fresh install runs `systemctl enable --now nebula-agent.service` so the daemon comes up immediately in **idle-standby** (#88) — no enrollment yet, no server traffic, journal logs one hint and the process sleeps;
+- on upgrade leaves the current enable-state alone, and leaves `/etc/nebula-agent/agent.yml` and `/etc/nebula/{host.crt,host.key,ca.crt,config.yml}` untouched;
+- on removal stops and disables the service but keeps `/etc/nebula-agent` and `/etc/nebula` intact (so host keys survive accidental removals). `apt purge` / `dnf remove --purge` will additionally delete the system user.
+
+Bind the host with one command after install:
+
+```sh
+sudo nebula-agent enroll --server <url> --token <token>
+```
+
+The running daemon detects the freshly written files within ~10 seconds and transitions from idle-standby to the poll loop without a restart. See [Enrollment](#enrollment) for the full flow.
 
 Checksums for every artifact are published in `checksums.txt` next to the package.
 
@@ -242,65 +250,64 @@ it through `POST /api/v1/hosts/{id}/enrollment-token` (or via the UI).
 
 ### 2. On the host
 
+After `apt install` / `dnf install`, `nebula-agent.service` is already running in **idle-standby** (#88) — confirm via `systemctl status nebula-agent`. Bind the host with one command:
+
 ```sh
-# First run: enrolls, writes config to /etc/nebula-agent/agent.yml (0600),
-# starts the poller. The token is single-use and is never written to disk.
+sudo nebula-agent enroll \
+  --server https://mgmt.example.com:8080 \
+  --token "$ENROLL_TOKEN"
+```
+
+The `enroll` subcommand:
+
+- generates both keypairs (X25519 for Nebula + Ed25519 for poll signatures);
+- hits `POST /api/v1/enroll` on the server;
+- atomically writes `agent.yml` (mode 0600) and the five enrollment files (see table below);
+- runs **one** confirmation signed poll so you see `enrollment successful (confirmation poll OK)` in the same command;
+- exits 0.
+
+The token is single-use and never persisted to disk. Pass `--force` to overwrite an existing enrollment (e.g. after key compromise) — without `--force` the command refuses to clobber `host.crt` / `agent.yml`.
+
+After a successful enrollment the agent owns the following files:
+
+| Path | Mode | Owner | Contents |
+|---|---|---|---|
+| `/etc/nebula-agent/agent.yml` | 0600 | agent | Agent daemon config (server URL, poll interval, paths). |
+| `/etc/nebula-agent/host.signing.key` | 0600 | **agent** | Ed25519 private key used only by the agent to sign poll requests (ADR 0004). Lives outside `/etc/nebula/` because Nebula does not read it. |
+| `/etc/nebula/host.key` | 0600 | Nebula | X25519 private key for the Nebula Noise handshake. |
+| `/etc/nebula/host.crt` | 0644 | Nebula | Signed certificate of this host. |
+| `/etc/nebula/ca.crt` | 0644 | Nebula | CA certificate (trust anchor for peer-cert verification). |
+| `/etc/nebula/config.yml` | 0644 | Nebula | Rendered Nebula config (lighthouses, firewall, …). |
+
+The running daemon detects all four required files (`agent.yml`, `host.crt`, `host.signing.key`) within ~10 s and transitions from idle-standby to the poll loop without a restart.
+
+### 3. Containers / non-systemd setups
+
+For Docker and other systemd-less environments where there is no idle daemon to wait, the legacy one-shot flow still works:
+
+```sh
 sudo nebula-agent \
   --server https://mgmt.example.com:8080 \
   --token "$ENROLL_TOKEN"
-
-# Optional: pick a non-default data dir on first run.
-sudo nebula-agent --server ... --token ... --data-dir /etc/nebula
 ```
 
-After a successful enrollment the agent writes the following to `data_dir`:
+That invocation enrolls and **then** starts the poll loop in the foreground. Use it as the container's main process (`ENTRYPOINT`).
 
-| File | Mode | Contents |
-|---|---|---|
-| `host.key` | 0600 | The host's Nebula X25519 private key (PEM, unencrypted). |
-| `host.signing.key` | 0600 | The host's Ed25519 private key used to sign poll requests (ADR 0004). |
-| `host.crt` | 0644 | The host's signed certificate. |
-| `ca.crt`   | 0644 | The CA certificate; used by `nebula` to verify peers. |
-| `config.yml` | 0644 | The rendered Nebula config. |
-
-The enrollment endpoint accepts the token exactly once. A second call with the same
-token returns `409 Conflict`.
-
-### 3. Starting the run loop
-
-Once the host has been enrolled, subsequent invocations need no arguments — the
-agent reads `/etc/nebula-agent/agent.yml`, finds `host.crt`, and starts polling:
-
-```sh
-sudo nebula-agent                                # default config path
-sudo nebula-agent --config /path/to/agent.yml    # non-default location
-```
-
-To change a setting later, edit the YAML file (preferred) or pass
-`--update-config` together with the override flag to overwrite a single field
-atomically:
+CLI overrides for the running daemon (e.g. `--poll-interval 60s`) take effect only with `--update-config`; otherwise a warning is logged and the on-disk file wins:
 
 ```sh
 sudo nebula-agent --update-config --poll-interval 60s
 ```
 
-CLI overrides without `--update-config` are ignored on subsequent runs (a
-warning is logged) so a one-shot flag never silently rewrites persisted state.
-
-The agent exits non-zero if the host's certificate is missing and no `--token`
-is supplied — the error message tells you to pass `--token TOK` to enroll.
-
 ### Legacy subcommands (deprecated)
 
-The previous two-step ceremony still works for one release for backward
-compatibility with existing scripts:
+`nebula-agent run` is a deprecated alias for `nebula-agent` without a subcommand:
 
 ```sh
-sudo nebula-agent enroll --server ... --token ... --data-dir /etc/nebula
 sudo nebula-agent run --config /etc/nebula-agent/agent.yml
 ```
 
-Both print a deprecation warning on stderr; switch to the unified form when
+It prints a deprecation warning on stderr; switch to the unified form when
 convenient.
 
 ## Agent authorization (ADR 0004)
@@ -314,17 +321,14 @@ decision history.
 
 ### Keys on disk
 
-After a successful enrollment the agent's `data_dir` holds two private keys, both
-mode `0600`:
+After a successful enrollment two private keys exist on the host, both mode `0600`. They live in **separate directories** because they belong to separate processes (#88):
 
-| File | Purpose |
-|---|---|
-| `host.key` | X25519 private key used by Nebula for the Noise handshake between peers. |
-| `host.signing.key` | Ed25519 private key used only by the agent to sign poll requests. Never seen by Nebula. |
+| Path | Owner | Purpose |
+|---|---|---|
+| `/etc/nebula/host.key` | Nebula | X25519 private key used by Nebula for the Noise handshake between peers. |
+| `/etc/nebula-agent/host.signing.key` | agent | Ed25519 private key used only by the agent to sign poll requests. Never seen by Nebula. |
 
-The two keys share lifetime — force-rotate and re-enroll regenerate both
-together. The Ed25519 key exists because X25519 (the curve of `host.crt`) is a
-DH scheme that cannot sign arbitrary messages.
+The two keys share lifetime — force-rotate and re-enroll regenerate both together. The Ed25519 key exists because X25519 (the curve of `host.crt`) is a DH scheme that cannot sign arbitrary messages.
 
 ### Headers on every poll
 
@@ -527,11 +531,13 @@ Useful after the host's keys are believed compromised. Two flavours:
    On the host:
 
    ```sh
-   sudo systemctl stop nebula-agent nebula
-   sudo rm /etc/nebula/{host.crt,host.key,host.signing.key,ca.crt,config.yml}
-   sudo nebula-agent --server <url> --token <new-token>
-   sudo systemctl start nebula nebula-agent
+   sudo rm /etc/nebula/{host.crt,host.key,ca.crt,config.yml} \
+           /etc/nebula-agent/host.signing.key /etc/nebula-agent/agent.yml
+   sudo nebula-agent enroll --server <url> --token <new-token>
    ```
+
+   The running daemon (still in poll loop or already in idle-standby after
+   the deletions) picks up the new artefacts within ~10 s.
 
 2. **Server-driven force-rotate** (no operator action on the host). On the
    server:

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -39,13 +39,23 @@ type EnrollResponse struct {
 // fresh (rekey) or bound to an unenrolled host (initial enroll), so the
 // agent path is identical. Exposed separately so the cmd-side rekey loop
 // reads cleanly.
-func Reenroll(serverURL, token, dataDir string) error {
-	return Enroll(serverURL, token, dataDir)
+func Reenroll(serverURL, token, dataDir, signingKeyPath string) error {
+	return Enroll(serverURL, token, dataDir, signingKeyPath)
 }
 
 // Enroll performs the enrollment flow: generates keypair, sends public key
-// to the server with the token, saves received cert and config to dataDir.
-func Enroll(serverURL, token, dataDir string) error {
+// to the server with the token, saves received cert and config to dataDir,
+// and writes the Ed25519 signing private key to signingKeyPath.
+//
+// signingKeyPath is intentionally separate from dataDir — Nebula's data dir
+// holds Nebula-owned secrets (host.key / host.crt / ca.crt / config.yml),
+// while the agent's PoP signing key (ADR 0004) is the agent's concern and
+// lives next to agent.yml (default /etc/nebula-agent/host.signing.key). The
+// parent directory of signingKeyPath is created with mode 0o755 if missing.
+func Enroll(serverURL, token, dataDir, signingKeyPath string) error {
+	if signingKeyPath == "" {
+		return fmt.Errorf("signingKeyPath is required")
+	}
 	// Generate X25519 keypair (for the Nebula handshake cert).
 	privKey := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, privKey); err != nil {
@@ -111,8 +121,12 @@ func Enroll(serverURL, token, dataDir string) error {
 	}
 
 	// Save signing private key (ADR 0004 — used to sign poll requests).
+	// Lives in its own directory, not dataDir; create parent if missing.
+	if err := os.MkdirAll(filepath.Dir(signingKeyPath), 0o755); err != nil {
+		return fmt.Errorf("create signing key dir: %w", err)
+	}
 	signingPrivPEM := pem.EncodeToMemory(&pem.Block{Type: SigningPrivateKeyPEMType, Bytes: signingPriv})
-	if err := os.WriteFile(filepath.Join(dataDir, "host.signing.key"), signingPrivPEM, 0o600); err != nil {
+	if err := os.WriteFile(signingKeyPath, signingPrivPEM, 0o600); err != nil {
 		return fmt.Errorf("write signing key: %w", err)
 	}
 

--- a/internal/agent/enroll_test.go
+++ b/internal/agent/enroll_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestEnroll_Success(t *testing.T) {
 	dir := t.TempDir()
+	agentDir := t.TempDir()
+	signingKeyPath := filepath.Join(agentDir, "host.signing.key")
 
 	// Mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -51,13 +53,13 @@ func TestEnroll_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err := Enroll(server.URL, "test-token", dir)
+	err := Enroll(server.URL, "test-token", dir, signingKeyPath)
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
 
-	// Verify files
-	for _, name := range []string{"ca.crt", "host.crt", "host.key", "host.signing.key", "config.yml"} {
+	// Nebula-side files live in dataDir.
+	for _, name := range []string{"ca.crt", "host.crt", "host.key", "config.yml"} {
 		path := filepath.Join(dir, name)
 		info, err := os.Stat(path)
 		if err != nil {
@@ -69,12 +71,25 @@ func TestEnroll_Success(t *testing.T) {
 		}
 	}
 
-	// Check key permissions
-	for _, secret := range []string{"host.key", "host.signing.key"} {
-		info, _ := os.Stat(filepath.Join(dir, secret))
-		if info.Mode().Perm() != 0o600 {
-			t.Errorf("%s permissions = %o, want 0600", secret, info.Mode().Perm())
-		}
+	// Signing key lives at the explicit signingKeyPath, NOT in dataDir.
+	if _, err := os.Stat(filepath.Join(dir, "host.signing.key")); !os.IsNotExist(err) {
+		t.Errorf("host.signing.key must NOT be in dataDir; got err = %v", err)
+	}
+	info, err := os.Stat(signingKeyPath)
+	if err != nil {
+		t.Fatalf("signing key not at %s: %v", signingKeyPath, err)
+	}
+	if info.Size() == 0 {
+		t.Error("signing key file is empty")
+	}
+
+	// Check key permissions on both private keys.
+	hostKeyInfo, _ := os.Stat(filepath.Join(dir, "host.key"))
+	if hostKeyInfo.Mode().Perm() != 0o600 {
+		t.Errorf("host.key permissions = %o, want 0600", hostKeyInfo.Mode().Perm())
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("host.signing.key permissions = %o, want 0600", info.Mode().Perm())
 	}
 }
 
@@ -85,7 +100,7 @@ func TestEnroll_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err := Enroll(server.URL, "bad-token", t.TempDir())
+	err := Enroll(server.URL, "bad-token", t.TempDir(), filepath.Join(t.TempDir(), "host.signing.key"))
 	if err == nil {
 		t.Fatal("expected error for server error response, got nil")
 	}

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -106,11 +106,12 @@ func errorsAs(err error, target any) bool {
 
 // PollerConfig holds configuration for the Poller.
 type PollerConfig struct {
-	ServerURL   string
-	Fingerprint string
-	DataDir     string
-	Interval    time.Duration
-	PIDFile     string
+	ServerURL      string
+	Fingerprint    string
+	DataDir        string
+	SigningKeyPath string
+	Interval       time.Duration
+	PIDFile        string
 }
 
 // Poller periodically checks the management server for updates.
@@ -126,7 +127,10 @@ type Poller struct {
 // returned error is propagated to the caller; the agent must re-enroll
 // before polling can resume.
 func NewPoller(cfg PollerConfig, logger *slog.Logger) (*Poller, error) {
-	priv, err := loadSigningKey(filepath.Join(cfg.DataDir, "host.signing.key"))
+	if cfg.SigningKeyPath == "" {
+		return nil, fmt.Errorf("PollerConfig.SigningKeyPath is required")
+	}
+	priv, err := loadSigningKey(cfg.SigningKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("load signing key: %w", err)
 	}
@@ -182,6 +186,14 @@ func (p *Poller) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+// PollOnce performs a single signed poll iteration and returns. The enroll
+// subcommand uses it to verify the freshly enrolled host can reach the
+// server before exiting. Errors are informational — callers decide whether
+// to gate behaviour on them; the daemon's Run() never invokes PollOnce.
+func (p *Poller) PollOnce(ctx context.Context) error {
+	return p.poll(ctx)
 }
 
 func (p *Poller) poll(ctx context.Context) error {

--- a/internal/agent/poller_rekey_test.go
+++ b/internal/agent/poller_rekey_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -23,11 +24,12 @@ func TestPoll_ReturnsRekeyError(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p, err := NewPoller(PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
+		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
 		Interval:    time.Hour,
 	}, slog.Default())
 	if err != nil {
@@ -62,11 +64,12 @@ func TestPoll_RejectsRekeyWithoutToken(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p, err := NewPoller(PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
+		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
 		Interval:    time.Hour,
 	}, slog.Default())
 	if err != nil {
@@ -95,11 +98,12 @@ func TestRun_StopsOnRekey(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
+		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
 		Interval:    20 * time.Millisecond,
 	})
 

--- a/internal/agent/poller_revocation_test.go
+++ b/internal/agent/poller_revocation_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -18,11 +19,12 @@ func TestPoll_ReturnsRevocationErrorOn403(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p, err := NewPoller(PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
+		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
 		Interval:    time.Hour,
 	}, slog.Default())
 	if err != nil {
@@ -54,11 +56,12 @@ func TestPoll_ReturnsRevocationErrorOn410(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p, err := NewPoller(PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
+		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
 		Interval:    time.Hour,
 	}, slog.Default())
 	if err != nil {
@@ -80,11 +83,12 @@ func TestRun_StopsOnRevocation(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
+		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
 		Interval:    20 * time.Millisecond,
 	})
 

--- a/internal/agent/poller_signing_key_path_test.go
+++ b/internal/agent/poller_signing_key_path_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+)
+
+// TestNewPoller_LoadsFromExplicitSigningKeyPath confirms that the poller
+// reads the Ed25519 signing key from PollerConfig.SigningKeyPath rather than
+// from DataDir/host.signing.key. #88 separates the agent's own secret from
+// Nebula's data dir.
+func TestNewPoller_LoadsFromExplicitSigningKeyPath(t *testing.T) {
+	dataDir := t.TempDir()
+	agentDir := t.TempDir()
+	signingKeyPath := filepath.Join(agentDir, "host.signing.key")
+	writeSigningKey(t, signingKeyPath)
+
+	p, err := NewPoller(PollerConfig{
+		ServerURL:      "http://example.invalid",
+		Fingerprint:    "test-fp",
+		DataDir:        dataDir,
+		SigningKeyPath: signingKeyPath,
+	}, slog.Default())
+	if err != nil {
+		t.Fatalf("NewPoller: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil poller")
+	}
+}
+
+// TestNewPoller_RequiresSigningKeyPath confirms NewPoller rejects an empty
+// SigningKeyPath instead of silently falling back to DataDir/host.signing.key
+// (which would re-introduce the concern leak #88 fixes).
+func TestNewPoller_RequiresSigningKeyPath(t *testing.T) {
+	if _, err := NewPoller(PollerConfig{DataDir: t.TempDir()}, slog.Default()); err == nil {
+		t.Fatal("expected error when SigningKeyPath is empty")
+	}
+}

--- a/internal/agent/poller_test.go
+++ b/internal/agent/poller_test.go
@@ -18,17 +18,18 @@ import (
 	corepop "github.com/juev/nebula-mesh/internal/pop"
 )
 
-// writeSigningKey seeds a temp data dir with a freshly generated Ed25519
-// signing private key in the on-disk PEM format the poller expects. Returns
-// the matching public key so tests can verify signatures.
-func writeSigningKey(t *testing.T, dir string) ed25519.PublicKey {
+// writeSigningKey writes a freshly generated Ed25519 private key to the
+// given path in the on-disk PEM format the poller expects. Returns the
+// matching public key so tests can verify signatures. The parent directory
+// must already exist.
+func writeSigningKey(t *testing.T, path string) ed25519.PublicKey {
 	t.Helper()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: SigningPrivateKeyPEMType, Bytes: priv})
-	if err := os.WriteFile(filepath.Join(dir, "host.signing.key"), pemBytes, 0o600); err != nil {
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return pub
@@ -36,12 +37,28 @@ func writeSigningKey(t *testing.T, dir string) ed25519.PublicKey {
 
 func newPoller(t *testing.T, cfg PollerConfig) *Poller {
 	t.Helper()
+	if cfg.SigningKeyPath == "" {
+		// Default: put the signing key in a sibling dir to DataDir so tests
+		// that pre-write a signing key with writeSigningKey-on-DataDir
+		// continue to find it through the legacy code path. The cleaner
+		// fixture (signing key outside DataDir) is exercised by
+		// TestNewPoller_LoadsFromExplicitSigningKeyPath.
+		cfg.SigningKeyPath = filepath.Join(cfg.DataDir, "host.signing.key")
+	}
 	p, err := NewPoller(cfg, slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
 	p.signalFunc = func() error { return nil }
 	return p
+}
+
+// seedSigningKeyAt is a convenience helper for tests that don't care where
+// the signing key lives — it writes one into the given DataDir's
+// host.signing.key (consistent with the default chosen by newPoller above).
+func seedSigningKeyAt(t *testing.T, dataDir string) {
+	t.Helper()
+	writeSigningKey(t, filepath.Join(dataDir, "host.signing.key"))
 }
 
 func TestPoller_NoUpdates(t *testing.T) {
@@ -57,7 +74,7 @@ func TestPoller_NoUpdates(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
@@ -92,7 +109,7 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
@@ -135,7 +152,7 @@ func TestPoller_WithConfigUpdate(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
@@ -178,7 +195,7 @@ func TestPoller_SignsRequest(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "fp-123",
@@ -211,7 +228,7 @@ func TestPoll_RespectsContext(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	writeSigningKey(t, dir)
+	seedSigningKeyAt(t, dir)
 	p := newPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -13,6 +13,7 @@ import (
 type AgentConfig struct {
 	ServerURL        string        `yaml:"server_url"`
 	DataDir          string        `yaml:"data_dir"`
+	SigningKeyPath   string        `yaml:"signing_key_path"`
 	PollInterval     time.Duration `yaml:"poll_interval"`
 	NebulaConfigPath string        `yaml:"nebula_config_path"`
 	NebulaPIDFile    string        `yaml:"nebula_pid_file"`
@@ -20,9 +21,14 @@ type AgentConfig struct {
 
 // DefaultAgentConfig returns a config populated with the defaults the agent
 // applies when fields are missing.
+//
+// SigningKeyPath defaults to /etc/nebula-agent/host.signing.key — agent's
+// Ed25519 poll-signature key lives next to agent.yml, deliberately *not* in
+// /etc/nebula where Nebula's own secrets live (ADR 0004 + #88).
 func DefaultAgentConfig() *AgentConfig {
 	return &AgentConfig{
 		DataDir:          "/etc/nebula",
+		SigningKeyPath:   "/etc/nebula-agent/host.signing.key",
 		PollInterval:     30 * time.Second,
 		NebulaConfigPath: "/etc/nebula/config.yml",
 	}

--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -67,6 +67,20 @@ func TestLoadAgentConfig_Defaults(t *testing.T) {
 	if cfg.NebulaConfigPath != "/etc/nebula/config.yml" {
 		t.Errorf("NebulaConfigPath = %q, want default %q", cfg.NebulaConfigPath, "/etc/nebula/config.yml")
 	}
+	if cfg.SigningKeyPath != "/etc/nebula-agent/host.signing.key" {
+		t.Errorf("SigningKeyPath = %q, want default %q", cfg.SigningKeyPath, "/etc/nebula-agent/host.signing.key")
+	}
+}
+
+// TestAgentConfig_DefaultsHaveSigningKeyPath pins the per-agent signing-key
+// path to /etc/nebula-agent/ — outside Nebula's data_dir. The location is part
+// of the supported on-disk layout (ADR 0004 + #88) and is documented in
+// docs/agent.md; changing it requires a migration plan.
+func TestAgentConfig_DefaultsHaveSigningKeyPath(t *testing.T) {
+	cfg := DefaultAgentConfig()
+	if cfg.SigningKeyPath != "/etc/nebula-agent/host.signing.key" {
+		t.Errorf("SigningKeyPath = %q, want %q", cfg.SigningKeyPath, "/etc/nebula-agent/host.signing.key")
+	}
 }
 
 func TestLoadAgentConfig_MissingServerURL(t *testing.T) {


### PR DESCRIPTION
## Summary

Three coordinated changes so `apt install nebula-agent` followed by `systemctl enable --now` is a safe, default install (and so the `.deb` / `.rpm` postinst can actually do that itself).

### 1. Idle-standby in the daemon

When no `agent.yml` or no enrollment files exist on disk, `runUnified` no longer fatal-exits. It logs one hint and polls the filesystem every 10s for the missing artefacts. SIGINT/SIGTERM exits cleanly. No fatal restart-loop under systemd.

### 2. First-class `nebula-agent enroll`

Takes `--config`, `--server`, `--token`, `--data-dir`, `--signing-key-path`, `--poll-interval`, `--force`. Writes `agent.yml` + the five enrollment files, then runs **one** synchronous signed poll so the operator sees "enrollment + first poll OK" in the same command. A failed first poll is logged but does **not** flip the exit code — the on-disk state is good; the idle daemon will retry. `--force` overrides an existing enrollment.

### 3. Move `host.signing.key` out of `/etc/nebula`

The Ed25519 poll signing key is the agent's concern (ADR 0004 PoP), not Nebula's, so it now lives at `/etc/nebula-agent/host.signing.key` — next to `agent.yml`. `/etc/nebula/` keeps only Nebula's own files (`host.key`, `host.crt`, `ca.crt`, `config.yml`). `agent.Enroll` and `PollerConfig` take an explicit `signingKeyPath`; `AgentConfig` gains a `SigningKeyPath` field with the new default.

### Packaging + docs

- `deploy/packaging/postinstall.sh` now runs `systemctl enable --now` on fresh install (DEB: empty `$1` or `configure` without `$2`; RPM: `1`); upgrades leave the enable-state alone; chroot builds skip via `[ -d /run/systemd/system ]`.
- `docs/agent.md` rewrites the Installation and Enrollment sections to match the new flow (apt install → idle service → `nebula-agent enroll`); the keys-on-disk table reflects the new signing-key location; the re-enroll walkthrough drops `host.signing.key` from the `/etc/nebula` cleanup list.

### Breaking changes (no migration shim — no fleet exists)

- `agent.Enroll` / `agent.Reenroll` signature gained a fourth `signingKeyPath` argument.
- `PollerConfig` gained a required `SigningKeyPath` field.
- `host.signing.key` path moved.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] `bash -n deploy/packaging/postinstall.sh`
- [x] New tests: `TestAgentConfig_DefaultsHaveSigningKeyPath`, `TestNewPoller_LoadsFromExplicitSigningKeyPath`, `TestNewPoller_RequiresSigningKeyPath`, `TestRun_StandbyWhenConfigMissing`, `TestRun_StandbyWhenCertMissing`, `TestCheckEnrollment_ReturnsCfgWhenReady`, `TestRun_LeavesStandbyAfterFilesAppear`, `TestEnrollSubcommand_WritesFiles`, `TestEnrollSubcommand_FirstPollFailureIsNonFatal`, `TestEnrollSubcommand_RefusesWhenAlreadyEnrolled`, `TestEnrollSubcommand_RequiresServerAndToken`.
- [x] Existing tests updated for the new `Enroll` / `PollerConfig` signatures and the new signing-key path.

Closes #88.
