### PR TITLE
chore(go): bump toolchain from 1.26.1 to 1.26.3 (clears govulncheck stdlib CVEs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juev/nebula-mesh
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc


### PR DESCRIPTION
## Summary

`govulncheck` against current `main` reports 9 reachable stdlib vulnerabilities, all fixed in `go1.26.3`. After the bump, the scan returns "No vulnerabilities found."

## Why this matters here

The reachable vulns that touch code paths in this project:

| Vuln | Affected stdlib | Reached via |
|---|---|---|
| GO-2026-4865 / 4980 / 4982 | `html/template` XSS variants | `web.Web.renderWithStatus` |
| GO-2026-4870 | `crypto/tls` (KeyUpdate DoS) | `http.Server.ListenAndServeTLS`, agent HTTPS calls |
| GO-2026-4866 | `crypto/x509` (case-sensitive name constraints auth bypass) | same TLS listener path |
| GO-2026-4918 | `net/http` | agent HTTP client |
| GO-2026-4971 | `net` | agent HTTP client |

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test -race -count=1 ./...` — all 14 packages pass
- [x] `golangci-lint v2.12 run --timeout=5m` — 0 issues
- [x] `govulncheck ./...` → "No vulnerabilities found"

## Notes

The `.github/workflows/ci.yml` pin (`go-version: '1.26'`) already floats to the latest 1.26.x and needs no change. Only `go.mod`'s `go` directive is updated.