### PR TITLE
fix(web): stop stats partial from nesting layout + Cache-Control: no-store on /ui/*

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -570,9 +570,8 @@ func (w *Web) handlePartialStats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	stats := computeStats(hosts, len(networks))
-	w.renderForRequest(rw, r, "dashboard.html", map[string]any{
-		"Active": "dashboard",
-		"Stats":  stats,
+	w.renderForRequest(rw, r, "stats_partial.html", map[string]any{
+		"Stats": stats,
 	})
 }
 

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -3,32 +3,7 @@
 {{define "content"}}
 <h1>Dashboard</h1>
 
-<div class="stats-grid" hx-get="/ui/partials/stats" hx-trigger="every 30s" hx-swap="outerHTML">
-    <div class="stat-card">
-        <div class="stat-value">{{.Stats.TotalHosts}}</div>
-        <div class="stat-label">Total Hosts</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-value">{{.Stats.EnrolledHosts}}</div>
-        <div class="stat-label">Enrolled</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-value">{{.Stats.PendingHosts}}</div>
-        <div class="stat-label">Pending</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-value">{{.Stats.BlockedHosts}}</div>
-        <div class="stat-label">Blocked</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-value">{{.Stats.Networks}}</div>
-        <div class="stat-label">Networks</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-value">{{.Stats.ExpiringCerts}}</div>
-        <div class="stat-label">Expiring Soon</div>
-    </div>
-</div>
+{{template "stats" .}}
 
 {{if .RecentHosts}}
 <div class="card">

--- a/internal/web/templates/stats_partial.html
+++ b/internal/web/templates/stats_partial.html
@@ -1,0 +1,28 @@
+{{define "stats"}}
+<div class="stats-grid" hx-get="/ui/partials/stats" hx-trigger="every 30s" hx-swap="outerHTML">
+    <div class="stat-card">
+        <div class="stat-value">{{.Stats.TotalHosts}}</div>
+        <div class="stat-label">Total Hosts</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-value">{{.Stats.EnrolledHosts}}</div>
+        <div class="stat-label">Enrolled</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-value">{{.Stats.PendingHosts}}</div>
+        <div class="stat-label">Pending</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-value">{{.Stats.BlockedHosts}}</div>
+        <div class="stat-label">Blocked</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-value">{{.Stats.Networks}}</div>
+        <div class="stat-label">Networks</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-value">{{.Stats.ExpiringCerts}}</div>
+        <div class="stat-label">Expiring Soon</div>
+    </div>
+</div>
+{{end}}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -55,6 +55,17 @@ func (w *Web) WithRateLimiter(l *ratelimit.Limiter) {
 	w.setupRoutes()
 }
 
+// noStore tells the browser not to cache UI responses. Without this Chrome
+// will sometimes serve a stale page from bfcache after a 303 redirect lands
+// back on the same URL, so freshly created networks / hosts only appear
+// after a hard reload.
+func (w *Web) noStore(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Cache-Control", "no-store")
+		next.ServeHTTP(rw, r)
+	})
+}
+
 // rateLimitMiddleware blocks requests for ip+group when the bucket is
 // drained. Audit log calls are made by the handler when the request is
 // admitted; rate-limited refusals only emit the 429 + Retry-After here.
@@ -135,7 +146,12 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		"ca_detail.html",
 	}
 	for _, page := range pages {
-		tmpl, err := template.ParseFS(templateFS, "templates/layout.html", "templates/"+page)
+		files := []string{"templates/layout.html", "templates/" + page}
+		// dashboard.html references the "stats" partial via {{template "stats" .}}
+		if page == "dashboard.html" {
+			files = append(files, "templates/stats_partial.html")
+		}
+		tmpl, err := template.ParseFS(templateFS, files...)
 		if err != nil {
 			return nil, fmt.Errorf("parse template %s: %w", page, err)
 		}
@@ -150,6 +166,15 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		}
 		w.templates[page] = tmpl
 	}
+
+	// Standalone partial for HTMX polling — rendered without layout so the
+	// `every 30s` swap on .stats-grid does not embed a whole new sidebar +
+	// dashboard inside the existing one.
+	partial, err := template.ParseFS(templateFS, "templates/stats_partial.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse stats_partial.html: %w", err)
+	}
+	w.templates["stats_partial.html"] = partial
 
 	w.setupRoutes()
 	return w, nil
@@ -187,6 +212,7 @@ func (w *Web) setupRoutes() {
 	r.Group(func(r chi.Router) {
 		r.Use(w.rateLimitMiddleware("ui"))
 		r.Use(w.requireAuth)
+		r.Use(w.noStore)
 		r.Get("/ui/", w.handleDashboard)
 		r.Get("/ui/hosts", w.handleHosts)
 		r.Get("/ui/hosts/new", w.handleHostNew)
@@ -273,6 +299,9 @@ func (w *Web) render(rw http.ResponseWriter, name string, data any) {
 	execName := "layout.html"
 	if name == "login.html" || name == "login_totp.html" || name == "register.html" {
 		execName = name
+	}
+	if name == "stats_partial.html" {
+		execName = "stats"
 	}
 	var buf bytes.Buffer
 	if err := tmpl.ExecuteTemplate(&buf, execName, data); err != nil {


### PR DESCRIPTION
## Summary

- `/ui/partials/stats` rendered the full `dashboard.html` through the layout, so the htmx 30s `outerHTML` swap embedded a fresh sidebar+main inside `.stats-grid` every cycle — the UI visibly nested itself three deep after ~90s. Split the stats markup into a standalone `stats_partial.html` parsed both into `dashboard.html` (as the named `stats` block) and as a layout-less template for the partial endpoint.
- Add a `noStore` middleware that sets `Cache-Control: no-store` on every protected `/ui/*` response. Without it Chrome's bfcache served pre-create snapshots of `/ui/networks` and `/ui/hosts` back after the `303 See Other` redirect, masking newly created records until a hard reload.

## Test plan

- [ ] `go test ./internal/web/...`
- [ ] Local smoke: open dashboard, wait ≥ 90s, confirm no nested sidebars appear in DOM.
- [ ] Local smoke: create a network in `/ui/networks`, verify it shows up after the 303 redirect without a hard reload.
- [ ] `curl -I` on `/ui/networks` shows `Cache-Control: no-store`.
- [ ] `curl` on `/ui/partials/stats` returns only the `<div class="stats-grid">` fragment (no `<body>`, no `<nav>`).
