### PR TITLE
fix(hosts): reject lighthouse/relay without public_ip+listen_port (closes #94)

### DIFF
--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -63,6 +63,10 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 	if role == "" {
 		role = models.HostRoleHost
 	}
+	if err := models.ValidateRoleReachability(role, req.PublicIP, req.ListenPort); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	if err := validateHostAdvanced(req.Advanced); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())

--- a/internal/api/hosts_role_reachability_test.go
+++ b/internal/api/hosts_role_reachability_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// TestCreateHost_RoleReachability mirrors issue #94 — a host created with
+// role=lighthouse or role=relay must carry a non-empty public_ip and a
+// non-zero listen_port; otherwise the host is never advertised to peers
+// and the operator only notices via peer config inspection.
+func TestCreateHost_RoleReachability(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	cases := []struct {
+		name       string
+		role       string
+		publicIP   string
+		listenPort int
+		nebulaIP   string
+		want       int
+		wantSubstr string
+	}{
+		{
+			name:       "lighthouse without public_ip is rejected",
+			role:       "lighthouse",
+			publicIP:   "",
+			listenPort: 4242,
+			nebulaIP:   "192.168.100.10",
+			want:       http.StatusBadRequest,
+			wantSubstr: "public_ip",
+		},
+		{
+			name:       "lighthouse without listen_port is rejected",
+			role:       "lighthouse",
+			publicIP:   "203.0.113.1",
+			listenPort: 0,
+			nebulaIP:   "192.168.100.11",
+			want:       http.StatusBadRequest,
+			wantSubstr: "listen_port",
+		},
+		{
+			name:       "relay without public_ip is rejected",
+			role:       "relay",
+			publicIP:   "",
+			listenPort: 4242,
+			nebulaIP:   "192.168.100.12",
+			want:       http.StatusBadRequest,
+			wantSubstr: "public_ip",
+		},
+		{
+			name:       "relay without listen_port is rejected",
+			role:       "relay",
+			publicIP:   "203.0.113.2",
+			listenPort: 0,
+			nebulaIP:   "192.168.100.13",
+			want:       http.StatusBadRequest,
+			wantSubstr: "listen_port",
+		},
+		{
+			name:       "host role allows empty reachability",
+			role:       "host",
+			publicIP:   "",
+			listenPort: 0,
+			nebulaIP:   "192.168.100.14",
+			want:       http.StatusCreated,
+		},
+		{
+			name:       "lighthouse with both fields is accepted",
+			role:       "lighthouse",
+			publicIP:   "203.0.113.3",
+			listenPort: 4242,
+			nebulaIP:   "192.168.100.15",
+			want:       http.StatusCreated,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(createHostRequest{
+				NetworkID:  netID,
+				Name:       "h-" + strings.ReplaceAll(tc.name, " ", "-"),
+				NebulaIP:   tc.nebulaIP,
+				Role:       tc.role,
+				PublicIP:   tc.publicIP,
+				ListenPort: tc.listenPort,
+			})
+			req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+			authRequest(req)
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d, body: %s", w.Code, tc.want, w.Body.String())
+			}
+			if tc.wantSubstr != "" && !strings.Contains(w.Body.String(), tc.wantSubstr) {
+				t.Errorf("body = %q, want substring %q", w.Body.String(), tc.wantSubstr)
+			}
+			if tc.want == http.StatusCreated {
+				var resp createHostResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("decode response: %v", err)
+				}
+				if resp.Host.Role != models.HostRole(tc.role) {
+					t.Errorf("role = %q, want %q", resp.Host.Role, tc.role)
+				}
+			}
+		})
+	}
+}

--- a/internal/models/host.go
+++ b/internal/models/host.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"errors"
+	"strings"
+	"time"
+)
 
 type HostStatus string
 
@@ -26,6 +30,36 @@ func ValidRole(r HostRole) bool {
 	default:
 		return false
 	}
+}
+
+// ErrRoleRequiresPublicIP is returned when a host with role=lighthouse or
+// role=relay is created without a non-empty public_ip. Such a host would
+// never be advertised to peers (see internal/api/enroll.go where
+// static_host_map / lighthouse.hosts only include hosts whose PublicIP is
+// set), so accept-and-silently-drop is replaced with reject-at-create.
+var ErrRoleRequiresPublicIP = errors.New("public_ip is required when role is lighthouse or relay")
+
+// ErrRoleRequiresListenPort is the listen_port counterpart of
+// ErrRoleRequiresPublicIP: peers compose static_host_map entries as
+// "public_ip:listen_port", so a zero port produces the same silent failure.
+var ErrRoleRequiresListenPort = errors.New("listen_port is required when role is lighthouse or relay")
+
+// ValidateRoleReachability rejects role/reachability combinations that
+// would result in a silently-useless host. role=lighthouse and role=relay
+// must both ship with a routable public_ip and a non-zero listen_port —
+// otherwise peer config.yml renders an empty static_host_map and the host
+// is never dialed (issue #94).
+func ValidateRoleReachability(role HostRole, publicIP string, listenPort int) error {
+	if role != HostRoleLighthouse && role != HostRoleRelay {
+		return nil
+	}
+	if strings.TrimSpace(publicIP) == "" {
+		return ErrRoleRequiresPublicIP
+	}
+	if listenPort == 0 {
+		return ErrRoleRequiresListenPort
+	}
+	return nil
 }
 
 type Host struct {

--- a/internal/models/host_test.go
+++ b/internal/models/host_test.go
@@ -1,6 +1,9 @@
 package models
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestValidRole(t *testing.T) {
 	tests := []struct {
@@ -20,6 +23,44 @@ func TestValidRole(t *testing.T) {
 		t.Run(string(tt.role), func(t *testing.T) {
 			if got := ValidRole(tt.role); got != tt.want {
 				t.Errorf("ValidRole(%q) = %v, want %v", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateRoleReachability(t *testing.T) {
+	tests := []struct {
+		name       string
+		role       HostRole
+		publicIP   string
+		listenPort int
+		wantErr    error
+	}{
+		{"host: no constraints", HostRoleHost, "", 0, nil},
+		{"host: empty alias", "", "", 0, nil},
+		{"lighthouse: both set", HostRoleLighthouse, "203.0.113.1", 4242, nil},
+		{"relay: both set", HostRoleRelay, "203.0.113.2", 4242, nil},
+
+		{"lighthouse: missing public_ip", HostRoleLighthouse, "", 4242, ErrRoleRequiresPublicIP},
+		{"lighthouse: whitespace public_ip", HostRoleLighthouse, "   ", 4242, ErrRoleRequiresPublicIP},
+		{"lighthouse: missing listen_port", HostRoleLighthouse, "203.0.113.1", 0, ErrRoleRequiresListenPort},
+		{"lighthouse: both missing → public_ip wins", HostRoleLighthouse, "", 0, ErrRoleRequiresPublicIP},
+
+		{"relay: missing public_ip", HostRoleRelay, "", 4242, ErrRoleRequiresPublicIP},
+		{"relay: missing listen_port", HostRoleRelay, "203.0.113.1", 0, ErrRoleRequiresListenPort},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateRoleReachability(tt.role, tt.publicIP, tt.listenPort)
+			if tt.wantErr == nil {
+				if got != nil {
+					t.Errorf("got error %v, want nil", got)
+				}
+				return
+			}
+			if !errors.Is(got, tt.wantErr) {
+				t.Errorf("got error %v, want %v", got, tt.wantErr)
 			}
 		})
 	}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -653,6 +653,11 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 	if role == "" {
 		role = models.HostRoleHost
 	}
+	publicIP := r.FormValue("public_ip")
+	if err := models.ValidateRoleReachability(role, publicIP, listenPort); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	var groups []string
 	if g := strings.TrimSpace(r.FormValue("groups")); g != "" {
@@ -680,7 +685,7 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		Role:         role,
 		IsLighthouse: role == models.HostRoleLighthouse,
 		IsRelay:      role == models.HostRoleRelay,
-		PublicIP:     r.FormValue("public_ip"),
+		PublicIP:     publicIP,
 		ListenPort:   listenPort,
 		Status:       models.HostStatusPending,
 		Advanced:     advanced,

--- a/internal/web/host_role_reachability_test.go
+++ b/internal/web/host_role_reachability_test.go
@@ -1,0 +1,102 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// TestCreateHostViaUI_RoleReachability mirrors issue #94 — the host create
+// form must reject role=lighthouse / role=relay without a non-empty
+// public_ip and a non-zero listen_port. Without this, peer config.yml
+// silently renders an empty static_host_map and the lighthouse is never
+// dialed.
+func TestCreateHostViaUI_RoleReachability(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "net-rr", Name: "test", CIDR: "10.0.0.0/24", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name       string
+		role       string
+		publicIP   string
+		listenPort string
+		nebulaIP   string
+		wantStatus int
+		wantSubstr string
+	}{
+		{
+			name:       "lighthouse without public_ip rejected",
+			role:       "lighthouse",
+			publicIP:   "",
+			listenPort: "4242",
+			nebulaIP:   "10.0.0.5",
+			wantStatus: http.StatusBadRequest,
+			wantSubstr: "public_ip",
+		},
+		{
+			name:       "lighthouse without listen_port rejected",
+			role:       "lighthouse",
+			publicIP:   "203.0.113.1",
+			listenPort: "",
+			nebulaIP:   "10.0.0.6",
+			wantStatus: http.StatusBadRequest,
+			wantSubstr: "listen_port",
+		},
+		{
+			name:       "relay without public_ip rejected",
+			role:       "relay",
+			publicIP:   "",
+			listenPort: "4242",
+			nebulaIP:   "10.0.0.7",
+			wantStatus: http.StatusBadRequest,
+			wantSubstr: "public_ip",
+		},
+		{
+			name:       "lighthouse with both fields accepted",
+			role:       "lighthouse",
+			publicIP:   "203.0.113.2",
+			listenPort: "4242",
+			nebulaIP:   "10.0.0.8",
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			form := url.Values{
+				"network_id":  {"net-rr"},
+				"name":        {"h-" + strings.ReplaceAll(tc.name, " ", "-")},
+				"nebula_ip":   {tc.nebulaIP},
+				"role":        {tc.role},
+				"public_ip":   {tc.publicIP},
+				"listen_port": {tc.listenPort},
+			}
+			req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			for _, c := range cookies {
+				req.AddCookie(c)
+			}
+			rec := httptest.NewRecorder()
+			w.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d, body: %s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantSubstr != "" && !strings.Contains(rec.Body.String(), tc.wantSubstr) {
+				t.Errorf("body = %q, want substring %q", rec.Body.String(), tc.wantSubstr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Reject creation of `role=lighthouse` / `role=relay` hosts that lack a non-empty `public_ip` or a non-zero `listen_port`.
- Add `models.ValidateRoleReachability` + sentinel errors `ErrRoleRequiresPublicIP` / `ErrRoleRequiresListenPort`.
- Wire the check into both create paths: `POST /api/v1/hosts` and `POST /ui/hosts`.

## Why

Previously such a host succeeded silently but was never embedded into peer config (`static_host_map` / `lighthouse.hosts` in `internal/api/enroll.go` skip it when `PublicIP == ""`), so the lighthouse looked enrolled while no peer could dial it. The operator only noticed by inspecting a peer's rendered `config.yml`.

## Test plan

- [x] `go test -race ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New unit tests:
  - `internal/models`: `TestValidateRoleReachability` (host/lighthouse/relay × missing/whitespace/both)
  - `internal/api`: `TestCreateHost_RoleReachability` (API rejects each missing combination, accepts both)
  - `internal/web`: `TestCreateHostViaUI_RoleReachability` (UI same matrix)

Closes #94.
