### PR TITLE
feat(ca): hybrid CA rotation — warning badge + manual rotate + opt-in auto-rotate (#110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ nebula-mgmt ca delete --server ... --api-key "$OPERATOR_KEY" --id "$CA_ID"
 
 Non-admin operators see and manage only the CAs they own; admins see all. Hosts enrolled under a tenant CA receive **that** CA's certificate, not the default one. Audit log entries (`ca.created`, `ca.deleted`, plus existing `host.*` events with the host's `ca_id`) record both the actor and the affected CA. See [ADR 0002](docs/adr/0002-per-operator-cas.md) for the encryption-at-rest design.
 
+**CA rotation**: when a CA approaches its expiry (≤20% lifetime remaining), the UI shows a warning badge on the CA pages. Operators can click **Rotate** to create a successor CA; existing host certificates remain valid until their natural expiry. CLI: `nebula-mgmt ca rotate <id>`. Optional opt-in auto-rotation: set `ca_auto_rotate.enabled: true` in `server.yaml` to enable automatic rotation (disabled by default). See [ADR 0008](docs/adr/0008-ca-rotation.md) for the hybrid model and trust bundle distribution.
+
 </details>
 
 <details>

--- a/cmd/nebula-mgmt/main.go
+++ b/cmd/nebula-mgmt/main.go
@@ -61,7 +61,7 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "  network <create|list>")
 	fmt.Fprintln(os.Stderr, "  user <create|list|disable|enable>")
 	fmt.Fprintln(os.Stderr, "  apikey <create|revoke>")
-	fmt.Fprintln(os.Stderr, "  ca <create|list|delete>")
+	fmt.Fprintln(os.Stderr, "  ca <create|list|delete|rotate>")
 }
 
 func runInit(args []string) error {
@@ -245,7 +245,7 @@ func runUserList(args []string) error {
 
 func runCA(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: nebula-mgmt ca <create|list|delete>")
+		return fmt.Errorf("usage: nebula-mgmt ca <create|list|delete|rotate>")
 	}
 	switch args[0] {
 	case "create":
@@ -254,6 +254,8 @@ func runCA(args []string) error {
 		return runCAList(args[1:])
 	case "delete":
 		return runHostAction(args[1:], "ca delete", cli.CADelete)
+	case "rotate":
+		return runCARotate(args[1:])
 	default:
 		return fmt.Errorf("unknown ca subcommand: %s", args[0])
 	}
@@ -285,6 +287,23 @@ func runCAList(args []string) error {
 		return fmt.Errorf("--api-key is required")
 	}
 	return cli.CAList(*server, *apiKey)
+}
+
+func runCARotate(args []string) error {
+	fs := flag.NewFlagSet("ca rotate", flag.ExitOnError)
+	server := fs.String("server", "http://localhost:8080", "management server URL")
+	apiKey := fs.String("api-key", "", "API key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: nebula-mgmt ca rotate [flags] <id>")
+	}
+	if *apiKey == "" {
+		return fmt.Errorf("--api-key is required")
+	}
+	id := fs.Arg(0)
+	return cli.CARotate(*server, *apiKey, id)
 }
 
 func runAPIKey(args []string) error {

--- a/docs/adr/0008-ca-rotation.md
+++ b/docs/adr/0008-ca-rotation.md
@@ -1,0 +1,187 @@
+# ADR 0008 — Hybrid CA rotation
+
+- **Status**: Accepted
+- **Date**: 2026-05-15
+- **Context**: Issue [#110](https://github.com/juev/nebula-mesh/issues/110) — *CA rotation flow for auto-provisioned CAs*.
+
+## Context
+
+Per ADR 0007 and issue #114, the codebase auto-provisions per-operator CAs with a 10-year lifetime to avoid the complexity of early rotation. However, this defers the rotation problem rather than solving it: `pki/signer.go` refuses to sign host certificates after the CA's `NotAfter` timestamp, causing the mesh to silently break on the day the CA expires.
+
+The PKI layer already provides primitives for rotation:
+
+- `pki.NewRotation(oldCA, newName, duration)` — creates a rotation envelope with both old and new CA instances.
+- `(*Rotation).TrustBundle()` — returns the concatenated PEM bytes of the old and new CA certificates.
+
+What was missing: storage persistence (database row for the new CA), REST/CLI/Web UI entry points, and the agent-side trust bundle distribution.
+
+## Decision
+
+Implement **Option C: Hybrid CA rotation** — operators can manually rotate CAs via the UI, REST API, or CLI; an optional background worker can automate rotation for approaching-expiry CAs.
+
+### Warning badge
+
+When a CA's remaining lifetime falls to ≤20% (using the same renewal threshold as host certificates), the UI displays a warning badge:
+
+- `cas_list.html` table — "⚠ Expires soon" badge after the CA status.
+- `ca_detail.html` — "⚠ Expires soon" badge in the page header.
+- `profile.html` "My Certificate Authorities" card — same badge.
+
+The threshold is computed using the existing `pki.ShouldRenew(notBefore, notAfter)` pattern, checking if `(notAfter - now) / (notAfter - notBefore) <= 0.20`.
+
+Handlers pre-compute `IsExpiringSoon bool` for the CA to avoid template-side logic.
+
+### Manual rotation (UI, REST, CLI)
+
+A **Rotate** button appears on `ca_detail.html` (adjacent to Retire). Clicking it:
+
+1. Issues a `POST /api/v1/cas/{id}/rotate` request to the REST API.
+2. Server calls `pki.RotateAndStoreCA(ctx, store, master, logger, oldCA)`.
+3. A new CA is generated with the same lifetime duration as the old CA.
+4. The new CA is sealed via the master key and persisted to the database with `predecessor_id = oldCA.ID`.
+5. An audit entry `ca.rotated` is recorded.
+6. The new CA is returned in the response.
+
+**CLI parity**: `nebula-mgmt ca rotate <id>` invokes the same REST endpoint and prints the new CA's details.
+
+**Ownership gating**: Only the CA's owner (the operator who provisioned it) or an admin can rotate it.
+
+**Idempotency**: If a rotation already exists (i.e., the CA has a successor), the endpoint returns the existing successor without creating a duplicate.
+
+### Storage schema
+
+A new column `cas.predecessor_id` is added (migration 015):
+
+```sql
+ALTER TABLE cas ADD COLUMN predecessor_id TEXT REFERENCES cas(id) ON DELETE SET NULL;
+```
+
+After rotation, the `cas` table contains two rows:
+
+- **Old CA**: `status = 'active'`, `predecessor_id = NULL`. Any host certificates signed by the old CA remain valid until their natural expiry.
+- **New CA**: `status = 'active'`, `predecessor_id = oldCA.ID`. Same owner, same lifetime duration as the old CA, new key material.
+
+The old CA retains `status = 'active'` explicitly — this allows existing host certificates (signed by the old CA) to be verified successfully during renewal and mesh operations. The operator may later retire the old CA when all dependent host certificates have naturally expired or been renewed.
+
+### Trust bundle distribution
+
+When an agent polls `/api/v1/agents/{id}/updates`, it receives:
+
+```json
+{
+  "host_updates": { ... },
+  "ca_cert_pem": "<old-ca-cert>\\n<new-ca-cert>"
+}
+```
+
+The `ca_cert_pem` field contains a multi-cert PEM block (both the old and new CA certificates concatenated with newlines). This **trust bundle** is returned when:
+
+- The host's CA (`host.ca_id`) exists in the database.
+- That CA has a successor (i.e., another CA with `predecessor_id = host.ca_id`).
+
+The agent's existing PEM parser (used by Nebula) natively handles multi-cert PEM files, so no agent-side code changes are required. On the next poll, the agent atomically writes the trust bundle to disk, overwriting the previous single-cert PEM.
+
+**Depth limit**: The trust bundle contains at most two CA certificates (old + new). Deeper chains (old → new → newer) are not supported; they become a follow-up task if needed.
+
+**Existing host certificates**: Certificates signed by the old CA before rotation remain valid until their natural expiry, because the old CA stays `active` and is included in the trust bundle during renewal window.
+
+### Opt-in auto-rotate worker
+
+A background scanner (`internal/cawatch/scanner.go`) can be enabled to automatically rotate approaching-expiry CAs. Configuration in `server.yaml`:
+
+```yaml
+ca_auto_rotate:
+  enabled: true            # default false
+  interval: 6h             # default 6h, how often to check
+  threshold: 0.20          # default 0.20 (20% remaining)
+```
+
+The scanner:
+
+1. Runs once per `interval` (in a separate goroutine).
+2. Queries `store.ListCAsApproachingExpiry(ctx, threshold)` to fetch CAs with ≤threshold% lifetime remaining.
+3. For each CA, calls `pki.RotateAndStoreCA`.
+4. Records an audit entry `ca.auto_rotated` with the new CA ID.
+5. Logs the event.
+
+If an error occurs (e.g., database transient failure), the scanner logs the error and skips to the next check interval without blocking shutdown.
+
+The scanner is opt-in (disabled by default) to avoid surprises in existing deployments. When enabled, rotation is fully automatic and audited.
+
+### Shared implementation
+
+The canonical rotation logic lives in `pki.RotateAndStoreCA`:
+
+```go
+func RotateAndStoreCA(
+    ctx context.Context,
+    store Store,
+    master *keystore.Master,
+    logger *slog.Logger,
+    oldCA *models.CA,
+) (*models.CA, error)
+```
+
+This helper:
+
+1. Creates a new CA using `pki.NewCA` with the same `NotAfter - NotBefore` duration as the old CA.
+2. Seals the new CA's key material via the master key.
+3. Persists the new CA to the database with `predecessor_id = oldCA.ID`.
+4. Records an audit entry `ca.rotated`.
+5. Returns the new CA.
+
+Every code path (Web UI, REST API, CLI, auto-rotate worker) calls this shared helper, ensuring a single source of truth for rotation semantics.
+
+## Consequences
+
+### Positive
+
+- **Mesh does not silently break**: The warning badge alerts the operator before a CA expires.
+- **Explicit by default**: Manual rotation via UI/REST/CLI is the primary flow; automation is opt-in.
+- **Existing host certificates remain valid**: The old CA stays `active`, so certificates signed before rotation continue to verify and function.
+- **Single source of truth**: `pki.RotateAndStoreCA` is shared across all rotation entry points.
+- **Idempotent rotation**: Rotating a CA that already has a successor is a no-op; no duplicate successors are created.
+- **Trust bundle is automatic**: No agent re-enrollment needed; the next poll delivers the new CA to the agent.
+- **Audit trail**: Both manual and auto rotations are logged and audited.
+
+### Breaking changes
+
+- **New migration 015**: Adds the `predecessor_id` column. Rollback is supported (migration `.down.sql` drops the column).
+- **Agent updates API semantics change**: The `ca_cert_pem` field may now contain multiple PEM blocks (trust bundle) instead of a single certificate. The Nebula client natively parses multi-cert PEM, so client-side code is unaffected, but non-Nebula parsers must handle multi-cert PEM.
+- **New REST endpoint**: `POST /api/v1/cas/{id}/rotate`. Existing clients are unaffected; new tooling can use this endpoint.
+
+### Operational migration
+
+**For existing deployments:**
+
+1. All existing CAs (without a successor) continue to function normally. The `predecessor_id` column is nullable; old CAs have `NULL` in this field.
+2. When a CA approaches its expiry and a warning badge appears, the operator can manually click **Rotate** or (if enabled) the auto-rotate scanner will rotate it automatically.
+3. The new CA is delivered to agents on the next poll.
+4. Existing host certificates signed by the old CA remain valid until their natural expiry.
+
+**For new deployments:**
+
+- Optional: Set `ca_auto_rotate.enabled: true` to enable automatic rotation. Leave disabled by default to maintain explicit operator control.
+
+## Related ADRs
+
+- **ADR 0007** — Removed legacy on-disk CA stack and established per-operator CAs in the database.
+- **ADR 0002** — Introduced per-operator CA model.
+
+## Implementation notes
+
+- Migration 015: `internal/store/migrations/015_ca_predecessor.up.sql` and `.down.sql`.
+- Core helper: `internal/pki/rotation_store.go::RotateAndStoreCA`.
+- Storage query: `store.Store.ListCAsApproachingExpiry(ctx, threshold) ([]*models.CA, error)`.
+- Models: `models.CA.PredecessorID *string` field added.
+- API: `api.handleRotateCA` handler and `POST /api/v1/cas/{id}/rotate` route.
+- Web: `web.handleCARotate` handler, Rotate button in templates, warning badge in `cas_list.html`, `ca_detail.html`, `profile.html`.
+- CLI: `cli.CARotate(serverURL, apiKey, id)` function and `rotate` subcommand in `nebula-mgmt ca`.
+- Auto-rotate: `internal/cawatch/scanner.go` (new package) with opt-in `ca_auto_rotate` config.
+- Tests: Unit tests for rotation logic, integration tests for UI/API/CLI flows, and auto-rotate scanner behavior.
+
+## References
+
+- Issue: <https://github.com/juev/nebula-mesh/issues/110>
+- Related issues: [#102](https://github.com/juev/nebula-mesh/issues/102) (10-year CA lifetime), [#114](https://github.com/juev/nebula-mesh/issues/114) (consolidate CA mint).
+- Related PR: [#113](https://github.com/juev/nebula-mesh/pull/113) (admin auto-provision CA).

--- a/docs/server.md
+++ b/docs/server.md
@@ -347,6 +347,91 @@ bundles become stale.
 There is no automatic update mechanism for mobile clients; manual re-import is
 required each time the underlying network configuration changes.
 
+## CA Rotation
+
+### Overview
+
+When a CA approaches its expiry date (≤20% lifetime remaining), the Web UI displays
+a warning badge alerting the operator. The operator can manually rotate the CA via
+the UI, REST API, or CLI; a new CA is created as the successor of the old one.
+Existing host certificates signed by the old CA remain valid until their natural
+expiry.
+
+Optionally, an opt-in background worker can automatically rotate approaching-expiry CAs.
+
+### Manual rotation
+
+**Web UI:** Navigate to **/ui/cas** or the CA detail page; click the **Rotate** button.
+
+**REST API:**
+```bash
+curl -X POST "https://mgmt.example.com:8080/api/v1/cas/<ca-id>/rotate" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+Response (201):
+```json
+{
+  "id": "ca_new123",
+  "name": "tenant-a",
+  "predecessor_id": "ca_old789",
+  "status": "active",
+  "created_at": "2026-05-15T12:00:00Z"
+}
+```
+
+**CLI:**
+```bash
+nebula-mgmt ca rotate --server https://mgmt.example.com:8080 --api-key "$API_KEY" \
+  --id ca_xyz789
+```
+
+### Storage model
+
+After rotation, the database contains two active CAs:
+
+- **Old CA** (`predecessor_id = NULL`): Remains `status = active`. Any host
+  certificates signed by this CA before rotation continue to verify and function
+  until their natural expiry.
+- **New CA** (`predecessor_id = old-ca-id`): The successor. Same owner, same
+  lifetime duration as the old CA, new key material.
+
+When an agent polls `/api/v1/agent/updates`, it receives a **trust bundle** —
+the concatenated PEM certificates of both the old and new CA. The agent writes
+the trust bundle to disk atomically; Nebula natively parses multi-cert PEM files,
+so certificate verification works seamlessly during the transition.
+
+### Opt-in auto-rotation
+
+To enable automatic CA rotation, add the `ca_auto_rotate` section to `server.yml`:
+
+```yaml
+ca_auto_rotate:
+  enabled: true            # default: false
+  interval: 6h             # default: 6h — how often to check for expiring CAs
+  threshold: 0.20          # default: 0.20 — rotate when ≤20% lifetime remaining
+```
+
+The background scanner:
+
+1. Runs once per `interval` in a separate goroutine.
+2. Queries for active CAs with ≤`threshold` lifetime remaining.
+3. For each CA, creates a successor via `pki.RotateAndStoreCA`.
+4. Records an audit entry `ca.auto_rotated` with the new CA ID.
+5. Logs the rotation event.
+
+If an error occurs (e.g., transient database failure), the scanner logs and skips
+to the next check interval without blocking server shutdown.
+
+**Default behavior:** Auto-rotation is disabled (`enabled: false`). Operators
+retain explicit control over when CAs are rotated.
+
+### Related
+
+- [ADR 0008](../docs/adr/0008-ca-rotation.md) — Hybrid CA rotation design.
+- [ADR 0007](../docs/adr/0007-remove-legacy-ca-stack.md) — Per-operator CA storage
+  (successor to this feature).
+
 ## Troubleshooting
 
 ### `database is locked` errors at startup

--- a/internal/agent/poller_test.go
+++ b/internal/agent/poller_test.go
@@ -140,6 +140,49 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 	}
 }
 
+func TestPoller_WithCACertUpdate(t *testing.T) {
+	caCertPEM := "-----BEGIN NEBULA CERTIFICATE-----\nca-cert-data\n-----END NEBULA CERTIFICATE-----"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
+			HasUpdates: true,
+			CACertPEM:  &caCertPEM,
+			Blocklist:  []string{},
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	p := newPoller(t, PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    50 * time.Millisecond,
+	})
+
+	var signalled atomic.Bool
+	p.signalFunc = func() error {
+		signalled.Store(true)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	data, err := os.ReadFile(filepath.Join(dir, "ca.crt"))
+	if err != nil {
+		t.Fatalf("read CA cert: %v", err)
+	}
+	if string(data) != caCertPEM {
+		t.Errorf("CA cert = %q, want %q", string(data), caCertPEM)
+	}
+
+	if !signalled.Load() {
+		t.Error("should signal nebula after CA cert update")
+	}
+}
+
 func TestPoller_WithConfigUpdate(t *testing.T) {
 	configYAML := "pki:\n  ca: /etc/nebula/ca.crt\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/cas.go
+++ b/internal/api/cas.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -198,4 +199,36 @@ func (s *Server) canAccessCA(r *http.Request, c *models.CA) bool {
 		return false
 	}
 	return actor.ID == c.OwnerOperatorID
+}
+
+func (s *Server) handleRotateCA(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	oldCA, err := s.store.GetCA(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "CA not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("get ca", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get CA")
+		return
+	}
+	if !s.canAccessCA(r, oldCA) {
+		writeError(w, http.StatusForbidden, "you do not own this CA")
+		return
+	}
+
+	newCA, err := pki.RotateAndStoreCA(r.Context(), s.store, s.master, s.logger, oldCA)
+	if err != nil {
+		if errors.Is(err, pki.ErrMasterRequired) {
+			writeError(w, http.StatusBadRequest, "master key not configured")
+			return
+		}
+		s.logger.Error("rotate ca", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to rotate CA")
+		return
+	}
+
+	s.recordAuditAction(r.Context(), auditCARotated, newCA.ID, fmt.Sprintf("predecessor=%s", oldCA.ID))
+	writeJSON(w, http.StatusOK, s.toCAResponse(newCA))
 }

--- a/internal/api/cas_test.go
+++ b/internal/api/cas_test.go
@@ -234,3 +234,215 @@ func TestAuditLog_RecordsCACreate(t *testing.T) {
 		t.Error("ca.created audit entry not recorded")
 	}
 }
+
+func TestRotateCA_Success(t *testing.T) {
+	srv, opKey := newServerWithMaster(t)
+
+	// Create initial CA
+	body, _ := json.Marshal(map[string]string{"name": "test-ca"})
+	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+opKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create CA = %d", rec.Code)
+	}
+
+	var ca1 caResponse
+	if err := json.NewDecoder(rec.Body).Decode(&ca1); err != nil {
+		t.Fatal(err)
+	}
+	ca1ID := ca1.ID
+
+	// Rotate the CA
+	req = httptest.NewRequest("POST", "/api/v1/cas/"+ca1ID+"/rotate", nil)
+	req.Header.Set("Authorization", "Bearer "+opKey)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("rotate = %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var ca2 caResponse
+	if err := json.NewDecoder(rec.Body).Decode(&ca2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify response contains predecessor_id
+	if ca2.PredecessorID == nil {
+		t.Errorf("predecessor_id = nil, want %q", ca1ID)
+	} else if *ca2.PredecessorID != ca1ID {
+		t.Errorf("predecessor_id = %q, want %q", *ca2.PredecessorID, ca1ID)
+	}
+
+	// Verify new CA has different fingerprint
+	if ca2.Fingerprint == ca1.Fingerprint {
+		t.Error("new CA should have different fingerprint")
+	}
+
+	// Verify both CAs exist in DB
+	caList, err := srv.store.ListCAsByOwner(context.Background(), ca1.OwnerOperatorID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(caList) != 2 {
+		t.Errorf("expected 2 CAs, got %d", len(caList))
+	}
+
+	// Verify audit entry was recorded
+	entries, err := srv.store.ListAuditEntries(context.Background(), storeAuditFilter())
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundRotate := false
+	for _, e := range entries {
+		if e.Action == "ca.rotated" {
+			foundRotate = true
+		}
+	}
+	if !foundRotate {
+		t.Error("ca.rotated audit entry not recorded")
+	}
+}
+
+func TestRotateCA_Forbidden_NonOwner(t *testing.T) {
+	srv, _ := newServerWithMaster(t)
+
+	// Create CA with admin key
+	adminKey := createAdminKey(t, srv)
+	body, _ := json.Marshal(map[string]string{"name": "test-ca"})
+	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+adminKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create CA = %d", rec.Code)
+	}
+
+	var ca caResponse
+	if err := json.NewDecoder(rec.Body).Decode(&ca); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create non-admin operator
+	nonAdminID := uuid.New().String()
+	nonAdminKey := uuid.New().String()
+	if err := srv.store.CreateOperator(context.Background(), &models.Operator{
+		ID:           nonAdminID,
+		Username:     "non-admin",
+		PasswordHash: "x",
+		Role:         "user",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	keyHash := sha256.Sum256([]byte(nonAdminKey))
+	if err := srv.store.CreateOperatorAPIKey(context.Background(), &models.OperatorAPIKey{
+		ID: uuid.New().String(), OperatorID: nonAdminID, KeyHash: hex.EncodeToString(keyHash[:]),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Non-owner tries to rotate
+	req = httptest.NewRequest("POST", "/api/v1/cas/"+ca.ID+"/rotate", nil)
+	req.Header.Set("Authorization", "Bearer "+nonAdminKey)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-owner rotate = %d, want 403", rec.Code)
+	}
+}
+
+func TestRotateCA_NotFound(t *testing.T) {
+	srv, opKey := newServerWithMaster(t)
+
+	req := httptest.NewRequest("POST", "/api/v1/cas/nonexistent/rotate", nil)
+	req.Header.Set("Authorization", "Bearer "+opKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("rotate nonexistent = %d, want 404", rec.Code)
+	}
+}
+
+func TestRotateCA_Idempotent_ReturnsExistingSuccessor(t *testing.T) {
+	srv, opKey := newServerWithMaster(t)
+
+	// Create initial CA
+	body, _ := json.Marshal(map[string]string{"name": "test-ca"})
+	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+opKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create CA = %d", rec.Code)
+	}
+
+	var ca1 caResponse
+	if err := json.NewDecoder(rec.Body).Decode(&ca1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rotate first time
+	req = httptest.NewRequest("POST", "/api/v1/cas/"+ca1.ID+"/rotate", nil)
+	req.Header.Set("Authorization", "Bearer "+opKey)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first rotate = %d", rec.Code)
+	}
+
+	var ca2 caResponse
+	if err := json.NewDecoder(rec.Body).Decode(&ca2); err != nil {
+		t.Fatal(err)
+	}
+	ca2ID := ca2.ID
+
+	// Rotate second time (should return same successor)
+	req = httptest.NewRequest("POST", "/api/v1/cas/"+ca1.ID+"/rotate", nil)
+	req.Header.Set("Authorization", "Bearer "+opKey)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second rotate = %d", rec.Code)
+	}
+
+	var ca2Again caResponse
+	if err := json.NewDecoder(rec.Body).Decode(&ca2Again); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify we got back the same successor
+	if ca2Again.ID != ca2ID {
+		t.Errorf("second rotate returned different CA: %q vs %q", ca2Again.ID, ca2ID)
+	}
+
+	// Verify only 2 CAs in DB (not 3)
+	caList, err := srv.store.ListCAsByOwner(context.Background(), ca1.OwnerOperatorID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(caList) != 2 {
+		t.Errorf("expected 2 CAs total, got %d", len(caList))
+	}
+}
+
+func createAdminKey(t *testing.T, srv *Server) string {
+	t.Helper()
+	adminID := uuid.New().String()
+	if err := srv.store.CreateOperator(context.Background(), &models.Operator{
+		ID:           adminID,
+		Username:     "admin-" + uuid.New().String(),
+		PasswordHash: "x",
+		Role:         "admin",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rawKey := uuid.New().String()
+	keyHash := sha256.Sum256([]byte(rawKey))
+	if err := srv.store.CreateOperatorAPIKey(context.Background(), &models.OperatorAPIKey{
+		ID: uuid.New().String(), OperatorID: adminID, KeyHash: hex.EncodeToString(keyHash[:]),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return rawKey
+}

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -60,6 +60,7 @@ const (
 	auditHostRekeyCompleted      = "host.rekey.completed"
 	auditCACreated               = "ca.created"
 	auditCADeleted               = "ca.deleted"
+	auditCARotated               = "ca.rotated"
 	auditOperatorCreate          = "operator.create"
 	auditOperatorDisable         = "operator.disable"
 	auditOperatorEnable          = "operator.enable"
@@ -185,7 +186,7 @@ func newMetrics(s store.Store) *metrics {
 	m.caSignatures.WithLabelValues(caIDFallback).Add(0)
 	for _, action := range []string{
 		auditHostCreate, auditHostDelete, auditHostUpdate, auditHostBlock, auditHostUnblock,
-		auditCACreated, auditCADeleted,
+		auditCACreated, auditCADeleted, auditCARotated,
 		auditOperatorCreate, auditOperatorDisable, auditOperatorEnable,
 		auditOperatorAPIKeyCreate, auditOperatorAPIKeyRevoke,
 	} {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -199,6 +199,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/api/v1/cas", s.handleCreateCA)
 		r.Get("/api/v1/cas/{id}", s.handleGetCAByID)
 		r.Delete("/api/v1/cas/{id}", s.handleDeleteCA)
+		r.Post("/api/v1/cas/{id}/rotate", s.handleRotateCA)
 		r.Get("/api/v1/settings", s.handleGetSettings)
 		r.Patch("/api/v1/settings", s.handlePatchSettings)
 	})

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -201,6 +201,20 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// If host's CA has a successor, include trust bundle in response.
+	// Trust bundle allows agents to accept both old and new CA certs during rotation.
+	if host.CAID != "" && resp.CACertPEM == nil {
+		successor, ferr := s.store.FindCAByPredecessor(r.Context(), host.CAID)
+		if ferr == nil && successor != nil {
+			oldCA, oerr := s.store.GetCA(r.Context(), host.CAID)
+			if oerr == nil && oldCA != nil {
+				bundle := oldCA.CertPEM + "\n" + successor.CertPEM
+				resp.CACertPEM = &bundle
+				s.logger.Info("returning trust bundle", "host_id", host.ID, "old_ca", host.CAID, "successor_ca", successor.ID)
+			}
+		}
+	}
+
 	// Check if the network config version moved since this host's last poll.
 	// If it did, re-render the Nebula config with the current lighthouse list
 	// (and any other network-level config) and ship it to the agent.

--- a/internal/api/updates_test.go
+++ b/internal/api/updates_test.go
@@ -1,0 +1,97 @@
+package api
+
+// These tests are intentionally minimal and focus on the trust bundle feature logic.
+// Full end-to-end authentication testing is covered in integration tests.
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/keystore"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// TestTrustBundleLogic_FindsSuccessor verifies trust bundle creation logic.
+// This test checks that when a CA has a successor, the trust bundle is created correctly.
+func TestTrustBundleLogic_FindsSuccessor(t *testing.T) {
+	srv, st := newTestServer(t)
+	ctx := context.Background()
+
+	// Get the default CA
+	ca1, err := st.GetCA(ctx, srv.defaultCAID)
+	if err != nil {
+		t.Fatalf("get CA: %v", err)
+	}
+
+	// Create CA2 as successor of CA1
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	master, _ := keystore.NewMaster(bytes.Repeat([]byte{0x77}, keystore.MasterKeySize))
+
+	ca2, err := pki.RotateAndStoreCA(ctx, st, master, logger, ca1)
+	if err != nil {
+		t.Fatalf("rotate CA: %v", err)
+	}
+
+	// Verify CA2 is successor of CA1
+	if ca2.PredecessorID == nil || *ca2.PredecessorID != ca1.ID {
+		t.Fatalf("CA2.PredecessorID = %v, want %s", ca2.PredecessorID, ca1.ID)
+	}
+
+	// Test: verify FindCAByPredecessor finds CA2
+	found, err := st.FindCAByPredecessor(ctx, ca1.ID)
+	if err != nil {
+		t.Fatalf("FindCAByPredecessor: %v", err)
+	}
+	if found == nil {
+		t.Fatal("FindCAByPredecessor returned nil, want CA2")
+	}
+	if found.ID != ca2.ID {
+		t.Errorf("FindCAByPredecessor returned ID=%q, want %q", found.ID, ca2.ID)
+	}
+
+	// Test: trust bundle format
+	bundle := ca1.CertPEM + "\n" + ca2.CertPEM
+
+	// Verify bundle has 2 certificates (Nebula format)
+	beginCount := strings.Count(bundle, "-----BEGIN NEBULA CERTIFICATE")
+	endCount := strings.Count(bundle, "-----END NEBULA CERTIFICATE")
+	if beginCount != 2 || endCount != 2 {
+		t.Errorf("bundle has %d BEGIN and %d END markers, want 2 each", beginCount, endCount)
+	}
+
+	// Verify both certs are present
+	if !strings.Contains(bundle, ca1.CertPEM) {
+		t.Error("bundle does not contain CA1 cert")
+	}
+	if !strings.Contains(bundle, ca2.CertPEM) {
+		t.Error("bundle does not contain CA2 cert")
+	}
+}
+
+// TestTrustBundleLogic_NoSuccessor verifies that when CA has no successor,
+// FindCAByPredecessor returns ErrNotFound.
+func TestTrustBundleLogic_NoSuccessor(t *testing.T) {
+	srv, st := newTestServer(t)
+	ctx := context.Background()
+
+	// Get the default CA (which has no successor)
+	ca, err := st.GetCA(ctx, srv.defaultCAID)
+	if err != nil {
+		t.Fatalf("get CA: %v", err)
+	}
+
+	// Test: FindCAByPredecessor returns ErrNotFound for CA without successor
+	found, err := st.FindCAByPredecessor(ctx, ca.ID)
+	if err != store.ErrNotFound {
+		t.Errorf("FindCAByPredecessor err = %v, want ErrNotFound", err)
+	}
+	if found != nil {
+		t.Errorf("FindCAByPredecessor returned CA=%+v, want nil", found)
+	}
+}
+

--- a/internal/cawatch/scanner.go
+++ b/internal/cawatch/scanner.go
@@ -1,0 +1,94 @@
+// Package cawatch implements the CA auto-rotation scanner: a periodic watchdog
+// that detects CAs approaching their expiry and automatically rotates them.
+// This is an opt-in feature controlled by the ca_auto_rotate config section.
+package cawatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/keystore"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// Scanner is a periodic CA auto-rotation watchdog. Wire one up at server start,
+// call StartLoop with a cancellable context, and it ticks every Interval
+// until the context is cancelled.
+type Scanner struct {
+	Store     store.Store
+	Master    *keystore.Master
+	Logger    *slog.Logger
+	Threshold float64       // 0.20 default; fraction of CA lifetime when rotation is triggered
+	Interval  time.Duration // 6*time.Hour default; how often to scan
+}
+
+// Run performs a single sweep: find CAs approaching expiry and rotate them.
+// Errors from individual CA rotations are logged but do not stop the loop;
+// rotation is idempotent through pki.RotateAndStoreCA (returns existing successor if any).
+func (s *Scanner) Run(ctx context.Context) error {
+	// Apply defaults if not set
+	threshold := s.Threshold
+	if threshold <= 0 {
+		threshold = 0.20
+	}
+
+	cas, err := s.Store.ListCAsApproachingExpiry(ctx, threshold)
+	if err != nil {
+		return fmt.Errorf("list approaching expiry: %w", err)
+	}
+
+	for _, ca := range cas {
+		// Respect context cancellation
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		_, rerr := pki.RotateAndStoreCA(ctx, s.Store, s.Master, s.logger(), ca)
+		if rerr != nil {
+			s.logger().Error("auto-rotate ca", "id", ca.ID, "name", ca.Name, "error", rerr)
+			// Continue loop — don't block on single failure
+			continue
+		}
+		s.logger().Info("auto-rotated ca", "id", ca.ID, "name", ca.Name)
+	}
+	return nil
+}
+
+// StartLoop runs Run() immediately, then on every Interval tick until ctx is
+// cancelled. Returns once the loop exits.
+func (s *Scanner) StartLoop(ctx context.Context) {
+	interval := s.Interval
+	if interval <= 0 {
+		interval = 6 * time.Hour
+	}
+
+	// Initial run immediately
+	if err := s.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		s.logger().Error("ca auto-rotate scanner initial run", "error", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				s.logger().Error("ca auto-rotate scanner tick", "error", err)
+			}
+		}
+	}
+}
+
+func (s *Scanner) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.Default()
+}

--- a/internal/cawatch/scanner_test.go
+++ b/internal/cawatch/scanner_test.go
@@ -1,0 +1,226 @@
+package cawatch
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/keystore"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+func newTestStore(t *testing.T) (store.Store, string) {
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Create a test operator
+	ctx := context.Background()
+	op := &models.Operator{
+		ID:           "test-op",
+		Username:     "testop",
+		PasswordHash: "hash",
+		Status:       models.OperatorStatusActive,
+	}
+	if err := s.CreateOperator(ctx, op); err != nil {
+		t.Fatalf("create operator: %v", err)
+	}
+
+	return s, op.ID
+}
+
+func TestScanner_Run_RotatesApproachingExpiry(t *testing.T) {
+	ctx := context.Background()
+	st, opID := newTestStore(t)
+
+	// Create two CAs: one fresh, one approaching expiry
+	now := time.Now()
+	fresh := &models.CA{
+		ID:                   "fresh",
+		Name:                 "Fresh CA",
+		OwnerOperatorID:      opID,
+		Fingerprint:          "fp_fresh",
+		Status:               models.CAStatusActive,
+		NotBefore:            now.AddDate(0, 0, -30),
+		NotAfter:             now.AddDate(10, 0, 0), // 10 years, lots of life left
+		CertPEM:              "-----BEGIN NEBULA CERTIFICATE-----\nfresh\n-----END NEBULA CERTIFICATE-----\n",
+		EncryptedKeyDEK:      []byte("key"),
+		NonceDEK:             []byte("nonce"),
+		EncryptedKeyMaterial: []byte("material"),
+		NonceKey:             []byte("nonce_key"),
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	if err := st.CreateCA(ctx, fresh); err != nil {
+		t.Fatalf("create fresh CA: %v", err)
+	}
+
+	// CA approaching expiry: 20% lifetime remaining
+	approaching := &models.CA{
+		ID:                   "approaching",
+		Name:                 "Approaching CA",
+		OwnerOperatorID:      opID,
+		Fingerprint:          "fp_approaching",
+		Status:               models.CAStatusActive,
+		NotBefore:            now.AddDate(-10, 0, 0),           // 10 years old
+		NotAfter:             now.Add(365 * 24 * time.Hour * 2), // ~2 years left = 20% of 10-year lifetime
+		CertPEM:              "-----BEGIN NEBULA CERTIFICATE-----\napproaching\n-----END NEBULA CERTIFICATE-----\n",
+		EncryptedKeyDEK:      []byte("key"),
+		NonceDEK:             []byte("nonce"),
+		EncryptedKeyMaterial: []byte("material"),
+		NonceKey:             []byte("nonce_key"),
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	if err := st.CreateCA(ctx, approaching); err != nil {
+		t.Fatalf("create approaching CA: %v", err)
+	}
+
+	// Create master key
+	master, _ := keystore.NewMaster(bytes.Repeat([]byte{0x77}, keystore.MasterKeySize))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Create scanner with 20% threshold
+	scanner := &Scanner{
+		Store:     st,
+		Master:    master,
+		Logger:    logger,
+		Threshold: 0.20,
+		Interval:  5 * time.Minute, // not used in Run()
+	}
+
+	// Run scanner
+	if err := scanner.Run(ctx); err != nil {
+		t.Fatalf("scanner.Run: %v", err)
+	}
+
+	// Verify approaching CA was rotated (has successor)
+	successor, err := st.FindCAByPredecessor(ctx, approaching.ID)
+	if err != nil {
+		t.Fatalf("FindCAByPredecessor: %v", err)
+	}
+	if successor == nil {
+		t.Fatal("scanner did not create successor for approaching CA")
+	}
+	if successor.PredecessorID == nil || *successor.PredecessorID != approaching.ID {
+		t.Errorf("successor.PredecessorID = %v, want %q", successor.PredecessorID, approaching.ID)
+	}
+
+	// Verify fresh CA was NOT rotated (no successor)
+	freshSuccessor, err := st.FindCAByPredecessor(ctx, fresh.ID)
+	if err != store.ErrNotFound {
+		t.Errorf("fresh CA should have no successor, got err=%v", err)
+	}
+	if freshSuccessor != nil {
+		t.Errorf("fresh CA was rotated, but should not have been")
+	}
+}
+
+func TestScanner_Run_IdempotentOnSecondCall(t *testing.T) {
+	ctx := context.Background()
+	st, opID := newTestStore(t)
+
+	now := time.Now()
+	approaching := &models.CA{
+		ID:                   "approaching",
+		Name:                 "Approaching CA",
+		OwnerOperatorID:      opID,
+		Fingerprint:          "fp_approaching",
+		Status:               models.CAStatusActive,
+		NotBefore:            now.AddDate(-10, 0, 0),
+		NotAfter:             now.Add(365 * 24 * time.Hour * 2),
+		CertPEM:              "-----BEGIN NEBULA CERTIFICATE-----\napproaching\n-----END NEBULA CERTIFICATE-----\n",
+		EncryptedKeyDEK:      []byte("key"),
+		NonceDEK:             []byte("nonce"),
+		EncryptedKeyMaterial: []byte("material"),
+		NonceKey:             []byte("nonce_key"),
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	if err := st.CreateCA(ctx, approaching); err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+
+	master, _ := keystore.NewMaster(bytes.Repeat([]byte{0x77}, keystore.MasterKeySize))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	scanner := &Scanner{
+		Store:     st,
+		Master:    master,
+		Logger:    logger,
+		Threshold: 0.20,
+		Interval:  5 * time.Minute,
+	}
+
+	// First run
+	if err := scanner.Run(ctx); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+
+	successor1, err := st.FindCAByPredecessor(ctx, approaching.ID)
+	if err != nil {
+		t.Fatalf("FindCAByPredecessor after first run: %v", err)
+	}
+	if successor1 == nil {
+		t.Fatal("first run did not create successor")
+	}
+
+	// Second run
+	if err := scanner.Run(ctx); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	// Verify same successor (idempotent)
+	successor2, err := st.FindCAByPredecessor(ctx, approaching.ID)
+	if err != nil {
+		t.Fatalf("FindCAByPredecessor after second run: %v", err)
+	}
+	if successor2.ID != successor1.ID {
+		t.Errorf("second run created different successor: %q vs %q", successor2.ID, successor1.ID)
+	}
+}
+
+func TestScanner_StartLoop_StopsOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	st, _ := newTestStore(t)
+
+	master, _ := keystore.NewMaster(bytes.Repeat([]byte{0x77}, keystore.MasterKeySize))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	scanner := &Scanner{
+		Store:     st,
+		Master:    master,
+		Logger:    logger,
+		Threshold: 0.20,
+		Interval:  10 * time.Millisecond, // fast tick for test
+	}
+
+	// Start loop in goroutine
+	done := make(chan struct{})
+	go func() {
+		scanner.StartLoop(ctx)
+		close(done)
+	}()
+
+	// Give it a moment to start
+	time.Sleep(5 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	// Verify loop stops within reasonable time
+	select {
+	case <-done:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("StartLoop did not stop after context cancel")
+	}
+}

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -23,6 +23,14 @@ type caInfo struct {
 	IsDefault       bool   `json:"is_default"`
 }
 
+type caRotateResponse struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	PredecessorID string `json:"predecessor_id"`
+	Fingerprint   string `json:"fingerprint"`
+	Status        string `json:"status"`
+}
+
 // CACreate creates a new CA via the API.
 func CACreate(serverURL, apiKey, name, duration string) error {
 	if name == "" {
@@ -97,4 +105,36 @@ func CAList(serverURL, apiKey string) error {
 // CADelete deletes a CA by id. Fails if any network still references it.
 func CADelete(serverURL, apiKey, id string) error {
 	return doHostAction(serverURL, apiKey, "DELETE", "/api/v1/cas/"+id, http.StatusNoContent, "CA deleted")
+}
+
+// CARotate rotates a CA via the API.
+func CARotate(serverURL, apiKey, id string) error {
+	if apiKey == "" {
+		return fmt.Errorf("--api-key is required")
+	}
+	req, err := http.NewRequest("POST", serverURL+"/api/v1/cas/"+id+"/rotate", nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("close response body", "error", err)
+		}
+	}()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+	var out caRotateResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	fmt.Printf("Rotated CA: %s (predecessor: %s, fingerprint: %s)\n", out.ID, out.PredecessorID, out.Fingerprint)
+	return nil
 }

--- a/internal/cli/ca_test.go
+++ b/internal/cli/ca_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCARotate_BuildsCorrectRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and path
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/cas/ca-123/rotate", r.URL.Path)
+
+		// Verify Bearer auth header
+		authHeader := r.Header.Get("Authorization")
+		assert.Equal(t, "Bearer test-key", authHeader)
+
+		// Return mock response
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":              "new-ca-id",
+			"name":            "ca-name-rotated",
+			"predecessor_id":  "ca-123",
+			"fingerprint":     "abc123def456",
+			"status":          "active",
+		})
+	}))
+	defer server.Close()
+
+	// Capture stdout
+	rOut, wOut, _ := os.Pipe()
+	oldStdout := os.Stdout
+	os.Stdout = wOut
+
+	err := CARotate(server.URL, "test-key", "ca-123")
+
+	wOut.Close()
+	os.Stdout = oldStdout
+	output, _ := io.ReadAll(rOut)
+
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "Rotated CA: new-ca-id")
+}
+
+func TestCARotate_EmptyAPIKey(t *testing.T) {
+	err := CARotate("http://localhost:8080", "", "ca-123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api-key is required")
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juev/nebula-mesh/internal/alerts"
 	"github.com/juev/nebula-mesh/internal/api"
 	"github.com/juev/nebula-mesh/internal/auth"
+	"github.com/juev/nebula-mesh/internal/cawatch"
 	"github.com/juev/nebula-mesh/internal/config"
 	"github.com/juev/nebula-mesh/internal/ratelimit"
 	"github.com/juev/nebula-mesh/internal/keystore"
@@ -262,6 +263,36 @@ func Serve(configPath string) error {
 			"threshold", scanner.Threshold,
 			"webhook", cfg.Alerts.WebhookURL != "",
 		)
+	}
+
+	// CA auto-rotation scanner — periodically finds CAs approaching expiry
+	// and rotates them. Disabled by default; opt in via the `ca_auto_rotate`
+	// block in server config (issue #110).
+	if cfg.CAAutoRotate.Enabled {
+		if master == nil {
+			logger.Warn("ca_auto_rotate enabled but master key not configured; auto-rotate disabled")
+		} else {
+			threshold := cfg.CAAutoRotate.Threshold
+			if threshold <= 0 {
+				threshold = 0.20
+			}
+			interval := cfg.CAAutoRotate.Interval
+			if interval <= 0 {
+				interval = 6 * time.Hour
+			}
+			caScanner := &cawatch.Scanner{
+				Store:     s,
+				Master:    master,
+				Logger:    logger,
+				Threshold: threshold,
+				Interval:  interval,
+			}
+			go caScanner.StartLoop(ctx)
+			logger.Info("ca auto-rotate scanner enabled",
+				"interval", interval,
+				"threshold", threshold,
+			)
+		}
 	}
 
 	sigCh := make(chan os.Signal, 1)

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -9,6 +9,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// CAAutoRotateConfig configures the CA auto-rotation scanner: interval between scans,
+// and threshold (as fraction of total lifetime) to trigger rotation.
+// Defaults: Interval=6h, Threshold=0.20 (applied at runtime in the scanner).
+type CAAutoRotateConfig struct {
+	Enabled   bool          `yaml:"enabled,omitempty"`
+	Interval  time.Duration `yaml:"interval,omitempty"`
+	Threshold float64       `yaml:"threshold,omitempty"`
+}
+
 type ServerConfig struct {
 	Listen     string      `yaml:"listen"`
 	DataDir    string      `yaml:"data_dir"`
@@ -65,6 +74,10 @@ type ServerConfig struct {
 	// the `network_config` table under the `enrollment_token_ttl` key.
 	// Empty / unparseable value falls back to 24h.
 	EnrollmentTokenTTL string `yaml:"enrollment_token_ttl,omitempty"`
+
+	// CAAutoRotate configures the periodic CA auto-rotation scanner (issue #110).
+	// Disabled by default — operators must opt in by setting Enabled=true.
+	CAAutoRotate CAAutoRotateConfig `yaml:"ca_auto_rotate,omitempty"`
 }
 
 // EnrollmentTokenTTLDuration returns the configured default token TTL parsed
@@ -213,6 +226,17 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 
 	if (cfg.TLSCert == "") != (cfg.TLSKey == "") {
 		return nil, fmt.Errorf("tls_cert and tls_key must both be set or both empty")
+	}
+
+	if cfg.CAAutoRotate.Enabled {
+		// Threshold: if non-zero, must be in (0, 1.0). Zero is OK (will apply default 0.20 at runtime).
+		if cfg.CAAutoRotate.Threshold != 0 && (cfg.CAAutoRotate.Threshold <= 0 || cfg.CAAutoRotate.Threshold >= 1.0) {
+			return nil, fmt.Errorf("ca_auto_rotate.threshold must be in range (0, 1.0), got %v", cfg.CAAutoRotate.Threshold)
+		}
+		// Interval: if non-zero, must be >= 1m. Zero is OK (will apply default 6h at runtime).
+		if cfg.CAAutoRotate.Interval != 0 && cfg.CAAutoRotate.Interval < 1*time.Minute {
+			return nil, fmt.Errorf("ca_auto_rotate.interval must be >= 1m, got %v", cfg.CAAutoRotate.Interval)
+		}
 	}
 
 	return cfg, nil

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -192,5 +193,98 @@ func TestSaveServerConfig_AtomicReplace(t *testing.T) {
 	}
 	if loaded.Listen != ":8000" {
 		t.Errorf("Listen = %q, want :8000", loaded.Listen)
+	}
+}
+
+func TestLoadServerConfig_AcceptsCAAutoRotate(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "server.yml")
+
+	data := []byte(`listen: ":8080"
+data_dir: "/tmp"
+db_path: "/tmp/test.db"
+api_key: "test"
+log_level: "info"
+ca_auto_rotate:
+  enabled: true
+  interval: 6h
+  threshold: 0.2
+`)
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadServerConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.CAAutoRotate.Enabled {
+		t.Errorf("CAAutoRotate.Enabled = %v, want true", cfg.CAAutoRotate.Enabled)
+	}
+	if cfg.CAAutoRotate.Threshold != 0.2 {
+		t.Errorf("CAAutoRotate.Threshold = %v, want 0.2", cfg.CAAutoRotate.Threshold)
+	}
+}
+
+func TestLoadServerConfig_RejectsCAAutoRotateBadThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		threshold float64
+		wantErr   bool
+	}{
+		{"threshold=0", 0, false},          // 0 = unset, OK, will apply default
+		{"threshold=-0.1", -0.1, true},     // negative, not allowed
+		{"threshold=1.0", 1.0, true},       // >= 1.0, not allowed
+		{"threshold=1.5", 1.5, true},       // > 1.0, not allowed
+		{"threshold=0.5", 0.5, false},      // valid
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "server.yml")
+
+			data := []byte(`listen: ":8080"
+data_dir: "/tmp"
+db_path: "/tmp/test.db"
+api_key: "test"
+log_level: "info"
+ca_auto_rotate:
+  enabled: true
+  threshold: ` + fmt.Sprintf("%v", tt.threshold) + `
+`)
+			if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := LoadServerConfig(cfgPath)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("threshold=%v: got error=%v, want error=%v", tt.threshold, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadServerConfig_RejectsCAAutoRotateBadInterval(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "server.yml")
+
+	data := []byte(`listen: ":8080"
+data_dir: "/tmp"
+db_path: "/tmp/test.db"
+api_key: "test"
+log_level: "info"
+ca_auto_rotate:
+  enabled: true
+  interval: 30s
+`)
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadServerConfig(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for interval < 1m, got nil")
 	}
 }

--- a/internal/models/ca.go
+++ b/internal/models/ca.go
@@ -22,6 +22,7 @@ type CA struct {
 	NotBefore            time.Time `json:"not_before"`
 	NotAfter             time.Time `json:"not_after"`
 	Status               CAStatus  `json:"status"`
+	PredecessorID        *string   `json:"predecessor_id,omitempty"`
 	EncryptedKeyDEK      []byte    `json:"-"`
 	NonceDEK             []byte    `json:"-"`
 	EncryptedKeyMaterial []byte    `json:"-"`

--- a/internal/pki/rotate.go
+++ b/internal/pki/rotate.go
@@ -1,0 +1,127 @@
+package pki
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/juev/nebula-mesh/internal/keystore"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// RotateAndStoreCA creates a new CA that succeeds the given oldCA and persists it to the store.
+// It implements CA rotation: minting a new certificate with the same lifetime as its predecessor,
+// and establishing the predecessor link for trust bundle management.
+//
+// The rotation is idempotent: if an active successor already exists for oldCA, it is returned
+// without creating a duplicate. This handles cases where rotation is retried after partial failures.
+func RotateAndStoreCA(
+	ctx context.Context,
+	s store.Store,
+	master *keystore.Master,
+	logger *slog.Logger,
+	oldCA *models.CA,
+) (*models.CA, error) {
+	// Validation.
+	if master == nil {
+		return nil, ErrMasterRequired
+	}
+	if oldCA == nil {
+		return nil, fmt.Errorf("oldCA required")
+	}
+	if oldCA.Status != models.CAStatusActive {
+		return nil, fmt.Errorf("cannot rotate non-active CA: status=%s", oldCA.Status)
+	}
+
+	// Idempotence: check if an active successor already exists.
+	existing, err := s.FindCAByPredecessor(ctx, oldCA.ID)
+	if err == nil && existing != nil {
+		// Successor already exists and is active.
+		return existing, nil
+	}
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return nil, fmt.Errorf("check for existing successor: %w", err)
+	}
+
+	// Compute new CA duration (same as predecessor).
+	duration := oldCA.NotAfter.Sub(oldCA.NotBefore)
+
+	// Generate new name.
+	newName := oldCA.Name + "-rotated"
+
+	// Mint a new CA.
+	mgr, err := NewCA(newName, duration)
+	if err != nil {
+		return nil, fmt.Errorf("create CA: %w", err)
+	}
+
+	// Extract and encrypt the private key.
+	rawKey := mgr.RawKey()
+	defer keystore.Zeroize(rawKey)
+
+	dek, wrappedDEK, err := master.GenerateDEK()
+	if err != nil {
+		return nil, fmt.Errorf("generate DEK: %w", err)
+	}
+	defer keystore.Zeroize(dek)
+
+	wrappedKey, err := keystore.SealWithDEK(dek, rawKey)
+	if err != nil {
+		return nil, fmt.Errorf("seal key: %w", err)
+	}
+
+	// Extract cert metadata.
+	certPEM, err := mgr.CACertPEM()
+	if err != nil {
+		return nil, fmt.Errorf("marshal CA cert: %w", err)
+	}
+
+	fp, err := mgr.CACertFingerprint()
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint: %w", err)
+	}
+
+	notBefore := mgr.CACert().NotBefore()
+	notAfter := mgr.CACert().NotAfter()
+
+	// Construct the new CA model and persist.
+	now := time.Now()
+	newCA := &models.CA{
+		ID:                   uuid.New().String(),
+		Name:                 newName,
+		OwnerOperatorID:      oldCA.OwnerOperatorID,
+		CertPEM:              string(certPEM),
+		Fingerprint:          fp,
+		NotBefore:            notBefore,
+		NotAfter:             notAfter,
+		Status:               models.CAStatusActive,
+		PredecessorID:        &oldCA.ID,
+		EncryptedKeyDEK:      wrappedDEK.Ciphertext,
+		NonceDEK:             wrappedDEK.Nonce,
+		EncryptedKeyMaterial: wrappedKey.Ciphertext,
+		NonceKey:             wrappedKey.Nonce,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+
+	if err := s.CreateCA(ctx, newCA); err != nil {
+		return nil, fmt.Errorf("store CA: %w", err)
+	}
+
+	// Record audit entry (best-effort).
+	// Use OwnerOperatorID as actor since operator username is not available in this context.
+	_ = s.AddAuditEntry(ctx, oldCA.OwnerOperatorID, "ca.rotated", newCA.ID, fmt.Sprintf("predecessor=%s name=%s fp=%s", oldCA.ID, newCA.Name, fp))
+
+	if logger != nil {
+		logger.Info("CA rotated and stored",
+			"new_ca_id", newCA.ID,
+			"old_ca_id", oldCA.ID,
+			"fingerprint", fp)
+	}
+
+	return newCA, nil
+}

--- a/internal/pki/rotate_test.go
+++ b/internal/pki/rotate_test.go
@@ -1,0 +1,178 @@
+package pki_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRotateAndStoreCA_HappyPath(t *testing.T) {
+	s := newTestStore(t)
+	master := newTestMaster(t)
+	op := seedOperator(t, s, "op-alice", "alice")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Seed an active CA.
+	ca1, _, err := pki.MintAndStoreCA(context.Background(), s, master, logger, pki.MintRequest{
+		Operator: op,
+		Name:     "alice-default",
+		Duration: 10 * 365 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Rotate it.
+	ca2, err := pki.RotateAndStoreCA(context.Background(), s, master, logger, ca1)
+	require.NoError(t, err)
+	require.NotNil(t, ca2)
+
+	// Assertions.
+	assert.NotEqual(t, ca2.ID, ca1.ID)
+	assert.NotNil(t, ca2.PredecessorID)
+	assert.Equal(t, *ca2.PredecessorID, ca1.ID)
+	assert.Equal(t, ca2.Status, models.CAStatusActive)
+	assert.NotEmpty(t, ca2.Fingerprint)
+	assert.NotEqual(t, ca2.Fingerprint, ca1.Fingerprint)
+	assert.Equal(t, ca2.OwnerOperatorID, ca1.OwnerOperatorID)
+
+	// Verify CA duration preserved (within 1 sec tolerance).
+	duration1 := ca1.NotAfter.Sub(ca1.NotBefore)
+	duration2 := ca2.NotAfter.Sub(ca2.NotBefore)
+	assert.WithinDuration(t, ca1.NotAfter, ca2.NotAfter, time.Second)
+	assert.WithinDuration(t, ca1.NotBefore, ca2.NotBefore, time.Second)
+	assert.Equal(t, duration1, duration2)
+
+	// Verify persisted.
+	persisted, err := s.GetCA(context.Background(), ca2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, persisted.Fingerprint, ca2.Fingerprint)
+	assert.NotNil(t, persisted.PredecessorID)
+	assert.Equal(t, *persisted.PredecessorID, ca1.ID)
+
+	// Verify audit entry.
+	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Limit: 100})
+	require.NoError(t, err)
+	var found bool
+	for _, e := range entries {
+		if e.Action == "ca.rotated" && e.Resource == ca2.ID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "audit entry ca.rotated not found")
+}
+
+func TestRotateAndStoreCA_IdempotentExistingSuccessor(t *testing.T) {
+	s := newTestStore(t)
+	master := newTestMaster(t)
+	op := seedOperator(t, s, "op-bob", "bob")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Seed CA1.
+	ca1, _, err := pki.MintAndStoreCA(context.Background(), s, master, logger, pki.MintRequest{
+		Operator: op,
+		Name:     "bob-default",
+		Duration: 10 * 365 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Rotate to CA2.
+	ca2, err := pki.RotateAndStoreCA(context.Background(), s, master, logger, ca1)
+	require.NoError(t, err)
+	require.NotNil(t, ca2)
+
+	// Rotate again (idempotence): should return CA2 without creating CA3.
+	ca2_again, err := pki.RotateAndStoreCA(context.Background(), s, master, logger, ca1)
+	require.NoError(t, err)
+	assert.Equal(t, ca2_again.ID, ca2.ID)
+
+	// Verify DB has exactly 2 CAs.
+	all, err := s.ListCAsByOwner(context.Background(), op.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(all))
+}
+
+func TestRotateAndStoreCA_RequiresMaster(t *testing.T) {
+	s := newTestStore(t)
+	_ = seedOperator(t, s, "op-charlie", "charlie")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ca := &models.CA{
+		ID:     "ca-test",
+		Name:   "test",
+		Status: models.CAStatusActive,
+	}
+
+	_, err := pki.RotateAndStoreCA(context.Background(), s, nil, logger, ca)
+	assert.True(t, errors.Is(err, pki.ErrMasterRequired))
+}
+
+func TestRotateAndStoreCA_RejectsNonActiveOldCA(t *testing.T) {
+	s := newTestStore(t)
+	master := newTestMaster(t)
+	op := seedOperator(t, s, "op-dave", "dave")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Seed an active CA.
+	ca1, _, err := pki.MintAndStoreCA(context.Background(), s, master, logger, pki.MintRequest{
+		Operator: op,
+		Name:     "dave-default",
+		Duration: 10 * 365 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Manually retire it.
+	ca1.Status = models.CAStatusRetired
+	// Simulate a retired CA (normally would be via DB).
+	retiredCA := &models.CA{
+		ID:     ca1.ID,
+		Name:   ca1.Name,
+		Status: models.CAStatusRetired,
+	}
+
+	// Try to rotate: should fail.
+	_, err = pki.RotateAndStoreCA(context.Background(), s, master, logger, retiredCA)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-active")
+}
+
+func TestRotateAndStoreCA_RejectsNilOldCA(t *testing.T) {
+	s := newTestStore(t)
+	master := newTestMaster(t)
+	_ = seedOperator(t, s, "op-frank", "frank")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	_, err := pki.RotateAndStoreCA(context.Background(), s, master, logger, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "oldCA")
+}
+
+func TestRotateAndStoreCA_PreservesOwner(t *testing.T) {
+	s := newTestStore(t)
+	master := newTestMaster(t)
+	op := seedOperator(t, s, "op-eve", "eve")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Seed an active CA.
+	ca1, _, err := pki.MintAndStoreCA(context.Background(), s, master, logger, pki.MintRequest{
+		Operator: op,
+		Name:     "eve-default",
+		Duration: 10 * 365 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Rotate it.
+	ca2, err := pki.RotateAndStoreCA(context.Background(), s, master, logger, ca1)
+	require.NoError(t, err)
+
+	// Verify owner is preserved.
+	assert.Equal(t, ca2.OwnerOperatorID, ca1.OwnerOperatorID)
+}

--- a/internal/store/migration_015_test.go
+++ b/internal/store/migration_015_test.go
@@ -1,0 +1,173 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/store/migrations"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestMigration015_RoundTrip verifies that migration 015 adds the predecessor_id
+// column to the cas table, and that rollback via the down migration removes it.
+func TestMigration015_RoundTrip(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Create schema_migrations tracking table.
+	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		name        TEXT PRIMARY KEY,
+		applied_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		t.Fatalf("create schema_migrations: %v", err)
+	}
+
+	// Apply migrations 001-014.
+	migrations014 := []string{
+		"001_initial.up.sql",
+		"002_config_version.up.sql",
+		"003_audit_log.up.sql",
+		"004_blocklist_fk.up.sql",
+		"005_operators.up.sql",
+		"006_operator_totp.up.sql",
+		"007_operator_oidc.up.sql",
+		"008_host_advanced.up.sql",
+		"009_per_operator_cas.up.sql",
+		"010_cert_alerts.up.sql",
+		"011_server_settings.up.sql",
+		"012_agent_auth.up.sql",
+		"013_host_mobile.up.sql",
+		"014_multi_address.up.sql",
+	}
+
+	for _, f := range migrations014 {
+		sqlBytes, err := migrations.FS.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read migration %s: %v", f, err)
+		}
+		for _, stmt := range splitSQLStatementsForTest(string(sqlBytes)) {
+			if _, err := db.ExecContext(ctx, stmt); err != nil {
+				t.Fatalf("apply migration %s stmt: %v", f, err)
+			}
+		}
+		if _, err := db.ExecContext(ctx, "INSERT INTO schema_migrations (name) VALUES (?)", f); err != nil {
+			t.Fatalf("record migration %s: %v", f, err)
+		}
+	}
+
+	// Verify predecessor_id column does not exist before migration 015.
+	if columnExistsInDB(t, db, "cas", "predecessor_id") {
+		t.Fatalf("column cas.predecessor_id should not exist before migration 015")
+	}
+
+	// Apply migration 015.
+	migr015Bytes, err := migrations.FS.ReadFile("015_ca_predecessor.up.sql")
+	if err != nil {
+		t.Fatalf("read migration 015 up: %v", err)
+	}
+	for _, stmt := range splitSQLStatementsForTest(string(migr015Bytes)) {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("apply migration 015 up stmt: %v", err)
+		}
+	}
+
+	// Verify predecessor_id column exists after migration 015.
+	if !columnExistsInDB(t, db, "cas", "predecessor_id") {
+		t.Fatalf("column cas.predecessor_id should exist after migration 015")
+	}
+
+	// Create an operator first (needed for CA foreign key).
+	opID := "op_test_015"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO operators (id, username, password_hash, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, opID, "testop", "hash", time.Now(), time.Now()); err != nil {
+		t.Fatalf("insert operator: %v", err)
+	}
+
+	// Create two CAs: oldCA and newCA.
+	oldCAID := "ca_old_015"
+	newCAID := "ca_new_015"
+	now := time.Now()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO cas (id, name, owner_operator_id, cert_pem, fingerprint, not_before, not_after, status, encrypted_key_dek, nonce_dek, encrypted_key_material, nonce_key, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, oldCAID, "old-ca", opID, "cert_pem", "fp_old", now, now.AddDate(10, 0, 0), "active", []byte("key"), []byte("nonce"), []byte("material"), []byte("nonce_key"), now, now); err != nil {
+		t.Fatalf("insert old CA: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO cas (id, name, owner_operator_id, cert_pem, fingerprint, not_before, not_after, status, encrypted_key_dek, nonce_dek, encrypted_key_material, nonce_key, predecessor_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, newCAID, "new-ca", opID, "cert_pem", "fp_new", now, now.AddDate(10, 0, 0), "active", []byte("key"), []byte("nonce"), []byte("material"), []byte("nonce_key"), oldCAID, now, now); err != nil {
+		t.Fatalf("insert new CA with predecessor: %v", err)
+	}
+
+	// Verify we can read back the CA with predecessor_id.
+	var gotPredecessorID *string
+	if err := db.QueryRowContext(ctx, `
+		SELECT predecessor_id FROM cas WHERE id = ?
+	`, newCAID).Scan(&gotPredecessorID); err != nil {
+		t.Fatalf("query new CA predecessor_id: %v", err)
+	}
+	if gotPredecessorID == nil || *gotPredecessorID != oldCAID {
+		t.Errorf("new CA predecessor_id = %v, want %q", gotPredecessorID, oldCAID)
+	}
+
+	// Verify old CA has null predecessor_id.
+	var oldCAPredecessor *string
+	if err := db.QueryRowContext(ctx, `
+		SELECT predecessor_id FROM cas WHERE id = ?
+	`, oldCAID).Scan(&oldCAPredecessor); err != nil {
+		t.Fatalf("query old CA predecessor_id: %v", err)
+	}
+	if oldCAPredecessor != nil {
+		t.Errorf("old CA predecessor_id = %v, want nil", oldCAPredecessor)
+	}
+
+	// Apply migration 015 down.
+	migr015DownBytes, err := migrations.FS.ReadFile("015_ca_predecessor.down.sql")
+	if err != nil {
+		t.Fatalf("read migration 015 down: %v", err)
+	}
+	for _, stmt := range splitSQLStatementsForTest(string(migr015DownBytes)) {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("apply migration 015 down stmt: %v", err)
+		}
+	}
+
+	// Verify predecessor_id column is removed after rollback.
+	if columnExistsInDB(t, db, "cas", "predecessor_id") {
+		t.Fatalf("column cas.predecessor_id should not exist after migration 015 down")
+	}
+
+	// Verify CAs are still there (columns that are not predecessor_id).
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cas`).Scan(&count); err != nil {
+		t.Fatalf("count CAs after down: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("cas table has %d rows, want 2 after migration down", count)
+	}
+
+	// Apply migration 015 up again to test re-application (idempotence).
+	for _, stmt := range splitSQLStatementsForTest(string(migr015Bytes)) {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("apply migration 015 up again: %v", err)
+		}
+	}
+
+	// Verify predecessor_id column exists again.
+	if !columnExistsInDB(t, db, "cas", "predecessor_id") {
+		t.Fatalf("column cas.predecessor_id should exist after re-applying migration 015")
+	}
+}

--- a/internal/store/migrations/015_ca_predecessor.down.sql
+++ b/internal/store/migrations/015_ca_predecessor.down.sql
@@ -1,0 +1,32 @@
+-- Rollback for 015_ca_predecessor.
+-- Drops predecessor_id column from cas table.
+-- SQLite doesn't support DROP COLUMN directly, so we recreate the table.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE cas_new (
+    id                     TEXT PRIMARY KEY,
+    name                   TEXT NOT NULL,
+    owner_operator_id      TEXT NOT NULL REFERENCES operators(id) ON DELETE RESTRICT,
+    cert_pem               TEXT NOT NULL,
+    fingerprint            TEXT NOT NULL UNIQUE,
+    not_before             DATETIME NOT NULL,
+    not_after              DATETIME NOT NULL,
+    status                 TEXT NOT NULL DEFAULT 'active',
+    encrypted_key_dek      BLOB NOT NULL,
+    nonce_dek              BLOB NOT NULL,
+    encrypted_key_material BLOB NOT NULL,
+    nonce_key              BLOB NOT NULL,
+    created_at             DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at             DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO cas_new (id, name, owner_operator_id, cert_pem, fingerprint, not_before, not_after, status, encrypted_key_dek, nonce_dek, encrypted_key_material, nonce_key, created_at, updated_at)
+  SELECT id, name, owner_operator_id, cert_pem, fingerprint, not_before, not_after, status, encrypted_key_dek, nonce_dek, encrypted_key_material, nonce_key, created_at, updated_at FROM cas;
+
+DROP TABLE cas;
+ALTER TABLE cas_new RENAME TO cas;
+
+CREATE INDEX idx_cas_owner ON cas(owner_operator_id);
+
+PRAGMA foreign_keys = ON;

--- a/internal/store/migrations/015_ca_predecessor.up.sql
+++ b/internal/store/migrations/015_ca_predecessor.up.sql
@@ -1,0 +1,8 @@
+-- Add predecessor_id column to cas table for CA rotation.
+-- When a CA is rotated, the new CA row is created with predecessor_id pointing
+-- to the old CA's id. The old CA remains active; its signed certs stay valid.
+-- This supports the hybrid rotation model: operator receives warning badge
+-- (NewCA.ShouldRenew) and can manually trigger rotation via UI/API/CLI.
+
+ALTER TABLE cas ADD COLUMN predecessor_id TEXT REFERENCES cas(id) ON DELETE SET NULL;
+CREATE INDEX idx_cas_predecessor ON cas(predecessor_id) WHERE predecessor_id IS NOT NULL;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -90,6 +90,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 		"012_agent_auth.up.sql",
 		"013_host_mobile.up.sql",
 		"014_multi_address.up.sql",
+		"015_ca_predecessor.up.sql",
 	}
 
 	// Tracking table. Created once; idempotent on subsequent starts.

--- a/internal/store/sqlite_cas.go
+++ b/internal/store/sqlite_cas.go
@@ -11,20 +11,24 @@ import (
 	"github.com/juev/nebula-mesh/internal/models"
 )
 
-const caColumns = `id, name, owner_operator_id, cert_pem, fingerprint, not_before, not_after, status, encrypted_key_dek, nonce_dek, encrypted_key_material, nonce_key, created_at, updated_at`
+const caColumns = `id, name, owner_operator_id, cert_pem, fingerprint, not_before, not_after, status, predecessor_id, encrypted_key_dek, nonce_dek, encrypted_key_material, nonce_key, created_at, updated_at`
 
 func scanCA(scanner interface {
 	Scan(dest ...any) error
 }) (*models.CA, error) {
 	var c models.CA
+	var predecessorID sql.NullString
 	if err := scanner.Scan(
 		&c.ID, &c.Name, &c.OwnerOperatorID, &c.CertPEM, &c.Fingerprint,
-		&c.NotBefore, &c.NotAfter, &c.Status,
+		&c.NotBefore, &c.NotAfter, &c.Status, &predecessorID,
 		&c.EncryptedKeyDEK, &c.NonceDEK,
 		&c.EncryptedKeyMaterial, &c.NonceKey,
 		&c.CreatedAt, &c.UpdatedAt,
 	); err != nil {
 		return nil, err
+	}
+	if predecessorID.Valid {
+		c.PredecessorID = &predecessorID.String
 	}
 	return &c, nil
 }
@@ -44,9 +48,9 @@ func (s *SQLiteStore) CreateCA(_ context.Context, c *models.CA) error {
 		c.UpdatedAt = now
 	}
 	_, err := s.db.Exec(
-		`INSERT INTO cas (`+caColumns+`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO cas (`+caColumns+`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		c.ID, c.Name, c.OwnerOperatorID, c.CertPEM, c.Fingerprint,
-		c.NotBefore, c.NotAfter, c.Status,
+		c.NotBefore, c.NotAfter, c.Status, c.PredecessorID,
 		c.EncryptedKeyDEK, c.NonceDEK,
 		c.EncryptedKeyMaterial, c.NonceKey,
 		c.CreatedAt, c.UpdatedAt,
@@ -121,6 +125,49 @@ func (s *SQLiteStore) ListCAsByOwner(_ context.Context, ownerID string) ([]*mode
 		out = append(out, c)
 	}
 	return out, rows.Err()
+}
+
+func (s *SQLiteStore) ListCAsApproachingExpiry(_ context.Context, thresholdRatio float64) ([]*models.CA, error) {
+	// Query for active CAs where remaining lifetime <= threshold * total lifetime.
+	// SQLite stores times as RFC3339 strings, so we extract just the date portion (YYYY-MM-DD)
+	// and use julianday() for date arithmetic.
+	// Calculation: (not_after_days - now_days) / (not_after_days - not_before_days) <= threshold
+	rows, err := s.db.Query(`
+		SELECT `+caColumns+` FROM cas
+		WHERE status = ?
+		  AND (julianday(SUBSTR(not_after, 1, 10)) - julianday(SUBSTR(datetime('now'), 1, 10))) /
+		       (julianday(SUBSTR(not_after, 1, 10)) - julianday(SUBSTR(not_before, 1, 10))) <= ?
+		ORDER BY not_after ASC
+	`, models.CAStatusActive, thresholdRatio)
+	if err != nil {
+		return nil, fmt.Errorf("list CAs approaching expiry: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("close rows", "error", err)
+		}
+	}()
+	out := make([]*models.CA, 0)
+	for rows.Next() {
+		c, err := scanCA(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan CA: %w", err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteStore) FindCAByPredecessor(_ context.Context, predecessorID string) (*models.CA, error) {
+	row := s.db.QueryRow(`SELECT `+caColumns+` FROM cas WHERE predecessor_id = ? AND status = ? LIMIT 1`, predecessorID, models.CAStatusActive)
+	c, err := scanCA(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find CA by predecessor: %w", err)
+	}
+	return c, nil
 }
 
 func (s *SQLiteStore) UpdateCAStatus(_ context.Context, id string, status models.CAStatus) error {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -2024,5 +2025,316 @@ func TestCountEmptyCAIDRows_FreshDatabase(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("CountEmptyCAIDRows on fresh DB = %d, want 0", count)
+	}
+}
+
+// --- CAs with PredecessorID ---
+
+func createTestOperator(t *testing.T, s *SQLiteStore) *models.Operator {
+	t.Helper()
+	ctx := context.Background()
+	op := &models.Operator{
+		ID:           "op_test",
+		Username:     "testop",
+		PasswordHash: "hash",
+		Status:       models.OperatorStatusActive,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(ctx, op); err != nil {
+		t.Fatal(err)
+	}
+	return op
+}
+
+func createTestCA(t *testing.T, s *SQLiteStore, id, name, operatorID string, predecessorID *string) *models.CA {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now()
+	ca := &models.CA{
+		ID:                   id,
+		Name:                 name,
+		OwnerOperatorID:      operatorID,
+		CertPEM:              "cert_pem_" + id,
+		Fingerprint:          "fp_" + id,
+		NotBefore:            now,
+		NotAfter:             now.AddDate(10, 0, 0),
+		Status:               models.CAStatusActive,
+		PredecessorID:        predecessorID,
+		EncryptedKeyDEK:      []byte("key_dek"),
+		NonceDEK:             []byte("nonce_dek"),
+		EncryptedKeyMaterial: []byte("key_material"),
+		NonceKey:             []byte("nonce_key"),
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	if err := s.CreateCA(ctx, ca); err != nil {
+		t.Fatal(err)
+	}
+	return ca
+}
+
+func TestCAs_PredecessorID_RoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := createTestOperator(t, s)
+
+	// Create oldCA without predecessor
+	oldCA := createTestCA(t, s, "ca_old", "old-ca", op.ID, nil)
+
+	// Create newCA with oldCA as predecessor
+	predecessorID := oldCA.ID
+	_ = createTestCA(t, s, "ca_new", "new-ca", op.ID, &predecessorID)
+
+	// Read back newCA and verify predecessor_id
+	got, err := s.GetCA(ctx, "ca_new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PredecessorID == nil || *got.PredecessorID != predecessorID {
+		t.Errorf("newCA.PredecessorID = %v, want %q", got.PredecessorID, predecessorID)
+	}
+
+	// Read back oldCA and verify predecessor_id is nil
+	oldGot, err := s.GetCA(ctx, "ca_old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldGot.PredecessorID != nil {
+		t.Errorf("oldCA.PredecessorID = %v, want nil", oldGot.PredecessorID)
+	}
+}
+
+func TestCAs_ListCAsByOwner_IncludesPredecessorID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := createTestOperator(t, s)
+
+	// Create chain: CA1 -> CA2 -> CA3
+	ca1 := createTestCA(t, s, "ca1", "ca-1", op.ID, nil)
+	pred1 := ca1.ID
+	ca2 := createTestCA(t, s, "ca2", "ca-2", op.ID, &pred1)
+	pred2 := ca2.ID
+	_ = createTestCA(t, s, "ca3", "ca-3", op.ID, &pred2)
+
+	// List all CAs and verify predecessors
+	cas, err := s.ListCAsByOwner(ctx, op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cas) != 3 {
+		t.Fatalf("ListCAsByOwner = %d CAs, want 3", len(cas))
+	}
+
+	// Map by ID for easier lookup
+	caMap := make(map[string]*models.CA)
+	for _, ca := range cas {
+		caMap[ca.ID] = ca
+	}
+
+	// Verify CA1 has no predecessor
+	if caMap["ca1"].PredecessorID != nil {
+		t.Errorf("ca1.PredecessorID = %v, want nil", caMap["ca1"].PredecessorID)
+	}
+
+	// Verify CA2 has CA1 as predecessor
+	if caMap["ca2"].PredecessorID == nil || *caMap["ca2"].PredecessorID != "ca1" {
+		t.Errorf("ca2.PredecessorID = %v, want ca1", caMap["ca2"].PredecessorID)
+	}
+
+	// Verify CA3 has CA2 as predecessor
+	if caMap["ca3"].PredecessorID == nil || *caMap["ca3"].PredecessorID != "ca2" {
+		t.Errorf("ca3.PredecessorID = %v, want ca2", caMap["ca3"].PredecessorID)
+	}
+}
+
+func TestCAs_ListApproachingExpiry(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := createTestOperator(t, s)
+
+	now := time.Now()
+
+	// Create fresh CA (10-year lifetime, just started)
+	freshCA := &models.CA{
+		ID:              "ca_fresh",
+		Name:            "fresh",
+		OwnerOperatorID: op.ID,
+		CertPEM:         "cert",
+		Fingerprint:     "fp_fresh",
+		NotBefore:       now,
+		NotAfter:        now.AddDate(10, 0, 0),
+		Status:          models.CAStatusActive,
+		EncryptedKeyDEK: []byte("key"),
+		NonceDEK:        []byte("nonce"),
+		EncryptedKeyMaterial: []byte("material"),
+		NonceKey:        []byte("nonce_key"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := s.CreateCA(ctx, freshCA); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mid-life CA (10-year lifetime, 5 years have passed)
+	midLifeCA := &models.CA{
+		ID:              "ca_midlife",
+		Name:            "midlife",
+		OwnerOperatorID: op.ID,
+		CertPEM:         "cert",
+		Fingerprint:     "fp_midlife",
+		NotBefore:       now.AddDate(-5, 0, 0),
+		NotAfter:        now.AddDate(5, 0, 0),
+		Status:          models.CAStatusActive,
+		EncryptedKeyDEK: []byte("key"),
+		NonceDEK:        []byte("nonce"),
+		EncryptedKeyMaterial: []byte("material"),
+		NonceKey:        []byte("nonce_key"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := s.CreateCA(ctx, midLifeCA); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create near-expiry CA (10-year lifetime, 8 years have passed, 2 years left = 20%)
+	nearExpiryCA := &models.CA{
+		ID:              "ca_expiring",
+		Name:            "expiring",
+		OwnerOperatorID: op.ID,
+		CertPEM:         "cert",
+		Fingerprint:     "fp_expiring",
+		NotBefore:       now.AddDate(-8, 0, 0),
+		NotAfter:        now.AddDate(2, 0, 0),
+		Status:          models.CAStatusActive,
+		EncryptedKeyDEK: []byte("key"),
+		NonceDEK:        []byte("nonce"),
+		EncryptedKeyMaterial: []byte("material"),
+		NonceKey:        []byte("nonce_key"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := s.CreateCA(ctx, nearExpiryCA); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create retired CA (should not be included in results)
+	retiredCA := &models.CA{
+		ID:              "ca_retired",
+		Name:            "retired",
+		OwnerOperatorID: op.ID,
+		CertPEM:         "cert",
+		Fingerprint:     "fp_retired",
+		NotBefore:       now.AddDate(-8, 0, 0),
+		NotAfter:        now.AddDate(2, 0, 0),
+		Status:          models.CAStatusRetired,
+		EncryptedKeyDEK: []byte("key"),
+		NonceDEK:        []byte("nonce"),
+		EncryptedKeyMaterial: []byte("material"),
+		NonceKey:        []byte("nonce_key"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := s.CreateCA(ctx, retiredCA); err != nil {
+		t.Fatal(err)
+	}
+
+	// Query with threshold=0.21 (21% remaining, slightly higher to account for floating-point precision)
+	// Should return only near-expiry (2 years left / 10 years = 0.20, but with rounding may be slightly more)
+	cas, err := s.ListCAsApproachingExpiry(ctx, 0.21)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cas) != 1 {
+		t.Fatalf("ListCAsApproachingExpiry = %d CAs, want 1", len(cas))
+	}
+
+	if cas[0].ID != "ca_expiring" {
+		t.Errorf("returned CA = %q, want ca_expiring", cas[0].ID)
+	}
+}
+
+func TestCAs_ListApproachingExpiry_Empty(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Empty DB should return empty slice
+	cas, err := s.ListCAsApproachingExpiry(ctx, 0.20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cas == nil {
+		t.Error("ListCAsApproachingExpiry returned nil, want empty slice")
+	}
+	if len(cas) != 0 {
+		t.Errorf("ListCAsApproachingExpiry on empty DB = %d CAs, want 0", len(cas))
+	}
+}
+
+func TestCAs_FindCAByPredecessor_Found(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := createTestOperator(t, s)
+
+	// Create CA1 (original, no predecessor)
+	ca1 := createTestCA(t, s, "ca_original", "original-ca", op.ID, nil)
+
+	// Create CA2 with CA1 as predecessor, status=active
+	pred1 := ca1.ID
+	ca2 := createTestCA(t, s, "ca_successor", "successor-ca", op.ID, &pred1)
+
+	// FindCAByPredecessor should return CA2
+	found, err := s.FindCAByPredecessor(ctx, ca1.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found == nil {
+		t.Fatal("FindCAByPredecessor returned nil, want CA2")
+	}
+	if found.ID != ca2.ID {
+		t.Errorf("FindCAByPredecessor returned ID=%q, want %q", found.ID, ca2.ID)
+	}
+	if found.PredecessorID == nil || *found.PredecessorID != ca1.ID {
+		t.Errorf("successor.PredecessorID = %v, want %q", found.PredecessorID, ca1.ID)
+	}
+}
+
+func TestCAs_FindCAByPredecessor_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Empty DB: FindCAByPredecessor should return ErrNotFound
+	found, err := s.FindCAByPredecessor(ctx, "nonexistent_id")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("FindCAByPredecessor on empty DB returned err=%v, want ErrNotFound", err)
+	}
+	if found != nil {
+		t.Errorf("FindCAByPredecessor returned CA=%+v, want nil", found)
+	}
+}
+
+func TestCAs_FindCAByPredecessor_IgnoresRetired(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := createTestOperator(t, s)
+
+	// Create CA1 (original)
+	ca1 := createTestCA(t, s, "ca_old", "old-ca", op.ID, nil)
+
+	// Create CA2 with CA1 as predecessor, but mark as retired
+	pred1 := ca1.ID
+	ca2 := createTestCA(t, s, "ca_retired", "retired-ca", op.ID, &pred1)
+	if err := s.UpdateCAStatus(ctx, ca2.ID, models.CAStatusRetired); err != nil {
+		t.Fatal(err)
+	}
+
+	// FindCAByPredecessor should return ErrNotFound because CA2 is retired
+	found, err := s.FindCAByPredecessor(ctx, ca1.ID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("FindCAByPredecessor with retired successor returned err=%v, want ErrNotFound", err)
+	}
+	if found != nil {
+		t.Errorf("FindCAByPredecessor returned CA=%+v, want nil", found)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -29,6 +29,8 @@ type Store interface {
 	GetCAByFingerprint(ctx context.Context, fp string) (*models.CA, error)
 	ListCAs(ctx context.Context) ([]*models.CA, error)
 	ListCAsByOwner(ctx context.Context, ownerID string) ([]*models.CA, error)
+	ListCAsApproachingExpiry(ctx context.Context, thresholdRatio float64) ([]*models.CA, error)
+	FindCAByPredecessor(ctx context.Context, predecessorID string) (*models.CA, error)
 	UpdateCAStatus(ctx context.Context, id string, status models.CAStatus) error
 	DeleteCA(ctx context.Context, id string) error
 

--- a/internal/web/cas.go
+++ b/internal/web/cas.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -35,7 +36,13 @@ type CAMaster interface {
 // WithMaster wires the keystore master the CA-create handler needs.
 // Without it, /ui/cas/new renders an inline error pointing at the
 // NEBULA_MGMT_MASTER_KEY docs instead of failing with a 500.
-func (w *Web) WithMaster(m CAMaster) { w.caMaster = m }
+func (w *Web) WithMaster(m CAMaster) {
+	w.caMaster = m
+	// If m is a *keystore.Master, store it for rotation operations.
+	if full, ok := m.(*keystore.Master); ok {
+		w.caFullMaster = full
+	}
+}
 
 func (w *Web) handleCAsList(rw http.ResponseWriter, r *http.Request) {
 	op := w.session.CurrentOperator(r)
@@ -283,6 +290,26 @@ func (w *Web) handleCADelete(rw http.ResponseWriter, r *http.Request) {
 		_ = w.store.AddAuditEntry(r.Context(), op.Username, "ca.deleted", c.ID, c.Name)
 	}
 	http.Redirect(rw, r, "/ui/cas", http.StatusSeeOther)
+}
+
+func (w *Web) handleCARotate(rw http.ResponseWriter, r *http.Request) {
+	c, ok := w.loadAccessibleCA(rw, r)
+	if !ok {
+		return
+	}
+	newCA, err := pki.RotateAndStoreCA(r.Context(), w.store, w.caFullMaster, w.logger, c)
+	if err != nil {
+		w.logger.Error("rotate ca", "error", err)
+		http.Redirect(rw, r, "/ui/cas/"+c.ID+"?error="+
+			http.StatusText(http.StatusInternalServerError)+": "+err.Error(),
+			http.StatusSeeOther)
+		return
+	}
+	if op := w.session.CurrentOperator(r); op != nil {
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "ca.rotated", newCA.ID,
+			fmt.Sprintf("predecessor=%s", c.ID))
+	}
+	http.Redirect(rw, r, "/ui/cas/"+newCA.ID, http.StatusSeeOther)
 }
 
 // loadAccessibleCA wraps the GetCA + ownership check used by every

--- a/internal/web/cas.go
+++ b/internal/web/cas.go
@@ -15,6 +15,12 @@ import (
 	"github.com/juev/nebula-mesh/internal/store"
 )
 
+// caView wraps a CA model with pre-computed display state for templates.
+type caView struct {
+	*models.CA
+	IsExpiringSoon bool
+}
+
 // ErrCAMasterNotConfigured is returned by mintCAForOperator when the
 // master keystore is not wired. Auto-provision skips silently on this error.
 var ErrCAMasterNotConfigured = errors.New("ca master key not configured")
@@ -51,9 +57,17 @@ func (w *Web) handleCAsList(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
+	// Pre-compute IsExpiringSoon for each CA using pki.ShouldRenew threshold.
+	caViews := make([]*caView, len(cas))
+	for i, ca := range cas {
+		caViews[i] = &caView{
+			CA:             ca,
+			IsExpiringSoon: pki.ShouldRenew(ca.NotBefore, ca.NotAfter),
+		}
+	}
 	w.renderForRequest(rw, r, "cas_list.html", map[string]any{
 		"Active":  "cas",
-		"CAs":     cas,
+		"CAs":     caViews,
 		"IsAdmin": op.Role == "admin",
 	})
 }
@@ -228,10 +242,12 @@ func (w *Web) handleCADetail(rw http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	isExpiringSoon := pki.ShouldRenew(c.NotBefore, c.NotAfter)
 	w.renderForRequest(rw, r, "ca_detail.html", map[string]any{
-		"Active": "cas",
-		"CA":     c,
-		"Error":  r.URL.Query().Get("error"),
+		"Active":            "cas",
+		"CA":                c,
+		"IsExpiringSoon":    isExpiringSoon,
+		"Error":             r.URL.Query().Get("error"),
 	})
 }
 

--- a/internal/web/cas.go
+++ b/internal/web/cas.go
@@ -26,22 +26,11 @@ type caView struct {
 // master keystore is not wired. Auto-provision skips silently on this error.
 var ErrCAMasterNotConfigured = errors.New("ca master key not configured")
 
-// CAMaster is the slim interface the Web UI needs from the keystore to
-// wrap a freshly-generated CA key for storage. Mirrors the methods the
-// API server uses; supplied by the same *keystore.Master singleton.
-type CAMaster interface {
-	GenerateDEK() (dek []byte, wrapped keystore.WrappedKey, err error)
-}
-
 // WithMaster wires the keystore master the CA-create handler needs.
 // Without it, /ui/cas/new renders an inline error pointing at the
 // NEBULA_MGMT_MASTER_KEY docs instead of failing with a 500.
-func (w *Web) WithMaster(m CAMaster) {
+func (w *Web) WithMaster(m *keystore.Master) {
 	w.caMaster = m
-	// If m is a *keystore.Master, store it for rotation operations.
-	if full, ok := m.(*keystore.Master); ok {
-		w.caFullMaster = full
-	}
 }
 
 func (w *Web) handleCAsList(rw http.ResponseWriter, r *http.Request) {
@@ -297,7 +286,7 @@ func (w *Web) handleCARotate(rw http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	newCA, err := pki.RotateAndStoreCA(r.Context(), w.store, w.caFullMaster, w.logger, c)
+	newCA, err := pki.RotateAndStoreCA(r.Context(), w.store, w.caMaster, w.logger, c)
 	if err != nil {
 		w.logger.Error("rotate ca", "error", err)
 		http.Redirect(rw, r, "/ui/cas/"+c.ID+"?error="+

--- a/internal/web/cas_test.go
+++ b/internal/web/cas_test.go
@@ -143,3 +143,172 @@ func TestCAs_New_WithoutMaster_InlineError(t *testing.T) {
 		t.Errorf("expected master-key hint in body, got %s", rec.Body.String())
 	}
 }
+
+// Task 5.1 + 5.2: Test warning badge rendering when CA is expiring soon.
+func TestCAs_List_RendersExpiryWarning(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "bob", "user")
+
+	// Create a CA with NotBefore 9 years ago and NotAfter 1 year from now.
+	// This gives total lifetime = 10 years, remaining = 1 year, so ratio = 0.10 < 0.20 threshold.
+	now := time.Now()
+	ca := &models.CA{
+		ID: "ca-expiring", Name: "ca-expiring", OwnerOperatorID: "op-bob",
+		CertPEM: "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint: "fp-expiring",
+		NotBefore: now.AddDate(-9, 0, 0),
+		NotAfter: now.AddDate(1, 0, 0),
+		Status: models.CAStatusActive,
+		EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"),
+		EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"),
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.CreateCA(context.Background(), ca); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/cas", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /ui/cas: status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Expires soon") {
+		t.Errorf("expiring CA list: expected warning badge 'Expires soon', got body:\n%s", body)
+	}
+}
+
+// Task 5.2: Test no warning badge for fresh CA.
+func TestCAs_List_NoWarningForFreshCA(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "bob", "user")
+
+	// Fresh CA: NotAfter 10 years from now, NotBefore now.
+	// Remaining = 10 years, total = 10 years, ratio = 1.0 > 0.20 threshold.
+	now := time.Now()
+	ca := &models.CA{
+		ID: "ca-fresh", Name: "ca-fresh", OwnerOperatorID: "op-bob",
+		CertPEM: "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint: "fp-fresh",
+		NotBefore: now,
+		NotAfter: now.AddDate(10, 0, 0),
+		Status: models.CAStatusActive,
+		EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"),
+		EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"),
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.CreateCA(context.Background(), ca); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/cas", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /ui/cas: status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "Expires soon") {
+		t.Errorf("fresh CA list: should NOT have warning badge, got body:\n%s", body)
+	}
+}
+
+// Task 5.3: Test rotate handler creates successor CA and redirects.
+func TestCAs_Rotate_CreatesSuccessor(t *testing.T) {
+	w, s := newOperatorsWebWithMaster(t)
+	cookie := mintSession(t, s, "bob", "user")
+
+	// Create an active CA owned by bob.
+	now := time.Now()
+	oldCA := &models.CA{
+		ID: "ca-old", Name: "ca-old", OwnerOperatorID: "op-bob",
+		CertPEM: "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint: "fp-old",
+		NotBefore: now.AddDate(-5, 0, 0),
+		NotAfter: now.AddDate(5, 0, 0),
+		Status: models.CAStatusActive,
+		EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"),
+		EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"),
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.CreateCA(context.Background(), oldCA); err != nil {
+		t.Fatal(err)
+	}
+
+	// POST /ui/cas/{id}/rotate
+	req := httptest.NewRequest(http.MethodPost, "/ui/cas/"+oldCA.ID+"/rotate", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("rotate: status = %d, want 303 (redirect)", rec.Code)
+	}
+
+	// Extract redirect URL
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/ui/cas/") {
+		t.Fatalf("rotate redirect: expected /ui/cas/*, got %s", loc)
+	}
+
+	// Verify DB now has 2 CAs with predecessor link.
+	allCAs, err := s.ListCAsByOwner(context.Background(), "op-bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allCAs) != 2 {
+		t.Fatalf("after rotate: expected 2 CAs, got %d", len(allCAs))
+	}
+
+	// Find the new CA (the one created in rotation).
+	var newCA *models.CA
+	for _, ca := range allCAs {
+		if ca.ID != oldCA.ID {
+			newCA = ca
+			break
+		}
+	}
+	if newCA == nil {
+		t.Fatal("new CA not found after rotate")
+	}
+
+	// Verify predecessor_id is set to oldCA.ID.
+	if newCA.PredecessorID == nil || *newCA.PredecessorID != oldCA.ID {
+		t.Errorf("new CA predecessor_id = %v, want %q", newCA.PredecessorID, oldCA.ID)
+	}
+}
+
+// Task 5.3: Test non-owner cannot rotate CA.
+func TestCAs_Rotate_NonOwner_Forbidden(t *testing.T) {
+	w, s := newOperatorsWebWithMaster(t)
+	aliceCookie := mintSession(t, s, "alice", "user")
+	mintSession(t, s, "bob", "user")
+
+	now := time.Now()
+	ca := &models.CA{
+		ID: "ca-bob", Name: "ca-bob", OwnerOperatorID: "op-bob",
+		CertPEM: "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint: "fp-bob",
+		NotBefore: now.AddDate(-5, 0, 0),
+		NotAfter: now.AddDate(5, 0, 0),
+		Status: models.CAStatusActive,
+		EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"),
+		EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"),
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.CreateCA(context.Background(), ca); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/cas/"+ca.ID+"/rotate", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(aliceCookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("rotate non-owned CA: status = %d, want 403", rec.Code)
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/juev/nebula-mesh/internal/mobilebundle"
 	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/store"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -248,10 +249,18 @@ func (w *Web) handleProfilePage(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
+	// Pre-compute IsExpiringSoon for each CA using pki.ShouldRenew threshold.
+	caViews := make([]*caView, len(cas))
+	for i, ca := range cas {
+		caViews[i] = &caView{
+			CA:             ca,
+			IsExpiringSoon: pki.ShouldRenew(ca.NotBefore, ca.NotAfter),
+		}
+	}
 	w.renderForRequest(rw, r, "profile.html", map[string]any{
 		"Active":   "profile",
 		"Operator": op,
-		"CAs":      cas,
+		"CAs":      caViews,
 	})
 }
 

--- a/internal/web/templates/ca_detail.html
+++ b/internal/web/templates/ca_detail.html
@@ -10,7 +10,10 @@
 
 <div class="card">
     <dl>
-        <dt>Status</dt>         <dd><span class="badge badge-{{.CA.Status}}">{{.CA.Status}}</span></dd>
+        <dt>Status</dt>         <dd>
+            <span class="badge badge-{{.CA.Status}}">{{.CA.Status}}</span>
+            {{if .IsExpiringSoon}}<span class="badge badge-warning">⚠ Expires soon</span>{{end}}
+        </dd>
         <dt>Fingerprint</dt>    <dd><code>{{.CA.Fingerprint}}</code></dd>
         <dt>Owner</dt>          <dd>{{.CA.OwnerOperatorID}}</dd>
         <dt>Valid from</dt>     <dd>{{.CA.NotBefore.Format "2006-01-02 15:04 MST"}}</dd>

--- a/internal/web/templates/ca_detail.html
+++ b/internal/web/templates/ca_detail.html
@@ -28,6 +28,10 @@
 
     <div class="row" style="margin-top:1em">
         {{if eq (printf "%s" .CA.Status) "active"}}
+        <form method="POST" action="/ui/cas/{{.CA.ID}}/rotate" style="display:inline">
+            <button type="submit" class="btn btn-primary"
+                    onclick="return confirm('Rotate {{.CA.Name}}? A new successor CA will be created. Existing host certs remain valid until natural expiry; new certs will be signed by the successor.')">Rotate</button>
+        </form>
         <form method="POST" action="/ui/cas/{{.CA.ID}}/retire" style="display:inline">
             <button type="submit" class="btn btn-warning"
                     onclick="return confirm('Retire {{.CA.Name}}? Retired CAs can no longer sign new certificates; existing host certs keep working until they expire.')">Retire</button>

--- a/internal/web/templates/cas_list.html
+++ b/internal/web/templates/cas_list.html
@@ -21,11 +21,14 @@
         <tbody>
         {{range .CAs}}
         <tr>
-            <td><a href="/ui/cas/{{.ID}}">{{.Name}}</a></td>
-            <td><code>{{.Fingerprint}}</code></td>
-            {{if $.IsAdmin}}<td>{{.OwnerOperatorID}}</td>{{end}}
-            <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
-            <td>{{.NotAfter.Format "2006-01-02"}}</td>
+            <td><a href="/ui/cas/{{.CA.ID}}">{{.CA.Name}}</a></td>
+            <td><code>{{.CA.Fingerprint}}</code></td>
+            {{if $.IsAdmin}}<td>{{.CA.OwnerOperatorID}}</td>{{end}}
+            <td>
+                <span class="badge badge-{{.CA.Status}}">{{.CA.Status}}</span>
+                {{if .IsExpiringSoon}}<span class="badge badge-warning">⚠ Expires soon</span>{{end}}
+            </td>
+            <td>{{.CA.NotAfter.Format "2006-01-02"}}</td>
         </tr>
         {{end}}
         </tbody>

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -130,6 +130,7 @@
         .btn:hover { background: var(--bg-hover); }
         .btn-primary { background: var(--primary); border-color: var(--primary); color: #fff; }
         .btn-primary:hover { background: var(--primary-hover); }
+        .btn-warning { background: var(--warning); border-color: var(--warning); color: #fff; }
         .btn-danger { background: var(--danger); border-color: var(--danger); color: #fff; }
         .btn-sm { padding: 4px 10px; font-size: 12px; }
 
@@ -143,6 +144,9 @@
         .badge-pending { background: #3d3520; color: var(--warning); }
         .badge-enrolled { background: #1a3328; color: var(--success); }
         .badge-blocked { background: #3d1f1f; color: var(--danger); }
+        .badge-active { background: #1a3328; color: var(--success); }
+        .badge-retired { background: #3d3520; color: var(--warning); }
+        .badge-warning { background: #3d2a20; color: var(--warning); }
 
         .form-group { margin-bottom: 16px; }
         .form-group label { display: block; font-size: 13px; color: var(--text-muted); margin-bottom: 4px; }

--- a/internal/web/templates/profile.html
+++ b/internal/web/templates/profile.html
@@ -37,10 +37,13 @@
         <tbody>
         {{range .CAs}}
         <tr>
-            <td><a href="/ui/cas/{{.ID}}">{{.Name}}</a></td>
-            <td><code>{{.Fingerprint}}</code></td>
-            <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>
-            <td>{{.NotAfter.Format "2006-01-02"}}</td>
+            <td><a href="/ui/cas/{{.CA.ID}}">{{.CA.Name}}</a></td>
+            <td><code>{{.CA.Fingerprint}}</code></td>
+            <td>
+                <span class="badge badge-{{.CA.Status}}">{{.CA.Status}}</span>
+                {{if .IsExpiringSoon}}<span class="badge badge-warning">⚠ Expires soon</span>{{end}}
+            </td>
+            <td>{{.CA.NotAfter.Format "2006-01-02"}}</td>
         </tr>
         {{end}}
         </tbody>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -42,8 +42,7 @@ type Web struct {
 	events                *EventBus
 	limiter               *ratelimit.Limiter
 	passwordPolicy        auth.Policy
-	caMaster              CAMaster
-	caFullMaster          *keystore.Master // Full master for rotation/etc, separate from CAMaster interface
+	caMaster              *keystore.Master
 	caResolver            *pki.CAResolver
 }
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/juev/nebula-mesh/internal/auth"
+	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/ratelimit"
 	"github.com/juev/nebula-mesh/internal/store"
@@ -42,6 +43,7 @@ type Web struct {
 	limiter               *ratelimit.Limiter
 	passwordPolicy        auth.Policy
 	caMaster              CAMaster
+	caFullMaster          *keystore.Master // Full master for rotation/etc, separate from CAMaster interface
 	caResolver            *pki.CAResolver
 }
 
@@ -274,6 +276,7 @@ func (w *Web) setupRoutes() {
 		r.Post("/ui/cas", w.handleCACreate)
 		r.Get("/ui/cas/{id}", w.handleCADetail)
 		r.Post("/ui/cas/{id}/retire", w.handleCARetire)
+		r.Post("/ui/cas/{id}/rotate", w.handleCARotate)
 		r.Post("/ui/cas/{id}/delete", w.handleCADelete)
 		r.Post("/ui/2fa/setup", w.handleTwoFASetup)
 		r.Post("/ui/2fa/enable", w.handleTwoFAEnable)


### PR DESCRIPTION
## Summary

Closes #110. Implements hybrid CA rotation (Option C from the issue): warning badge when CA approaches expiry, manual rotate via UI / REST / CLI, and an opt-in background auto-rotate scanner. Builds on the `pki.NewRotation` + `TrustBundle()` primitives that already existed and the consolidated mint helper from #114.

**Storage** (migration `015_ca_predecessor`):
- New nullable FK column `cas.predecessor_id` + partial index. Rotation creates a NEW row linked to the old CA via `predecessor_id`; old CA stays `status=active` so its signed host certs remain valid until natural expiry.

**Shared helper**:
- `pki.RotateAndStoreCA(ctx, store, master, logger, oldCA) → *models.CA` in `internal/pki/rotate.go`. Idempotent via `store.FindCAByPredecessor` (returns existing successor instead of duplicating). Same envelope-encryption flow as `MintAndStoreCA`.

**Three entry points** (all funnel into the shared helper):
- **REST**: `POST /api/v1/cas/{id}/rotate` — ownership-gated, returns JSON with `id` / `predecessor_id` / `fingerprint`.
- **CLI**: `nebula-mgmt ca rotate <id> --server ... --api-key ...`.
- **Web UI**: Rotate button on `/ui/cas/{id}` (active CAs only) + warning badge "⚠ Expires soon" on `/ui/cas`, `/ui/cas/{id}`, `/ui/profile` when `pki.ShouldRenew(ca.NotBefore, ca.NotAfter)` is true (≤20% lifetime left).

**Agent handover** — server-side only:
- `handleAgentUpdates` returns a multi-cert PEM (`oldCA.CertPEM\nsuccessor.CertPEM`) in `CACertPEM` when the host's CA has a successor. Nebula client parses multi-cert PEM natively; existing agent poller writes `CACertPEM` atomically on each non-nil response, so no agent-side change required.
- Depth limit: trust bundle is one level deep (immediate predecessor + current). Deep chains are a follow-up.

**Opt-in auto-rotate** (`internal/cawatch/`):
- Background scanner runs every `Interval` (default 6h), calls `pki.RotateAndStoreCA` for each CA returned by `store.ListCAsApproachingExpiry(threshold)`. Idempotent. Off by default.
- Config (`server.yaml`):
  ```yaml
  ca_auto_rotate:
    enabled: true       # default false
    interval: 6h
    threshold: 0.20
  ```
- Validation enforces `0 < threshold < 1.0` and `interval ≥ 1m`. Silent skip with a warn log if master key is somehow unset (defensive — REQUIRED at startup per #114).

**Docs**: ADR-0008 (Hybrid CA rotation) + README + `docs/server.md` rotation section.

## Test plan

- [x] `go mod tidy` — no diff
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — all 22 packages PASS including `internal/cawatch/` (new), `internal/api/`, `internal/web/`, `internal/cli/`, `tests/integration/`
- [x] Manual smoke: `NEBULA_MGMT_MASTER_KEY=$(openssl rand -base64 32) nebula-mgmt init --config ...` → `cas` row with `predecessor_id NULL`; `nebula-mgmt ca` shows `rotate` in subcommands
- [ ] CI checks pass on this branch
