### PR TITLE
feat(web): auto-provision default CA for admin operators (#111)

### DIFF
--- a/internal/web/auto_provision_test.go
+++ b/internal/web/auto_provision_test.go
@@ -213,7 +213,7 @@ func TestProvisionDefaultCA_IdempotentWhenAlreadyHasCA(t *testing.T) {
 	}
 }
 
-func TestProvisionDefaultCA_SkipsForAdminRole(t *testing.T) {
+func TestProvisionDefaultCA_AutoProvisionsForAdminRole(t *testing.T) {
 	w, s := newOperatorsWebWithMaster(t)
 	ctx := context.Background()
 
@@ -231,19 +231,33 @@ func TestProvisionDefaultCA_SkipsForAdminRole(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Provision for admin should skip.
+	// Provision for admin should auto-provision default CA.
 	err := w.provisionDefaultCA(ctx, op)
 	if err != nil {
 		t.Fatalf("provisionDefaultCA for admin = %v, want nil", err)
 	}
 
-	// Verify no CA was created.
+	// Verify CA was created.
 	cas, err := s.ListCAsByOwner(ctx, op.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cas) != 0 {
-		t.Fatalf("ListCAsByOwner returned %d CA(s), want 0", len(cas))
+	if len(cas) != 1 {
+		t.Fatalf("ListCAsByOwner returned %d CA(s), want 1", len(cas))
+	}
+
+	ca := cas[0]
+	if ca.Name != "admin-default" {
+		t.Errorf("CA name = %q, want admin-default", ca.Name)
+	}
+	if ca.Status != models.CAStatusActive {
+		t.Errorf("CA status = %q, want %q", ca.Status, models.CAStatusActive)
+	}
+	if ca.Fingerprint == "" {
+		t.Error("CA fingerprint is empty")
+	}
+	if ca.OwnerOperatorID != op.ID {
+		t.Errorf("CA owner = %q, want %q", ca.OwnerOperatorID, op.ID)
 	}
 }
 

--- a/internal/web/cas.go
+++ b/internal/web/cas.go
@@ -139,19 +139,14 @@ func (w *Web) mintCAForOperator(ctx context.Context, op *models.Operator, name s
 }
 
 // provisionDefaultCA is the idempotent onboarding-time hook for auto-provisioning
-// a default CA. If op is a non-admin operator with zero active CAs, mints
-// <op.Username>-default with a 10-year lifetime. Silently skips (returns nil) when
-// the master key is not configured, when op is an admin, or when op already has
-// an active CA. Returns any error from mintCAForOperator if minting is attempted.
+// a default CA. If op has zero active CAs, mints <op.Username>-default with a
+// 10-year lifetime. Silently skips (returns nil) when the master key is not
+// configured or when op already has an active CA. Returns any error from
+// mintCAForOperator if minting is attempted.
 func (w *Web) provisionDefaultCA(ctx context.Context, op *models.Operator) error {
 	// Skip if no master key configured.
 	if w.caMaster == nil {
 		w.logger.Warn("auto-provision skipped: master key not configured")
-		return nil
-	}
-
-	// Skip if operator is admin.
-	if op.Role != "user" {
 		return nil
 	}
 

--- a/internal/web/oidc_auto_provision_test.go
+++ b/internal/web/oidc_auto_provision_test.go
@@ -61,7 +61,7 @@ func TestOIDCUpsert_AutoProvisionsForUserRole(t *testing.T) {
 	}
 }
 
-func TestOIDCUpsert_DoesNotProvisionForAdminRole(t *testing.T) {
+func TestOIDCUpsert_AutoProvisionsForAdminRole(t *testing.T) {
 	w, s := newOperatorsWebWithMaster(t)
 	ctx := context.Background()
 
@@ -85,13 +85,27 @@ func TestOIDCUpsert_DoesNotProvisionForAdminRole(t *testing.T) {
 		t.Errorf("Role = %q, want admin", op.Role)
 	}
 
-	// Verify NO CA was created (admins should not auto-provision).
+	// Verify CA was auto-provisioned.
 	cas, err := s.ListCAsByOwner(ctx, op.ID)
 	if err != nil {
 		t.Fatalf("ListCAsByOwner failed: %v", err)
 	}
-	if len(cas) != 0 {
-		t.Fatalf("ListCAsByOwner returned %d CAs, want 0", len(cas))
+	if len(cas) != 1 {
+		t.Fatalf("ListCAsByOwner returned %d CAs, want 1", len(cas))
+	}
+
+	ca := cas[0]
+	if ca.Name != "bob-default" {
+		t.Errorf("CA name = %q, want bob-default", ca.Name)
+	}
+	if ca.Status != models.CAStatusActive {
+		t.Errorf("CA status = %q, want %q", ca.Status, models.CAStatusActive)
+	}
+	if ca.Fingerprint == "" {
+		t.Error("CA fingerprint is empty")
+	}
+	if ca.OwnerOperatorID != op.ID {
+		t.Errorf("CA owner = %q, want %q", ca.OwnerOperatorID, op.ID)
 	}
 }
 

--- a/internal/web/operator_create_auto_provision_test.go
+++ b/internal/web/operator_create_auto_provision_test.go
@@ -73,9 +73,9 @@ func TestAdminCreatesUser_AutoProvisions(t *testing.T) {
 	}
 }
 
-// TestAdminCreatesAdmin_DoesNotAutoProvision verifies that when an admin
-// creates an admin-role operator, no CA is auto-provisioned.
-func TestAdminCreatesAdmin_DoesNotAutoProvision(t *testing.T) {
+// TestAdminCreatesAdmin_AutoProvisions verifies that when an admin
+// creates an admin-role operator, a default CA is auto-provisioned.
+func TestAdminCreatesAdmin_AutoProvisions(t *testing.T) {
 	w, s := newOperatorsWebWithMaster(t)
 
 	// Create admin session.
@@ -108,13 +108,27 @@ func TestAdminCreatesAdmin_DoesNotAutoProvision(t *testing.T) {
 		t.Fatalf("GetOperatorByUsername(charlie) = %v", err)
 	}
 
-	// Verify no CA was created.
+	// Verify CA was created.
 	cas, err := s.ListCAsByOwner(ctx, charlie.ID)
 	if err != nil {
 		t.Fatalf("ListCAsByOwner = %v", err)
 	}
-	if len(cas) != 0 {
-		t.Fatalf("charlie should have 0 CAs, got %d", len(cas))
+	if len(cas) != 1 {
+		t.Fatalf("charlie should have 1 CA, got %d", len(cas))
+	}
+
+	ca := cas[0]
+	if ca.Name != "charlie-default" {
+		t.Errorf("CA name = %q, want charlie-default", ca.Name)
+	}
+	if ca.Status != models.CAStatusActive {
+		t.Errorf("CA status = %q, want %q", ca.Status, models.CAStatusActive)
+	}
+	if ca.Fingerprint == "" {
+		t.Error("CA fingerprint is empty")
+	}
+	if ca.OwnerOperatorID != charlie.ID {
+		t.Errorf("CA owner = %q, want %q", ca.OwnerOperatorID, charlie.ID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #111. Relaxes the role guard in `provisionDefaultCA` so admin-role operators created through OIDC first-login or admin-creates-X paths receive their own default CA — same behavior already established for user-role operators.

After #114, the `init`-time admin auto-provisioning was already in place (admin seeded by `SeedAdminOperator` gets `admin-default` CA directly via `pki.MintAndStoreCA`). This PR closes the remaining gap: alternate operator-creation paths (OIDC, admin-creates-admin) that flow through `Web.provisionDefaultCA`.

- Remove `if op.Role != "user" { return nil }` from `internal/web/cas.go::provisionDefaultCA`.
- Update docstring (drop "non-admin operator" / "when op is an admin" phrases).
- Flip three admin-skip tests to admin-positive (per issue spec):
  - `TestProvisionDefaultCA_SkipsForAdminRole` → `TestProvisionDefaultCA_AutoProvisionsForAdminRole`
  - `TestAdminCreatesAdmin_DoesNotAutoProvision` → `TestAdminCreatesAdmin_AutoProvisions`
  - `TestOIDCUpsert_DoesNotProvisionForAdminRole` → `TestOIDCUpsert_AutoProvisionsForAdminRole`

Idempotence check (`ListCAsByOwner` + active scan) remains intact and correctly prevents duplicates for both roles.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./internal/web/...` — 0 issues
- [x] `go test -race ./...` — all 22 packages PASS
- [x] Three flipped tests pass with admin-positive assertions
- [ ] CI checks pass on this branch
