### PR TITLE
fix(web): render inline form errors on host/network create (closes #91)

### DIFF
--- a/internal/web/form_inline_errors_test.go
+++ b/internal/web/form_inline_errors_test.go
@@ -1,0 +1,176 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// TestHostCreate_InlineErrorPreservesForm — issue #91. On a host-create
+// validation failure the server must re-render host_new.html (not a
+// bare 400 error page), preserve the operator's input, and show the
+// error inline.
+func TestHostCreate_InlineErrorPreservesForm(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "net-inline", Name: "test", CIDR: "10.0.0.0/24", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Submit a duplicate-IP / out-of-CIDR error to exercise the
+	// nebula_ip branch. 10.0.0.300 is not a valid IPv4 address, which
+	// trips netip.ParseAddr inside validateHostIPForNetwork.
+	form := url.Values{
+		"network_id":      {"net-inline"},
+		"name":            {"preserved-name"},
+		"nebula_ip":       {"10.99.99.99"}, // outside 10.0.0.0/24
+		"role":            {"host"},
+		"groups":          {"web, prod"},
+		"adv_listen_host": {"0.0.0.0"},
+	}
+	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+
+	// Re-rendered the form, not a bare error page.
+	if !strings.Contains(body, `name="name"`) || !strings.Contains(body, `name="nebula_ip"`) {
+		t.Fatalf("body is not the host_new form:\n%s", body)
+	}
+	// Submitted values preserved.
+	if !strings.Contains(body, `value="preserved-name"`) {
+		t.Errorf("body should preserve submitted Name field: missing value=\"preserved-name\"")
+	}
+	if !strings.Contains(body, `value="10.99.99.99"`) {
+		t.Errorf("body should preserve submitted nebula_ip field")
+	}
+	if !strings.Contains(body, `value="web, prod"`) {
+		t.Errorf("body should preserve submitted groups field")
+	}
+	// Selected network is sticky.
+	if !strings.Contains(body, `value="net-inline" selected`) {
+		t.Errorf("selected network option should be marked selected:\n%s", body)
+	}
+	// Error banner is rendered with the actual reason from validateHostIP.
+	if !strings.Contains(body, `role="alert"`) {
+		t.Errorf("body should render alert banner; got:\n%s", body)
+	}
+}
+
+func TestHostCreate_InlineErrorPreservesRole(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "net-role", Name: "n", CIDR: "10.0.0.0/24", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"network_id": {"net-role"},
+		"name":       {"lh-1"},
+		"nebula_ip":  {"10.0.0.5"},
+		"role":       {"lighthouse"}, // requires public_ip + listen_port → fails
+	}
+	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `value="lighthouse" selected`) {
+		t.Errorf("body should preserve selected role=lighthouse:\n%s", body)
+	}
+	if !strings.Contains(body, "public_ip") {
+		t.Errorf("body should explain why the form failed; missing the word 'public_ip'")
+	}
+}
+
+// TestNetworkCreate_InlineErrorPreservesForm — issue #91 for the network
+// create form (which lives expanded on /ui/networks).
+func TestNetworkCreate_InlineErrorPreservesForm(t *testing.T) {
+	w, _ := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	form := url.Values{
+		"name": {"prod-net"},
+		"cidr": {"not-a-cidr"},
+	}
+	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `value="prod-net"`) {
+		t.Errorf("body should preserve submitted Name")
+	}
+	if !strings.Contains(body, `value="not-a-cidr"`) {
+		t.Errorf("body should preserve submitted CIDR")
+	}
+	if !strings.Contains(body, `role="alert"`) {
+		t.Errorf("body should render alert banner")
+	}
+	if !strings.Contains(body, `invalid CIDR`) {
+		t.Errorf("body should contain the actual error explanation; got:\n%s", body)
+	}
+	// The create form should not be hidden on validation error.
+	if strings.Contains(body, `id="new-network" class="card" style="display:none"`) {
+		t.Errorf("create form should be visible (not display:none) on validation error")
+	}
+}
+
+func TestNetworkCreate_InlineErrorRequiredFields(t *testing.T) {
+	w, _ := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	form := url.Values{
+		"name": {""},
+		"cidr": {""},
+	}
+	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `name and cidr are required`) {
+		t.Errorf("body should explain missing fields; got:\n%s", rec.Body.String())
+	}
+}

--- a/internal/web/form_state.go
+++ b/internal/web/form_state.go
@@ -1,0 +1,92 @@
+package web
+
+import "net/http"
+
+// hostFormState captures the values submitted to /ui/hosts so a validation
+// failure can re-render host_new.html with the operator's inputs preserved
+// instead of dropping them on a bare 400 error page (issue #91).
+//
+// String types throughout — including ListenPort and AdvMTU — so that the
+// template can echo the operator's literal input back verbatim ("70000")
+// even when it failed numeric validation.
+type hostFormState struct {
+	NetworkID       string
+	Name            string
+	NebulaIP        string
+	Role            string
+	Groups          string
+	PublicIP        string
+	ListenPort      string
+	AdvListenHost   string
+	AdvMTU          string
+	AdvTunDevice    string
+	AdvPunchy       string
+	AdvUnsafeRoutes string
+}
+
+func newHostFormState(r *http.Request) hostFormState {
+	return hostFormState{
+		NetworkID:       r.FormValue("network_id"),
+		Name:            r.FormValue("name"),
+		NebulaIP:        r.FormValue("nebula_ip"),
+		Role:            r.FormValue("role"),
+		Groups:          r.FormValue("groups"),
+		PublicIP:        r.FormValue("public_ip"),
+		ListenPort:      r.FormValue("listen_port"),
+		AdvListenHost:   r.FormValue("adv_listen_host"),
+		AdvMTU:          r.FormValue("adv_mtu"),
+		AdvTunDevice:    r.FormValue("adv_tun_device"),
+		AdvPunchy:       r.FormValue("adv_punchy"),
+		AdvUnsafeRoutes: r.FormValue("adv_unsafe_routes"),
+	}
+}
+
+// networkFormState is the network-create equivalent of hostFormState.
+type networkFormState struct {
+	Name string
+	CIDR string
+}
+
+func newNetworkFormState(r *http.Request) networkFormState {
+	return networkFormState{
+		Name: r.FormValue("name"),
+		CIDR: r.FormValue("cidr"),
+	}
+}
+
+// renderHostNewError re-renders /ui/hosts/new with the submitted form
+// values preserved and an inline error banner. Returns 400 because the
+// request payload is the cause; the body is a full HTML page so the
+// browser does not show a bare error.
+func (w *Web) renderHostNewError(rw http.ResponseWriter, r *http.Request, form hostFormState, errMsg string) {
+	networks, err := w.store.ListNetworks(r.Context())
+	if err != nil {
+		w.logger.Error("list networks for host form", "error", err)
+		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
+		return
+	}
+	w.renderForRequestWithStatus(rw, r, http.StatusBadRequest, "host_new.html", map[string]any{
+		"Active":   "hosts",
+		"Networks": networks,
+		"Form":     form,
+		"Error":    errMsg,
+	})
+}
+
+// renderNetworksError re-renders /ui/networks with the create form
+// expanded, the submitted values preserved, and an inline error banner.
+func (w *Web) renderNetworksError(rw http.ResponseWriter, r *http.Request, form networkFormState, errMsg string) {
+	networks, err := w.store.ListNetworks(r.Context())
+	if err != nil {
+		w.logger.Error("list networks", "error", err)
+		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
+		return
+	}
+	w.renderForRequestWithStatus(rw, r, http.StatusBadRequest, "networks.html", map[string]any{
+		"Active":     "networks",
+		"Networks":   networks,
+		"Form":       form,
+		"Error":      errMsg,
+		"ShowCreate": true,
+	})
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -607,6 +607,8 @@ func (w *Web) handleHostNew(rw http.ResponseWriter, r *http.Request) {
 	w.renderForRequest(rw, r, "host_new.html", map[string]any{
 		"Active":   "hosts",
 		"Networks": networks,
+		"Form":     hostFormState{},
+		"Error":    "",
 	})
 }
 
@@ -616,50 +618,50 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	nebulaIP := r.FormValue("nebula_ip")
-	networkID := r.FormValue("network_id")
+	form := newHostFormState(r)
+
+	nebulaIP := form.NebulaIP
+	networkID := form.NetworkID
 	if nebulaIP != "" && networkID != "" {
 		if err := validateHostIPForNetwork(r.Context(), w.store, networkID, nebulaIP, ""); err != nil {
-			http.Error(rw, err.Error(), http.StatusBadRequest)
+			w.renderHostNewError(rw, r, form, err.Error())
 			return
 		}
 	} else if nebulaIP != "" {
 		if _, err := netip.ParseAddr(nebulaIP); err != nil {
-			http.Error(rw, "invalid nebula_ip: "+err.Error(), http.StatusBadRequest)
+			w.renderHostNewError(rw, r, form, "invalid nebula_ip: "+err.Error())
 			return
 		}
 	}
 
-	listenPortStr := r.FormValue("listen_port")
 	var listenPort int
-	if listenPortStr != "" {
+	if form.ListenPort != "" {
 		var err error
-		listenPort, err = strconv.Atoi(listenPortStr)
+		listenPort, err = strconv.Atoi(form.ListenPort)
 		if err != nil {
-			http.Error(rw, "invalid listen_port: must be a number", http.StatusBadRequest)
+			w.renderHostNewError(rw, r, form, "invalid listen_port: must be a number")
 			return
 		}
 		if listenPort < 0 || listenPort > 65535 {
-			http.Error(rw, "listen_port must be between 0 and 65535", http.StatusBadRequest)
+			w.renderHostNewError(rw, r, form, "listen_port must be between 0 and 65535")
 			return
 		}
 	}
-	role := models.HostRole(r.FormValue("role"))
+	role := models.HostRole(form.Role)
 	if !models.ValidRole(role) {
-		http.Error(rw, "invalid role", http.StatusBadRequest)
+		w.renderHostNewError(rw, r, form, "invalid role")
 		return
 	}
 	if role == "" {
 		role = models.HostRoleHost
 	}
-	publicIP := r.FormValue("public_ip")
-	if err := models.ValidateRoleReachability(role, publicIP, listenPort); err != nil {
-		http.Error(rw, err.Error(), http.StatusBadRequest)
+	if err := models.ValidateRoleReachability(role, form.PublicIP, listenPort); err != nil {
+		w.renderHostNewError(rw, r, form, err.Error())
 		return
 	}
 
 	var groups []string
-	if g := strings.TrimSpace(r.FormValue("groups")); g != "" {
+	if g := strings.TrimSpace(form.Groups); g != "" {
 		for _, s := range strings.Split(g, ",") {
 			groups = append(groups, strings.TrimSpace(s))
 		}
@@ -670,21 +672,21 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 
 	advanced, err := parseAdvancedFromForm(r)
 	if err != nil {
-		http.Error(rw, err.Error(), http.StatusBadRequest)
+		w.renderHostNewError(rw, r, form, err.Error())
 		return
 	}
 
 	now := time.Now()
 	host := &models.Host{
 		ID:           uuid.New().String(),
-		NetworkID:    r.FormValue("network_id"),
-		Name:         r.FormValue("name"),
+		NetworkID:    networkID,
+		Name:         form.Name,
 		NebulaIP:     nebulaIP,
 		Groups:       groups,
 		Role:         role,
 		IsLighthouse: role == models.HostRoleLighthouse,
 		IsRelay:      role == models.HostRoleRelay,
-		PublicIP:     publicIP,
+		PublicIP:     form.PublicIP,
 		ListenPort:   listenPort,
 		Status:       models.HostStatusPending,
 		Advanced:     advanced,
@@ -774,8 +776,11 @@ func (w *Web) handleNetworks(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.renderForRequest(rw, r, "networks.html", map[string]any{
-		"Active":   "networks",
-		"Networks": networks,
+		"Active":     "networks",
+		"Networks":   networks,
+		"Form":       networkFormState{},
+		"Error":      "",
+		"ShowCreate": false,
 	})
 }
 
@@ -784,21 +789,20 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "bad request", http.StatusBadRequest)
 		return
 	}
-	name := r.FormValue("name")
-	cidr := r.FormValue("cidr")
-	if name == "" || cidr == "" {
-		http.Error(rw, "name and cidr are required", http.StatusBadRequest)
+	form := newNetworkFormState(r)
+	if form.Name == "" || form.CIDR == "" {
+		w.renderNetworksError(rw, r, form, "name and cidr are required")
 		return
 	}
-	if _, err := netip.ParsePrefix(cidr); err != nil {
-		http.Error(rw, "invalid CIDR: "+err.Error(), http.StatusBadRequest)
+	if _, err := netip.ParsePrefix(form.CIDR); err != nil {
+		w.renderNetworksError(rw, r, form, "invalid CIDR: "+err.Error())
 		return
 	}
 
 	network := &models.Network{
 		ID:        uuid.New().String(),
-		Name:      name,
-		CIDR:      cidr,
+		Name:      form.Name,
+		CIDR:      form.CIDR,
 		CreatedAt: time.Now(),
 	}
 

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -4,46 +4,48 @@
 <h1>New Host</h1>
 
 <div class="card">
+    {{if .Error}}<div class="error" role="alert" style="color: var(--danger); margin-bottom: 16px;">{{.Error}}</div>{{end}}
     <form method="POST" action="/ui/hosts">
         <div class="form-group">
             <label>Network</label>
             <select name="network_id" class="form-control" required>
                 <option value="">Select network...</option>
+                {{$selected := .Form.NetworkID}}
                 {{range .Networks}}
-                <option value="{{.ID}}">{{.Name}} ({{.CIDR}})</option>
+                <option value="{{.ID}}"{{if eq .ID $selected}} selected{{end}}>{{.Name}} ({{.CIDR}})</option>
                 {{end}}
             </select>
         </div>
         <div class="form-group">
             <label>Name</label>
-            <input type="text" name="name" class="form-control" placeholder="web-1" required>
+            <input type="text" name="name" class="form-control" placeholder="web-1" value="{{.Form.Name}}" required>
         </div>
         <div class="form-group">
             <label>Nebula IP</label>
-            <input type="text" name="nebula_ip" class="form-control" placeholder="192.168.100.10" required>
+            <input type="text" name="nebula_ip" class="form-control" placeholder="192.168.100.10" value="{{.Form.NebulaIP}}" required>
         </div>
         <div class="form-group">
             <label>Role</label>
             <select name="role" class="form-control">
-                <option value="host">Host</option>
-                <option value="lighthouse">Lighthouse</option>
-                <option value="relay">Relay</option>
+                <option value="host"{{if eq .Form.Role "host"}} selected{{end}}>Host</option>
+                <option value="lighthouse"{{if eq .Form.Role "lighthouse"}} selected{{end}}>Lighthouse</option>
+                <option value="relay"{{if eq .Form.Role "relay"}} selected{{end}}>Relay</option>
             </select>
         </div>
         <div class="form-group">
             <label>Groups (comma-separated)</label>
-            <input type="text" name="groups" class="form-control" placeholder="web, prod">
+            <input type="text" name="groups" class="form-control" placeholder="web, prod" value="{{.Form.Groups}}">
         </div>
         <div class="form-group">
             <label>Public IP (for lighthouse/relay)</label>
-            <input type="text" name="public_ip" class="form-control" placeholder="203.0.113.10">
+            <input type="text" name="public_ip" class="form-control" placeholder="203.0.113.10" value="{{.Form.PublicIP}}">
         </div>
         <div class="form-group">
             <label>Listen Port (for lighthouse/relay)</label>
-            <input type="number" name="listen_port" class="form-control" placeholder="4242">
+            <input type="number" name="listen_port" class="form-control" placeholder="4242" value="{{.Form.ListenPort}}">
         </div>
 
-        <details style="margin: 16px 0;">
+        <details style="margin: 16px 0;"{{if or .Form.AdvListenHost .Form.AdvMTU .Form.AdvTunDevice .Form.AdvPunchy .Form.AdvUnsafeRoutes}} open{{end}}>
             <summary style="cursor: pointer; padding: 8px; color: var(--text-muted); font-size: 14px;">
                 Advanced configuration (optional)
             </summary>
@@ -53,27 +55,27 @@
             </p>
             <div class="form-group">
                 <label>Listen host (advanced.listen_host)</label>
-                <input type="text" name="adv_listen_host" class="form-control" placeholder="0.0.0.0">
+                <input type="text" name="adv_listen_host" class="form-control" placeholder="0.0.0.0" value="{{.Form.AdvListenHost}}">
             </div>
             <div class="form-group">
                 <label>TUN MTU (advanced.mtu)</label>
-                <input type="number" name="adv_mtu" class="form-control" placeholder="1300" min="576" max="9216">
+                <input type="number" name="adv_mtu" class="form-control" placeholder="1300" min="576" max="9216" value="{{.Form.AdvMTU}}">
             </div>
             <div class="form-group">
                 <label>TUN device name (advanced.tun_device)</label>
-                <input type="text" name="adv_tun_device" class="form-control" placeholder="nebula1">
+                <input type="text" name="adv_tun_device" class="form-control" placeholder="nebula1" value="{{.Form.AdvTunDevice}}">
             </div>
             <div class="form-group">
                 <label>Punchy (advanced.punchy)</label>
                 <select name="adv_punchy" class="form-control">
-                    <option value="">inherit (true)</option>
-                    <option value="true">force true</option>
-                    <option value="false">disable</option>
+                    <option value=""{{if eq .Form.AdvPunchy ""}} selected{{end}}>inherit (true)</option>
+                    <option value="true"{{if eq .Form.AdvPunchy "true"}} selected{{end}}>force true</option>
+                    <option value="false"{{if eq .Form.AdvPunchy "false"}} selected{{end}}>disable</option>
                 </select>
             </div>
             <div class="form-group">
                 <label>Unsafe routes (one per line: <code>CIDR via NEBULA_IP</code>)</label>
-                <textarea name="adv_unsafe_routes" class="form-control" rows="3" placeholder="192.168.10.0/24 via 10.0.0.99"></textarea>
+                <textarea name="adv_unsafe_routes" class="form-control" rows="3" placeholder="192.168.10.0/24 via 10.0.0.99">{{.Form.AdvUnsafeRoutes}}</textarea>
             </div>
         </details>
 

--- a/internal/web/templates/networks.html
+++ b/internal/web/templates/networks.html
@@ -6,16 +6,17 @@
     <button class="btn btn-primary" onclick="document.getElementById('new-network').style.display='block'">+ New Network</button>
 </div>
 
-<div id="new-network" class="card" style="display:none">
+<div id="new-network" class="card"{{if not .ShowCreate}} style="display:none"{{end}}>
     <h2>Create Network</h2>
+    {{if .Error}}<div class="error" role="alert" style="color: var(--danger); margin-bottom: 16px;">{{.Error}}</div>{{end}}
     <form method="POST" action="/ui/networks">
         <div class="form-group">
             <label>Name</label>
-            <input type="text" name="name" class="form-control" placeholder="production" required>
+            <input type="text" name="name" class="form-control" placeholder="production" value="{{.Form.Name}}" required>
         </div>
         <div class="form-group">
             <label>CIDR</label>
-            <input type="text" name="cidr" class="form-control" placeholder="192.168.100.0/24" required>
+            <input type="text" name="cidr" class="form-control" placeholder="192.168.100.0/24" value="{{.Form.CIDR}}" required>
         </div>
         <button type="submit" class="btn btn-primary">Create</button>
     </form>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -279,16 +279,23 @@ func (w *Web) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 // without each handler having to pass it explicitly. Standalone login /
 // register pages take this path too — the field is just unused there.
 func (w *Web) renderForRequest(rw http.ResponseWriter, r *http.Request, name string, data map[string]any) {
+	w.renderForRequestWithStatus(rw, r, 0, name, data)
+}
+
+// renderForRequestWithStatus is renderForRequest with an explicit HTTP
+// status code (e.g. 400 for form validation errors). status=0 means "leave
+// it to net/http" (defaults to 200).
+func (w *Web) renderForRequestWithStatus(rw http.ResponseWriter, r *http.Request, status int, name string, data map[string]any) {
 	if data == nil {
 		data = map[string]any{}
 	}
 	if _, present := data["CurrentUser"]; !present {
 		data["CurrentUser"] = w.session.CurrentOperator(r)
 	}
-	w.render(rw, name, data)
+	w.renderWithStatus(rw, status, name, data)
 }
 
-func (w *Web) render(rw http.ResponseWriter, name string, data any) {
+func (w *Web) renderWithStatus(rw http.ResponseWriter, status int, name string, data map[string]any) {
 	tmpl, ok := w.templates[name]
 	if !ok {
 		w.logger.Error("template not found", "template", name)
@@ -310,6 +317,9 @@ func (w *Web) render(rw http.ResponseWriter, name string, data any) {
 		return
 	}
 	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if status != 0 {
+		rw.WriteHeader(status)
+	}
 	if _, err := buf.WriteTo(rw); err != nil {
 		w.logger.Error("write response", "template", name, "error", err)
 	}


### PR DESCRIPTION
## Summary

- `/ui/hosts` and `/ui/networks` re-render their forms on validation failure with the operator's input preserved and an inline error banner, instead of dumping a bare 400 error page.
- Add `hostFormState` / `networkFormState` value types and per-page error renderers (`renderHostNewError`, `renderNetworksError`).
- Make role/network/advanced-punchy options sticky; auto-expand the advanced section when any advanced field was filled in; auto-open the network create card when the re-render carries an error.

## Why

Previously a single `http.Error(rw, ..., 400)` per validation branch produced a blank white page with the raw error text. The only way back to the form was the browser's back button, which doesn't always preserve form input. This mirrors the pattern `handleRegister` already uses for `register.html`.

Status stays 400 — the request is at fault — but the body is now a full HTML page rendered into the same layout, so the browser does not blank-page.

## Test plan

- [x] `go test -race ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New unit tests:
  - `TestHostCreate_InlineErrorPreservesForm` — name/nebula_ip/groups/network preserved, alert rendered, error explanation included.
  - `TestHostCreate_InlineErrorPreservesRole` — role=lighthouse failure preserves the selected role and surfaces `public_ip` in the explanation.
  - `TestNetworkCreate_InlineErrorPreservesForm` — name + cidr preserved, alert rendered, create card visible (not `display:none`).
  - `TestNetworkCreate_InlineErrorRequiredFields` — missing both fields → explanatory error.

Closes #91.
