### PR TITLE
fix(tests): add explicit return after t.Fatal in web session-cookie test

### DIFF
--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -117,6 +117,7 @@ func TestSession_CookieSecureFlag(t *testing.T) {
 	}
 	if live == nil {
 		t.Fatal("session cookie not set after login")
+		return
 	}
 	if !live.Secure {
 		t.Error("session cookie missing Secure attribute")
@@ -143,6 +144,7 @@ func TestSession_CookieSecureFlag(t *testing.T) {
 	}
 	if del == nil {
 		t.Fatal("logout did not emit a session-cookie delete")
+		return
 	}
 	if !del.Secure || !del.HttpOnly || del.SameSite != http.SameSiteLaxMode {
 		t.Errorf("logout cookie attribute drift: Secure=%v HttpOnly=%v SameSite=%v",


### PR DESCRIPTION
## Summary

Companion to 2571bdd. CI's golangci-lint v2.12 flagged two SA5011 hits in `TestSession_CookieSecureFlag` that don't reproduce locally — staticcheck's call-graph cache couldn't prove `t.Fatal → FailNow → Goexit` terminates, so the post-nil-check dereferences (`live.Secure`, `del.Secure`, ...) looked reachable.

## Change

Two `return` statements after `t.Fatal` in `internal/web/web_test.go`. Same mechanical workaround 2571bdd applied elsewhere — no behavior change; `t.Fatal` already stops the test.

## Why this slipped past pre-flight

The SA5011 false-positive is intermittent (golangci-lint #5979). Local cold-cache runs of `golangci-lint v2.12.2` on this file produce `0 issues.`; CI's environment hits a different analyzer cache state and flags it. PR #130 surfaced the failure.

## Reference

- Upstream issue: https://github.com/golangci/golangci-lint/issues/5979
- Prior workaround commit: 2571bdd

## Verification

- `golangci-lint cache clean && golangci-lint run --timeout=5m ./internal/web/...` → `0 issues.`
- `go test -race -count=1 ./internal/web/...` → pass