### PR TITLE
fix(tests): return after t.Fatal in web_test.go (SA5011)

### DIFF
--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -117,6 +117,7 @@ func TestSession_CookieSecureFlag(t *testing.T) {
 	}
 	if live == nil {
 		t.Fatal("session cookie not set after login")
+		return
 	}
 	if !live.Secure {
 		t.Error("session cookie missing Secure attribute")
@@ -143,6 +144,7 @@ func TestSession_CookieSecureFlag(t *testing.T) {
 	}
 	if del == nil {
 		t.Fatal("logout did not emit a session-cookie delete")
+		return
 	}
 	if !del.Secure || !del.HttpOnly || del.SameSite != http.SameSiteLaxMode {
 		t.Errorf("logout cookie attribute drift: Secure=%v HttpOnly=%v SameSite=%v",


### PR DESCRIPTION
Follow-up to your 2571bdd. `TestSession_CookieSecureFlag` (added in c13d5b2) has the same SA5011 pattern in two spots that the 2571bdd pass missed: `t.Fatal` on a nil check followed by pointer dereference. Adding the explicit `return` in both, mirroring 2571bdd verbatim.

Fixes:

- `internal/web/web_test.go:118-120` — `if live == nil { t.Fatal(...) }`
- `internal/web/web_test.go:143-145` — `if del == nil { t.Fatal(...) }`

main's CI has been red on the last three runs (#26174412762, #26173196549, #26172281029) — all SA5011 on these two spots.

`make ci` green locally.