### PR TITLE
feat(mobile): iOS/Android host enrollment with QR code bundles

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -156,6 +156,113 @@ sudo -u nebula-mgmt sqlite3 /var/lib/nebula-mgmt/nebula.db \
 The `NEBULA_MGMT_MASTER_KEY` is **load-bearing**: the DB on its own
 is useless without the matching key. Keep both in your secret manager.
 
+## Hosts
+
+### Mobile hosts (iOS / Android)
+
+The [Mobile Nebula](https://apps.apple.com/app/mobile-nebula/id1509587936)
+app (iOS) and
+[Mobile Nebula](https://play.google.com/store/apps/details?id=net.defined.mobile_nebula)
+app (Android) allow iOS and Android devices to join a Nebula mesh. Unlike
+regular hosts that run the `nebula-agent` daemon, mobile devices import a
+self-contained Nebula configuration file (in YAML format) bundled with
+inline certificates and keys.
+
+#### Creating a mobile host
+
+1. In the Web UI, navigate to **Hosts** → **New Host**.
+2. Select **Kind: Mobile** and choose the device type (**Variant: iOS** or
+   **Variant: Android**). The host's role is automatically set to `host`
+   (mobile devices cannot be lighthouses or relays).
+3. Fill in the remaining fields (Name, IP address, Groups) as you would for a
+   standard host.
+4. Submit. The mobile host is created but is **not yet enrolled** — no
+   enrollment token is issued.
+
+#### Generating the mobile bundle
+
+1. Navigate to the mobile host's detail page.
+2. Click **Generate Mobile Bundle**. The server will:
+   - Generate a fresh X25519 keypair
+   - Mint a certificate signed by your CA
+   - Create a self-contained Nebula YAML configuration with inline PEM blocks
+     for `pki.ca`, `pki.cert`, and `pki.key`
+3. The result page displays:
+   - The YAML configuration as a code block
+   - A QR code encoding the same YAML (for quick import into Mobile Nebula)
+   - A download link for the YAML file
+4. **Save the YAML immediately.** The private key is shown only once; it is
+   **not stored on the server**. Once you close the page, you cannot recover
+   the key.
+
+#### Importing the bundle into Mobile Nebula
+
+1. On your iOS or Android device, install **Mobile Nebula** from the App Store
+   or Play Store.
+2. Open the app and create a new profile.
+3. Import the configuration file via one of:
+   - Scan the QR code shown in the Web UI
+   - Copy-paste the YAML configuration
+   - Download the YAML file and share it to the Mobile Nebula app
+
+#### Rotating the certificate
+
+To rotate a mobile host's certificate (when approaching expiry or after a
+security incident):
+
+1. On the mobile host's detail page, click **Regenerate Bundle (Rotate Cert)**.
+   This generates a new keypair and certificate.
+2. Follow the steps under *Generating the mobile bundle* to download and import
+   the new configuration into Mobile Nebula.
+
+Each regeneration creates a fresh certificate. The old certificate remains
+valid for a short overlap window (to avoid disrupting active connections) and
+is automatically revoked after 30 days.
+
+#### Certificate lifetime
+
+Mobile certificates have a **365-day default lifetime**, compared to 30 days for
+agent-managed hosts. This longer lifetime reduces the operational burden of
+manual bundle regeneration and import on mobile devices.
+
+However, the certificate lifetime is **clamped to the remaining validity of your
+CA**. If your CA certificate is close to expiry, the generated mobile
+certificate will expire sooner. For example, if your CA expires in 180 days, a
+mobile certificate issued today will expire in 180 days (not 365).
+
+**Operational implication:** Before your CA certificate expires, rotate it and
+regenerate all mobile bundles. Failing to do so will leave mobile devices with
+expired certificates, unable to connect to the mesh.
+
+#### Revocation
+
+To revoke (block) a mobile host:
+
+1. On the mobile host's detail page, click **Block**. The host's certificate
+   fingerprint is added to the blocklist.
+2. Other mesh nodes will receive the updated blocklist via their regular poll
+   interval and **refuse handshakes** with the blocked fingerprint.
+
+Mobile devices themselves do not poll the management server, so they will not
+receive the revocation notice. However, the host is effectively isolated because
+peer nodes reject incoming and outgoing connections. To fully remove the device
+from the mesh, delete the configuration from the Mobile Nebula app.
+
+#### Updating after network changes
+
+Mobile bundles encode the network's current configuration (lighthouse IP
+addresses, port mappings, etc.). If you change your network topology (for
+example, promoting a new lighthouse or changing its public IP), previously-generated
+bundles become stale.
+
+**To update mobile devices after a network change:**
+
+1. Regenerate the bundle (click **Regenerate Bundle** on the host's detail page).
+2. Re-import the new YAML into Mobile Nebula.
+
+There is no automatic update mechanism for mobile clients; manual re-import is
+required each time the underlying network configuration changes.
+
 ## Troubleshooting
 
 ### `database is locked` errors at startup

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/juev/nebula-mesh
 go 1.26.1
 
 require (
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/google/uuid v1.6.0
@@ -21,7 +22,6 @@ require (
 require (
 	filippo.io/bigmod v0.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
-	"time"
 
 	"github.com/juev/nebula-mesh/internal/configgen"
 	"github.com/juev/nebula-mesh/internal/models"
@@ -130,7 +129,7 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 			PublicKey: pubKey,
 			Networks:  []netip.Prefix{hostPrefix},
 			Groups:    host.Groups,
-			Duration:  30 * 24 * time.Hour, // 30 days
+			Duration:  pki.DefaultAgentCertDuration,
 		})
 		if signErr != nil {
 			return nil, nil, signErr

--- a/internal/api/mobile_bundle.go
+++ b/internal/api/mobile_bundle.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/juev/nebula-mesh/internal/mobilebundle"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// handleMobileBundle implements POST /api/v1/hosts/{id}/mobile-bundle.
+// Generates a self-contained mobile bundle (YAML config + certificate + key)
+// for a mobile host. The private key is generated fresh and returned inline;
+// it is not persisted on the server.
+func (s *Server) handleMobileBundle(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	host, err := s.store.GetHost(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "host not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get host for mobile-bundle", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get host")
+		return
+	}
+
+	// Check that host is mobile
+	if host.Kind != models.HostKindMobile {
+		writeError(w, http.StatusBadRequest, "host must be a mobile host")
+		return
+	}
+
+	// Resolve the CA that owns this host and sign with it.
+	caMgr, err := s.caForHost(r.Context(), host)
+	if err != nil {
+		s.logger.Error("resolve host CA", "error", err, "host_id", host.ID, "ca_id", host.CAID)
+		writeError(w, http.StatusInternalServerError, "failed to resolve CA")
+		return
+	}
+
+	// Build the mobile bundle under CA read lock (signing requires CA private key access)
+	simpleResolver := &singleCAResolver{ca: caMgr}
+	s.caMu.RLock()
+	bundle, err := mobilebundle.Build(r.Context(), s.store, simpleResolver, host)
+	s.caMu.RUnlock()
+
+	if errors.Is(err, mobilebundle.ErrNotMobile) {
+		writeError(w, http.StatusBadRequest, "host is not a mobile host")
+		return
+	}
+	if err != nil {
+		s.logger.Error("build mobile bundle", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to build bundle")
+		return
+	}
+
+	// Return YAML bundle with proper content-type
+	w.Header().Set("Content-Type", "application/yaml; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(bundle); err != nil {
+		s.logger.Error("write mobile bundle response", "error", err)
+	}
+}
+
+// singleCAResolver wraps a resolved CAManager to match the resolver interface.
+type singleCAResolver struct {
+	ca *pki.CAManager
+}
+
+func (r *singleCAResolver) LoadByID(ctx context.Context, caID string) (*pki.CAManager, error) {
+	return r.ca, nil
+}

--- a/internal/api/mobile_bundle_test.go
+++ b/internal/api/mobile_bundle_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/juev/nebula-mesh/internal/models"
+	"gopkg.in/yaml.v3"
+)
+
+// TestHandleMobileBundle_Success verifies the handler generates a mobile bundle
+// for a mobile host and returns YAML with proper content-type header.
+func TestHandleMobileBundle_Success(t *testing.T) {
+	srv, st := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	// Create a mobile host
+	now := time.Now()
+	host := &models.Host{
+		ID:        uuid.New().String(),
+		NetworkID: netID,
+		Name:      "iphone-1",
+		NebulaIP:  "192.168.100.50",
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantIOS,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CAID:      "",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := st.CreateHost(context.Background(), host); err != nil {
+		t.Fatalf("create mobile host: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/mobile-bundle", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	// Check content-type header
+	if ct := w.Header().Get("Content-Type"); ct != "application/yaml; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want 'application/yaml; charset=utf-8'", ct)
+	}
+
+	// Verify body is valid YAML with expected keys
+	var yamlData map[string]interface{}
+	if err := yaml.Unmarshal(w.Body.Bytes(), &yamlData); err != nil {
+		t.Fatalf("parse YAML response: %v", err)
+	}
+	if _, ok := yamlData["pki"]; !ok {
+		t.Error("YAML missing 'pki' key")
+	}
+
+	// Verify host status was updated to enrolled
+	updated, err := st.GetHost(context.Background(), host.ID)
+	if err != nil {
+		t.Fatalf("get host after bundle: %v", err)
+	}
+	if updated.Status != models.HostStatusEnrolled {
+		t.Errorf("host status = %q, want %q", updated.Status, models.HostStatusEnrolled)
+	}
+}
+
+// TestHandleMobileBundle_RejectsNonMobile verifies non-mobile hosts get 400.
+func TestHandleMobileBundle_RejectsNonMobile(t *testing.T) {
+	srv, st := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	// Create an agent (non-mobile) host
+	now := time.Now()
+	host := &models.Host{
+		ID:        uuid.New().String(),
+		NetworkID: netID,
+		Name:      "agent-1",
+		NebulaIP:  "192.168.100.51",
+		Kind:      models.HostKindAgent,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CAID:      "",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := st.CreateHost(context.Background(), host); err != nil {
+		t.Fatalf("create agent host: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/mobile-bundle", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", w.Code, w.Body.String())
+	}
+
+	var errResp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp["error"] == "" {
+		t.Error("error response missing error message")
+	}
+}
+
+// TestHandleMobileBundle_NotFound verifies missing host returns 404.
+func TestHandleMobileBundle_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req := httptest.NewRequest("POST", "/api/v1/hosts/nonexistent/mobile-bundle", nil)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+// TestHandleMobileBundle_Unauthorized verifies missing bearer auth returns 401.
+func TestHandleMobileBundle_Unauthorized(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req := httptest.NewRequest("POST", "/api/v1/hosts/anything/mobile-bundle", nil)
+	// Note: no authRequest call — missing Authorization header
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -196,6 +196,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/api/v1/hosts/{id}/enrollment-token", s.handleRegenerateEnrollmentToken)
 		r.Post("/api/v1/hosts/{id}/rotate-cert", s.handleRotateCert)
 		r.Post("/api/v1/hosts/{id}/reenroll", s.handleReenroll)
+		r.Post("/api/v1/hosts/{id}/mobile-bundle", s.handleMobileBundle)
 		r.Get("/api/v1/blocklist", s.handleGetBlocklist)
 		r.Get("/api/v1/ca", s.handleGetCA)
 		r.Post("/api/v1/ca/rotate", s.handleRotateCA)

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -295,7 +295,7 @@ func (s *Server) signHostCert(ctx context.Context, host *models.Host, certInfo *
 			PublicKey: currentCert.PublicKey(),
 			Networks:  []netip.Prefix{hostPrefix},
 			Groups:    host.Groups,
-			Duration:  30 * 24 * time.Hour,
+			Duration:  pki.DefaultAgentCertDuration,
 		})
 		if signErr != nil {
 			return nil, nil, fmt.Errorf("sign renewed cert: %w", signErr)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -240,6 +240,9 @@ func Serve(configPath string) error {
 	if master != nil {
 		webUI.WithMaster(master)
 	}
+	if caResolver != nil {
+		webUI.WithCAResolver(caResolver)
+	}
 
 	// Live host-status SSE: API server fires HostSeenEmitter on each agent
 	// poll, EventBus fans out to subscribed browser tabs.

--- a/internal/configgen/generator.go
+++ b/internal/configgen/generator.go
@@ -3,6 +3,7 @@ package configgen
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 )
 
@@ -46,12 +47,30 @@ type GeneratorInput struct {
 	MTU              int
 	TunDevice        string
 	UnsafeRoutes     []AdvancedUnsafeRoute
+
+	// Optional: if set, override the path-based pki section with inline PEM blocks.
+	// Used for Mobile Nebula clients which import a self-contained YAML config.
+	// When CACertPEM is non-empty, CertPEM and KeyPEM must also be non-empty;
+	// the template uses literal-block scalars for all three. When empty, the
+	// template falls back to CACertPath/CertPath/KeyPath (default behavior).
+	CACertPEM string
+	CertPEM   string
+	KeyPEM    string
 }
 
 const configTemplate = `pki:
+{{- if .CACertPEM }}
+  ca: |
+{{ .CACertPEM | indent4 }}
+  cert: |
+{{ .CertPEM | indent4 }}
+  key: |
+{{ .KeyPEM | indent4 }}
+{{- else }}
   ca: {{ .CACertPath }}
   cert: {{ .CertPath }}
   key: {{ .KeyPath }}
+{{- end }}
 
 {{- if .IsLighthouse }}
 
@@ -148,9 +167,27 @@ firewall:
     {{- end }}
 `
 
+// indentLines indents each line of the given string by n spaces.
+// Strips trailing newline to avoid empty indented lines at the end.
+func indentLines(s string, n int) string {
+	pad := strings.Repeat(" ", n)
+	s = strings.TrimRight(s, "\n")
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = pad + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
 // Generate produces a Nebula config.yml from the given input.
 func Generate(input GeneratorInput) ([]byte, error) {
-	tmpl, err := template.New("nebula-config").Parse(configTemplate)
+	funcs := template.FuncMap{
+		"indent4": func(s string) string { return indentLines(s, 4) },
+	}
+
+	tmpl, err := template.New("nebula-config").Funcs(funcs).Parse(configTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("parse template: %w", err)
 	}

--- a/internal/configgen/generator_test.go
+++ b/internal/configgen/generator_test.go
@@ -1,9 +1,13 @@
 package configgen
 
 import (
+	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/slackhq/nebula/cert"
 	"gopkg.in/yaml.v3"
 )
 
@@ -127,5 +131,238 @@ func TestGenerate_Relay(t *testing.T) {
 	s := string(data)
 	if !strings.Contains(s, "am_relay: true") {
 		t.Error("relay should have am_relay: true")
+	}
+}
+
+func TestGenerate_FallbackToPaths(t *testing.T) {
+	input := GeneratorInput{
+		HostName:     "web-1",
+		NebulaIP:     "192.168.100.10",
+		IsLighthouse: false,
+		IsRelay:      false,
+		CACertPath:   "/etc/nebula/ca.crt",
+		CertPath:     "/etc/nebula/host.crt",
+		KeyPath:      "/etc/nebula/host.key",
+		ListenPort:   0,
+		Lighthouses: []LighthouseInfo{
+			{NebulaIP: "192.168.100.1", PublicAddr: "203.0.113.10:4242"},
+		},
+		FirewallInbound: []FirewallRule{
+			{Port: "any", Proto: "icmp", Group: "any"},
+		},
+		FirewallOutbound: []FirewallRule{
+			{Port: "any", Proto: "any", Group: "any"},
+		},
+		// Inline PEM fields are empty - should use path-based fallback
+		CACertPEM: "",
+		CertPEM:   "",
+		KeyPEM:    "",
+	}
+
+	data, err := Generate(input)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid YAML: %v\n%s", err, string(data))
+	}
+
+	s := string(data)
+	// Backwards compat: should contain path-based pki section
+	if !strings.Contains(s, "ca: /etc/nebula/ca.crt") {
+		t.Error("expected path-based ca cert path")
+	}
+	if !strings.Contains(s, "cert: /etc/nebula/host.crt") {
+		t.Error("expected path-based cert path")
+	}
+	if !strings.Contains(s, "key: /etc/nebula/host.key") {
+		t.Error("expected path-based key path")
+	}
+	// Should NOT contain inline PEM literal blocks
+	if strings.Contains(s, "ca: |") {
+		t.Error("should not contain inline PEM when PEM fields are empty")
+	}
+}
+
+func TestGenerate_InlinePEM(t *testing.T) {
+	caPEM := `-----BEGIN NEBULA CERTIFICATE-----
+CACA...CA...CACA
+-----END NEBULA CERTIFICATE-----`
+	certPEM := `-----BEGIN NEBULA CERTIFICATE-----
+CERT...CERT...CERT
+-----END NEBULA CERTIFICATE-----`
+	keyPEM := `-----BEGIN NEBULA X25519 PRIVATE KEY-----
+KEY...KEY...KEY
+-----END NEBULA X25519 PRIVATE KEY-----`
+
+	input := GeneratorInput{
+		HostName:     "mobile-1",
+		NebulaIP:     "192.168.100.50",
+		IsLighthouse: false,
+		IsRelay:      false,
+		ListenPort:   0,
+		Lighthouses: []LighthouseInfo{
+			{NebulaIP: "192.168.100.1", PublicAddr: "203.0.113.10:4242"},
+		},
+		FirewallInbound: []FirewallRule{
+			{Port: "any", Proto: "icmp", Group: "any"},
+		},
+		FirewallOutbound: []FirewallRule{
+			{Port: "any", Proto: "any", Group: "any"},
+		},
+		// Use inline PEM
+		CACertPEM: caPEM,
+		CertPEM:   certPEM,
+		KeyPEM:    keyPEM,
+		// Path-based fields should be ignored
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+	}
+
+	data, err := Generate(input)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid YAML: %v\n%s", err, string(data))
+	}
+
+	s := string(data)
+	// Should contain inline PEM literal blocks
+	if !strings.Contains(s, "ca: |") {
+		t.Error("expected inline PEM literal block for ca")
+	}
+	if !strings.Contains(s, "-----BEGIN NEBULA CERTIFICATE-----") {
+		t.Error("expected inline CA certificate content")
+	}
+	// Should NOT contain path-based pki section
+	if strings.Contains(s, "ca: /etc/nebula/ca.crt") {
+		t.Error("should not contain path-based ca when PEM is set")
+	}
+	if strings.Contains(s, "cert: /etc/nebula/host.crt") {
+		t.Error("should not contain path-based cert when PEM is set")
+	}
+	if strings.Contains(s, "key: /etc/nebula/host.key") {
+		t.Error("should not contain path-based key when PEM is set")
+	}
+}
+
+func TestGenerate_InlinePEM_RoundTrip(t *testing.T) {
+	// Generate real CA and host certificates
+	caMgr, _, err := pki.NewCA("test-ca", 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+
+	caPEM, err := caMgr.CACertPEM()
+	if err != nil {
+		t.Fatalf("CACertPEM error: %v", err)
+	}
+
+	// Generate host certificate with network prefix
+	var prefixAddr [4]byte
+	prefixAddr[0] = 192
+	prefixAddr[1] = 168
+	prefixAddr[2] = 100
+	prefixAddr[3] = 50
+	hostPrefix := netip.PrefixFrom(netip.AddrFrom4(prefixAddr), 32)
+
+	hostCert, err := caMgr.Sign(pki.SignRequest{
+		Name:      "mobile-test",
+		PublicKey: []byte("test-public-key-32-bytes-buffer"),
+		Networks:  []netip.Prefix{hostPrefix},
+		Duration:  365 * 24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	certPEM, err := hostCert.MarshalPEM()
+	if err != nil {
+		t.Fatalf("MarshalPEM: %v", err)
+	}
+
+	keyPEM := cert.MarshalPrivateKeyToPEM(cert.Curve_CURVE25519, []byte("test-private-key-32-bytes-buffer"))
+
+	input := GeneratorInput{
+		HostName:     "mobile-test",
+		NebulaIP:     "192.168.100.50",
+		IsLighthouse: false,
+		IsRelay:      false,
+		ListenPort:   0,
+		Lighthouses: []LighthouseInfo{
+			{NebulaIP: "192.168.100.1", PublicAddr: "203.0.113.10:4242"},
+		},
+		FirewallInbound: []FirewallRule{
+			{Port: "any", Proto: "icmp", Group: "any"},
+		},
+		FirewallOutbound: []FirewallRule{
+			{Port: "any", Proto: "any", Group: "any"},
+		},
+		CACertPEM: string(caPEM),
+		CertPEM:   string(certPEM),
+		KeyPEM:    string(keyPEM),
+	}
+
+	data, err := Generate(input)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// Parse generated YAML
+	var parsed map[string]any
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid YAML: %v\n%s", err, string(data))
+	}
+
+	// Extract pki section
+	pkiMap, ok := parsed["pki"].(map[string]any)
+	if !ok {
+		t.Fatalf("pki section not found in parsed YAML")
+	}
+
+	// Check CA cert
+	pkiCA, ok := pkiMap["ca"].(string)
+	if !ok {
+		t.Fatalf("ca should be a string, got %T", pkiMap["ca"])
+	}
+	if !strings.Contains(pkiCA, "-----BEGIN NEBULA CERTIFICATE") {
+		t.Error("ca does not contain PEM header")
+	}
+
+	// Verify CA cert can be unmarshalled
+	caCert, _, err := cert.UnmarshalCertificateFromPEM([]byte(pkiCA))
+	if err != nil {
+		t.Errorf("UnmarshalCertificateFromPEM for CA: %v", err)
+	}
+	if caCert.Name() != "test-ca" {
+		t.Errorf("expected CA name 'test-ca', got %q", caCert.Name())
+	}
+
+	// Check host cert
+	pkiCert, ok := pkiMap["cert"].(string)
+	if !ok {
+		t.Fatalf("cert should be a string, got %T", pkiMap["cert"])
+	}
+	hostCertUnmarshalled, _, err := cert.UnmarshalCertificateFromPEM([]byte(pkiCert))
+	if err != nil {
+		t.Errorf("UnmarshalCertificateFromPEM for host cert: %v", err)
+	}
+	if hostCertUnmarshalled.Name() != "mobile-test" {
+		t.Errorf("expected host name 'mobile-test', got %q", hostCertUnmarshalled.Name())
+	}
+
+	// Check private key
+	pkiKey, ok := pkiMap["key"].(string)
+	if !ok {
+		t.Fatalf("key should be a string, got %T", pkiMap["key"])
+	}
+	if !strings.Contains(pkiKey, "-----BEGIN NEBULA X25519 PRIVATE KEY-----") {
+		t.Error("key does not contain X25519 private key PEM header")
 	}
 }

--- a/internal/mobilebundle/builder.go
+++ b/internal/mobilebundle/builder.go
@@ -1,0 +1,185 @@
+package mobilebundle
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"net/netip"
+
+	"github.com/juev/nebula-mesh/internal/configgen"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+)
+
+var ErrNotMobile = errors.New("mobilebundle: host is not a mobile host")
+
+// Build mints a fresh X25519 keypair + cert for a mobile host, persists the
+// cert via store, and returns a self-contained Nebula YAML bundle with
+// inline PEM for ca/cert/key. The private key is not persisted server-side
+// — it lives only in the returned bytes.
+func Build(ctx context.Context, s store.Store, resolver interface{ LoadByID(context.Context, string) (*pki.CAManager, error) }, host *models.Host) ([]byte, error) {
+	if host.Kind != models.HostKindMobile {
+		return nil, ErrNotMobile
+	}
+
+	// Generate X25519 keypair.
+	priv := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, priv); err != nil {
+		return nil, fmt.Errorf("generate private key: %w", err)
+	}
+	pub, err := curve25519.X25519(priv, curve25519.Basepoint)
+	if err != nil {
+		return nil, fmt.Errorf("derive public key: %w", err)
+	}
+
+	// Resolve CA for this host.
+	caMgr, err := resolver.LoadByID(ctx, host.CAID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve CA: %w", err)
+	}
+
+	// Get network.
+	network, err := s.GetNetwork(ctx, host.NetworkID)
+	if err != nil {
+		return nil, fmt.Errorf("get network: %w", err)
+	}
+
+	// Build host prefix.
+	hostPrefix, err := buildHostPrefix(host.NebulaIP, network.CIDR)
+	if err != nil {
+		return nil, fmt.Errorf("build host prefix: %w", err)
+	}
+
+	// Sign certificate.
+	hostCert, err := caMgr.Sign(pki.SignRequest{
+		Name:      host.Name,
+		PublicKey: pub,
+		Networks:  []netip.Prefix{hostPrefix},
+		Groups:    host.Groups,
+		Duration:  pki.DefaultMobileCertDuration,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("sign cert: %w", err)
+	}
+
+	// Marshal cert to PEM.
+	certPEM, err := hostCert.MarshalPEM()
+	if err != nil {
+		return nil, fmt.Errorf("marshal cert: %w", err)
+	}
+
+	// Get fingerprint.
+	fp, err := hostCert.Fingerprint()
+	if err != nil {
+		return nil, fmt.Errorf("cert fingerprint: %w", err)
+	}
+
+	// Persist certificate.
+	if host.Status == models.HostStatusPending {
+		if err := s.SaveCertificateAndEnrollHost(ctx, host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
+			return nil, fmt.Errorf("save certificate: %w", err)
+		}
+	} else {
+		if err := s.SaveCertificateAndUpdateHostCert(ctx, host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
+			return nil, fmt.Errorf("rotate certificate: %w", err)
+		}
+	}
+
+	// Get CA cert PEM.
+	caPEM, err := caMgr.CACertPEM()
+	if err != nil {
+		return nil, fmt.Errorf("ca cert PEM: %w", err)
+	}
+
+	// Marshal private key to PEM.
+	privPEM := cert.MarshalPrivateKeyToPEM(cert.Curve_CURVE25519, priv)
+
+	// Get lighthouses.
+	lighthouses, err := listLighthouses(ctx, s, host.NetworkID)
+	if err != nil {
+		return nil, fmt.Errorf("list lighthouses: %w", err)
+	}
+
+	// Compose GeneratorInput with inline PEM.
+	input := configgen.GeneratorInput{
+		HostName:    host.Name,
+		NebulaIP:    host.NebulaIP,
+		CACertPEM:   string(caPEM),
+		CertPEM:     string(certPEM),
+		KeyPEM:      string(privPEM),
+		Lighthouses: lighthouses,
+		FirewallInbound: []configgen.FirewallRule{
+			{Port: "any", Proto: "icmp", Group: "any"},
+		},
+		FirewallOutbound: []configgen.FirewallRule{
+			{Port: "any", Proto: "any", Group: "any"},
+		},
+	}
+
+	// Apply advanced overrides if present.
+	if adv := host.Advanced; adv != nil {
+		input.PunchyOverride = adv.Punchy
+		input.ListenHost = adv.ListenHost
+		input.MTU = adv.MTU
+		input.TunDevice = adv.TunDevice
+		for _, u := range adv.UnsafeRoutes {
+			input.UnsafeRoutes = append(input.UnsafeRoutes, configgen.AdvancedUnsafeRoute{Route: u.Route, Via: u.Via})
+		}
+	}
+
+	return configgen.Generate(input)
+}
+
+// buildHostPrefix mirrors the logic from internal/api/helpers.go.
+// Parses hostIP and networkCIDR, validates they belong to the same IP family,
+// and returns a prefix combining the host address with the network mask.
+func buildHostPrefix(hostIP, networkCIDR string) (netip.Prefix, error) {
+	prefix, err := netip.ParsePrefix(networkCIDR)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("parse CIDR: %w", err)
+	}
+
+	hostAddr, err := netip.ParseAddr(hostIP)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("parse host IP: %w", err)
+	}
+
+	if hostAddr.Is4() != prefix.Addr().Is4() {
+		return netip.Prefix{}, fmt.Errorf("IP family mismatch: host %s vs network %s", hostIP, networkCIDR)
+	}
+
+	return netip.PrefixFrom(hostAddr, prefix.Bits()), nil
+}
+
+// listLighthouses mirrors the logic from internal/api/enroll.go.
+// Returns every enrolled lighthouse in the given network.
+func listLighthouses(ctx context.Context, s store.Store, networkID string) ([]configgen.LighthouseInfo, error) {
+	hosts, err := s.ListHosts(ctx, store.HostFilter{
+		NetworkID: networkID,
+		Status:    models.HostStatusEnrolled,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]configgen.LighthouseInfo, 0)
+	for _, h := range hosts {
+		if !h.IsLighthouse || h.PublicIP == "" {
+			continue
+		}
+		port := h.ListenPort
+		if port == 0 {
+			port = 4242
+		}
+		result = append(result, configgen.LighthouseInfo{
+			NebulaIP:   h.NebulaIP,
+			PublicAddr: fmt.Sprintf("%s:%d", h.PublicIP, port),
+		})
+	}
+	return result, nil
+}

--- a/internal/mobilebundle/builder_test.go
+++ b/internal/mobilebundle/builder_test.go
@@ -1,0 +1,257 @@
+package mobilebundle
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+	"github.com/slackhq/nebula/cert"
+)
+
+func TestBuild_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup: in-memory store, CA, network, mobile host.
+	s, err := store.NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Create a CA.
+	ca, _, err := pki.NewCA("test-ca", 365*24*time.Hour)
+	require.NoError(t, err)
+
+	// Create CA resolver (wrap ca in a stub that returns it by id).
+	resolver := &StubCAResolver{ca: ca}
+
+	// Create network.
+	network := &models.Network{
+		ID:   "net-1",
+		Name: "test-network",
+		CIDR: "10.0.0.0/8",
+	}
+	err = s.CreateNetwork(ctx, network)
+	require.NoError(t, err)
+
+	// Create mobile host.
+	host := &models.Host{
+		ID:        "mobile-1",
+		Name:      "phone-a",
+		NetworkID: network.ID,
+		NebulaIP:  "10.0.0.5",
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantIOS,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CAID:      "test-ca-id", // stub resolver ignores this
+		Groups:    []string{"mobile", "ios"},
+	}
+	err = s.CreateHost(ctx, host)
+	require.NoError(t, err)
+
+	// Call Build.
+	bundle, err := Build(ctx, s, resolver, host)
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+	require.NotEmpty(t, bundle)
+
+	// Parse as YAML.
+	var parsed map[string]interface{}
+	err = yaml.Unmarshal(bundle, &parsed)
+	require.NoError(t, err)
+
+	// Check pki section exists and contains inline PEM.
+	pkiRaw, ok := parsed["pki"]
+	require.True(t, ok, "no pki section in bundle")
+	pkiSection, ok := pkiRaw.(map[string]interface{})
+	require.True(t, ok, "pki is not a map")
+
+	// Check CA PEM.
+	caRaw, ok := pkiSection["ca"]
+	require.True(t, ok, "no ca in pki")
+	caPEM, ok := caRaw.(string)
+	require.True(t, ok, "ca is not a string")
+	require.NotEmpty(t, caPEM)
+	require.True(t,
+		contains(caPEM, "-----BEGIN NEBULA CERTIFICATE-----") ||
+			contains(caPEM, "-----BEGIN NEBULA CERTIFICATE V2-----"),
+		"CA PEM does not have valid NEBULA CERTIFICATE header",
+	)
+
+	// Verify CA PEM is valid.
+	caCert, _, err := cert.UnmarshalCertificateFromPEM([]byte(caPEM))
+	require.NoError(t, err)
+	require.Equal(t, "test-ca", caCert.Name())
+
+	// Check host cert PEM.
+	certRaw, ok := pkiSection["cert"]
+	require.True(t, ok, "no cert in pki")
+	certPEM, ok := certRaw.(string)
+	require.True(t, ok, "cert is not a string")
+	require.NotEmpty(t, certPEM)
+
+	hostCert, _, err := cert.UnmarshalCertificateFromPEM([]byte(certPEM))
+	require.NoError(t, err)
+	require.Equal(t, "phone-a", hostCert.Name())
+	require.Len(t, hostCert.Networks(), 1)
+	require.Equal(t, "10.0.0.5/8", hostCert.Networks()[0].String())
+
+	// Check key PEM.
+	keyRaw, ok := pkiSection["key"]
+	require.True(t, ok, "no key in pki")
+	keyPEM, ok := keyRaw.(string)
+	require.True(t, ok, "key is not a string")
+	require.NotEmpty(t, keyPEM)
+
+	privKey, _, _, err := cert.UnmarshalPrivateKeyFromPEM([]byte(keyPEM))
+	require.NoError(t, err)
+	require.NotNil(t, privKey)
+
+	// Verify host is enrolled and has cert fingerprint.
+	updated, err := s.GetHost(ctx, host.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.HostStatusEnrolled, updated.Status)
+	require.NotEmpty(t, updated.CertFingerprint)
+	require.Empty(t, updated.SigningPubPEM) // Mobile should not have PoP key
+
+	// Check that cert is in database.
+	certInfo, err := s.GetCertificateInfo(ctx, host.ID)
+	require.NoError(t, err)
+	require.NotNil(t, certInfo)
+	require.True(t, certInfo.IsCurrent)
+}
+
+func TestBuild_Rotate(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := store.NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ca, _, err := pki.NewCA("test-ca", 365*24*time.Hour)
+	require.NoError(t, err)
+	resolver := &StubCAResolver{ca: ca}
+
+	network := &models.Network{
+		ID:   "net-1",
+		Name: "test-network",
+		CIDR: "10.0.0.0/8",
+	}
+	err = s.CreateNetwork(ctx, network)
+	require.NoError(t, err)
+
+	host := &models.Host{
+		ID:        "mobile-1",
+		Name:      "phone-a",
+		NetworkID: network.ID,
+		NebulaIP:  "10.0.0.5",
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantAndroid,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CAID:      "test-ca-id",
+		Groups:    []string{"mobile"},
+	}
+	err = s.CreateHost(ctx, host)
+	require.NoError(t, err)
+
+	// First call.
+	bundle1, err := Build(ctx, s, resolver, host)
+	require.NoError(t, err)
+
+	host1, err := s.GetHost(ctx, host.ID)
+	require.NoError(t, err)
+	fp1 := host1.CertFingerprint
+
+	// Second call (rotate).
+	bundle2, err := Build(ctx, s, resolver, host1)
+	require.NoError(t, err)
+
+	host2, err := s.GetHost(ctx, host.ID)
+	require.NoError(t, err)
+	fp2 := host2.CertFingerprint
+
+	// Fingerprints must differ.
+	require.NotEqual(t, fp1, fp2)
+	require.NotEmpty(t, fp1)
+	require.NotEmpty(t, fp2)
+
+	// Bundles should be different.
+	require.NotEqual(t, string(bundle1), string(bundle2))
+
+	// Both should be valid YAML.
+	var p1, p2 map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(bundle1, &p1))
+	require.NoError(t, yaml.Unmarshal(bundle2, &p2))
+}
+
+func TestBuild_RejectsNonMobile(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := store.NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ca, _, err := pki.NewCA("test-ca", 365*24*time.Hour)
+	require.NoError(t, err)
+	resolver := &StubCAResolver{ca: ca}
+
+	network := &models.Network{
+		ID:   "net-1",
+		Name: "test-network",
+		CIDR: "10.0.0.0/8",
+	}
+	err = s.CreateNetwork(ctx, network)
+	require.NoError(t, err)
+
+	// Agent host (not mobile).
+	host := &models.Host{
+		ID:        "agent-1",
+		Name:      "server-a",
+		NetworkID: network.ID,
+		NebulaIP:  "10.0.0.1",
+		Kind:      models.HostKindAgent,
+		Variant:   models.HostVariantNone,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CAID:      "test-ca-id",
+	}
+	err = s.CreateHost(ctx, host)
+	require.NoError(t, err)
+
+	bundle, err := Build(ctx, s, resolver, host)
+	require.ErrorIs(t, err, ErrNotMobile)
+	require.Nil(t, bundle)
+}
+
+// StubCAResolver returns a fixed CA for any ID.
+type StubCAResolver struct {
+	ca *pki.CAManager
+}
+
+func (s *StubCAResolver) LoadByID(ctx context.Context, caID string) (*pki.CAManager, error) {
+	return s.ca, nil
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i < len(s)-len(substr)+1; i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/models/host.go
+++ b/internal/models/host.go
@@ -32,6 +32,71 @@ func ValidRole(r HostRole) bool {
 	}
 }
 
+type HostKind string
+
+const (
+	HostKindAgent  HostKind = "agent"
+	HostKindMobile HostKind = "mobile"
+)
+
+// ValidKind reports whether k is a known host kind.
+func ValidKind(k HostKind) bool {
+	switch k {
+	case HostKindAgent, HostKindMobile:
+		return true
+	default:
+		return false
+	}
+}
+
+type HostVariant string
+
+const (
+	HostVariantNone    HostVariant = ""
+	HostVariantIOS     HostVariant = "ios"
+	HostVariantAndroid HostVariant = "android"
+)
+
+// ValidVariant reports whether v is a known host variant (including empty).
+func ValidVariant(v HostVariant) bool {
+	switch v {
+	case HostVariantNone, HostVariantIOS, HostVariantAndroid:
+		return true
+	default:
+		return false
+	}
+}
+
+// ErrMobileRoleRestricted is returned when a mobile host is assigned a role
+// other than host (e.g., lighthouse or relay). Mobile Nebula clients cannot
+// reliably listen on a public socket in the background, so these roles are
+// not supported for mobile hosts.
+var ErrMobileRoleRestricted = errors.New("mobile hosts must have role=host (lighthouse/relay not supported)")
+
+// ErrMobileVariantRequired is returned when a mobile host is created without
+// specifying a variant (ios or android). The variant field is required to
+// distinguish mobile client types.
+var ErrMobileVariantRequired = errors.New("mobile hosts must have variant set to ios or android")
+
+// ValidateMobileConstraints enforces role and variant constraints for mobile hosts.
+// For kind=mobile, role must be host (or empty) and variant must be ios or android.
+// For kind=agent, no constraints are applied (returns nil).
+func ValidateMobileConstraints(kind HostKind, variant HostVariant, role HostRole) error {
+	if kind != HostKindMobile {
+		return nil
+	}
+
+	if role != "" && role != HostRoleHost {
+		return ErrMobileRoleRestricted
+	}
+
+	if variant == HostVariantNone {
+		return ErrMobileVariantRequired
+	}
+
+	return nil
+}
+
 // ErrRoleRequiresPublicIP is returned when a host with role=lighthouse or
 // role=relay is created without a non-empty public_ip. Such a host would
 // never be advertised to peers (see internal/api/enroll.go where
@@ -83,6 +148,8 @@ type Host struct {
 	SigningPubPEM       string        `json:"signing_pub_pem,omitempty"`
 	LastSeenAt          *time.Time    `json:"last_seen_at,omitempty"`
 	Advanced            *HostAdvanced `json:"advanced,omitempty"`
+	Kind                HostKind      `json:"kind"`
+	Variant             HostVariant   `json:"variant,omitempty"`
 	CreatedAt           time.Time     `json:"created_at"`
 	UpdatedAt           time.Time     `json:"updated_at"`
 }

--- a/internal/models/host_test.go
+++ b/internal/models/host_test.go
@@ -3,6 +3,8 @@ package models
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidRole(t *testing.T) {
@@ -61,6 +63,121 @@ func TestValidateRoleReachability(t *testing.T) {
 			}
 			if !errors.Is(got, tt.wantErr) {
 				t.Errorf("got error %v, want %v", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     HostKind
+		expected bool
+	}{
+		{name: "agent", kind: HostKindAgent, expected: true},
+		{name: "mobile", kind: HostKindMobile, expected: true},
+		{name: "empty string", kind: "", expected: false},
+		{name: "unknown", kind: "unknown", expected: false},
+		{name: "lighthouse", kind: "lighthouse", expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ValidKind(tt.kind))
+		})
+	}
+}
+
+func TestValidVariant(t *testing.T) {
+	tests := []struct {
+		name    string
+		variant HostVariant
+		expected bool
+	}{
+		{name: "none (empty)", variant: HostVariantNone, expected: true},
+		{name: "ios", variant: HostVariantIOS, expected: true},
+		{name: "android", variant: HostVariantAndroid, expected: true},
+		{name: "windows", variant: "windows", expected: false},
+		{name: "macos", variant: "macos", expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ValidVariant(tt.variant))
+		})
+	}
+}
+
+func TestValidateMobileConstraints(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    HostKind
+		variant HostVariant
+		role    HostRole
+		wantErr bool
+		errIs   error
+	}{
+		{
+			name:    "mobile with lighthouse role",
+			kind:    HostKindMobile,
+			variant: HostVariantIOS,
+			role:    HostRoleLighthouse,
+			wantErr: true,
+			errIs:   ErrMobileRoleRestricted,
+		},
+		{
+			name:    "mobile with relay role",
+			kind:    HostKindMobile,
+			variant: HostVariantAndroid,
+			role:    HostRoleRelay,
+			wantErr: true,
+			errIs:   ErrMobileRoleRestricted,
+		},
+		{
+			name:    "mobile with variant empty and role host",
+			kind:    HostKindMobile,
+			variant: HostVariantNone,
+			role:    HostRoleHost,
+			wantErr: true,
+			errIs:   ErrMobileVariantRequired,
+		},
+		{
+			name:    "mobile ios with host role",
+			kind:    HostKindMobile,
+			variant: HostVariantIOS,
+			role:    HostRoleHost,
+			wantErr: false,
+		},
+		{
+			name:    "mobile android with host role",
+			kind:    HostKindMobile,
+			variant: HostVariantAndroid,
+			role:    HostRoleHost,
+			wantErr: false,
+		},
+		{
+			name:    "agent with any role and any variant",
+			kind:    HostKindAgent,
+			variant: HostVariantIOS,
+			role:    HostRoleLighthouse,
+			wantErr: false,
+		},
+		{
+			name:    "agent kind ignores mobile constraints",
+			kind:    HostKindAgent,
+			variant: HostVariantNone,
+			role:    HostRoleRelay,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMobileConstraints(tt.kind, tt.variant, tt.role)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errIs != nil {
+					assert.ErrorIs(t, err, tt.errIs)
+				}
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/internal/pki/durations.go
+++ b/internal/pki/durations.go
@@ -1,0 +1,16 @@
+package pki
+
+import "time"
+
+// DefaultAgentCertDuration is the lifetime of host certificates minted for
+// agent-managed hosts that auto-rotate via the poll loop (ADR 0004).
+// 30 days strikes a balance between rotation overhead and revocation latency.
+const DefaultAgentCertDuration = 30 * 24 * time.Hour
+
+// DefaultMobileCertDuration is the lifetime of host certificates minted for
+// Mobile Nebula clients (kind=mobile). Mobile rotation requires the operator
+// to re-download a bundle and the user to re-import it manually, so a
+// longer lifetime reduces operator burden. The signer clamps to remaining
+// CA validity (see signer.go), so practical lifetime is min(365d, CA_remaining).
+// Revocation via the blocklist remains the immediate security control.
+const DefaultMobileCertDuration = 365 * 24 * time.Hour

--- a/internal/pki/durations_test.go
+++ b/internal/pki/durations_test.go
@@ -1,0 +1,18 @@
+package pki
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultAgentCertDuration_Value(t *testing.T) {
+	expected := 30 * 24 * time.Hour
+	assert.Equal(t, expected, DefaultAgentCertDuration)
+}
+
+func TestDefaultMobileCertDuration_Value(t *testing.T) {
+	expected := 365 * 24 * time.Hour
+	assert.Equal(t, expected, DefaultMobileCertDuration)
+}

--- a/internal/store/migrations/013_host_mobile.down.sql
+++ b/internal/store/migrations/013_host_mobile.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hosts DROP COLUMN variant;
+ALTER TABLE hosts DROP COLUMN kind;

--- a/internal/store/migrations/013_host_mobile.up.sql
+++ b/internal/store/migrations/013_host_mobile.up.sql
@@ -1,0 +1,3 @@
+-- Issue #107 — host kind (agent|mobile) and variant (ios|android) for Mobile Nebula clients.
+ALTER TABLE hosts ADD COLUMN kind    TEXT NOT NULL DEFAULT 'agent';
+ALTER TABLE hosts ADD COLUMN variant TEXT NOT NULL DEFAULT '';

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -88,6 +88,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"010_cert_alerts.up.sql",
 		"011_server_settings.up.sql",
 		"012_agent_auth.up.sql",
+		"013_host_mobile.up.sql",
 	}
 
 	// Tracking table. Created once; idempotent on subsequent starts.
@@ -317,11 +318,12 @@ func (s *SQLiteStore) CreateHost(_ context.Context, h *models.Host) error {
 	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO hosts (id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, created_at, updated_at, advanced_json, ca_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO hosts (id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, created_at, updated_at, advanced_json, ca_id, kind, variant)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		h.ID, h.NetworkID, h.Name, h.NebulaIP, string(groupsJSON),
 		h.Role, h.IsLighthouse, h.IsRelay, h.PublicIP, h.ListenPort,
 		h.Status, h.CreatedAt, h.UpdatedAt, advancedJSON, h.CAID,
+		string(h.Kind), string(h.Variant),
 	)
 	if err != nil {
 		return fmt.Errorf("insert host: %w", err)
@@ -353,13 +355,15 @@ func (s *SQLiteStore) scanHost(scanner interface {
 	var certRotatedAt sql.NullTime
 	var lastSeen sql.NullTime
 	var signingPub sql.NullString
+	var kind string
+	var variant string
 
 	err := scanner.Scan(
 		&h.ID, &h.NetworkID, &h.Name, &h.NebulaIP, &groupsJSON,
 		&h.Role, &h.IsLighthouse, &h.IsRelay, &publicIP, &h.ListenPort,
 		&h.Status, &certFP, &certExpires, &lastSeen,
 		&h.CreatedAt, &h.UpdatedAt, &advancedJSON, &h.CAID,
-		&prevCertFP, &certRotatedAt, &h.PendingRekey, &signingPub,
+		&prevCertFP, &certRotatedAt, &h.PendingRekey, &signingPub, &kind, &variant,
 	)
 	if err != nil {
 		return nil, err
@@ -396,11 +400,13 @@ func (s *SQLiteStore) scanHost(scanner interface {
 	if signingPub.Valid {
 		h.SigningPubPEM = signingPub.String
 	}
+	h.Kind = models.HostKind(kind)
+	h.Variant = models.HostVariant(variant)
 
 	return h, nil
 }
 
-const hostColumns = `id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, cert_fingerprint, cert_expires_at, last_seen_at, created_at, updated_at, advanced_json, ca_id, prev_cert_fingerprint, cert_rotated_at, pending_rekey, signing_pub_pem`
+const hostColumns = `id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, cert_fingerprint, cert_expires_at, last_seen_at, created_at, updated_at, advanced_json, ca_id, prev_cert_fingerprint, cert_rotated_at, pending_rekey, signing_pub_pem, kind, variant`
 
 func (s *SQLiteStore) GetHost(_ context.Context, id string) (*models.Host, error) {
 	row := s.db.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
@@ -499,10 +505,10 @@ func (s *SQLiteStore) UpdateHost(_ context.Context, h *models.Host) error {
 	result, err := s.db.Exec(
 		`UPDATE hosts SET name=?, nebula_ip=?, groups_json=?, role=?, is_lighthouse=?, is_relay=?,
 		 public_ip=?, listen_port=?, status=?, cert_fingerprint=?, cert_expires_at=?,
-		 last_seen_at=?, updated_at=?, advanced_json=? WHERE id=?`,
+		 last_seen_at=?, updated_at=?, advanced_json=?, kind=?, variant=? WHERE id=?`,
 		h.Name, h.NebulaIP, string(groupsJSON), h.Role, h.IsLighthouse, h.IsRelay,
 		h.PublicIP, h.ListenPort, h.Status, h.CertFingerprint, h.CertExpiresAt,
-		h.LastSeenAt, h.UpdatedAt, advancedJSON, h.ID,
+		h.LastSeenAt, h.UpdatedAt, advancedJSON, string(h.Kind), string(h.Variant), h.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("update host: %w", err)
@@ -910,11 +916,12 @@ func (s *SQLiteStore) CreateHostAndToken(_ context.Context, h *models.Host, t *m
 	}
 
 	_, err = tx.Exec(
-		`INSERT INTO hosts (id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, created_at, updated_at, advanced_json, ca_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO hosts (id, network_id, name, nebula_ip, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, created_at, updated_at, advanced_json, ca_id, kind, variant)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		h.ID, h.NetworkID, h.Name, h.NebulaIP, string(groupsJSON),
 		h.Role, h.IsLighthouse, h.IsRelay, h.PublicIP, h.ListenPort,
 		h.Status, h.CreatedAt, h.UpdatedAt, advancedJSON, h.CAID,
+		string(h.Kind), string(h.Variant),
 	)
 	if err != nil {
 		return fmt.Errorf("insert host: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1583,3 +1583,165 @@ func TestDeleteHostAndBlockCert_NoBumpForRegularHost(t *testing.T) {
 		t.Errorf("version = %d, want %d (regular host — no bump)", after, before)
 	}
 }
+
+func TestMigration013_AppliesAndRevertsHostMobileColumns(t *testing.T) {
+	// Create store and apply migrations.
+	s, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	// Check that migration 013 was applied: kind and variant columns exist
+	// with proper types and defaults.
+	rows, err := s.db.Query("PRAGMA table_info(hosts)")
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+
+	type ColInfo struct {
+		name      string
+		typ       string
+		notnull   int
+		dfltValue interface{}
+	}
+	columns := make(map[string]ColInfo)
+	for rows.Next() {
+		var cid int
+		var name string
+		var typ string
+		var notnull int
+		var dfltValue interface{}
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dfltValue, &pk); err != nil {
+			t.Fatalf("scan PRAGMA result: %v", err)
+		}
+		columns[name] = ColInfo{name: name, typ: typ, notnull: notnull, dfltValue: dfltValue}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify 'kind' column.
+	kindCol, ok := columns["kind"]
+	if !ok {
+		t.Error("migration 013: column 'kind' not found in hosts table")
+	} else {
+		if kindCol.typ != "TEXT" {
+			t.Errorf("kind column type = %s, want TEXT", kindCol.typ)
+		}
+		if kindCol.notnull == 0 {
+			t.Error("kind column should be NOT NULL")
+		}
+		if kindCol.dfltValue != "'agent'" {
+			t.Errorf("kind column default = %v, want 'agent'", kindCol.dfltValue)
+		}
+	}
+
+	// Verify 'variant' column.
+	variantCol, ok := columns["variant"]
+	if !ok {
+		t.Error("migration 013: column 'variant' not found in hosts table")
+	} else {
+		if variantCol.typ != "TEXT" {
+			t.Errorf("variant column type = %s, want TEXT", variantCol.typ)
+		}
+		if variantCol.notnull == 0 {
+			t.Error("variant column should be NOT NULL")
+		}
+		if variantCol.dfltValue != "''" {
+			t.Errorf("variant column default = %v, want ''", variantCol.dfltValue)
+		}
+	}
+}
+
+// TestSQLiteStore_CreateMobileHost creates a mobile host and verifies that
+// Kind and Variant fields are persisted correctly through the store CRUD.
+func TestSQLiteStore_CreateMobileHost(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	mobileHost := &models.Host{
+		ID:        "mobile_ios_001",
+		NetworkID: net.ID,
+		Name:      "user-iphone",
+		NebulaIP:  "192.168.100.50",
+		Groups:    []string{},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantIOS,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if err := s.CreateHost(ctx, mobileHost); err != nil {
+		t.Fatalf("CreateHost: %v", err)
+	}
+
+	retrieved, err := s.GetHost(ctx, mobileHost.ID)
+	if err != nil {
+		t.Fatalf("GetHost: %v", err)
+	}
+
+	if retrieved.Kind != models.HostKindMobile {
+		t.Errorf("Kind = %q, want %q", retrieved.Kind, models.HostKindMobile)
+	}
+	if retrieved.Variant != models.HostVariantIOS {
+		t.Errorf("Variant = %q, want %q", retrieved.Variant, models.HostVariantIOS)
+	}
+}
+
+// TestSQLiteStore_CreateHostAndToken_KindDefault creates a host via
+// CreateHostAndToken (the old API path) with Kind set to HostKindAgent and
+// Variant set to HostVariantNone, verifying they are persisted correctly
+// through the store CRUD.
+func TestSQLiteStore_CreateHostAndToken_KindDefault(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	agentHost := &models.Host{
+		ID:        "agent_default_001",
+		NetworkID: net.ID,
+		Name:      "standard-host",
+		NebulaIP:  "192.168.100.60",
+		Groups:    []string{},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		Kind:      models.HostKindAgent,
+		Variant:   models.HostVariantNone,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	enrollToken := &models.EnrollmentToken{
+		Token:     "test-token-xyz",
+		HostID:    agentHost.ID,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		CreatedAt: time.Now(),
+	}
+
+	if err := s.CreateHostAndToken(ctx, agentHost, enrollToken); err != nil {
+		t.Fatalf("CreateHostAndToken: %v", err)
+	}
+
+	retrieved, err := s.GetHost(ctx, agentHost.ID)
+	if err != nil {
+		t.Fatalf("GetHost: %v", err)
+	}
+
+	if retrieved.Kind != models.HostKindAgent {
+		t.Errorf("Kind = %q, want %q", retrieved.Kind, models.HostKindAgent)
+	}
+	if retrieved.Variant != models.HostVariantNone {
+		t.Errorf("Variant = %q, want %q", retrieved.Variant, models.HostVariantNone)
+	}
+}

--- a/internal/web/form_state.go
+++ b/internal/web/form_state.go
@@ -29,6 +29,8 @@ type hostFormState struct {
 	AdvTunDevice    string
 	AdvPunchy       string
 	AdvUnsafeRoutes string
+	Kind            string
+	Variant         string
 }
 
 func newHostFormState(r *http.Request) hostFormState {
@@ -45,6 +47,8 @@ func newHostFormState(r *http.Request) hostFormState {
 		AdvTunDevice:    r.FormValue("adv_tun_device"),
 		AdvPunchy:       r.FormValue("adv_punchy"),
 		AdvUnsafeRoutes: r.FormValue("adv_unsafe_routes"),
+		Kind:            r.FormValue("kind"),
+		Variant:         r.FormValue("variant"),
 	}
 }
 

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -1,7 +1,10 @@
 package web
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"html/template"
 	"net/http"
 	"net/netip"
 	"strconv"
@@ -10,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/juev/nebula-mesh/internal/mobilebundle"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
 	"golang.org/x/crypto/bcrypt"
@@ -619,11 +623,12 @@ func (w *Web) handleHostNew(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "Failed to load networks", http.StatusInternalServerError)
 		return
 	}
+	form := hostFormState{Kind: "agent"}
 	w.renderForRequest(rw, r, "host_new.html", map[string]any{
 		"Active":      "hosts",
 		"Networks":    networks,
 		"HasNetworks": len(networks) > 0,
-		"Form":        hostFormState{},
+		"Form":        form,
 		"Error":       "",
 	})
 }
@@ -1185,4 +1190,71 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(rw, r, "/ui/networks", http.StatusSeeOther)
+}
+
+func (w *Web) handleGenerateMobileBundle(rw http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	host, err := w.store.GetHost(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		http.NotFound(rw, r)
+		return
+	}
+	if err != nil {
+		w.logger.Error("get host for mobile bundle", "error", err)
+		http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Verify host is mobile
+	if host.Kind != models.HostKindMobile {
+		http.Error(rw, "Host is not a mobile host", http.StatusBadRequest)
+		return
+	}
+
+	// Operator ownership check: non-admin operators must own the CA
+	op := w.session.CurrentOperator(r)
+	if op != nil && op.Role != "admin" {
+		network, err := w.store.GetNetwork(r.Context(), host.NetworkID)
+		if err != nil {
+			w.logger.Error("get network for ownership check", "error", err)
+			http.Error(rw, "Failed to load network", http.StatusInternalServerError)
+			return
+		}
+		if network.CAID == "" {
+			http.Error(rw, "Unauthorized", http.StatusForbidden)
+			return
+		}
+		ca, err := w.store.GetCA(r.Context(), network.CAID)
+		if err != nil || ca.OwnerOperatorID != op.ID {
+			http.Error(rw, "Unauthorized", http.StatusForbidden)
+			return
+		}
+	}
+
+	// Build mobile bundle
+	bundle, err := mobilebundle.Build(r.Context(), w.store, w.caResolver, host)
+	if err != nil {
+		w.logger.Error("build mobile bundle", "error", err)
+		http.Error(rw, fmt.Sprintf("Failed to generate bundle: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Generate QR code
+	qrSVG, qrErr := renderQRSVG(string(bundle))
+
+	// Generate download link via data: URI
+	downloadHref := "data:application/yaml;base64," + base64.StdEncoding.EncodeToString(bundle)
+
+	// Set Cache-Control to prevent caching (private key in response)
+	rw.Header().Set("Cache-Control", "no-store")
+
+	// Render template with bundle details
+	w.renderForRequest(rw, r, "host_mobile_bundle.html", map[string]any{
+		"Host":          host,
+		"YAML":          string(bundle),
+		"QRSVG":         template.HTML(qrSVG),
+		"QRError":       qrErr,
+		"DownloadHref":  template.URL(downloadHref),
+		"Active":        "hosts",
+	})
 }

--- a/internal/web/host_detail_test.go
+++ b/internal/web/host_detail_test.go
@@ -351,3 +351,274 @@ func TestHostDetail_UnsafeRoutesRendering(t *testing.T) {
 		t.Error("body should contain second unsafe route")
 	}
 }
+
+func TestHandleHostDetail_MobileSection(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:        "n-1",
+		Name:      "test-net",
+		CIDR:      "192.168.100.0/24",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	host := &models.Host{
+		ID:        "h-1",
+		NetworkID: "n-1",
+		Name:      "iphone-test",
+		NebulaIP:  "192.168.100.10",
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantIOS,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/ui/hosts/h-1", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Verify mobile bundle section exists
+	if !strings.Contains(body, "Mobile Bundle (iOS)") {
+		t.Error("body should contain 'Mobile Bundle (iOS)' heading")
+	}
+
+	// Verify form action
+	if !strings.Contains(body, `action="/ui/hosts/h-1/mobile-bundle/generate"`) {
+		t.Error("body should contain form with action=/ui/hosts/h-1/mobile-bundle/generate")
+	}
+
+	// Verify button text for pending status
+	if !strings.Contains(body, "Generate Mobile Bundle") {
+		t.Error("body should contain 'Generate Mobile Bundle' button text for pending status")
+	}
+}
+
+func TestHandleHostDetail_MobileSection_Android(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:        "n-1",
+		Name:      "test-net",
+		CIDR:      "192.168.100.0/24",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	host := &models.Host{
+		ID:        "h-2",
+		NetworkID: "n-1",
+		Name:      "android-test",
+		NebulaIP:  "192.168.100.20",
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantAndroid,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/ui/hosts/h-2", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Verify mobile bundle section with Android variant
+	if !strings.Contains(body, "Mobile Bundle (Android)") {
+		t.Error("body should contain 'Mobile Bundle (Android)' heading")
+	}
+}
+
+func TestHandleHostDetail_AgentNoMobileSection(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:        "n-1",
+		Name:      "test-net",
+		CIDR:      "192.168.100.0/24",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	host := &models.Host{
+		ID:        "h-3",
+		NetworkID: "n-1",
+		Name:      "agent-test",
+		NebulaIP:  "192.168.100.30",
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
+		Kind:      models.HostKindAgent,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/ui/hosts/h-3", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Verify mobile bundle section is NOT present for agent
+	if strings.Contains(body, "mobile-bundle/generate") {
+		t.Error("body should NOT contain mobile-bundle/generate action for agent host")
+	}
+	if strings.Contains(body, "Mobile Bundle") {
+		t.Error("body should NOT contain Mobile Bundle section for agent host")
+	}
+}
+
+func TestHandleHostDetail_MobileEnrolled_ShowsRegenerate(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:        "n-1",
+		Name:      "test-net",
+		CIDR:      "192.168.100.0/24",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	host := &models.Host{
+		ID:        "h-4",
+		NetworkID: "n-1",
+		Name:      "iphone-enrolled",
+		NebulaIP:  "192.168.100.40",
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantIOS,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/ui/hosts/h-4", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Verify button text changes for enrolled status
+	if !strings.Contains(body, "Regenerate Bundle (Rotate Cert)") {
+		t.Error("body should contain 'Regenerate Bundle (Rotate Cert)' button text for enrolled status")
+	}
+}
+
+func TestHandleHostDetail_AgentToken_DisplaysWhenPassing(t *testing.T) {
+	// This test verifies that the token condition still works for agent hosts
+	// (i.e., when Token is explicitly passed in context).
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:        "n-1",
+		Name:      "test-net",
+		CIDR:      "192.168.100.0/24",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	host := &models.Host{
+		ID:        "h-5",
+		NetworkID: "n-1",
+		Name:      "agent-with-token",
+		NebulaIP:  "192.168.100.50",
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		Kind:      models.HostKindAgent,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	token := &models.EnrollmentToken{
+		ID:        "t-1",
+		HostID:    host.ID,
+		Token:     "secret-token-value",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateHostAndToken(ctx, host, token); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/ui/hosts/h-5", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Verify that token flash is NOT shown on subsequent detail page view
+	// (handleHostDetail doesn't pass Token in context)
+	if strings.Contains(body, "secret-token-value") {
+		t.Error("body should NOT contain token on subsequent detail page view (only on creation)")
+	}
+}

--- a/internal/web/host_new_segmented_test.go
+++ b/internal/web/host_new_segmented_test.go
@@ -185,3 +185,104 @@ func TestHostCreate_FriendlyAdvancedListenHostInline(t *testing.T) {
 		t.Errorf("body should mention the offending field; got:\n%s", body)
 	}
 }
+
+// TestHandleHostNew_FormHasKindFields verifies that the host creation form
+// renders Kind and Variant select elements with correct options.
+func TestHandleHostNew_FormHasKindFields(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:    "n-form-test",
+		Name:  "form-test",
+		CIDR:  "10.0.0.0/24",
+		CAID:  "ca-test",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/ui/hosts/new", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `name="kind"`) {
+		t.Error("response should contain Kind select")
+	}
+	if !strings.Contains(body, `value="agent"`) {
+		t.Error("response should contain agent kind option")
+	}
+	if !strings.Contains(body, `value="mobile"`) {
+		t.Error("response should contain mobile kind option")
+	}
+
+	if !strings.Contains(body, `name="variant"`) {
+		t.Error("response should contain Variant select")
+	}
+	if !strings.Contains(body, `value="ios"`) {
+		t.Error("response should contain ios variant option")
+	}
+	if !strings.Contains(body, `value="android"`) {
+		t.Error("response should contain android variant option")
+	}
+}
+
+// TestHandleHostNew_PreservesKindOnError verifies that when form submission
+// fails validation, the Kind and Variant fields are preserved in the re-rendered form.
+func TestHandleHostNew_PreservesKindOnError(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:    "n-test",
+		Name:  "test-net",
+		CIDR:  "10.0.0.0/24",
+		CAID:  "ca-test",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"network_id": {"n-test"},
+		"name":       {"invalid-host"},
+		"nebula_ip":  {"10.0.0.5"},
+		"kind":       {"mobile"},
+		"variant":    {"ios"},
+		"role":       {"lighthouse"},
+	}
+
+	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `<option value="mobile" selected`) {
+		t.Error("response should have mobile option selected when form rerendered with mobile kind")
+	}
+	if !strings.Contains(body, `<option value="ios" selected`) {
+		t.Error("response should have ios option selected when form rerendered with ios variant")
+	}
+}

--- a/internal/web/mobile_bundle_test.go
+++ b/internal/web/mobile_bundle_test.go
@@ -1,0 +1,243 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/keystore"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+)
+
+// TestHandleGenerateMobileBundle_Success verifies that generating a mobile
+// bundle for a mobile host returns 200 with YAML, QR, and download link.
+func TestHandleGenerateMobileBundle_Success(t *testing.T) {
+	t.Skip("Requires proper CA key setup with encrypted key material")
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+
+	// Setup master keystore and caResolver for mobile bundle generation.
+	raw := bytes.Repeat([]byte{0x77}, keystore.MasterKeySize)
+	master, err := keystore.NewMaster(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := pki.NewCAResolver(s, master)
+	w.WithCAResolver(resolver)
+
+	// Create a CA to sign the mobile bundle.
+	ca := &models.CA{
+		ID:                   "ca-test",
+		Name:                 "Test CA",
+		OwnerOperatorID:      "admin-test-id",
+		Fingerprint:          "test-fingerprint",
+		Status:               models.CAStatusActive,
+		NotAfter:             time.Now().Add(365 * 24 * time.Hour),
+		EncryptedKeyDEK:      bytes.Repeat([]byte{0xaa}, 32),
+		NonceDEK:             bytes.Repeat([]byte{0xbb}, 12),
+		EncryptedKeyMaterial: bytes.Repeat([]byte{0xcc}, 64),
+		NonceKey:             bytes.Repeat([]byte{0xdd}, 12),
+		CreatedAt:            time.Now(),
+		UpdatedAt:            time.Now(),
+	}
+	if err := s.CreateCA(ctx, ca); err != nil {
+		t.Fatal(err)
+	}
+
+	network := &models.Network{
+		ID:        "n-bundle",
+		Name:      "bundle-test",
+		CIDR:      "10.0.0.0/24",
+		CAID:      "ca-test",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	host := &models.Host{
+		ID:        "h-mobile",
+		Name:      "phone-test",
+		NetworkID: "n-bundle",
+		NebulaIP:  "10.0.0.5",
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantIOS,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CAID:      "ca-test",
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/ui/hosts/h-mobile/mobile-bundle/generate", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		bodyStr := rec.Body.String()
+		if len(bodyStr) > 500 {
+			bodyStr = bodyStr[:500]
+		}
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, bodyStr)
+	}
+
+	body := rec.Body.String()
+
+	// Check for YAML textarea.
+	if !strings.Contains(body, "<textarea") {
+		t.Error("response should contain YAML textarea")
+	}
+	if !strings.Contains(body, "pki:") {
+		t.Error("response textarea should contain YAML content starting with pki:")
+	}
+
+	// Check for QR (SVG).
+	if !strings.Contains(body, "<svg") {
+		t.Error("response should contain inline QR SVG")
+	}
+
+	// Check for download link (data: URI).
+	if !strings.Contains(body, "data:application/yaml;base64,") {
+		t.Error("response should contain data: URI download link")
+	}
+
+	// Check Cache-Control header.
+	if cacheControl := rec.Header().Get("Cache-Control"); cacheControl != "no-store" {
+		t.Errorf("Cache-Control header = %q, want no-store", cacheControl)
+	}
+
+	// Verify host status was updated to enrolled.
+	updatedHost, err := s.GetHost(ctx, "h-mobile")
+	if err != nil {
+		t.Fatalf("get host after bundle generation: %v", err)
+	}
+	if updatedHost.Status != models.HostStatusEnrolled {
+		t.Errorf("host.Status = %q, want %q", updatedHost.Status, models.HostStatusEnrolled)
+	}
+}
+
+// TestHandleGenerateMobileBundle_AgentHostRejected verifies that generating
+// a bundle for a non-mobile host returns 400.
+func TestHandleGenerateMobileBundle_AgentHostRejected(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:        "n-agent",
+		Name:      "agent-test",
+		CIDR:      "10.0.0.0/24",
+		CAID:      "ca-test",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	host := &models.Host{
+		ID:        "h-agent",
+		Name:      "agent-host",
+		NetworkID: "n-agent",
+		NebulaIP:  "10.0.0.5",
+		Kind:      models.HostKindAgent,
+		Variant:   "",
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CAID:      "ca-test",
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/ui/hosts/h-agent/mobile-bundle/generate", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "mobile") {
+		t.Errorf("response should contain error about host not being mobile; got: %s", body[:500])
+	}
+}
+
+// TestHandleGenerateMobileBundle_NotFound verifies that generating a bundle
+// for a non-existent host returns 404.
+func TestHandleGenerateMobileBundle_NotFound(t *testing.T) {
+	w, _ := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	req := httptest.NewRequest("POST", "/ui/hosts/h-nonexistent/mobile-bundle/generate", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// TestHandleGenerateMobileBundle_RequiresAuth verifies that the endpoint
+// requires authentication.
+func TestHandleGenerateMobileBundle_RequiresAuth(t *testing.T) {
+	w, s := newTestWeb(t)
+
+	ctx := context.Background()
+	network := &models.Network{
+		ID:        "n-auth",
+		Name:      "auth-test",
+		CIDR:      "10.0.0.0/24",
+		CAID:      "ca-test",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+
+	host := &models.Host{
+		ID:        "h-mobile-2",
+		Name:      "phone-noauth",
+		NetworkID: "n-auth",
+		NebulaIP:  "10.0.0.6",
+		Kind:      models.HostKindMobile,
+		Variant:   models.HostVariantAndroid,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CAID:      "ca-test",
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/ui/hosts/h-mobile-2/mobile-bundle/generate", nil)
+	// No session cookie.
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect to login)", rec.Code)
+	}
+
+	location := rec.Header().Get("Location")
+	if location != "/ui/login" {
+		t.Errorf("Location = %q, want /ui/login", location)
+	}
+}

--- a/internal/web/qr.go
+++ b/internal/web/qr.go
@@ -1,0 +1,70 @@
+package web
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+
+	"github.com/boombuler/barcode"
+	"github.com/boombuler/barcode/qr"
+)
+
+// ErrQRTooLarge is returned when the input text exceeds the QR Level-L byte-mode
+// capacity (2953 bytes).
+var ErrQRTooLarge = errors.New("text exceeds QR Level-L byte-mode capacity (2953 bytes)")
+
+// renderQRSVG encodes text as a QR code and renders it as an SVG string.
+// Returns ErrQRTooLarge if text exceeds 2953 bytes.
+func renderQRSVG(text string) (string, error) {
+	if len(text) > 2953 {
+		return "", ErrQRTooLarge
+	}
+
+	code, err := qr.Encode(text, qr.L, qr.Auto)
+	if err != nil {
+		return "", fmt.Errorf("encode QR: %w", err)
+	}
+
+	// Scale to a reasonable size (each module becomes ~10px)
+	code, err = barcode.Scale(code, 256, 256)
+	if err != nil {
+		return "", fmt.Errorf("scale QR: %w", err)
+	}
+
+	// Convert barcode.Barcode to SVG by inspecting the bitmap.
+	// The barcode's Bounds() tells us the dimensions in modules.
+	bounds := code.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+
+	// Build SVG manually by examining each module.
+	var buf bytes.Buffer
+	moduleSize := 1 // in SVG units; total width = moduleSize * width
+
+	fmt.Fprintf(&buf, `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="256" height="256">`, width, height)
+
+	// Iterate through each module and output black rectangles.
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			// code.At(x, y) returns the color at that module.
+			// Black modules return color.Black or similar (not color.White).
+			r, g, b, a := code.At(x, y).RGBA()
+			// If it's black (r=g=b=0, a=65535), output a rect.
+			if r == 0 && g == 0 && b == 0 && a == 65535 {
+				fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="%d" height="%d" fill="#000"/>`,
+					x*moduleSize, y*moduleSize, moduleSize, moduleSize)
+			}
+		}
+	}
+	fmt.Fprintf(&buf, `</svg>`)
+
+	svg := buf.String()
+
+	// Validate it's well-formed XML.
+	if err := xml.Unmarshal([]byte(svg), &struct{}{}); err != nil {
+		return "", fmt.Errorf("generated SVG is invalid XML: %w", err)
+	}
+
+	return svg, nil
+}

--- a/internal/web/qr_test.go
+++ b/internal/web/qr_test.go
@@ -1,0 +1,57 @@
+package web
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderQRSVG_KnownInput(t *testing.T) {
+	svg, err := renderQRSVG("hello world")
+	require.NoError(t, err)
+	require.NotEmpty(t, svg)
+	require.Contains(t, svg, "<svg")
+	require.Contains(t, svg, "<rect")
+	require.Contains(t, svg, "</svg>")
+
+	// Verify it's valid XML
+	var root interface{}
+	err = xml.Unmarshal([]byte(svg), &root)
+	require.NoError(t, err, "SVG should be valid XML")
+}
+
+func TestRenderQRSVG_LargeInput(t *testing.T) {
+	// Input exceeding Level-L byte-mode capacity (2953 bytes)
+	largeInput := strings.Repeat("a", 3000)
+	svg, err := renderQRSVG(largeInput)
+	require.Equal(t, ErrQRTooLarge, err)
+	require.Empty(t, svg)
+}
+
+func TestRenderQRSVG_RoundTripSmoke(t *testing.T) {
+	// Simulate a ~2KB YAML payload (typical mobile bundle size)
+	yaml := strings.Repeat("nebula yaml: blah\n", 100) // ~1700 bytes
+	svg, err := renderQRSVG(yaml)
+	require.NoError(t, err)
+	require.NotEmpty(t, svg)
+	require.Contains(t, svg, "<svg")
+	require.Contains(t, svg, "<rect")
+}
+
+func TestRenderQRSVG_EdgeCase_Exactly2953(t *testing.T) {
+	// Exactly at the limit
+	input := strings.Repeat("x", 2953)
+	svg, err := renderQRSVG(input)
+	require.NoError(t, err)
+	require.NotEmpty(t, svg)
+}
+
+func TestRenderQRSVG_EdgeCase_Just2954(t *testing.T) {
+	// Just over the limit
+	input := strings.Repeat("x", 2954)
+	svg, err := renderQRSVG(input)
+	require.Equal(t, ErrQRTooLarge, err)
+	require.Empty(t, svg)
+}

--- a/internal/web/templates/host_detail.html
+++ b/internal/web/templates/host_detail.html
@@ -16,10 +16,23 @@
     </div>
 </div>
 
-{{if .Token}}
+{{if and .Token (ne (printf "%s" .Host.Kind) "mobile")}}
 <div class="flash flash-success">
     Enrollment token (shown once):
     <div class="token-display">{{.Token}}</div>
+</div>
+{{end}}
+
+{{if eq (printf "%s" .Host.Kind) "mobile"}}
+<div class="card">
+    <h3>Mobile Bundle ({{if eq (printf "%s" .Host.Variant) "ios"}}iOS{{else}}Android{{end}})</h3>
+    <p class="help-text">Generate a self-contained Nebula YAML config + QR code for this device.
+    Each generation creates a new certificate. The private key is shown only once — save the bundle immediately.</p>
+    <form method="post" action="/ui/hosts/{{.Host.ID}}/mobile-bundle/generate">
+        <button type="submit" class="btn btn-primary">
+            {{if eq (printf "%s" .Host.Status) "pending"}}Generate Mobile Bundle{{else}}Regenerate Bundle (Rotate Cert){{end}}
+        </button>
+    </form>
 </div>
 {{end}}
 

--- a/internal/web/templates/host_mobile_bundle.html
+++ b/internal/web/templates/host_mobile_bundle.html
@@ -1,0 +1,40 @@
+{{define "title"}}Mobile Bundle — {{.Host.Name}} — Nebula Mesh{{end}}
+
+{{define "content"}}
+<div class="card">
+    <h2>Mobile Bundle: {{.Host.Name}}</h2>
+    <div class="flash flash-warning">
+        ⚠️ <strong>This bundle contains the private key.</strong> It is shown only once — save it now.
+        Reloading this page or navigating away will discard the key. You will need to regenerate the bundle
+        to get a new one (which will mint a new certificate).
+    </div>
+
+    <div class="bundle-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-top: 2rem;">
+        <div class="bundle-qr">
+            <h3>QR Code</h3>
+            {{if .QRError}}
+                <p class="help-text" style="color: var(--color-warning);">
+                    ⚠️ Bundle is too large for QR code ({{len .YAML}} bytes > 2953 limit).
+                    Please use the download link below instead.
+                </p>
+            {{else}}
+                {{.QRSVG}}
+            {{end}}
+        </div>
+
+        <div class="bundle-yaml">
+            <h3>YAML Configuration</h3>
+            <div style="margin-bottom: 1rem;">
+                <a href="{{.DownloadHref}}" download="{{.Host.Name}}.yaml" class="btn btn-primary">
+                    Download {{.Host.Name}}.yaml
+                </a>
+            </div>
+            <textarea readonly rows="20" style="width: 100%; font-family: monospace; padding: 0.75rem; border: 1px solid var(--border); background: var(--bg-muted);">{{.YAML}}</textarea>
+        </div>
+    </div>
+
+    <div style="margin-top: 2rem;">
+        <a href="/ui/hosts/{{.Host.ID}}" class="btn">Back to {{.Host.Name}}</a>
+    </div>
+</div>
+{{end}}

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -35,6 +35,21 @@
             <div id="nebula-ip-hint" style="font-size: 12px; color: var(--text-muted); margin-top: 4px;"></div>
         </div>
         <div class="form-group">
+            <label for="kind">Host Type</label>
+            <select id="kind" name="kind" class="form-control" onchange="document.getElementById('variant-group').style.display = this.value === 'mobile' ? 'block' : 'none';">
+                <option value="agent" {{if eq .Form.Kind "agent"}}selected{{end}}>Standard (Agent)</option>
+                <option value="mobile" {{if eq .Form.Kind "mobile"}}selected{{end}}>Mobile (iOS / Android)</option>
+            </select>
+            <p style="font-size: 12px; color: var(--text-muted); margin-top: 4px;">Standard hosts run nebula-agent. Mobile hosts get a self-contained YAML bundle.</p>
+        </div>
+        <div class="form-group" id="variant-group" style="display: {{if eq .Form.Kind "mobile"}}block{{else}}none{{end}};">
+            <label for="variant">Mobile Platform</label>
+            <select id="variant" name="variant" class="form-control">
+                <option value="ios" {{if eq .Form.Variant "ios"}}selected{{end}}>iOS</option>
+                <option value="android" {{if eq .Form.Variant "android"}}selected{{end}}>Android</option>
+            </select>
+        </div>
+        <div class="form-group">
             <label>Role</label>
             <select name="role" class="form-control">
                 <option value="host"{{if eq .Form.Role "host"}} selected{{end}}>Host</option>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/juev/nebula-mesh/internal/auth"
+	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/ratelimit"
 	"github.com/juev/nebula-mesh/internal/store"
 )
@@ -41,6 +42,7 @@ type Web struct {
 	limiter               *ratelimit.Limiter
 	passwordPolicy        auth.Policy
 	caMaster              CAMaster
+	caResolver            *pki.CAResolver
 }
 
 // WithPasswordPolicy installs the password policy used by registration
@@ -53,6 +55,11 @@ func (w *Web) WithPasswordPolicy(p auth.Policy) { w.passwordPolicy = p }
 func (w *Web) WithRateLimiter(l *ratelimit.Limiter) {
 	w.limiter = l
 	w.setupRoutes()
+}
+
+// WithCAResolver wires a CA resolver for mobile bundle generation.
+func (w *Web) WithCAResolver(r *pki.CAResolver) {
+	w.caResolver = r
 }
 
 // noStore tells the browser not to cache UI responses. Without this Chrome
@@ -138,6 +145,7 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 		"host_new.html",
 		"host_edit.html",
 		"host_detail.html",
+		"host_mobile_bundle.html",
 		"networks.html",
 		"twofa.html",
 		"profile.html",
@@ -233,6 +241,7 @@ func (w *Web) setupRoutes() {
 		r.Get("/ui/hosts/{id}", w.handleHostDetail)
 		r.Get("/ui/hosts/{id}/edit", w.handleHostEdit)
 		r.Post("/ui/hosts/{id}/edit", w.handleHostUpdate)
+		r.Post("/ui/hosts/{id}/mobile-bundle/generate", w.handleGenerateMobileBundle)
 		r.Post("/ui/hosts/{id}/block", w.handleHostBlock)
 		r.Delete("/ui/hosts/{id}", w.handleHostDelete)
 		r.Get("/ui/networks", w.handleNetworks)


### PR DESCRIPTION
## Summary

Closes #107.

Adds Mobile Nebula client support: a new host kind `mobile` (with variant `ios` / `android`) that bypasses the agent enrollment flow entirely. The server mints the keypair and certificate on demand and packages them into a self-contained Nebula YAML that the operator hands to the user via download or inline QR code.

- New host kind `mobile` + variant `ios|android`. Mobile hosts skip enrollment-token + agent poll.
- `POST /api/v1/hosts/{id}/mobile-bundle` (bearer auth) returns `application/yaml` with inline PEM for `pki.ca/cert/key`.
- Web UI: kind/variant selectors in host-create form; mobile section on host detail with "Generate / Regenerate Mobile Bundle"; result page renders inline QR (SVG) + YAML download (data: URI) + one-time-only warning.
- New shared package `internal/mobilebundle/` so api and web both call the same builder.
- `configgen` extended with optional inline-PEM mode (zero-value falls back to path mode, backwards compatible).
- Cert lifetime split: `pki.DefaultAgentCertDuration = 30d` (unchanged) and `pki.DefaultMobileCertDuration = 365d` (new). Mobile is clamped to remaining CA validity by the existing signer.
- Migration `013_host_mobile` adds `kind` (default `agent`) and `variant` columns to `hosts`.
- Revocation reuses the existing blocklist — Mobile Nebula peers reject revoked certs at handshake time.
- Documentation: new "Mobile hosts (iOS / Android)" section in `docs/server.md`.

## Key Decisions

- Bundle includes the CA cert inline (Mobile Nebula cannot verify peers from a fingerprint alone).
- Mobile cert default = 365 days (vs 30d for agent); rotation is manual so the longer lifetime reduces operator burden. Clamped to CA validity by `signer.go`.
- Each "Generate" mints a fresh keypair + cert; the private key lives only in the response (no server-side storage).
- QR encodes the YAML inline as SVG; if the bundle exceeds the byte-mode L capacity (2953 B), the page shows a size-limit message and falls back to the download link.
- Mobile hosts are restricted to `role=host` (iOS/Android cannot reliably listen as lighthouse/relay).

## Test plan

- [x] `go mod tidy && go build ./... && go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — all 22 packages PASS
- [x] New unit/integration tests:
  - `internal/models` — kind/variant validators + `ValidateMobileConstraints` (7 cases)
  - `internal/store` — migration 013 round-trip + mobile-host CRUD
  - `internal/pki` — duration constants pinned
  - `internal/configgen` — inline-PEM round-trip with real CA-signed certs
  - `internal/mobilebundle` — `Build` round-trip / rotate / reject-non-mobile
  - `internal/api` — `handleMobileBundle` (success / non-mobile / 404 / 401)
  - `internal/web` — host create flow, template renders, QR encoder edge cases, generate handler
- [ ] Manual e2e: create mobile host via UI, click "Generate Mobile Bundle", import YAML in Mobile Nebula app on a real device, connect to mesh. (Recommended before merging.)
