### PR TITLE
chore: tighten data-dir and config.yml permissions (gosec defense-in-depth)

### DIFF
--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -117,8 +117,9 @@ func Enroll(serverURL, token, dataDir, signingKeyPath string) error {
 		return fmt.Errorf("decode enrollment response: %w", err)
 	}
 
-	// Ensure data directory exists
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+	// Ensure data directory exists. 0o750 — agent owns its cert/key files
+	// and no other local user needs to traverse this directory.
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
 		return fmt.Errorf("create data dir: %w", err)
 	}
 
@@ -130,7 +131,7 @@ func Enroll(serverURL, token, dataDir, signingKeyPath string) error {
 
 	// Save signing private key (ADR 0004 — used to sign poll requests).
 	// Lives in its own directory, not dataDir; create parent if missing.
-	if err := os.MkdirAll(filepath.Dir(signingKeyPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(signingKeyPath), 0o750); err != nil {
 		return fmt.Errorf("create signing key dir: %w", err)
 	}
 	signingPrivPEM := pem.EncodeToMemory(&pem.Block{Type: SigningPrivateKeyPEMType, Bytes: signingPriv})
@@ -148,8 +149,10 @@ func Enroll(serverURL, token, dataDir, signingKeyPath string) error {
 		return fmt.Errorf("write CA cert: %w", err)
 	}
 
-	// Save config
-	if err := os.WriteFile(filepath.Join(dataDir, "config.yml"), []byte(enrollResp.ConfigYAML), 0o644); err != nil {
+	// Save config. 0o640 — the agent config may embed enrollment metadata
+	// and refresh state; treat as secret-adjacent even though it's not the
+	// private key itself.
+	if err := os.WriteFile(filepath.Join(dataDir, "config.yml"), []byte(enrollResp.ConfigYAML), 0o640); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 
@@ -160,7 +163,7 @@ func Enroll(serverURL, token, dataDir, signingKeyPath string) error {
 // writable by the current process. It writes and removes a temp file
 // because Unix permissions alone cannot capture ACL/capability rules.
 func preflightWritable(dir string) error {
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create %s: %w", dir, err)
 	}
 	f, err := os.CreateTemp(dir, ".nebula-agent-preflight-")

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -27,8 +27,10 @@ func Init(configPath string) error {
 		return err
 	}
 
-	// Ensure data directory
-	if err := os.MkdirAll(cfg.DataDir, 0o755); err != nil {
+	// Ensure data directory. 0o750 — contains the SQLite DB and CA material
+	// (per ADR 0002 encrypted DEKs alongside the legacy CA files); no need
+	// for other local users to traverse.
+	if err := os.MkdirAll(cfg.DataDir, 0o750); err != nil {
 		return fmt.Errorf("create data dir: %w", err)
 	}
 

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -68,7 +68,7 @@ func SaveAgentConfig(path string, cfg *AgentConfig) error {
 	}
 
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
`gosec` flags four directory-creation sites at `0o755` and one WriteFile at `0o644` for `config.yml`. Pure defense-in-depth — no advisory associated.

## Changes
- `internal/agent/enroll.go`: `dataDir`, signing-key dir, preflight dir → `0o750`; `config.yml` → `0o640`
- `internal/cli/init.go`: server data dir → `0o750`
- `internal/config/agent.go`: agent config dir → `0o750`

The cert files (`host.crt`, `ca.crt`) stay `0o644` — they're public-by-design (transmitted to peers on handshake). Private keys are already `0o600`. The change narrows the surrounding directories so non-owner local users can't traverse to the cert/key files.

`config.yml` may embed enrollment metadata or refresh state, so treat it as secret-adjacent (`0o640`).

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...` — all 14 packages pass
- [x] `golangci-lint v2.12 run --timeout=5m` — 0 issues
- [x] `gosec ./...` — issue count drops from 32 → 27 (remainder are false positives I'm happy to walk through if useful)

## Notes
Other gosec findings I confirmed as real but NOT addressed here:
- G124 cookie attributes — already disclosed as SA #1 + SA #2
- G710 redirect/URL leak on `operators.go:251` (operator API key in query string) — filed separately as advisory `GHSA-9pg3-25fq-p6cc`