### PR TITLE
fix(web): gate network/host creation on operator-owned CA (closes #93)

### DIFF
--- a/internal/web/form_state.go
+++ b/internal/web/form_state.go
@@ -1,6 +1,11 @@
 package web
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
 
 // hostFormState captures the values submitted to /ui/hosts so a validation
 // failure can re-render host_new.html with the operator's inputs preserved
@@ -42,49 +47,142 @@ func newHostFormState(r *http.Request) hostFormState {
 }
 
 // networkFormState is the network-create equivalent of hostFormState.
+// CAID captures the operator's CA selection so the form can re-render
+// without losing it (issue #93 enforces that every network is tied to a
+// CA the operator owns).
 type networkFormState struct {
 	Name string
 	CIDR string
+	CAID string
 }
 
 func newNetworkFormState(r *http.Request) networkFormState {
 	return networkFormState{
 		Name: r.FormValue("name"),
 		CIDR: r.FormValue("cidr"),
+		CAID: r.FormValue("ca_id"),
 	}
+}
+
+// accessibleActiveCAs returns the active CAs the operator is allowed to
+// pick as the signing CA for a new network. admins see every active CA in
+// the system; users see only their own (mirrors handleCAsList in cas.go,
+// plus a Status=Active filter so retired CAs cannot ground a new network).
+func (w *Web) accessibleActiveCAs(ctx context.Context, op *models.Operator) ([]*models.CA, error) {
+	var (
+		cas []*models.CA
+		err error
+	)
+	if op.Role == "admin" {
+		cas, err = w.store.ListCAs(ctx)
+	} else {
+		cas, err = w.store.ListCAsByOwner(ctx, op.ID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*models.CA, 0, len(cas))
+	for _, c := range cas {
+		if c.Status == models.CAStatusActive {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+// accessibleNetworks returns the networks an operator can attach a host
+// to. admins see every network; users see only networks whose CAID
+// points at a CA they own. Legacy networks with an empty CAID are
+// visible to admins (they predate per-operator CAs) and hidden from
+// users (issue #93 — a self-registered user must not silently inherit
+// the seed admin's CA).
+func (w *Web) accessibleNetworks(ctx context.Context, op *models.Operator) ([]*models.Network, error) {
+	networks, err := w.store.ListNetworks(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if op.Role == "admin" {
+		return networks, nil
+	}
+	cas, err := w.store.ListCAsByOwner(ctx, op.ID)
+	if err != nil {
+		return nil, err
+	}
+	owned := make(map[string]struct{}, len(cas))
+	for _, c := range cas {
+		owned[c.ID] = struct{}{}
+	}
+	out := make([]*models.Network, 0, len(networks))
+	for _, n := range networks {
+		if n.CAID == "" {
+			continue
+		}
+		if _, ok := owned[n.CAID]; ok {
+			out = append(out, n)
+		}
+	}
+	return out, nil
+}
+
+// containsCAID reports whether the slice of CAs contains one with the
+// given id. Linear scan — caller pages are always small (admins rarely
+// have more than a handful of CAs, users have one or two).
+func containsCAID(cas []*models.CA, id string) bool {
+	for _, c := range cas {
+		if c.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 // renderHostNewError re-renders /ui/hosts/new with the submitted form
 // values preserved and an inline error banner. Returns 400 because the
 // request payload is the cause; the body is a full HTML page so the
-// browser does not show a bare error.
+// browser does not show a bare error. Networks are filtered through
+// accessibleNetworks so the operator only sees networks they own
+// (issue #93).
 func (w *Web) renderHostNewError(rw http.ResponseWriter, r *http.Request, form hostFormState, errMsg string) {
-	networks, err := w.store.ListNetworks(r.Context())
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	networks, err := w.accessibleNetworks(r.Context(), op)
 	if err != nil {
 		w.logger.Error("list networks for host form", "error", err)
 		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
 		return
 	}
 	w.renderForRequestWithStatus(rw, r, http.StatusBadRequest, "host_new.html", map[string]any{
-		"Active":   "hosts",
-		"Networks": networks,
-		"Form":     form,
-		"Error":    errMsg,
+		"Active":      "hosts",
+		"Networks":    networks,
+		"HasNetworks": len(networks) > 0,
+		"Form":        form,
+		"Error":       errMsg,
 	})
 }
 
 // renderNetworksError re-renders /ui/networks with the create form
 // expanded, the submitted values preserved, and an inline error banner.
-func (w *Web) renderNetworksError(rw http.ResponseWriter, r *http.Request, form networkFormState, errMsg string) {
+// cas is the list of CAs the operator may pick from (issue #93). When
+// empty the template hides the create form and shows the "create a CA
+// first" alert instead.
+func (w *Web) renderNetworksError(rw http.ResponseWriter, r *http.Request, form networkFormState, cas []*models.CA, errMsg string) {
 	networks, err := w.store.ListNetworks(r.Context())
 	if err != nil {
 		w.logger.Error("list networks", "error", err)
 		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
 		return
 	}
+	op := w.session.CurrentOperator(r)
+	isAdmin := op != nil && op.Role == "admin"
 	w.renderForRequestWithStatus(rw, r, http.StatusBadRequest, "networks.html", map[string]any{
 		"Active":     "networks",
 		"Networks":   networks,
+		"CAs":        cas,
+		"HasCAs":     len(cas) > 0,
+		"IsAdmin":    isAdmin,
 		"Form":       form,
 		"Error":      errMsg,
 		"ShowCreate": true,

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -598,17 +598,23 @@ func (w *Web) handleHosts(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (w *Web) handleHostNew(rw http.ResponseWriter, r *http.Request) {
-	networks, err := w.store.ListNetworks(r.Context())
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	networks, err := w.accessibleNetworks(r.Context(), op)
 	if err != nil {
 		w.logger.Error("list networks for host form", "error", err)
 		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
 		return
 	}
 	w.renderForRequest(rw, r, "host_new.html", map[string]any{
-		"Active":   "hosts",
-		"Networks": networks,
-		"Form":     hostFormState{},
-		"Error":    "",
+		"Active":      "hosts",
+		"Networks":    networks,
+		"HasNetworks": len(networks) > 0,
+		"Form":        hostFormState{},
+		"Error":       "",
 	})
 }
 
@@ -617,8 +623,42 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "bad request", http.StatusBadRequest)
 		return
 	}
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
 
 	form := newHostFormState(r)
+
+	// Resolve the chosen network and check that the operator is allowed
+	// to attach a host to it (issue #93). admins keep their existing
+	// blanket access; users must own the CA that signs the network.
+	var network *models.Network
+	if networkID := form.NetworkID; networkID != "" {
+		n, err := w.store.GetNetwork(r.Context(), networkID)
+		if errors.Is(err, store.ErrNotFound) {
+			w.renderHostNewError(rw, r, form, "network not found")
+			return
+		}
+		if err != nil {
+			w.logger.Error("get network for host create", "error", err)
+			http.Error(rw, "Failed to load network", http.StatusInternalServerError)
+			return
+		}
+		if op.Role != "admin" {
+			if n.CAID == "" {
+				w.renderHostNewError(rw, r, form, "this network is not tied to a CA you own — pick a network you created")
+				return
+			}
+			ca, err := w.store.GetCA(r.Context(), n.CAID)
+			if err != nil || ca.OwnerOperatorID != op.ID {
+				w.renderHostNewError(rw, r, form, "this network is not tied to a CA you own — pick a network you created")
+				return
+			}
+		}
+		network = n
+	}
 
 	nebulaIP := form.NebulaIP
 	networkID := form.NetworkID
@@ -680,6 +720,7 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 	host := &models.Host{
 		ID:           uuid.New().String(),
 		NetworkID:    networkID,
+		CAID:         networkCAID(network),
 		Name:         form.Name,
 		NebulaIP:     nebulaIP,
 		Groups:       groups,
@@ -766,18 +807,42 @@ func (w *Web) handleHostDelete(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
+// networkCAID extracts CAID from a (possibly nil) network. Nil network
+// happens when the operator submits an empty network_id; the host create
+// path falls through to its own validation in that case.
+func networkCAID(n *models.Network) string {
+	if n == nil {
+		return ""
+	}
+	return n.CAID
+}
+
 // --- Networks ---
 
 func (w *Web) handleNetworks(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
 	networks, err := w.store.ListNetworks(r.Context())
 	if err != nil {
 		w.logger.Error("list networks", "error", err)
 		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
 		return
 	}
+	cas, err := w.accessibleActiveCAs(r.Context(), op)
+	if err != nil {
+		w.logger.Error("list cas for networks page", "error", err)
+		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
+		return
+	}
 	w.renderForRequest(rw, r, "networks.html", map[string]any{
 		"Active":     "networks",
 		"Networks":   networks,
+		"CAs":        cas,
+		"HasCAs":     len(cas) > 0,
+		"IsAdmin":    op.Role == "admin",
 		"Form":       networkFormState{},
 		"Error":      "",
 		"ShowCreate": false,
@@ -789,13 +854,48 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "bad request", http.StatusBadRequest)
 		return
 	}
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+
 	form := newNetworkFormState(r)
+
+	cas, err := w.accessibleActiveCAs(r.Context(), op)
+	if err != nil {
+		w.logger.Error("list cas for network create", "error", err)
+		http.Error(rw, "Failed to load CAs", http.StatusInternalServerError)
+		return
+	}
+	// Non-admins must own at least one active CA. admins fall through
+	// to the legacy "no CA tied to network" path so existing deployments
+	// keep working until they migrate.
+	if op.Role != "admin" && len(cas) == 0 {
+		w.renderNetworksError(rw, r, form, cas, "You must create a CA before adding a network. Open the CAs page to mint one.")
+		return
+	}
+
 	if form.Name == "" || form.CIDR == "" {
-		w.renderNetworksError(rw, r, form, "name and cidr are required")
+		w.renderNetworksError(rw, r, form, cas, "name and cidr are required")
 		return
 	}
 	if _, err := netip.ParsePrefix(form.CIDR); err != nil {
-		w.renderNetworksError(rw, r, form, "invalid CIDR: "+err.Error())
+		w.renderNetworksError(rw, r, form, cas, "invalid CIDR: "+err.Error())
+		return
+	}
+
+	caID := form.CAID
+	if caID == "" && op.Role != "admin" {
+		if len(cas) == 1 {
+			caID = cas[0].ID
+		} else {
+			w.renderNetworksError(rw, r, form, cas, "pick a CA to sign certificates for this network")
+			return
+		}
+	}
+	if caID != "" && !containsCAID(cas, caID) {
+		w.renderNetworksError(rw, r, form, cas, "selected CA is not accessible to you")
 		return
 	}
 
@@ -803,6 +903,7 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 		ID:        uuid.New().String(),
 		Name:      form.Name,
 		CIDR:      form.CIDR,
+		CAID:      caID,
 		CreatedAt: time.Now(),
 	}
 

--- a/internal/web/operator_ca_gating_test.go
+++ b/internal/web/operator_ca_gating_test.go
@@ -1,0 +1,261 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// seedActiveCA inserts a minimally-populated active CA owned by the given
+// operator. Used in #93 gating tests where the precise key material is
+// irrelevant — only the ownership/status check matters.
+func seedActiveCA(t *testing.T, s store.Store, id, ownerID, name string) *models.CA {
+	t.Helper()
+	ca := &models.CA{
+		ID:                   id,
+		Name:                 name,
+		OwnerOperatorID:      ownerID,
+		Fingerprint:          "fp-" + id,
+		NotBefore:            time.Now(),
+		NotAfter:             time.Now().Add(time.Hour),
+		Status:               models.CAStatusActive,
+		EncryptedKeyDEK:      []byte("d"),
+		NonceDEK:             []byte("nd"),
+		EncryptedKeyMaterial: []byte("k"),
+		NonceKey:             []byte("nk"),
+		CreatedAt:            time.Now(),
+		UpdatedAt:            time.Now(),
+	}
+	if err := s.CreateCA(context.Background(), ca); err != nil {
+		t.Fatal(err)
+	}
+	return ca
+}
+
+// TestNetworkCreate_RejectsUserWithoutCA — issue #93. A self-registered
+// (role=user) operator with zero active CAs must not be able to create
+// a network. Re-render the networks page with an inline CTA pointing at
+// /ui/cas/new.
+func TestNetworkCreate_RejectsUserWithoutCA(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "alice", "user")
+
+	form := url.Values{"name": {"alice-net"}, "cidr": {"10.0.0.0/24"}}
+	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "/ui/cas/new") {
+		t.Errorf("body should link to /ui/cas/new, got:\n%s", body)
+	}
+	if !strings.Contains(body, "Create a CA") {
+		t.Errorf("body should explain the operator needs a CA, got:\n%s", body)
+	}
+
+	// And no network row was created in the store.
+	nets, err := s.ListNetworks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nets) != 0 {
+		t.Errorf("network should not have been created, got %d", len(nets))
+	}
+}
+
+// TestNetworkCreate_UserWithSingleCA — when the user owns exactly one
+// active CA, the network create handler must accept the form without an
+// explicit ca_id and persist the CA's id on the network.
+func TestNetworkCreate_UserWithSingleCA(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "alice", "user")
+	ca := seedActiveCA(t, s, "ca-alice", "op-alice", "alice-ca")
+
+	form := url.Values{"name": {"alice-net"}, "cidr": {"10.0.0.0/24"}}
+	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body: %s", rec.Code, rec.Body.String())
+	}
+	nets, err := s.ListNetworks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nets) != 1 {
+		t.Fatalf("got %d networks, want 1", len(nets))
+	}
+	if nets[0].CAID != ca.ID {
+		t.Errorf("network CAID = %q, want %q", nets[0].CAID, ca.ID)
+	}
+}
+
+// TestNetworkCreate_UserMustPickWhenMultipleCAs — operators with more
+// than one CA must explicitly pick one; otherwise the form re-renders
+// with the "pick a CA" message.
+func TestNetworkCreate_UserMustPickWhenMultipleCAs(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "alice", "user")
+	seedActiveCA(t, s, "ca-1", "op-alice", "ca-one")
+	seedActiveCA(t, s, "ca-2", "op-alice", "ca-two")
+
+	form := url.Values{"name": {"alice-net"}, "cidr": {"10.0.0.0/24"}}
+	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "pick a CA") {
+		t.Errorf("body should ask the operator to pick a CA")
+	}
+}
+
+// TestNetworkCreate_UserCannotPickForeignCA — a user must not be able to
+// submit another operator's CA id.
+func TestNetworkCreate_UserCannotPickForeignCA(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "alice", "user")
+	mintSession(t, s, "bob", "user") // FK target
+	seedActiveCA(t, s, "ca-alice", "op-alice", "alice-ca")
+	seedActiveCA(t, s, "ca-bob", "op-bob", "bob-ca")
+
+	form := url.Values{"name": {"alice-net"}, "cidr": {"10.0.0.0/24"}, "ca_id": {"ca-bob"}}
+	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not accessible") {
+		t.Errorf("body should reject the foreign CA")
+	}
+}
+
+// TestHostCreate_UserCannotCreateInForeignNetwork — even if the user
+// guesses the right network id, the host create handler must refuse a
+// network whose CA they do not own (issue #93). The check survives the
+// inline-error re-render added by #91.
+func TestHostCreate_UserCannotCreateInForeignNetwork(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "alice", "user")
+	mintSession(t, s, "bob", "user")
+	bobCA := seedActiveCA(t, s, "ca-bob", "op-bob", "bob-ca")
+	bobNet := &models.Network{ID: "n-bob", Name: "bob-net", CIDR: "10.10.0.0/24", CAID: bobCA.ID, CreatedAt: time.Now()}
+	if err := s.CreateNetwork(context.Background(), bobNet); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"network_id": {bobNet.ID},
+		"name":       {"sneaky-host"},
+		"nebula_ip":  {"10.10.0.10"},
+		"role":       {"host"},
+	}
+	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not tied to a CA you own") {
+		t.Errorf("body should explain ownership rejection")
+	}
+	// And nothing was persisted.
+	hosts, err := s.ListHosts(context.Background(), store.HostFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) != 0 {
+		t.Errorf("host must not be persisted; got %d", len(hosts))
+	}
+}
+
+// TestHostCreate_UserOwnedNetworkInheritsCAID — happy path. A user with
+// their own CA + network creates a host; the host row inherits the
+// network's CAID so the agent's cert is signed under that CA, not a
+// fallback / seed CA.
+func TestHostCreate_UserOwnedNetworkInheritsCAID(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "alice", "user")
+	ca := seedActiveCA(t, s, "ca-alice", "op-alice", "alice-ca")
+	net := &models.Network{ID: "n-alice", Name: "alice-net", CIDR: "10.20.0.0/24", CAID: ca.ID, CreatedAt: time.Now()}
+	if err := s.CreateNetwork(context.Background(), net); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"network_id": {net.ID},
+		"name":       {"alice-host"},
+		"nebula_ip":  {"10.20.0.5"},
+		"role":       {"host"},
+	}
+	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	hosts, err := s.ListHosts(context.Background(), store.HostFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("got %d hosts, want 1", len(hosts))
+	}
+	if hosts[0].CAID != ca.ID {
+		t.Errorf("host CAID = %q, want %q (inherited from network)", hosts[0].CAID, ca.ID)
+	}
+}
+
+// TestHostNew_UserWithoutAccessibleNetworks — a user with no networks
+// (no CA → no networks) hitting /ui/hosts/new sees the "no accessible
+// networks" alert instead of a broken form.
+func TestHostNew_UserWithoutAccessibleNetworks(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "alice", "user")
+
+	req := httptest.NewRequest("GET", "/ui/hosts/new", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "No accessible networks") {
+		t.Errorf("body should alert about missing networks; got:\n%s", body)
+	}
+	// And the form must not be there.
+	if strings.Contains(body, `name="nebula_ip"`) {
+		t.Errorf("form must be hidden when no networks are accessible")
+	}
+}

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -3,8 +3,16 @@
 {{define "content"}}
 <h1>New Host</h1>
 
+{{if .Error}}<div class="card error" role="alert" style="color: var(--danger); border-left: 3px solid var(--danger);">{{.Error}}</div>{{end}}
+
+{{if not .HasNetworks}}
+<div class="card alert" role="alert" style="border-left: 3px solid var(--danger);">
+    <strong>No accessible networks.</strong>
+    Create a network you own first — every host inherits its signing CA from its network.
+    <a href="/ui/networks">Networks →</a>
+</div>
+{{else}}
 <div class="card">
-    {{if .Error}}<div class="error" role="alert" style="color: var(--danger); margin-bottom: 16px;">{{.Error}}</div>{{end}}
     <form method="POST" action="/ui/hosts">
         <div class="form-group">
             <label>Network</label>
@@ -83,6 +91,7 @@
         <button type="submit" class="btn btn-primary">Create Host</button>
     </form>
 </div>
+{{end}}
 
 <script>
 (function() {

--- a/internal/web/templates/networks.html
+++ b/internal/web/templates/networks.html
@@ -3,9 +3,18 @@
 {{define "content"}}
 <div class="header-actions">
     <h1>Networks</h1>
+    {{if or .HasCAs .IsAdmin}}
     <button class="btn btn-primary" onclick="document.getElementById('new-network').style.display='block'">+ New Network</button>
+    {{end}}
 </div>
 
+{{if and (not .HasCAs) (not .IsAdmin)}}
+<div class="card alert" role="alert" style="border-left: 3px solid var(--danger);">
+    <strong>Create a CA first.</strong>
+    Every network must be tied to a certificate authority you own.
+    <a href="/ui/cas/new">Create a CA →</a>
+</div>
+{{else}}
 <div id="new-network" class="card"{{if not .ShowCreate}} style="display:none"{{end}}>
     <h2>Create Network</h2>
     {{if .Error}}<div class="error" role="alert" style="color: var(--danger); margin-bottom: 16px;">{{.Error}}</div>{{end}}
@@ -18,9 +27,28 @@
             <label>CIDR</label>
             <input type="text" name="cidr" class="form-control" placeholder="192.168.100.0/24" value="{{.Form.CIDR}}" required>
         </div>
+        {{if gt (len .CAs) 1}}
+        <div class="form-group">
+            <label>Signing CA</label>
+            <select name="ca_id" class="form-control" required>
+                <option value="">Select CA...</option>
+                {{$sel := .Form.CAID}}
+                {{range .CAs}}
+                <option value="{{.ID}}"{{if eq .ID $sel}} selected{{end}}>{{.Name}}</option>
+                {{end}}
+            </select>
+        </div>
+        {{else if eq (len .CAs) 1}}
+        {{$only := index .CAs 0}}
+        <input type="hidden" name="ca_id" value="{{$only.ID}}">
+        <div class="form-group" style="font-size: 12px; color: var(--text-muted);">
+            Signed by CA: <strong>{{$only.Name}}</strong>
+        </div>
+        {{end}}
         <button type="submit" class="btn btn-primary">Create</button>
     </form>
 </div>
+{{end}}
 
 {{if .Networks}}
 <div class="card">

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -42,6 +42,7 @@ func newTestWeb(t *testing.T) (*Web, *store.SQLiteStore) {
 		Username:     testUsername,
 		DisplayName:  "Administrator",
 		PasswordHash: string(hash),
+		Role:         "admin",
 	}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Per ADR 0002 every network is meant to be tied to a CA the operator owns. Until now a self-registered user (`role=user`) could `POST /ui/networks` / `POST /ui/hosts` with no CA at all — the network row was saved with an empty `ca_id`, the host inherited that empty value, and cert signing silently fell back to the seed admin's CA.

This PR tightens both create paths:

**`handleNetworkCreate`** (`POST /ui/networks`)
- Non-admin operator with zero active CAs gets an inline error + CTA pointing at `/ui/cas/new` (no network row written).
- Single-CA operators skip the picker (CA inferred).
- Multi-CA operators must explicitly pick; ownership re-validated server-side.
- `network.CAID` is now persisted from the chosen CA.

**`handleHostCreate`** (`POST /ui/hosts`)
- Chosen network is loaded once; non-admin must own its CA.
- `host.CAID` is inherited from `network.CAID` (no more silent fallback to the seed CA).
- Error message stays inline and survives the #91 re-render.

**`handleHostNew` / `handleNetworks`** (GET)
- Non-admin sees only the networks whose CA they own; legacy networks (CAID="") are admin-visible only.
- "No accessible networks" alert renders when the user has none.

**UI**
- `networks.html` gains a Signing-CA select (auto-hidden on 1 CA, full picker on 2+); the Create card is replaced by a "create a CA first" alert for non-admin users without CAs.
- `host_new.html` surfaces errors above the no-networks alert so ownership-rejection messages remain visible.

**Admin behavior is unchanged** (no CA required, can create networks without a `ca_id`) so existing deployments and the legacy single-CA path keep working until they migrate.

## Test plan

- [x] `go test -race ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New unit tests:
  - `TestNetworkCreate_RejectsUserWithoutCA` — 400 + CTA, no DB write.
  - `TestNetworkCreate_UserWithSingleCA` — accepted, `network.CAID` persisted.
  - `TestNetworkCreate_UserMustPickWhenMultipleCAs` — 400 + "pick a CA".
  - `TestNetworkCreate_UserCannotPickForeignCA` — 400 + "not accessible".
  - `TestHostCreate_UserCannotCreateInForeignNetwork` — 400 + "not tied to a CA you own"; no host persisted.
  - `TestHostCreate_UserOwnedNetworkInheritsCAID` — 200, `host.CAID == network.CAID`.
  - `TestHostNew_UserWithoutAccessibleNetworks` — alert renders, form hidden.

Closes #93.
