### PR TITLE
feat(web): pre-fill network prefix in Nebula IP field (closes #92)

### DIFF
--- a/internal/web/form_inline_errors_test.go
+++ b/internal/web/form_inline_errors_test.go
@@ -5,12 +5,21 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/juev/nebula-mesh/internal/models"
 )
+
+// hasSelectedOption reports whether body contains an <option> element with
+// value="<value>" that also carries the `selected` attribute. Other
+// attributes (data-cidr, name, …) between value and selected are allowed.
+func hasSelectedOption(body, value string) bool {
+	re := regexp.MustCompile(`<option [^>]*value="` + regexp.QuoteMeta(value) + `"[^>]* selected`)
+	return re.MatchString(body)
+}
 
 // TestHostCreate_InlineErrorPreservesForm — issue #91. On a host-create
 // validation failure the server must re-render host_new.html (not a
@@ -64,8 +73,10 @@ func TestHostCreate_InlineErrorPreservesForm(t *testing.T) {
 	if !strings.Contains(body, `value="web, prod"`) {
 		t.Errorf("body should preserve submitted groups field")
 	}
-	// Selected network is sticky.
-	if !strings.Contains(body, `value="net-inline" selected`) {
+	// Selected network is sticky — option for net-inline must carry the
+	// `selected` attribute, with any other attributes (data-cidr, …)
+	// allowed between value and selected.
+	if !hasSelectedOption(body, "net-inline") {
 		t.Errorf("selected network option should be marked selected:\n%s", body)
 	}
 	// Error banner is rendered with the actual reason from validateHostIP.
@@ -102,7 +113,7 @@ func TestHostCreate_InlineErrorPreservesRole(t *testing.T) {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, `value="lighthouse" selected`) {
+	if !hasSelectedOption(body, "lighthouse") {
 		t.Errorf("body should preserve selected role=lighthouse:\n%s", body)
 	}
 	if !strings.Contains(body, "public_ip") {

--- a/internal/web/host_new_prefix_hint_test.go
+++ b/internal/web/host_new_prefix_hint_test.go
@@ -1,0 +1,66 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// TestHostNewForm_NetworkOptionsHaveDataCIDR — issue #92. The network
+// <option> elements must carry data-cidr so the client-side prefill JS
+// can read the CIDR per option without round-tripping to the server.
+func TestHostNewForm_NetworkOptionsHaveDataCIDR(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	nets := []*models.Network{
+		{ID: "n-24", Name: "small", CIDR: "10.42.0.0/24", CreatedAt: time.Now()},
+		{ID: "n-16", Name: "medium", CIDR: "172.20.0.0/16", CreatedAt: time.Now()},
+		{ID: "n-12", Name: "odd", CIDR: "10.0.0.0/12", CreatedAt: time.Now()},
+	}
+	for _, n := range nets {
+		if err := s.CreateNetwork(ctx, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest("GET", "/ui/hosts/new", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	for _, n := range nets {
+		if !strings.Contains(body, `data-cidr="`+n.CIDR+`"`) {
+			t.Errorf("missing data-cidr=%q on option for network %s", n.CIDR, n.Name)
+		}
+	}
+
+	// The hint element + the prefill JS hook must be present.
+	if !strings.Contains(body, `id="nebula-ip-hint"`) {
+		t.Errorf(`body should contain id="nebula-ip-hint"`)
+	}
+	if !strings.Contains(body, `id="network-select"`) {
+		t.Errorf(`body should contain id="network-select"`)
+	}
+	if !strings.Contains(body, `id="nebula-ip-input"`) {
+		t.Errorf(`body should contain id="nebula-ip-input"`)
+	}
+	// The JS must include the byte-aligned-prefix routine so refactors
+	// don't silently drop it.
+	if !strings.Contains(body, "computeByteAlignedPrefix") {
+		t.Errorf("body should contain the computeByteAlignedPrefix JS helper")
+	}
+}

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -8,11 +8,11 @@
     <form method="POST" action="/ui/hosts">
         <div class="form-group">
             <label>Network</label>
-            <select name="network_id" class="form-control" required>
+            <select id="network-select" name="network_id" class="form-control" required>
                 <option value="">Select network...</option>
                 {{$selected := .Form.NetworkID}}
                 {{range .Networks}}
-                <option value="{{.ID}}"{{if eq .ID $selected}} selected{{end}}>{{.Name}} ({{.CIDR}})</option>
+                <option value="{{.ID}}" data-cidr="{{.CIDR}}"{{if eq .ID $selected}} selected{{end}}>{{.Name}} ({{.CIDR}})</option>
                 {{end}}
             </select>
         </div>
@@ -22,7 +22,8 @@
         </div>
         <div class="form-group">
             <label>Nebula IP</label>
-            <input type="text" name="nebula_ip" class="form-control" placeholder="192.168.100.10" value="{{.Form.NebulaIP}}" required>
+            <input id="nebula-ip-input" type="text" name="nebula_ip" class="form-control" placeholder="192.168.100.10" value="{{.Form.NebulaIP}}" required>
+            <div id="nebula-ip-hint" style="font-size: 12px; color: var(--text-muted); margin-top: 4px;"></div>
         </div>
         <div class="form-group">
             <label>Role</label>
@@ -82,4 +83,62 @@
         <button type="submit" class="btn btn-primary">Create Host</button>
     </form>
 </div>
+
+<script>
+(function() {
+    var sel = document.getElementById("network-select");
+    var ipInput = document.getElementById("nebula-ip-input");
+    var hint = document.getElementById("nebula-ip-hint");
+    if (!sel || !ipInput || !hint) {
+        return;
+    }
+
+    // computeByteAlignedPrefix returns the immutable octet prefix for a
+    // CIDR whose mask is a multiple of 8 (/8, /16, /24), e.g. "10.42.0/24"
+    // → "10.42.0.". Returns "" for any other mask — those need a free-form
+    // IP, so the JS shows only a hint instead of prefilling.
+    function computeByteAlignedPrefix(cidr) {
+        var m = /^(\d+)\.(\d+)\.(\d+)\.(\d+)\/(\d+)$/.exec(cidr);
+        if (!m) {
+            return "";
+        }
+        var bits = parseInt(m[5], 10);
+        if (bits === 8) { return m[1] + "."; }
+        if (bits === 16) { return m[1] + "." + m[2] + "."; }
+        if (bits === 24) { return m[1] + "." + m[2] + "." + m[3] + "."; }
+        return "";
+    }
+
+    var lastPrefix = "";
+
+    function update() {
+        var opt = sel.options[sel.selectedIndex];
+        var cidr = opt ? opt.getAttribute("data-cidr") : "";
+        if (!cidr) {
+            hint.textContent = "";
+            return;
+        }
+        var prefix = computeByteAlignedPrefix(cidr);
+        if (prefix) {
+            hint.textContent = "Network " + cidr + " — fill in the host portion only.";
+            // Replace the previous auto-filled prefix, but never clobber a
+            // value the operator typed in themselves (start of input differs
+            // from any known prefix we offered).
+            var current = ipInput.value;
+            if (current === "" || current === lastPrefix || (lastPrefix !== "" && current.indexOf(lastPrefix) === 0)) {
+                ipInput.value = prefix + (current.indexOf(lastPrefix) === 0 ? current.slice(lastPrefix.length) : "");
+            }
+            lastPrefix = prefix;
+        } else {
+            hint.textContent = "Network " + cidr + " — enter any IP within the range.";
+            lastPrefix = "";
+        }
+    }
+
+    sel.addEventListener("change", update);
+    // Run once on load so a re-rendered form (validation failure) or the
+    // initial GET with a single network selected still shows the hint.
+    update();
+})();
+</script>
 {{end}}


### PR DESCRIPTION
## Summary

- `/ui/hosts/new`: expand the network CIDR onto each `<option>` as `data-cidr`, then run a tiny script that:
  - prefills the Nebula IP input with the immutable byte-aligned prefix (`10.42.0.` for `/24`, `10.42.` for `/16`, `10.` for `/8`)
  - shows the chosen CIDR as a hint underneath
  - updates the prefix when the operator switches network
  - falls back to a textual hint for non-byte-aligned masks (`/12`, `/18`, `/23`) — those need a free-form IP, so prefilling would lie about the range
  - never clobbers a value the operator typed themselves (only replaces empty input or the previously auto-filled prefix)

## Why

The Nebula IP field used to be a free-form text input even though the network's CIDR pins the first N octets. Reduces typing and the most common class of "outside the network CIDR" mistakes. Server-side validation in `handleHostCreate` / `validateHostIPForNetwork` is unchanged; this is purely a cosmetic / UX nudge that survives the inline-error re-render from #91.

## Test plan

- [x] `go test -race ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestHostNewForm_NetworkOptionsHaveDataCIDR` — every network's CIDR is on `data-cidr`, the hint element + the JS hook are present.

Closes #92.
