### PR TITLE
fix(http): add security response headers middleware

### DIFF
--- a/internal/cli/security_headers.go
+++ b/internal/cli/security_headers.go
@@ -1,0 +1,32 @@
+package cli
+
+import "net/http"
+
+// securityHeaders wraps next with HTTP response security headers per advisory
+// GHSA-w7w5-5gcp-38rw: clickjacking, MIME sniffing, referrer leakage, and
+// (on TLS) protocol downgrade defenses.
+//
+// CSP keeps 'unsafe-inline' on script-src and style-src for compatibility
+// with existing inline <script>, <style>, onclick=, and style="..." usage
+// in templates. Tightening that requires extracting inline blocks and
+// rewiring inline event handlers, tracked separately.
+func securityHeaders(next http.Handler) http.Handler {
+	const csp = "default-src 'self'; " +
+		"script-src 'self' 'unsafe-inline'; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"img-src 'self' data:; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'none'; " +
+		"form-action 'self'"
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Content-Security-Policy", csp)
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("Referrer-Policy", "same-origin")
+		h.Set("X-Frame-Options", "DENY")
+		if r.TLS != nil {
+			h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/cli/security_headers_test.go
+++ b/internal/cli/security_headers_test.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSecurityHeaders_PlainHTTP(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := securityHeaders(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	h.ServeHTTP(rec, req)
+
+	got := rec.Result().Header
+
+	wantPrefix := map[string]string{
+		"Content-Security-Policy": "default-src 'self';",
+		"X-Content-Type-Options":  "nosniff",
+		"Referrer-Policy":         "same-origin",
+		"X-Frame-Options":         "DENY",
+	}
+	for k, prefix := range wantPrefix {
+		v := got.Get(k)
+		if v == "" {
+			t.Errorf("%s missing", k)
+			continue
+		}
+		if !strings.HasPrefix(v, prefix) {
+			t.Errorf("%s = %q, want prefix %q", k, v, prefix)
+		}
+	}
+
+	// HSTS must NOT be set on plain HTTP — sending it from a plain
+	// listener would invite the client to upgrade to a non-listening
+	// HTTPS endpoint.
+	if v := got.Get("Strict-Transport-Security"); v != "" {
+		t.Errorf("HSTS set on plain HTTP: %q", v)
+	}
+}
+
+func TestSecurityHeaders_TLS_SetsHSTS(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := securityHeaders(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	req.TLS = &tls.ConnectionState{}
+	h.ServeHTTP(rec, req)
+
+	hsts := rec.Result().Header.Get("Strict-Transport-Security")
+	if hsts == "" {
+		t.Fatal("HSTS missing on TLS request")
+	}
+	if !strings.Contains(hsts, "max-age=") {
+		t.Errorf("HSTS without max-age: %q", hsts)
+	}
+	if !strings.Contains(hsts, "includeSubDomains") {
+		t.Errorf("HSTS without includeSubDomains: %q", hsts)
+	}
+}
+
+func TestSecurityHeaders_CSPDirectives(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := securityHeaders(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rec, req)
+
+	csp := rec.Result().Header.Get("Content-Security-Policy")
+	want := []string{
+		"default-src 'self'",
+		"frame-ancestors 'none'",
+		"base-uri 'none'",
+		"form-action 'self'",
+	}
+	for _, d := range want {
+		if !strings.Contains(csp, d) {
+			t.Errorf("CSP missing %q; got %q", d, csp)
+		}
+	}
+}
+
+func TestSecurityHeaders_AppliedOnErrorResponse(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	h := securityHeaders(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if rec.Result().Header.Get("X-Frame-Options") != "DENY" {
+		t.Error("security headers stripped on error response")
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -227,7 +227,7 @@ func Serve(configPath string) error {
 
 	httpServer := &http.Server{
 		Addr:         cfg.Listen,
-		Handler:      mux,
+		Handler:      securityHeaders(mux),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}


### PR DESCRIPTION
## Summary

Closes **GHSA-w7w5-5gcp-38rw** (high). Adds a middleware wrapping the top-level mux in `internal/cli/serve.go` that sets standard browser-security response headers on every reply (both `/ui/*` and `/api/*`):

| Header | Value |
|---|---|
| `Content-Security-Policy` | `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `same-origin` |
| `X-Frame-Options` | `DENY` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` (only when `r.TLS != nil`) |

## Pragmatic CSP (deferred strict tightening)

CSP keeps `'unsafe-inline'` for `script-src` and `style-src` because current templates contain:

- 4 inline `<script>` blocks (host_new, host_edit, hosts SSE, host_mobile_bundle)
- 4 inline `<style>` blocks (layout, login, login_totp, register)
- 10 inline event handlers (`onclick=`/`onchange=`)
- 78 inline `style="..."` attributes

A strict CSP would require extracting all inline content to `/static/`, replacing `onclick=` with `addEventListener`, and converting inline styles to classes. That is a separate, larger refactor; the framing-protection / MIME / referrer / downgrade benefits from this PR are independent and deliverable now.

HSTS is intentionally conditional on `r.TLS != nil` — sending HSTS from a plain-HTTP listener would invite the client to upgrade to a non-listening HTTPS endpoint.

## Test plan

- [x] `TestSecurityHeaders_PlainHTTP` — all non-HSTS headers set, HSTS absent
- [x] `TestSecurityHeaders_TLS_SetsHSTS` — HSTS present with `max-age` + `includeSubDomains`
- [x] `TestSecurityHeaders_CSPDirectives` — `frame-ancestors`, `base-uri`, `form-action`, `default-src` all in CSP
- [x] `TestSecurityHeaders_AppliedOnErrorResponse` — headers set even when inner handler writes 5xx
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues
