### PR TITLE
fix(bootstrap): close SeedAdminOperator check-then-write race

### DIFF
--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -26,16 +26,14 @@ const DefaultAdminUsername = "admin"
 // auth path (bearerAuth) authenticates exclusively via operator_api_keys
 // and does NOT accept the config key as a bearer fallback.
 //
-// It returns true if a new admin was seeded so the caller can log it.
+// The empty-table check and the inserts are delegated to the store as a
+// single atomic operation (SeedInitialAdminOperator). Two concurrent
+// first-boot invocations therefore cannot both seed an admin row: the
+// race-loser's conditional INSERT sees a non-empty operators table and
+// returns (false, nil) without writing.
+//
+// It returns true if this call performed the seed so the caller can log it.
 func SeedAdminOperator(ctx context.Context, s store.Store, uiPassword, apiKey string) (bool, error) {
-	existing, err := s.ListOperators(ctx)
-	if err != nil {
-		return false, fmt.Errorf("list operators: %w", err)
-	}
-	if len(existing) > 0 {
-		return false, nil
-	}
-
 	secret := uiPassword
 	if secret == "" {
 		secret = apiKey
@@ -56,24 +54,22 @@ func SeedAdminOperator(ctx context.Context, s store.Store, uiPassword, apiKey st
 		PasswordHash: string(hash),
 		Role:         "admin",
 	}
-	if err := s.CreateOperator(ctx, op); err != nil {
-		return false, fmt.Errorf("create admin operator: %w", err)
-	}
-
+	var key *models.OperatorAPIKey
 	if apiKey != "" {
 		keyHash := sha256.Sum256([]byte(apiKey))
-		err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		key = &models.OperatorAPIKey{
 			ID:         uuid.New().String(),
 			OperatorID: op.ID,
 			Name:       "initial-admin-key",
 			KeyHash:    hex.EncodeToString(keyHash[:]),
-		})
-		if err != nil {
-			return false, fmt.Errorf("seed admin api key: %w", err)
 		}
 	}
 
-	return true, nil
+	seeded, err := s.SeedInitialAdminOperator(ctx, op, key)
+	if err != nil {
+		return false, fmt.Errorf("seed admin operator: %w", err)
+	}
+	return seeded, nil
 }
 
 // HashAPIKey hashes an API key for storage. Used by both bootstrap and the

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// TestSeedAdminOperator_ConcurrentBootDoesNotDuplicate exercises the
+// first-boot race: N concurrent callers attempt to seed an admin operator
+// against an empty store. Before the atomic SeedInitialAdminOperator path,
+// every goroutine's ListOperators saw an empty table and every one wrote a
+// fresh admin row with a fresh UUID, so the operators table ended up with
+// N admins. The contract this test pins:
+//
+//   - Exactly ONE caller reports `seeded == true`.
+//   - The other N-1 callers report `seeded == false` with err == nil.
+//   - Exactly ONE row exists in the operators table afterward.
+//   - Exactly ONE row exists in the operator_api_keys table afterward
+//     (because every caller passed apiKey != "").
+//
+// Mirrors netbird's TestCreateOwnerUser_ConcurrentRequests (PR #5754) for
+// the same bug-class on their owner-seeding path.
+func TestSeedAdminOperator_ConcurrentBootDoesNotDuplicate(t *testing.T) {
+	const workers = 10
+
+	// Use a file-backed database so the connection pool can hand each
+	// goroutine its own *sql.Conn. ":memory:" would force MaxOpenConns(1)
+	// (see NewSQLiteStore) which serializes the workers on a single
+	// connection and never actually exercises the WAL-mode multi-writer
+	// path the conditional INSERT relies on.
+	dbPath := filepath.Join(t.TempDir(), "seed.db")
+	s, err := store.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	var (
+		wg          sync.WaitGroup
+		seededCount atomic.Int32
+		errs        = make(chan error, workers)
+		start       = make(chan struct{})
+	)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			seeded, err := SeedAdminOperator(context.Background(), s, "init-password", "init-api-key")
+			if err != nil {
+				errs <- err
+				return
+			}
+			if seeded {
+				seededCount.Add(1)
+			}
+		}()
+	}
+
+	// Release all workers simultaneously to maximize the race window.
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("worker returned error: %v", err)
+	}
+
+	if got := seededCount.Load(); got != 1 {
+		t.Errorf("seeded count = %d, want exactly 1", got)
+	}
+
+	ops, err := s.ListOperators(context.Background())
+	if err != nil {
+		t.Fatalf("list operators: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Errorf("operators count = %d, want 1", len(ops))
+	} else if ops[0].Username != DefaultAdminUsername {
+		t.Errorf("operator username = %q, want %q", ops[0].Username, DefaultAdminUsername)
+	}
+
+	keys, err := s.ListOperatorAPIKeys(context.Background(), ops[0].ID)
+	if err != nil {
+		t.Fatalf("list api keys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Errorf("api keys count = %d, want 1", len(keys))
+	}
+}
+
+// TestSeedAdminOperator_NoSecretIsNoOp guards the existing
+// nothing-configured shortcut: when both uiPassword and apiKey are empty,
+// the seeder must return (false, nil) without touching the store.
+func TestSeedAdminOperator_NoSecretIsNoOp(t *testing.T) {
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	seeded, err := SeedAdminOperator(context.Background(), s, "", "")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if seeded {
+		t.Error("seeded = true with empty secrets, want false")
+	}
+
+	ops, err := s.ListOperators(context.Background())
+	if err != nil {
+		t.Fatalf("list operators: %v", err)
+	}
+	if len(ops) != 0 {
+		t.Errorf("operators count = %d, want 0", len(ops))
+	}
+}
+
+// TestSeedAdminOperator_IdempotentOnPopulatedStore pins the second-call
+// no-op contract: once an admin has been seeded, a subsequent SeedAdmin
+// call must report (false, nil) and not mutate the store.
+func TestSeedAdminOperator_IdempotentOnPopulatedStore(t *testing.T) {
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	seeded, err := SeedAdminOperator(context.Background(), s, "first-password", "first-key")
+	if err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+	if !seeded {
+		t.Fatal("first seed = false, want true")
+	}
+
+	seeded, err = SeedAdminOperator(context.Background(), s, "second-password", "second-key")
+	if err != nil {
+		t.Fatalf("second seed: %v", err)
+	}
+	if seeded {
+		t.Error("second seed = true, want false (already populated)")
+	}
+
+	ops, err := s.ListOperators(context.Background())
+	if err != nil {
+		t.Fatalf("list operators: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Errorf("operators count = %d, want 1 after second call", len(ops))
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 	"time"
 
@@ -32,7 +33,32 @@ type SQLiteStore struct {
 // NewSQLiteStore opens a SQLite database at the given path.
 // Use ":memory:" for in-memory database.
 func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	// Pragmas are passed via the modernc.org/sqlite DSN `_pragma=` form so
+	// they are applied on EVERY new pool connection, not just the first
+	// one that happens to serve a `db.Exec("PRAGMA ...")` call. This
+	// matters most for busy_timeout: without it the loser of a lock-
+	// upgrade contention returns SQLITE_BUSY immediately (default 0ms),
+	// and conditional-insert idioms like SeedInitialAdminOperator's
+	// `WHERE NOT EXISTS (SELECT 1 FROM operators)` only deliver their
+	// silent-no-op contract if the loser actually waits for the winner's
+	// commit. 5000ms is long enough to absorb realistic bootstrap and
+	// migration contention without masking real deadlocks.
+	dsn := dbPath
+	pragmas := []string{
+		"busy_timeout(5000)",
+		"foreign_keys(on)",
+		"journal_mode(WAL)",
+	}
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	for _, p := range pragmas {
+		dsn += sep + "_pragma=" + url.QueryEscape(p)
+		sep = "&"
+	}
+
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -44,18 +70,14 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		db.SetMaxOpenConns(1)
 	}
 
-	// Enable WAL mode and foreign keys. Setup runs at process start without
-	// an inherited context, so background is acceptable here.
-	for _, pragma := range []string{
-		"PRAGMA journal_mode=WAL",
-		"PRAGMA foreign_keys=ON",
-	} {
-		if _, err := db.ExecContext(context.Background(), pragma); err != nil {
-			if closeErr := db.Close(); closeErr != nil {
-				slog.Error("close db after pragma failure", "error", closeErr)
-			}
-			return nil, fmt.Errorf("exec %s: %w", pragma, err)
+	// Ping forces at least one connection open so a DSN-pragma failure
+	// (e.g. an unknown pragma name) surfaces here at construction time
+	// rather than on the first real query.
+	if err := db.PingContext(context.Background()); err != nil {
+		if closeErr := db.Close(); closeErr != nil {
+			slog.Error("close db after ping failure", "error", closeErr)
 		}
+		return nil, fmt.Errorf("ping database: %w", err)
 	}
 
 	return &SQLiteStore{db: db}, nil

--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -72,6 +72,98 @@ func (s *SQLiteStore) CreateOperator(ctx context.Context, op *models.Operator) e
 	return nil
 }
 
+// SeedInitialAdminOperator atomically inserts op (and key, if non-nil) only
+// when the operators table is empty. The check-then-write is wrapped in a
+// single transaction whose INSERT is guarded by `WHERE NOT EXISTS (SELECT 1
+// FROM operators)`, so two concurrent first-boot seed calls cannot both
+// succeed: the loser sees `RowsAffected() == 0` and returns (false, nil)
+// without touching the API-key table.
+//
+// Returns (true, nil) if this call performed the seed; (false, nil) if the
+// operators table already had at least one row (either because the caller
+// ran a second time on a populated DB, or because a concurrent boot won
+// the race). Any non-nil error indicates a real failure.
+func (s *SQLiteStore) SeedInitialAdminOperator(ctx context.Context, op *models.Operator, key *models.OperatorAPIKey) (bool, error) {
+	if op == nil {
+		return false, fmt.Errorf("operator is required")
+	}
+	if op.ID == "" || op.Username == "" || op.PasswordHash == "" {
+		return false, fmt.Errorf("operator id, username, password_hash are required")
+	}
+	now := time.Now()
+	if op.CreatedAt.IsZero() {
+		op.CreatedAt = now
+	}
+	if op.UpdatedAt.IsZero() {
+		op.UpdatedAt = now
+	}
+	if op.AuthProvider == "" {
+		op.AuthProvider = models.OperatorAuthLocal
+	}
+	if op.Status == "" {
+		op.Status = models.OperatorStatusActive
+	}
+	if op.Role == "" {
+		op.Role = "admin"
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Error("rollback", "error", err)
+		}
+	}()
+
+	// Conditional insert: succeeds (RowsAffected == 1) only on an empty
+	// operators table. The race-loser's INSERT sees a non-empty table and
+	// produces RowsAffected == 0 — no error, no row written.
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO operators (id, username, display_name, password_hash, auth_provider, status, role, oidc_issuer, oidc_subject, created_at, updated_at)
+		 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		 WHERE NOT EXISTS (SELECT 1 FROM operators)`,
+		op.ID, op.Username, op.DisplayName, op.PasswordHash,
+		op.AuthProvider, op.Status, op.Role,
+		op.OIDCIssuer, op.OIDCSubject,
+		op.CreatedAt, op.UpdatedAt,
+	)
+	if err != nil {
+		return false, fmt.Errorf("insert operator: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("seed admin operator rows: %w", err)
+	}
+	if rows == 0 {
+		// Another caller already populated the operators table; nothing
+		// to do, and we must NOT insert the API key under this op.ID
+		// because that operator row does not exist.
+		return false, nil
+	}
+
+	if key != nil {
+		if key.ID == "" || key.OperatorID == "" || key.KeyHash == "" {
+			return false, fmt.Errorf("api key id, operator_id, key_hash are required")
+		}
+		if key.CreatedAt.IsZero() {
+			key.CreatedAt = now
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO operator_api_keys (id, operator_id, name, key_hash, created_at) VALUES (?, ?, ?, ?, ?)`,
+			key.ID, key.OperatorID, key.Name, key.KeyHash, key.CreatedAt,
+		); err != nil {
+			return false, fmt.Errorf("insert api key: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit seed admin operator: %w", err)
+	}
+	return true, nil
+}
+
 // GetOperatorByOIDC returns the operator matching the issuer+subject pair, if
 // any. Used to look up federated operators after a successful OIDC callback.
 func (s *SQLiteStore) GetOperatorByOIDC(ctx context.Context, issuer, subject string) (*models.Operator, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -119,6 +119,12 @@ type Store interface {
 
 	// Operators
 	CreateOperator(ctx context.Context, op *models.Operator) error
+	// SeedInitialAdminOperator atomically inserts op (and optionally key,
+	// when key is non-nil) only if the operators table is empty. Returns
+	// (true, nil) when this call performed the seed, (false, nil) when
+	// another caller already populated the table. The check + insert run
+	// in a single transaction, so concurrent boots cannot both seed.
+	SeedInitialAdminOperator(ctx context.Context, op *models.Operator, key *models.OperatorAPIKey) (bool, error)
 	GetOperator(ctx context.Context, id string) (*models.Operator, error)
 	GetOperatorByUsername(ctx context.Context, username string) (*models.Operator, error)
 	GetOperatorByOIDC(ctx context.Context, issuer, subject string) (*models.Operator, error)


### PR DESCRIPTION
## Summary

Two concurrent `serve` (or `init`) boots against a fresh database both passed the `ListOperators` empty-check and both attempted to insert an admin row. The `operators.username` UNIQUE constraint kept the table consistent, but the loser's `CreateOperator` returned `UNIQUE constraint failed: operators.username` and surfaced as a startup failure. Bug-class match for netbird PR #5754 (`TestCreateOwnerUser_ConcurrentRequests`).

## Changes

- **`internal/store/{store,sqlite_operators}.go` — new `SeedInitialAdminOperator`**: move the empty-table check and the operator + API-key inserts into a single store-layer method. The check is fused into the operator INSERT via `WHERE NOT EXISTS (SELECT 1 FROM operators)` inside a transaction, so the loser's statement is a no-op (`RowsAffected == 0`) rather than a constraint violation, and the optional API-key insert runs in the same transaction only when the operator insert won. Race-loser returns `(false, nil)`, matching the existing "already populated, nothing to do" contract.

- **`internal/cli/bootstrap.go`**: drop the pre-check and the separate `CreateOperator` / `CreateOperatorAPIKey` calls; pass the populated operator and (optional) API-key structs to `SeedInitialAdminOperator` and surface its `seeded` boolean back through `SeedAdminOperator`'s return.

- **`internal/store/sqlite.go` — `busy_timeout=5000` + DSN-form pragmas**: without `busy_timeout` SQLite's default is 0 ms, so a lock-upgrade loser returns `SQLITE_BUSY` immediately instead of waiting for the holder's commit. Conditional-insert idioms like the new `WHERE NOT EXISTS` only deliver their silent-no-op contract if the loser actually waits for the winner. Switched the pragma init to the modernc.org/sqlite DSN `_pragma=` form so `busy_timeout`, `foreign_keys`, and `journal_mode` are applied on every new pool connection (the previous `db.Exec("PRAGMA ...")` loop only set them on whichever single pool connection served the call).

- **`internal/cli/bootstrap_test.go` — three tests**:
  - `TestSeedAdminOperator_ConcurrentBootDoesNotDuplicate`: 10 goroutines on a **file-backed** SQLite DB (`t.TempDir()`), each calling `SeedAdminOperator`. Asserts exactly one seed reported, exactly one operator row, exactly one API key row. File-backed (not `:memory:`) is required so the pool opens real concurrent connections — `:memory:` forces `MaxOpenConns(1)` which serializes the workers and gives a false-positive pass.
  - `TestSeedAdminOperator_NoSecretIsNoOp`: pins the empty-secrets shortcut.
  - `TestSeedAdminOperator_IdempotentOnPopulatedStore`: pins the second-call no-op contract.

## Test plan

- [x] `go test ./... -count=1 -race`: all 20 packages green
- [x] `golangci-lint run ./...` (v2.12.2, matches CI): 0 issues
- [x] Verified `TestSeedAdminOperator_ConcurrentBootDoesNotDuplicate` catches the race: against pre-fix code on a file-backed DB, 9-of-10 workers return `UNIQUE constraint failed: operators.username (2067)`; against fixed code all 10 succeed and the assertions hold.

## Notes on scope

The pragma rewrite in `sqlite.go` is broader than the bare `PRAGMA busy_timeout=5000` line that closes the race. The previous `db.Exec("PRAGMA ...")` loop also left `foreign_keys=ON` only on whichever single pool connection served the call — pool connections beyond that one had FK enforcement silently disabled, including the CASCADE between `operator_api_keys.operator_id` and `operators.id`. Switching to the DSN `_pragma=` form fixes both pragmas (busy_timeout for the race, foreign_keys as a latent FK-enforcement gap closure). Happy to split into a separate PR if you'd prefer to land the seed race fix independently.