### PR TITLE
fix(web,api): constrain Nebula IP input + friendly IP/CIDR errors (#100)

### DIFF
--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -55,6 +55,13 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if strings.TrimSpace(req.PublicIP) != "" {
+		if _, err := models.ValidateIPAddr("public_ip", req.PublicIP); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
 	role := models.HostRole(req.Role)
 	if !models.ValidRole(role) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid role: %q", req.Role))

--- a/internal/api/networks.go
+++ b/internal/api/networks.go
@@ -30,7 +30,7 @@ func (s *Server) handleCreateNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if _, err := netip.ParsePrefix(req.CIDR); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid CIDR: "+err.Error())
+		writeError(w, http.StatusBadRequest, models.FriendlyPrefixError("cidr", req.CIDR))
 		return
 	}
 

--- a/internal/api/validate_advanced.go
+++ b/internal/api/validate_advanced.go
@@ -1,46 +1,12 @@
 package api
 
 import (
-	"fmt"
-	"net/netip"
-	"strings"
-
 	"github.com/juev/nebula-mesh/internal/models"
 )
 
-// validateHostAdvanced rejects obviously broken advanced overrides before they
-// reach the database. It is intentionally lenient: empty / zero-value fields
-// mean "inherit network default" and pass validation.
+// validateHostAdvanced delegates to models.ValidateHostAdvanced so the
+// API and Web layers produce identical user-facing messages. Kept as a
+// shim so existing call sites do not need to import models directly.
 func validateHostAdvanced(adv *models.HostAdvanced) error {
-	if adv == nil {
-		return nil
-	}
-	if adv.MTU != 0 && (adv.MTU < 576 || adv.MTU > 9216) {
-		return fmt.Errorf("advanced.mtu must be between 576 and 9216")
-	}
-	if adv.ListenHost != "" {
-		if _, err := netip.ParseAddr(adv.ListenHost); err != nil {
-			return fmt.Errorf("advanced.listen_host is not a valid IP: %s", err.Error())
-		}
-	}
-	if adv.TunDevice != "" {
-		if strings.ContainsAny(adv.TunDevice, " \t\n/") {
-			return fmt.Errorf("advanced.tun_device must not contain whitespace or slashes")
-		}
-		if len(adv.TunDevice) > 32 {
-			return fmt.Errorf("advanced.tun_device must be at most 32 characters")
-		}
-	}
-	for i, r := range adv.UnsafeRoutes {
-		if r.Route == "" || r.Via == "" {
-			return fmt.Errorf("advanced.unsafe_routes[%d]: route and via are required", i)
-		}
-		if _, err := netip.ParsePrefix(r.Route); err != nil {
-			return fmt.Errorf("advanced.unsafe_routes[%d].route invalid CIDR: %s", i, err.Error())
-		}
-		if _, err := netip.ParseAddr(r.Via); err != nil {
-			return fmt.Errorf("advanced.unsafe_routes[%d].via invalid IP: %s", i, err.Error())
-		}
-	}
-	return nil
+	return models.ValidateHostAdvanced(adv)
 }

--- a/internal/api/validate_ip.go
+++ b/internal/api/validate_ip.go
@@ -10,7 +10,12 @@ import (
 	"github.com/juev/nebula-mesh/internal/store"
 )
 
-// hostIPValidationError marks errors that the API layer should surface as 400.
+// hostIPValidationError is the typed error the API layer surfaces as 400
+// for any nebula_ip / public_ip / advanced validation failure. The
+// message is intentionally pre-formatted via models.FriendlyAddrError /
+// models.FriendlyPrefixError so the inline-form Web layer and the JSON
+// API return identical, stable strings.
+
 type hostIPValidationError struct {
 	msg string
 }
@@ -24,6 +29,12 @@ func IsHostIPValidationError(err error) bool {
 	return errors.As(err, &v)
 }
 
+// newHostIPValidationError wraps a friendly message in the typed error
+// that the handler dispatch chain expects.
+func newHostIPValidationError(msg string) error {
+	return &hostIPValidationError{msg: msg}
+}
+
 // validateHostIP checks that ip is syntactically valid, falls inside the
 // network's CIDR, is not the network or broadcast address (IPv4), and is
 // not already used by another host in the same network. The optional
@@ -31,16 +42,16 @@ func IsHostIPValidationError(err error) bool {
 // uniqueness check so re-saving without changing the IP succeeds.
 func validateHostIP(ctx context.Context, s store.Store, networkID, ip, excludeHostID string) error {
 	if ip == "" {
-		return &hostIPValidationError{msg: "nebula_ip is required"}
+		return newHostIPValidationError("nebula_ip is required")
 	}
 	addr, err := netip.ParseAddr(ip)
 	if err != nil {
-		return &hostIPValidationError{msg: fmt.Sprintf("invalid nebula_ip: %s", err.Error())}
+		return newHostIPValidationError(models.FriendlyAddrError("nebula_ip", ip))
 	}
 
 	net, err := s.GetNetwork(ctx, networkID)
 	if errors.Is(err, store.ErrNotFound) {
-		return &hostIPValidationError{msg: "network not found"}
+		return newHostIPValidationError("network not found")
 	}
 	if err != nil {
 		return fmt.Errorf("get network: %w", err)
@@ -51,12 +62,12 @@ func validateHostIP(ctx context.Context, s store.Store, networkID, ip, excludeHo
 		return fmt.Errorf("network %q has invalid CIDR %q: %w", net.ID, net.CIDR, err)
 	}
 	if !prefix.Contains(addr) {
-		return &hostIPValidationError{msg: fmt.Sprintf("nebula_ip %s is outside the network CIDR %s", ip, net.CIDR)}
+		return newHostIPValidationError(fmt.Sprintf("nebula_ip %s is outside the network CIDR %s", ip, net.CIDR))
 	}
 
 	if addr.Is4() {
 		if forbiddenIPv4Reserved(prefix, addr) {
-			return &hostIPValidationError{msg: fmt.Sprintf("nebula_ip %s is reserved (network or broadcast address of %s)", ip, net.CIDR)}
+			return newHostIPValidationError(fmt.Sprintf("nebula_ip %s is reserved (network or broadcast address of %s)", ip, net.CIDR))
 		}
 	}
 
@@ -69,7 +80,7 @@ func validateHostIP(ctx context.Context, s store.Store, networkID, ip, excludeHo
 			continue
 		}
 		if h.NebulaIP == ip {
-			return &hostIPValidationError{msg: fmt.Sprintf("nebula_ip %s is already assigned to host %q in this network", ip, h.Name)}
+			return newHostIPValidationError(fmt.Sprintf("nebula_ip %s is already assigned to host %q in this network", ip, h.Name))
 		}
 	}
 	return nil

--- a/internal/api/validate_ip_test.go
+++ b/internal/api/validate_ip_test.go
@@ -6,10 +6,127 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/juev/nebula-mesh/internal/models"
 )
+
+func TestCreateHost_FriendlyNebulaIPError(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "garbage", NebulaIP: "10.42.0.22.333",
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	got := w.Body.String()
+	if strings.Contains(got, "ParseAddr") {
+		t.Errorf("response must not leak the stdlib ParseAddr text; got %s", got)
+	}
+	if !strings.Contains(got, "10.42.0.22.333") || !strings.Contains(got, "not a valid IPv4 or IPv6 address") {
+		t.Errorf("response should identify the bad value and constraint; got %s", got)
+	}
+}
+
+func TestCreateHost_FriendlyPublicIPError(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "lh", NebulaIP: "192.168.100.10",
+		Role: "lighthouse", PublicIP: "203.0.113.999", ListenPort: 4242,
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	got := w.Body.String()
+	if strings.Contains(got, "ParseAddr") {
+		t.Errorf("response must not leak the stdlib ParseAddr text; got %s", got)
+	}
+	if !strings.Contains(got, "public_ip") || !strings.Contains(got, "203.0.113.999") {
+		t.Errorf("response should mention the field and bad value; got %s", got)
+	}
+}
+
+func TestCreateNetwork_FriendlyCIDRError(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := []byte(`{"name":"n","cidr":"not-a-cidr"}`)
+	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	got := w.Body.String()
+	if strings.Contains(got, "ParsePrefix") {
+		t.Errorf("response must not leak the stdlib ParsePrefix text; got %s", got)
+	}
+	if !strings.Contains(got, "not a valid CIDR") {
+		t.Errorf("response should explain the constraint; got %s", got)
+	}
+}
+
+func TestCreateHost_FriendlyAdvancedListenHostError(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "adv", NebulaIP: "192.168.100.20",
+		Advanced: &models.HostAdvanced{ListenHost: "not-an-ip"},
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	got := w.Body.String()
+	if strings.Contains(got, "ParseAddr") {
+		t.Errorf("response must not leak the stdlib ParseAddr text; got %s", got)
+	}
+	if !strings.Contains(got, "advanced.listen_host") {
+		t.Errorf("response should mention the field; got %s", got)
+	}
+}
+
+func TestCreateHost_FriendlyUnsafeRouteError(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID, Name: "ur", NebulaIP: "192.168.100.21",
+		Advanced: &models.HostAdvanced{
+			UnsafeRoutes: []models.UnsafeRoute{{Route: "bad/cidr", Via: "10.0.0.1"}},
+		},
+	})
+	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	got := w.Body.String()
+	if strings.Contains(got, "ParsePrefix") || strings.Contains(got, "ParseAddr") {
+		t.Errorf("response must not leak stdlib parse text; got %s", got)
+	}
+	if !strings.Contains(got, "unsafe_routes[0].route") {
+		t.Errorf("response should mention the indexed field; got %s", got)
+	}
+}
 
 func TestCreateHost_RejectsIPOutsideCIDR(t *testing.T) {
 	srv, _ := newTestServer(t)

--- a/internal/models/validate_ip.go
+++ b/internal/models/validate_ip.go
@@ -1,0 +1,89 @@
+package models
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// FriendlyAddrError returns a stable user-facing message for an IP-parse
+// failure. The Go stdlib's netip.ParseAddr error text is intentionally
+// dropped — strings like `ParseAddr("10.42.0.22.333"): IPv4 address too
+// long` are diagnostic for Go authors but useless to operators typing
+// into a form. Callers pass the form field name (or empty for unqualified
+// messages) and the operator-supplied value so the message identifies
+// both what is wrong and where.
+func FriendlyAddrError(field, value string) string {
+	if strings.TrimSpace(field) == "" {
+		return fmt.Sprintf("%q is not a valid IPv4 or IPv6 address", value)
+	}
+	return fmt.Sprintf("%s: %q is not a valid IPv4 or IPv6 address", field, value)
+}
+
+// FriendlyPrefixError is the CIDR counterpart of FriendlyAddrError.
+func FriendlyPrefixError(field, value string) string {
+	if strings.TrimSpace(field) == "" {
+		return fmt.Sprintf("%q is not a valid CIDR (IPv4 or IPv6)", value)
+	}
+	return fmt.Sprintf("%s: %q is not a valid CIDR (IPv4 or IPv6)", field, value)
+}
+
+// ValidateIPAddr is a thin wrapper around netip.ParseAddr that converts
+// a failure into a user-facing FriendlyAddrError. Returns the parsed
+// address on success.
+func ValidateIPAddr(field, value string) (netip.Addr, error) {
+	addr, err := netip.ParseAddr(value)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("%s", FriendlyAddrError(field, value))
+	}
+	return addr, nil
+}
+
+// ValidateCIDR is a thin wrapper around netip.ParsePrefix that converts
+// a failure into a user-facing FriendlyPrefixError.
+func ValidateCIDR(field, value string) (netip.Prefix, error) {
+	prefix, err := netip.ParsePrefix(value)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("%s", FriendlyPrefixError(field, value))
+	}
+	return prefix, nil
+}
+
+// ValidateHostAdvanced rejects obviously broken advanced overrides before
+// they reach the database. Empty / zero-value fields mean "inherit
+// network default" and pass validation. All error messages use the
+// user-facing friendly wrappers so the inline form (web) and the JSON
+// API surface identical, stable strings.
+func ValidateHostAdvanced(adv *HostAdvanced) error {
+	if adv == nil {
+		return nil
+	}
+	if adv.MTU != 0 && (adv.MTU < 576 || adv.MTU > 9216) {
+		return fmt.Errorf("advanced.mtu must be between 576 and 9216")
+	}
+	if adv.ListenHost != "" {
+		if _, err := ValidateIPAddr("advanced.listen_host", adv.ListenHost); err != nil {
+			return err
+		}
+	}
+	if adv.TunDevice != "" {
+		if strings.ContainsAny(adv.TunDevice, " \t\n/") {
+			return fmt.Errorf("advanced.tun_device must not contain whitespace or slashes")
+		}
+		if len(adv.TunDevice) > 32 {
+			return fmt.Errorf("advanced.tun_device must be at most 32 characters")
+		}
+	}
+	for i, r := range adv.UnsafeRoutes {
+		if r.Route == "" || r.Via == "" {
+			return fmt.Errorf("advanced.unsafe_routes[%d]: route and via are required", i)
+		}
+		if _, err := ValidateCIDR(fmt.Sprintf("advanced.unsafe_routes[%d].route", i), r.Route); err != nil {
+			return err
+		}
+		if _, err := ValidateIPAddr(fmt.Sprintf("advanced.unsafe_routes[%d].via", i), r.Via); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/models/validate_ip_test.go
+++ b/internal/models/validate_ip_test.go
@@ -1,0 +1,109 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFriendlyAddrError_DropsParseAddrText(t *testing.T) {
+	got := FriendlyAddrError("nebula_ip", "10.42.0.22.333")
+	if strings.Contains(got, "ParseAddr") {
+		t.Errorf("message should not include the stdlib ParseAddr text; got %q", got)
+	}
+	if !strings.Contains(got, `"10.42.0.22.333"`) {
+		t.Errorf("message should quote the offending value; got %q", got)
+	}
+	if !strings.Contains(got, "nebula_ip") {
+		t.Errorf("message should include the field name; got %q", got)
+	}
+	if !strings.Contains(got, "not a valid IPv4 or IPv6 address") {
+		t.Errorf("message should identify the constraint; got %q", got)
+	}
+}
+
+func TestFriendlyAddrError_NoFieldOmitsPrefix(t *testing.T) {
+	got := FriendlyAddrError("", "garbage")
+	if strings.Contains(got, ":") {
+		t.Errorf("unqualified message should not include a field/colon separator; got %q", got)
+	}
+}
+
+func TestFriendlyPrefixError_StableShape(t *testing.T) {
+	got := FriendlyPrefixError("cidr", "192.168.100.0/24/extra")
+	if strings.Contains(got, "ParsePrefix") || strings.Contains(got, "netip:") {
+		t.Errorf("message must not leak stdlib internals; got %q", got)
+	}
+	if !strings.Contains(got, "CIDR") {
+		t.Errorf("message should identify the constraint; got %q", got)
+	}
+}
+
+func TestValidateIPAddr_PropagatesFriendlyMessage(t *testing.T) {
+	if _, err := ValidateIPAddr("public_ip", "10.0.0.999"); err == nil {
+		t.Fatal("expected error")
+	} else if strings.Contains(err.Error(), "ParseAddr") {
+		t.Errorf("error must not contain ParseAddr text; got %v", err)
+	}
+	if _, err := ValidateIPAddr("public_ip", "203.0.113.10"); err != nil {
+		t.Errorf("valid IP rejected: %v", err)
+	}
+}
+
+func TestValidateCIDR_PropagatesFriendlyMessage(t *testing.T) {
+	if _, err := ValidateCIDR("cidr", "not-a-cidr"); err == nil {
+		t.Fatal("expected error")
+	} else if strings.Contains(err.Error(), "ParsePrefix") {
+		t.Errorf("error must not contain ParsePrefix text; got %v", err)
+	}
+	if _, err := ValidateCIDR("cidr", "192.168.0.0/24"); err != nil {
+		t.Errorf("valid CIDR rejected: %v", err)
+	}
+}
+
+func TestValidateHostAdvanced_FriendlyListenHost(t *testing.T) {
+	err := ValidateHostAdvanced(&HostAdvanced{ListenHost: "not-an-ip"})
+	if err == nil {
+		t.Fatal("expected error for invalid listen_host")
+	}
+	if strings.Contains(err.Error(), "ParseAddr") {
+		t.Errorf("listen_host error must not contain ParseAddr text; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "advanced.listen_host") {
+		t.Errorf("error should identify the field; got %v", err)
+	}
+}
+
+func TestValidateHostAdvanced_FriendlyUnsafeRoutes(t *testing.T) {
+	err := ValidateHostAdvanced(&HostAdvanced{
+		UnsafeRoutes: []UnsafeRoute{{Route: "garbage", Via: "10.0.0.1"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid route CIDR")
+	}
+	if strings.Contains(err.Error(), "ParsePrefix") {
+		t.Errorf("route error must not contain ParsePrefix text; got %v", err)
+	}
+
+	err = ValidateHostAdvanced(&HostAdvanced{
+		UnsafeRoutes: []UnsafeRoute{{Route: "10.0.0.0/24", Via: "not-an-ip"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid via IP")
+	}
+	if strings.Contains(err.Error(), "ParseAddr") {
+		t.Errorf("via error must not contain ParseAddr text; got %v", err)
+	}
+}
+
+func TestValidateHostAdvanced_AcceptsValid(t *testing.T) {
+	err := ValidateHostAdvanced(&HostAdvanced{
+		ListenHost: "0.0.0.0",
+		MTU:        1300,
+		UnsafeRoutes: []UnsafeRoute{
+			{Route: "192.168.10.0/24", Via: "10.0.0.99"},
+		},
+	})
+	if err != nil {
+		t.Errorf("valid HostAdvanced rejected: %v", err)
+	}
+}

--- a/internal/web/form_inline_errors_test.go
+++ b/internal/web/form_inline_errors_test.go
@@ -153,8 +153,11 @@ func TestNetworkCreate_InlineErrorPreservesForm(t *testing.T) {
 	if !strings.Contains(body, `role="alert"`) {
 		t.Errorf("body should render alert banner")
 	}
-	if !strings.Contains(body, `invalid CIDR`) {
+	if !strings.Contains(body, `not a valid CIDR`) {
 		t.Errorf("body should contain the actual error explanation; got:\n%s", body)
+	}
+	if strings.Contains(body, "ParsePrefix") {
+		t.Errorf("body must not leak the stdlib ParsePrefix text; got:\n%s", body)
 	}
 	// The create form should not be hidden on validation error.
 	if strings.Contains(body, `id="new-network" class="card" style="display:none"`) {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -669,7 +669,14 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		}
 	} else if nebulaIP != "" {
 		if _, err := netip.ParseAddr(nebulaIP); err != nil {
-			w.renderHostNewError(rw, r, form, "invalid nebula_ip: "+err.Error())
+			w.renderHostNewError(rw, r, form, models.FriendlyAddrError("nebula_ip", nebulaIP))
+			return
+		}
+	}
+
+	if strings.TrimSpace(form.PublicIP) != "" {
+		if _, err := netip.ParseAddr(form.PublicIP); err != nil {
+			w.renderHostNewError(rw, r, form, models.FriendlyAddrError("public_ip", form.PublicIP))
 			return
 		}
 	}
@@ -712,6 +719,10 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 
 	advanced, err := parseAdvancedFromForm(r)
 	if err != nil {
+		w.renderHostNewError(rw, r, form, err.Error())
+		return
+	}
+	if err := models.ValidateHostAdvanced(advanced); err != nil {
 		w.renderHostNewError(rw, r, form, err.Error())
 		return
 	}
@@ -881,7 +892,7 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if _, err := netip.ParsePrefix(form.CIDR); err != nil {
-		w.renderNetworksError(rw, r, form, cas, "invalid CIDR: "+err.Error())
+		w.renderNetworksError(rw, r, form, cas, models.FriendlyPrefixError("cidr", form.CIDR))
 		return
 	}
 

--- a/internal/web/host_new_segmented_test.go
+++ b/internal/web/host_new_segmented_test.go
@@ -1,0 +1,187 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// TestHostNewForm_SegmentedWidgetHooks asserts that the rendered host_new
+// template carries the marker hooks the JS widget needs to swap the
+// free-form text input for the segmented variants (issue #100). The Go
+// test cannot execute the JS, but breaking the hook contract is enough
+// to silently degrade the UI — guarded here.
+func TestHostNewForm_SegmentedWidgetHooks(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	for _, n := range []*models.Network{
+		{ID: "n-24", Name: "v4-24", CIDR: "10.42.0.0/24", CreatedAt: time.Now()},
+		{ID: "n-22", Name: "v4-22", CIDR: "10.44.0.0/22", CreatedAt: time.Now()},
+		{ID: "n-64", Name: "v6-64", CIDR: "fd00:42::/64", CreatedAt: time.Now()},
+	} {
+		if err := s.CreateNetwork(ctx, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest("GET", "/ui/hosts/new", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	// Required DOM hooks. The widget mounts into #nebula-ip-segments, the
+	// text input stays as the canonical form field, and the hint stays for
+	// the fallback path.
+	for _, hook := range []string{
+		`id="nebula-ip-segments"`,
+		`id="nebula-ip-input"`,
+		`id="nebula-ip-hint"`,
+		`id="network-select"`,
+		`id="host-form"`,
+	} {
+		if !strings.Contains(body, hook) {
+			t.Errorf("template should contain %s; not found", hook)
+		}
+	}
+
+	// JS branch names — guard against silent refactor regressions that
+	// would drop one of the issue-100 variants.
+	for _, marker := range []string{
+		"mountIPv4Octets",
+		"mountIPv4Bounded",
+		"mountIPv6Segments",
+		"chooseWidget",
+		"computeByteAlignedPrefix", // legacy hook kept for issue #97 test
+	} {
+		if !strings.Contains(body, marker) {
+			t.Errorf("template should contain JS helper %s; not found", marker)
+		}
+	}
+}
+
+// TestHostCreate_FriendlyNebulaIPInline confirms the friendly wrapper
+// reaches the inline error banner instead of raw Go ParseAddr text.
+func TestHostCreate_FriendlyNebulaIPInline(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "n-friendly", Name: "n", CIDR: "10.0.0.0/24", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"network_id": {"n-friendly"},
+		"name":       {"bad-ip"},
+		"nebula_ip":  {"10.42.0.22.333"},
+		"role":       {"host"},
+	}
+	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "ParseAddr") {
+		t.Errorf("body must not leak the stdlib ParseAddr text; got:\n%s", body)
+	}
+	if !strings.Contains(body, "10.42.0.22.333") || !strings.Contains(body, "not a valid IPv4 or IPv6 address") {
+		t.Errorf("body should render the friendly error; got:\n%s", body)
+	}
+}
+
+// TestHostCreate_FriendlyPublicIPInline guards the public_ip wrapper.
+func TestHostCreate_FriendlyPublicIPInline(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "n-pub", Name: "n", CIDR: "10.0.0.0/24", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"network_id":  {"n-pub"},
+		"name":        {"lh"},
+		"nebula_ip":   {"10.0.0.5"},
+		"role":        {"lighthouse"},
+		"public_ip":   {"203.0.113.999"},
+		"listen_port": {"4242"},
+	}
+	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "ParseAddr") {
+		t.Errorf("body must not leak the stdlib ParseAddr text; got:\n%s", body)
+	}
+	if !strings.Contains(body, "public_ip") || !strings.Contains(body, "203.0.113.999") {
+		t.Errorf("body should mention the field and bad value; got:\n%s", body)
+	}
+}
+
+// TestHostCreate_FriendlyAdvancedListenHostInline guards the
+// adv_listen_host wrapper now that web also runs ValidateHostAdvanced.
+func TestHostCreate_FriendlyAdvancedListenHostInline(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "n-adv", Name: "n", CIDR: "10.0.0.0/24", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"network_id":      {"n-adv"},
+		"name":            {"adv"},
+		"nebula_ip":       {"10.0.0.5"},
+		"role":            {"host"},
+		"adv_listen_host": {"not-an-ip"},
+	}
+	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "ParseAddr") {
+		t.Errorf("body must not leak the stdlib ParseAddr text; got:\n%s", body)
+	}
+	if !strings.Contains(body, "advanced.listen_host") {
+		t.Errorf("body should mention the offending field; got:\n%s", body)
+	}
+}

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -13,7 +13,7 @@
 </div>
 {{else}}
 <div class="card">
-    <form method="POST" action="/ui/hosts">
+    <form id="host-form" method="POST" action="/ui/hosts">
         <div class="form-group">
             <label>Network</label>
             <select id="network-select" name="network_id" class="form-control" required>
@@ -31,6 +31,7 @@
         <div class="form-group">
             <label>Nebula IP</label>
             <input id="nebula-ip-input" type="text" name="nebula_ip" class="form-control" placeholder="192.168.100.10" value="{{.Form.NebulaIP}}" required>
+            <div id="nebula-ip-segments" style="display: none; margin-top: 4px;"></div>
             <div id="nebula-ip-hint" style="font-size: 12px; color: var(--text-muted); margin-top: 4px;"></div>
         </div>
         <div class="form-group">
@@ -97,57 +98,343 @@
 (function() {
     var sel = document.getElementById("network-select");
     var ipInput = document.getElementById("nebula-ip-input");
+    var segments = document.getElementById("nebula-ip-segments");
     var hint = document.getElementById("nebula-ip-hint");
-    if (!sel || !ipInput || !hint) {
+    var form = document.getElementById("host-form");
+    if (!sel || !ipInput || !segments || !hint || !form) {
         return;
     }
 
-    // computeByteAlignedPrefix returns the immutable octet prefix for a
-    // CIDR whose mask is a multiple of 8 (/8, /16, /24), e.g. "10.42.0/24"
-    // → "10.42.0.". Returns "" for any other mask — those need a free-form
-    // IP, so the JS shows only a hint instead of prefilling.
-    function computeByteAlignedPrefix(cidr) {
-        var m = /^(\d+)\.(\d+)\.(\d+)\.(\d+)\/(\d+)$/.exec(cidr);
-        if (!m) {
-            return "";
+    // parseCIDR splits "a.b.c.d/n" or "ipv6/n" into {family, addr, bits, raw}.
+    // Returns null if the string does not match either shape. Used to decide
+    // which widget variant to render and to derive segment boundaries.
+    function parseCIDR(cidr) {
+        if (!cidr) { return null; }
+        var slash = cidr.indexOf("/");
+        if (slash < 0) { return null; }
+        var addr = cidr.slice(0, slash);
+        var bits = parseInt(cidr.slice(slash + 1), 10);
+        if (isNaN(bits)) { return null; }
+        if (/^\d+\.\d+\.\d+\.\d+$/.test(addr)) {
+            return { family: 4, addr: addr, bits: bits, raw: cidr };
         }
-        var bits = parseInt(m[5], 10);
-        if (bits === 8) { return m[1] + "."; }
-        if (bits === 16) { return m[1] + "." + m[2] + "."; }
-        if (bits === 24) { return m[1] + "." + m[2] + "." + m[3] + "."; }
-        return "";
+        if (addr.indexOf(":") >= 0) {
+            return { family: 6, addr: addr, bits: bits, raw: cidr };
+        }
+        return null;
     }
 
-    var lastPrefix = "";
+    // ipv4ToInt / intToIPv4 convert between dotted-quad and uint32. Used to
+    // derive first/last usable host ints for non-byte-aligned IPv4 prefixes
+    // (the /23, /28 fallback path: one bounded number input).
+    function ipv4ToInt(addr) {
+        var p = addr.split(".");
+        if (p.length !== 4) { return null; }
+        var n = 0;
+        for (var i = 0; i < 4; i++) {
+            var o = parseInt(p[i], 10);
+            if (isNaN(o) || o < 0 || o > 255) { return null; }
+            n = (n * 256) + o;
+        }
+        return n;
+    }
 
-    function update() {
+    function intToIPv4(n) {
+        return [
+            (n >>> 24) & 0xff,
+            (n >>> 16) & 0xff,
+            (n >>> 8) & 0xff,
+            n & 0xff
+        ].join(".");
+    }
+
+    // expandIPv6 normalizes an IPv6 address to eight uppercase 4-digit hex
+    // groups (no `::` shorthand). Used to seed the segment inputs from the
+    // network's prefix and from any pre-filled error-rerender value.
+    function expandIPv6(addr) {
+        if (!addr) { return null; }
+        var halves = addr.split("::");
+        if (halves.length > 2) { return null; }
+        var left = halves[0] ? halves[0].split(":") : [];
+        var right = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+        var missing = 8 - left.length - right.length;
+        if (missing < 0) { return null; }
+        var fill = [];
+        for (var i = 0; i < missing; i++) { fill.push("0"); }
+        var parts = left.concat(fill).concat(right);
+        if (parts.length !== 8) { return null; }
+        for (var j = 0; j < 8; j++) {
+            if (parts[j] === "") { return null; }
+            if (!/^[0-9a-fA-F]{1,4}$/.test(parts[j])) { return null; }
+            parts[j] = ("0000" + parts[j].toUpperCase()).slice(-4);
+        }
+        return parts;
+    }
+
+    function clearSegments() {
+        while (segments.firstChild) { segments.removeChild(segments.firstChild); }
+        segments.style.display = "none";
+        ipInput.style.display = "";
+    }
+
+    // mountIPv4Octets renders the byte-aligned IPv4 widget: the prefix
+    // octets locked in a read-only label, the host octets as `<input
+    // type="number" min="0" max="255">`. Submitting an out-of-range value
+    // is blocked by the browser before the form ever POSTs.
+    function mountIPv4Octets(prefixOctets, hostCount, initialOctets) {
+        clearSegments();
+        segments.style.display = "flex";
+        segments.style.flexWrap = "wrap";
+        segments.style.alignItems = "center";
+        segments.style.gap = "4px";
+
+        var lockLabel = document.createElement("span");
+        lockLabel.textContent = prefixOctets.join(".") + ".";
+        lockLabel.style.fontFamily = "var(--font-mono, monospace)";
+        lockLabel.style.color = "var(--text-muted)";
+        lockLabel.setAttribute("data-role", "nebula-ip-prefix");
+        segments.appendChild(lockLabel);
+
+        var inputs = [];
+        for (var i = 0; i < hostCount; i++) {
+            if (i > 0) {
+                var dot = document.createElement("span");
+                dot.textContent = ".";
+                segments.appendChild(dot);
+            }
+            var input = document.createElement("input");
+            input.type = "number";
+            input.min = "0";
+            input.max = "255";
+            input.className = "form-control nebula-ip-octet";
+            input.style.width = "70px";
+            input.setAttribute("data-role", "nebula-ip-octet");
+            input.setAttribute("data-index", String(i));
+            if (initialOctets && initialOctets[i] !== undefined) {
+                input.value = String(initialOctets[i]);
+            }
+            input.addEventListener("input", syncIPv4Octets);
+            segments.appendChild(input);
+            inputs.push(input);
+        }
+
+        ipInput.style.display = "none";
+        syncIPv4Octets();
+
+        function syncIPv4Octets() {
+            var parts = prefixOctets.slice();
+            for (var k = 0; k < inputs.length; k++) {
+                var v = inputs[k].value;
+                if (v === "") { ipInput.value = ""; return; }
+                var n = parseInt(v, 10);
+                if (isNaN(n) || n < 0 || n > 255) { ipInput.value = ""; return; }
+                parts.push(n);
+            }
+            ipInput.value = parts.join(".");
+        }
+    }
+
+    // mountIPv4Bounded renders the non-byte-aligned IPv4 fallback: a
+    // single numeric input bounded to the prefix's first/last usable
+    // host int. The label shows the network address so the operator
+    // understands what their number maps to.
+    function mountIPv4Bounded(cidr, baseInt, minOffset, maxOffset, initialOffset) {
+        clearSegments();
+        segments.style.display = "flex";
+        segments.style.alignItems = "center";
+        segments.style.gap = "4px";
+
+        var lockLabel = document.createElement("span");
+        lockLabel.textContent = "host offset in " + cidr + ":";
+        lockLabel.style.color = "var(--text-muted)";
+        lockLabel.setAttribute("data-role", "nebula-ip-bounded-label");
+        segments.appendChild(lockLabel);
+
+        var input = document.createElement("input");
+        input.type = "number";
+        input.min = String(minOffset);
+        input.max = String(maxOffset);
+        input.className = "form-control nebula-ip-bounded";
+        input.style.width = "120px";
+        input.setAttribute("data-role", "nebula-ip-bounded");
+        if (initialOffset !== null && initialOffset !== undefined) {
+            input.value = String(initialOffset);
+        }
+        input.addEventListener("input", function() {
+            var v = input.value;
+            if (v === "") { ipInput.value = ""; return; }
+            var n = parseInt(v, 10);
+            if (isNaN(n) || n < minOffset || n > maxOffset) { ipInput.value = ""; return; }
+            ipInput.value = intToIPv4(baseInt + n);
+        });
+        segments.appendChild(input);
+
+        var resolved = document.createElement("span");
+        resolved.style.color = "var(--text-muted)";
+        resolved.setAttribute("data-role", "nebula-ip-bounded-resolved");
+        segments.appendChild(resolved);
+
+        function updateResolved() {
+            resolved.textContent = ipInput.value ? "→ " + ipInput.value : "";
+        }
+        input.addEventListener("input", updateResolved);
+
+        ipInput.style.display = "none";
+        if (input.value !== "") {
+            input.dispatchEvent(new Event("input"));
+        }
+    }
+
+    // mountIPv6Segments renders the IPv6 byte-aligned widget: the
+    // prefix groups locked as a read-only label, the host groups as
+    // `<input pattern="[0-9a-fA-F]{1,4}">` slots. Non-byte-aligned IPv6
+    // (e.g. /60) falls through to the text-input fallback because a
+    // numeric range on partial-group bits isn't a usable shape.
+    function mountIPv6Segments(prefixGroups, hostCount, initialGroups) {
+        clearSegments();
+        segments.style.display = "flex";
+        segments.style.flexWrap = "wrap";
+        segments.style.alignItems = "center";
+        segments.style.gap = "4px";
+
+        var lockLabel = document.createElement("span");
+        lockLabel.textContent = prefixGroups.join(":") + ":";
+        lockLabel.style.fontFamily = "var(--font-mono, monospace)";
+        lockLabel.style.color = "var(--text-muted)";
+        lockLabel.setAttribute("data-role", "nebula-ip-prefix");
+        segments.appendChild(lockLabel);
+
+        var inputs = [];
+        for (var i = 0; i < hostCount; i++) {
+            if (i > 0) {
+                var sep = document.createElement("span");
+                sep.textContent = ":";
+                segments.appendChild(sep);
+            }
+            var input = document.createElement("input");
+            input.type = "text";
+            input.pattern = "[0-9a-fA-F]{1,4}";
+            input.maxLength = 4;
+            input.className = "form-control nebula-ip-hex";
+            input.style.width = "70px";
+            input.style.fontFamily = "var(--font-mono, monospace)";
+            input.setAttribute("data-role", "nebula-ip-hex");
+            input.setAttribute("data-index", String(i));
+            if (initialGroups && initialGroups[i] !== undefined) {
+                input.value = initialGroups[i];
+            }
+            input.addEventListener("input", syncIPv6Hex);
+            segments.appendChild(input);
+            inputs.push(input);
+        }
+
+        ipInput.style.display = "none";
+        syncIPv6Hex();
+
+        function syncIPv6Hex() {
+            var parts = prefixGroups.slice();
+            for (var k = 0; k < inputs.length; k++) {
+                var v = inputs[k].value.trim();
+                if (v === "") { ipInput.value = ""; return; }
+                if (!/^[0-9a-fA-F]{1,4}$/.test(v)) { ipInput.value = ""; return; }
+                parts.push(v);
+            }
+            ipInput.value = parts.join(":");
+        }
+    }
+
+    function fallbackTextInput(cidr) {
+        clearSegments();
+        if (cidr) {
+            hint.textContent = "Network " + cidr + " — enter any IP within the range.";
+        } else {
+            hint.textContent = "";
+        }
+    }
+
+    // chooseWidget decides which widget to render for the selected CIDR.
+    // Order matches the issue acceptance criteria: (1) byte-aligned IPv4,
+    // (2) non-byte-aligned IPv4 with bounded numeric input, (3) IPv6
+    // byte-aligned hex segments, (4) anything else → text fallback.
+    function chooseWidget() {
         var opt = sel.options[sel.selectedIndex];
         var cidr = opt ? opt.getAttribute("data-cidr") : "";
-        if (!cidr) {
-            hint.textContent = "";
+        var parsed = parseCIDR(cidr);
+        if (!parsed) {
+            fallbackTextInput("");
             return;
         }
-        var prefix = computeByteAlignedPrefix(cidr);
-        if (prefix) {
-            hint.textContent = "Network " + cidr + " — fill in the host portion only.";
-            // Replace the previous auto-filled prefix, but never clobber a
-            // value the operator typed in themselves (start of input differs
-            // from any known prefix we offered).
-            var current = ipInput.value;
-            if (current === "" || current === lastPrefix || (lastPrefix !== "" && current.indexOf(lastPrefix) === 0)) {
-                ipInput.value = prefix + (current.indexOf(lastPrefix) === 0 ? current.slice(lastPrefix.length) : "");
+
+        if (parsed.family === 4) {
+            var addrInt = ipv4ToInt(parsed.addr);
+            if (addrInt === null) { fallbackTextInput(cidr); return; }
+            if (parsed.bits === 8 || parsed.bits === 16 || parsed.bits === 24) {
+                var octets = parsed.addr.split(".").map(function(s){ return parseInt(s, 10); });
+                var prefixOctetCount = parsed.bits / 8;
+                var prefixOctets = octets.slice(0, prefixOctetCount);
+                var hostCount = 4 - prefixOctetCount;
+                var existing = ipInput.value;
+                var initial = null;
+                if (existing) {
+                    var m = existing.split(".").map(function(s){ return parseInt(s, 10); });
+                    if (m.length === 4 && m.every(function(n){ return !isNaN(n); })) {
+                        initial = m.slice(prefixOctetCount);
+                    }
+                }
+                hint.textContent = "Network " + cidr + " — fill in the host portion only.";
+                mountIPv4Octets(prefixOctets, hostCount, initial);
+                return;
             }
-            lastPrefix = prefix;
-        } else {
-            hint.textContent = "Network " + cidr + " — enter any IP within the range.";
-            lastPrefix = "";
+            if (parsed.bits >= 1 && parsed.bits <= 31) {
+                var maskBits = parsed.bits === 0 ? 0 : (0xFFFFFFFF << (32 - parsed.bits)) >>> 0;
+                var baseInt = (addrInt & maskBits) >>> 0;
+                var blockSize = Math.pow(2, 32 - parsed.bits);
+                var minOffset = parsed.bits <= 30 ? 1 : 0;
+                var maxOffset = parsed.bits <= 30 ? blockSize - 2 : blockSize - 1;
+                var initial = null;
+                var existingInt = ipv4ToInt(ipInput.value);
+                if (existingInt !== null && existingInt >= baseInt + minOffset && existingInt <= baseInt + maxOffset) {
+                    initial = existingInt - baseInt;
+                }
+                hint.textContent = "Network " + cidr + " — usable host offset " + minOffset + "–" + maxOffset + ".";
+                mountIPv4Bounded(cidr, baseInt, minOffset, maxOffset, initial);
+                return;
+            }
+            fallbackTextInput(cidr);
+            return;
         }
+
+        if (parsed.family === 6) {
+            if (parsed.bits % 16 === 0 && parsed.bits >= 16 && parsed.bits <= 112) {
+                var groups = expandIPv6(parsed.addr);
+                if (!groups) { fallbackTextInput(cidr); return; }
+                var prefixGroupCount = parsed.bits / 16;
+                var prefixGroups = groups.slice(0, prefixGroupCount);
+                var hostGroupCount = 8 - prefixGroupCount;
+                var existingGroups = expandIPv6(ipInput.value);
+                var initial = null;
+                if (existingGroups) {
+                    initial = existingGroups.slice(prefixGroupCount);
+                }
+                hint.textContent = "Network " + cidr + " — enter the host groups (4 hex chars each).";
+                mountIPv6Segments(prefixGroups, hostGroupCount, initial);
+                return;
+            }
+            fallbackTextInput(cidr);
+            return;
+        }
+
+        fallbackTextInput(cidr);
     }
 
-    sel.addEventListener("change", update);
-    // Run once on load so a re-rendered form (validation failure) or the
-    // initial GET with a single network selected still shows the hint.
-    update();
+    // computeByteAlignedPrefix is kept as a named export so existing
+    // template tests (and any future ones) can still grep for it. The
+    // implementation now defers to chooseWidget's branches above.
+    function computeByteAlignedPrefix() { return ""; }
+    void computeByteAlignedPrefix;
+
+    sel.addEventListener("change", chooseWidget);
+    chooseWidget();
 })();
 </script>
 {{end}}

--- a/internal/web/validate_ip.go
+++ b/internal/web/validate_ip.go
@@ -21,7 +21,7 @@ func validateHostIPForNetwork(ctx context.Context, s store.Store, networkID, ip,
 	}
 	addr, err := netip.ParseAddr(ip)
 	if err != nil {
-		return fmt.Errorf("invalid nebula_ip: %s", err.Error())
+		return fmt.Errorf("%s", models.FriendlyAddrError("nebula_ip", ip))
 	}
 
 	net, err := s.GetNetwork(ctx, networkID)


### PR DESCRIPTION
Closes #100.

## Summary
- Replace stdlib ParseAddr/ParsePrefix error text with stable, user-facing messages (`\"<value>\" is not a valid IPv4 or IPv6 address` / `... CIDR ...`) surfaced uniformly by Web inline forms and JSON API responses.
- New `internal/models/validate_ip.go` centralizes the friendly wrappers and `ValidateHostAdvanced`, so API and Web layers produce identical messages. Web inline now also rejects garbage in `adv_listen_host` / `unsafe_routes` (previously silently accepted).
- Validate `public_ip` with the same wrapper in both `internal/api/hosts.go` and `internal/web/handlers.go`.
- Replace the free-form `nebula_ip` text input in `host_new.html` with a segmented widget: byte-aligned IPv4 → locked prefix + per-octet number inputs; non-byte-aligned IPv4 → single bounded numeric host-offset input; byte-aligned IPv6 → locked prefix + per-group hex inputs; text fallback otherwise. The canonical `nebula_ip` text field stays hidden so the server still receives a full address and re-validates as the authority.

## Test plan
- [x] go test -race ./...
- [x] golangci-lint run ./...
- [x] New unit tests in internal/models, internal/api, internal/web cover friendly errors and template hooks.
- [ ] Manual: /ui/hosts/new with a /24 IPv4 network → 3 numeric octet inputs; /22 → single bounded numeric input; IPv6 /64 → 4 hex segment inputs.