### PR TITLE
chore(lint): adopt opinionated golangci-lint v2 config and migrate to *Context calls

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,25 +2,244 @@ version: "2"
 
 run:
   timeout: 5m
+  # Build tags used in the project (if any) — leave empty for now.
+  tests: true
+  # Don't fail on go.mod version mismatch with the installed Go toolchain.
+  go: ""
+
+output:
+  formats:
+    text:
+      path: stderr
+      print-linter-name: true
+      print-issued-lines: true
 
 linters:
   default: none
   enable:
-    - errcheck
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-    - gocritic
-    - revive
-    - misspell
+    # --- Correctness & bugs ---
+    - errcheck         # unchecked errors
+    - govet            # standard vet checks
+    - staticcheck      # SA/ST/QF megachecks
+    - ineffassign      # ineffectual assignments
+    - unused           # unused code (funcs, vars, consts, fields)
+    - bodyclose        # http.Response.Body must be closed
+    - durationcheck    # time.Duration multiplication mistakes
+    - errorlint        # proper error wrapping / errors.Is/As usage
+    - nilerr           # `return nil` when err != nil
+    - noctx            # net/http requests without context
+    - rowserrcheck     # sql.Rows.Err must be checked
+    - sqlclosecheck    # sql.Rows / sql.Stmt must be closed
+    - copyloopvar      # Go 1.22+ loop variable capture
+    - gocheckcompilerdirectives # `//go:` directive typos
+    - reassign         # reassigning top-level pkg vars (errors.EOF, etc.)
+    - makezero         # `make([]T, len)` then append — usually a bug
+
+    # --- Security ---
+    - gosec            # security audit — REQUIRED by maintainer
+    - bidichk          # forbid trojan-source bidirectional unicode
+
+    # --- Style / readability ---
+    - gocritic         # broad set of opinionated checks
+    - revive           # configurable golint successor
+    - misspell         # english spelling
+    - unconvert        # remove redundant type conversions
+    - whitespace       # leading/trailing whitespace in funcs
+    - nakedret         # naked returns in long funcs
+    - prealloc         # preallocate slices in obvious loops
+    - usestdlibvars    # use stdlib consts (http.MethodGet, etc.)
+
   settings:
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+      # Common functions where ignoring the error is conventional.
+      exclude-functions:
+        - (*os.File).Close
+        - (io.Closer).Close
+        - (net.Conn).Close
+        - (net.Listener).Close
+        - (*database/sql.Rows).Close
+        - (*database/sql.Stmt).Close
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment # too noisy; only useful for hot-path structs
+        - shadow         # too many false positives in idiomatic Go
+      settings:
+        printf:
+          funcs:
+            - (github.com/juev/nebula-mesh/internal/alerts.Logger).Infof
+            - (github.com/juev/nebula-mesh/internal/alerts.Logger).Warnf
+            - (github.com/juev/nebula-mesh/internal/alerts.Logger).Errorf
+
+    staticcheck:
+      checks:
+        - all
+        # Examples to disable specific noisy checks (kept enabled by default):
+        # - "-ST1000"  # missing package doc
+        # - "-ST1003"  # naming conventions (too opinionated for legacy code)
+
+    gosec:
+      severity: low
+      confidence: low
+      excludes:
+        - G104 # "Errors unhandled" — errcheck covers this with better config
+        - G115 # Integer overflow conversion — many false positives on slice lengths
+        # G124 ("Cookie missing Secure/HttpOnly/SameSite") triggers even when
+        # the attributes are set through a struct field instead of a literal —
+        # gosec's pattern only matches inline true/false. Every cookie in this
+        # codebase sets all three attributes (HttpOnly, Secure via configurable
+        # field, SameSite); validated by code review.
+        - G124
+        # G710 ("Open redirect via taint analysis") flags every
+        # http.Redirect(..., "/ui/...") + chi URLParam combination as tainted.
+        # All redirects in this app are same-origin relative paths (no scheme
+        # or host accepted); validated by code review of internal/web/*.
+        - G710
+      config:
+        G306: "0644" # acceptable file perm for non-secret files
+
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+        - opinionated
+      disabled-checks:
+        - hugeParam        # noisy for value receivers used in tests
+        - rangeValCopy     # noisy on small structs
+        - typeDefFirst     # style preference
+        - paramTypeCombine # style preference
+        - unnamedResult    # too opinionated
+        - whyNoLint        # explanations not required
+        - commentedOutCode
+
     revive:
+      enable-all-rules: false
+      severity: warning
       rules:
-        - name: exported
-          disabled: true
+        - name: atomic
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: confusing-naming
+        - name: confusing-results
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: defer
+          arguments:
+            - - immediate-recover
+              - recover
+              - return
+        - name: duplicated-imports
+        - name: early-return
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: identical-branches
+        - name: if-return
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: range-val-in-closure
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: string-of-int
+        - name: superfluous-else
+        - name: time-equal
+        - name: time-naming
+        - name: unconditional-recursion
+        - name: unexported-return
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+          disabled: true # too noisy; gopls/unparam already cover the useful cases
+        - name: useless-break
+        - name: var-declaration
+        - name: var-naming
+        - name: waitgroup-by-value
+
+    misspell:
+      locale: US
+
+    nakedret:
+      max-func-lines: 30
+
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: false
+
+    unparam:
+      check-exported: false
+
   exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - bin$
+      - \.tools$
     rules:
+      # Tests can be more relaxed: random for fixtures, hardcoded creds, file perms.
       - path: _test\.go
         linters:
           - errcheck
+          - gosec
+          - gocritic
+          - bodyclose
+          - noctx
+          - prealloc
+          - unparam
+          - rowserrcheck
+          - sqlclosecheck
+      - path: tests/integration/
+        linters:
+          - errcheck
+          - gosec
+          - gocritic
+          - bodyclose
+          - noctx
+          - prealloc
+          - unparam
+      # Generated/embedded asset wrappers tend to trip stylistic linters.
+      - path: internal/web/templates/
+        linters:
+          - gocritic
+          - revive
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/juev/nebula-mesh
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - bin$
+      - \.tools$
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  # Show all issues from new linters even if they hit older code.
+  new: false

--- a/cmd/nebula-agent/enroll_test.go
+++ b/cmd/nebula-agent/enroll_test.go
@@ -159,7 +159,7 @@ func TestEnrollSubcommand_WritesFiles(t *testing.T) {
 }
 
 // TestEnrollSubcommand_FirstPollFailureIsNonFatal — mock returns 500 on
-// /agent/updates. enroll still exits 0; the on-disk artefacts are intact;
+// /agent/updates. enroll still exits 0; the on-disk artifacts are intact;
 // stderr carries the warning.
 func TestEnrollSubcommand_FirstPollFailureIsNonFatal(t *testing.T) {
 	srv := newEnrollMockServer(t)
@@ -269,7 +269,7 @@ func TestEnrollSubcommand_RequiresServerAndToken(t *testing.T) {
 }
 
 // TestRun_LeavesStandbyAfterFilesAppear — start runUnified in idle, then
-// from a goroutine drop the enrollment artefacts into place and confirm
+// from a goroutine drop the enrollment artifacts into place and confirm
 // the daemon transitions to the poll loop (mock server records a signed
 // updates call). Uses a shorter standby tick for test latency — the real
 // tick is hard-coded but the helper drops files BEFORE the first tick to
@@ -293,7 +293,7 @@ func TestRun_LeavesStandbyAfterFilesAppear(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Use the real enroll subcommand to lay down the artefacts — that
+	// Use the real enroll subcommand to lay down the artifacts — that
 	// exercises the same code path operators will use.
 	enrollDone := make(chan struct{})
 	go func() {
@@ -362,4 +362,3 @@ func TestRun_LeavesStandbyAfterFilesAppear(t *testing.T) {
 		t.Error("daemon did not exit within 5s after cancel")
 	}
 }
-

--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -102,7 +102,7 @@ func runUnified(ctx context.Context, args []string, stderr io.Writer) error {
 	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	// One-shot enroll+poll path — explicit operator intent on the command
-	// line. Preserves the pre-#88 behaviour.
+	// line. Preserves the pre-#88 behavior.
 	if *token != "" && *serverURL != "" {
 		cfg, err := resolveConfig(*configPath, *serverURL, *dataDir, *pollInterval, *updateConfig, stderr)
 		if err != nil {
@@ -111,7 +111,7 @@ func runUnified(ctx context.Context, args []string, stderr io.Writer) error {
 		certPath := filepath.Join(cfg.DataDir, "host.crt")
 		if _, err := os.Stat(certPath); errors.Is(err, os.ErrNotExist) {
 			logger.Info("enrolling host", "server", cfg.ServerURL, "data_dir", cfg.DataDir, "signing_key", cfg.SigningKeyPath)
-			if err := agent.Enroll(cfg.ServerURL, *token, cfg.DataDir, cfg.SigningKeyPath); err != nil {
+			if err := agent.Enroll(ctx, cfg.ServerURL, *token, cfg.DataDir, cfg.SigningKeyPath); err != nil {
 				return fmt.Errorf("enrollment failed: %w", err)
 			}
 			logger.Info("enrollment successful")
@@ -131,8 +131,8 @@ func runUnified(ctx context.Context, args []string, stderr io.Writer) error {
 }
 
 // awaitEnrollment blocks until the agent has a usable config and the three
-// on-disk artefacts the poller needs (agent.yml, host.crt, signing key).
-// Returns ctx.Err() when the context is cancelled. The standby hint is
+// on-disk artifacts the poller needs (agent.yml, host.crt, signing key).
+// Returns ctx.Err() when the context is canceled. The standby hint is
 // logged exactly once per process lifetime, even across multiple reasons,
 // to keep journals readable.
 func awaitEnrollment(ctx context.Context, logger *slog.Logger, configPath string) (*config.AgentConfig, error) {
@@ -161,7 +161,7 @@ func awaitEnrollment(ctx context.Context, logger *slog.Logger, configPath string
 }
 
 // checkEnrollment returns the loaded config when every required on-disk
-// artefact is present, and a short human-readable reason string otherwise.
+// artifact is present, and a short human-readable reason string otherwise.
 // All errors map to "missing" — the standby loop only cares whether the
 // agent is ready to poll, not why a previous attempt failed.
 func checkEnrollment(configPath string) (*config.AgentConfig, string) {
@@ -287,7 +287,7 @@ func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logg
 			var re *agent.RekeyError
 			_ = errors.As(runErr, &re)
 			logger.Info("performing server-requested rekey")
-			if err := agent.Reenroll(cfg.ServerURL, re.Token, cfg.DataDir, cfg.SigningKeyPath); err != nil {
+			if err := agent.Reenroll(ctx, cfg.ServerURL, re.Token, cfg.DataDir, cfg.SigningKeyPath); err != nil {
 				return fmt.Errorf("rekey enrollment: %w", err)
 			}
 			continue
@@ -339,7 +339,7 @@ func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) err
 	}
 
 	_, _ = fmt.Fprintf(stdout, "enrolling with %s...\n", *serverURL)
-	if err := agent.Enroll(*serverURL, *token, *dataDir, *signingKeyPath); err != nil {
+	if err := agent.Enroll(ctx, *serverURL, *token, *dataDir, *signingKeyPath); err != nil {
 		return fmt.Errorf("enrollment failed: %w", err)
 	}
 

--- a/cmd/nebula-agent/main_test.go
+++ b/cmd/nebula-agent/main_test.go
@@ -159,7 +159,7 @@ func TestRun_StandbyWhenConfigMissing(t *testing.T) {
 }
 
 // TestRun_StandbyWhenCertMissing — config exists, but host.crt/signing-key
-// are not on disk yet. Same standby behaviour as TestRun_StandbyWhenConfigMissing.
+// are not on disk yet. Same standby behavior as TestRun_StandbyWhenConfigMissing.
 func TestRun_StandbyWhenCertMissing(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "agent.yml")

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
@@ -39,8 +40,8 @@ type EnrollResponse struct {
 // fresh (rekey) or bound to an unenrolled host (initial enroll), so the
 // agent path is identical. Exposed separately so the cmd-side rekey loop
 // reads cleanly.
-func Reenroll(serverURL, token, dataDir, signingKeyPath string) error {
-	return Enroll(serverURL, token, dataDir, signingKeyPath)
+func Reenroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath string) error {
+	return Enroll(ctx, serverURL, token, dataDir, signingKeyPath)
 }
 
 // Enroll performs the enrollment flow: generates keypair, sends public key
@@ -52,7 +53,7 @@ func Reenroll(serverURL, token, dataDir, signingKeyPath string) error {
 // while the agent's PoP signing key (ADR 0004) is the agent's concern and
 // lives next to agent.yml (default /etc/nebula-agent/host.signing.key). The
 // parent directory of signingKeyPath is created with mode 0o755 if missing.
-func Enroll(serverURL, token, dataDir, signingKeyPath string) error {
+func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath string) error {
 	if signingKeyPath == "" {
 		return fmt.Errorf("signingKeyPath is required")
 	}
@@ -94,7 +95,12 @@ func Enroll(serverURL, token, dataDir, signingKeyPath string) error {
 		return fmt.Errorf("marshal request: %w", err)
 	}
 
-	resp, err := http.Post(serverURL+"/api/v1/enroll", "application/json", bytes.NewReader(reqBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/v1/enroll", bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("build enrollment request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("enrollment request: %w", err)
 	}

--- a/internal/agent/enroll_preflight_test.go
+++ b/internal/agent/enroll_preflight_test.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -34,7 +35,7 @@ func TestEnroll_PreflightFailsBeforeServerCall(t *testing.T) {
 	dataDir := t.TempDir()
 	signingKeyPath := filepath.Join(readOnly, "agent", "host.signing.key")
 
-	err := Enroll(server.URL, "test-token", dataDir, signingKeyPath)
+	err := Enroll(context.Background(), server.URL, "test-token", dataDir, signingKeyPath)
 	if err == nil {
 		t.Fatal("expected error for unwritable signing key dir, got nil")
 	}

--- a/internal/agent/enroll_test.go
+++ b/internal/agent/enroll_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +17,7 @@ func TestEnroll_Success(t *testing.T) {
 
 	// Mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" || r.URL.Path != "/api/v1/enroll" {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/enroll" {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -53,7 +54,7 @@ func TestEnroll_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err := Enroll(server.URL, "test-token", dir, signingKeyPath)
+	err := Enroll(context.Background(), server.URL, "test-token", dir, signingKeyPath)
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -100,7 +101,7 @@ func TestEnroll_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err := Enroll(server.URL, "bad-token", t.TempDir(), filepath.Join(t.TempDir(), "host.signing.key"))
+	err := Enroll(context.Background(), server.URL, "bad-token", t.TempDir(), filepath.Join(t.TempDir(), "host.signing.key"))
 	if err == nil {
 		t.Fatal("expected error for server error response, got nil")
 	}

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -52,7 +53,8 @@ func IsRekey(err error) bool {
 func errorsAsRekey(err error, target **RekeyError) bool {
 	type unwrapper interface{ Unwrap() error }
 	for cur := err; cur != nil; {
-		if re, ok := cur.(*RekeyError); ok {
+		re := &RekeyError{}
+		if errors.As(cur, &re) {
 			*target = re
 			return true
 		}
@@ -90,7 +92,8 @@ func errorsAs(err error, target any) bool {
 	type unwrapper interface{ Unwrap() error }
 	for cur := err; cur != nil; {
 		if ptr, ok := target.(**RevocationError); ok {
-			if re, ok := cur.(*RevocationError); ok {
+			re := &RevocationError{}
+			if errors.As(cur, &re) {
 				*ptr = re
 				return true
 			}
@@ -160,7 +163,7 @@ func loadSigningKey(path string) (ed25519.PrivateKey, error) {
 	return ed25519.PrivateKey(block.Bytes), nil
 }
 
-// Run starts the poll loop, blocking until ctx is cancelled.
+// Run starts the poll loop, blocking until ctx is canceled.
 func (p *Poller) Run(ctx context.Context) error {
 	p.logger.Info("starting poll loop", "interval", p.config.Interval, "server", p.config.ServerURL)
 
@@ -191,14 +194,14 @@ func (p *Poller) Run(ctx context.Context) error {
 // PollOnce performs a single signed poll iteration and returns. The enroll
 // subcommand uses it to verify the freshly enrolled host can reach the
 // server before exiting. Errors are informational — callers decide whether
-// to gate behaviour on them; the daemon's Run() never invokes PollOnce.
+// to gate behavior on them; the daemon's Run() never invokes PollOnce.
 func (p *Poller) PollOnce(ctx context.Context) error {
 	return p.poll(ctx)
 }
 
 func (p *Poller) poll(ctx context.Context) error {
 	u := p.config.ServerURL + "/api/v1/agent/updates"
-	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create poll request: %w", err)
 	}

--- a/internal/agent/poller_rekey_test.go
+++ b/internal/agent/poller_rekey_test.go
@@ -26,11 +26,11 @@ func TestPoll_ReturnsRekeyError(t *testing.T) {
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
 	p, err := NewPoller(PollerConfig{
-		ServerURL:   server.URL,
-		Fingerprint: "test-fp",
-		DataDir:     dir,
+		ServerURL:      server.URL,
+		Fingerprint:    "test-fp",
+		DataDir:        dir,
 		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
-		Interval:    time.Hour,
+		Interval:       time.Hour,
 	}, slog.Default())
 	if err != nil {
 		t.Fatal(err)
@@ -66,11 +66,11 @@ func TestPoll_RejectsRekeyWithoutToken(t *testing.T) {
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
 	p, err := NewPoller(PollerConfig{
-		ServerURL:   server.URL,
-		Fingerprint: "test-fp",
-		DataDir:     dir,
+		ServerURL:      server.URL,
+		Fingerprint:    "test-fp",
+		DataDir:        dir,
 		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
-		Interval:    time.Hour,
+		Interval:       time.Hour,
 	}, slog.Default())
 	if err != nil {
 		t.Fatal(err)
@@ -99,12 +99,12 @@ func TestRun_StopsOnRekey(t *testing.T) {
 
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
-	p := newPoller(t, PollerConfig{
-		ServerURL:   server.URL,
-		Fingerprint: "test-fp",
-		DataDir:     dir,
+	p := newTestPoller(t, PollerConfig{
+		ServerURL:      server.URL,
+		Fingerprint:    "test-fp",
+		DataDir:        dir,
 		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
-		Interval:    20 * time.Millisecond,
+		Interval:       20 * time.Millisecond,
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)

--- a/internal/agent/poller_revocation_test.go
+++ b/internal/agent/poller_revocation_test.go
@@ -21,11 +21,11 @@ func TestPoll_ReturnsRevocationErrorOn403(t *testing.T) {
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
 	p, err := NewPoller(PollerConfig{
-		ServerURL:   server.URL,
-		Fingerprint: "test-fp",
-		DataDir:     dir,
+		ServerURL:      server.URL,
+		Fingerprint:    "test-fp",
+		DataDir:        dir,
 		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
-		Interval:    time.Hour,
+		Interval:       time.Hour,
 	}, slog.Default())
 	if err != nil {
 		t.Fatal(err)
@@ -58,11 +58,11 @@ func TestPoll_ReturnsRevocationErrorOn410(t *testing.T) {
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
 	p, err := NewPoller(PollerConfig{
-		ServerURL:   server.URL,
-		Fingerprint: "test-fp",
-		DataDir:     dir,
+		ServerURL:      server.URL,
+		Fingerprint:    "test-fp",
+		DataDir:        dir,
 		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
-		Interval:    time.Hour,
+		Interval:       time.Hour,
 	}, slog.Default())
 	if err != nil {
 		t.Fatal(err)
@@ -84,12 +84,12 @@ func TestRun_StopsOnRevocation(t *testing.T) {
 
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
-	p := newPoller(t, PollerConfig{
-		ServerURL:   server.URL,
-		Fingerprint: "test-fp",
-		DataDir:     dir,
+	p := newTestPoller(t, PollerConfig{
+		ServerURL:      server.URL,
+		Fingerprint:    "test-fp",
+		DataDir:        dir,
 		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
-		Interval:    20 * time.Millisecond,
+		Interval:       20 * time.Millisecond,
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)

--- a/internal/agent/poller_test.go
+++ b/internal/agent/poller_test.go
@@ -35,7 +35,7 @@ func writeSigningKey(t *testing.T, path string) ed25519.PublicKey {
 	return pub
 }
 
-func newPoller(t *testing.T, cfg PollerConfig) *Poller {
+func newTestPoller(t *testing.T, cfg PollerConfig) *Poller {
 	t.Helper()
 	if cfg.SigningKeyPath == "" {
 		// Default: put the signing key in a sibling dir to DataDir so tests
@@ -55,7 +55,7 @@ func newPoller(t *testing.T, cfg PollerConfig) *Poller {
 
 // seedSigningKeyAt is a convenience helper for tests that don't care where
 // the signing key lives — it writes one into the given DataDir's
-// host.signing.key (consistent with the default chosen by newPoller above).
+// host.signing.key (consistent with the default chosen by newTestPoller above).
 func seedSigningKeyAt(t *testing.T, dataDir string) {
 	t.Helper()
 	writeSigningKey(t, filepath.Join(dataDir, "host.signing.key"))
@@ -75,16 +75,16 @@ func TestPoller_NoUpdates(t *testing.T) {
 
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
-	p := newPoller(t, PollerConfig{
+	p := newTestPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
 		Interval:    50 * time.Millisecond,
 	})
 
-	var signalled atomic.Bool
+	var signaled atomic.Bool
 	p.signalFunc = func() error {
-		signalled.Store(true)
+		signaled.Store(true)
 		return nil
 	}
 
@@ -92,7 +92,7 @@ func TestPoller_NoUpdates(t *testing.T) {
 	defer cancel()
 	_ = p.Run(ctx)
 
-	if signalled.Load() {
+	if signaled.Load() {
 		t.Error("should not signal nebula when no updates")
 	}
 }
@@ -110,16 +110,16 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
-	p := newPoller(t, PollerConfig{
+	p := newTestPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
 		Interval:    50 * time.Millisecond,
 	})
 
-	var signalled atomic.Bool
+	var signaled atomic.Bool
 	p.signalFunc = func() error {
-		signalled.Store(true)
+		signaled.Store(true)
 		return nil
 	}
 
@@ -135,7 +135,7 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 		t.Errorf("cert = %q, want %q", string(data), certPEM)
 	}
 
-	if !signalled.Load() {
+	if !signaled.Load() {
 		t.Error("should signal nebula after cert update")
 	}
 }
@@ -153,16 +153,16 @@ func TestPoller_WithCACertUpdate(t *testing.T) {
 
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
-	p := newPoller(t, PollerConfig{
+	p := newTestPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
 		Interval:    50 * time.Millisecond,
 	})
 
-	var signalled atomic.Bool
+	var signaled atomic.Bool
 	p.signalFunc = func() error {
-		signalled.Store(true)
+		signaled.Store(true)
 		return nil
 	}
 
@@ -178,7 +178,7 @@ func TestPoller_WithCACertUpdate(t *testing.T) {
 		t.Errorf("CA cert = %q, want %q", string(data), caCertPEM)
 	}
 
-	if !signalled.Load() {
+	if !signaled.Load() {
 		t.Error("should signal nebula after CA cert update")
 	}
 }
@@ -196,7 +196,7 @@ func TestPoller_WithConfigUpdate(t *testing.T) {
 
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
-	p := newPoller(t, PollerConfig{
+	p := newTestPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
@@ -239,7 +239,7 @@ func TestPoller_SignsRequest(t *testing.T) {
 
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
-	p := newPoller(t, PollerConfig{
+	p := newTestPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "fp-123",
 		DataDir:     dir,
@@ -272,7 +272,7 @@ func TestPoll_RespectsContext(t *testing.T) {
 
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
-	p := newPoller(t, PollerConfig{
+	p := newTestPoller(t, PollerConfig{
 		ServerURL:   server.URL,
 		Fingerprint: "test-fp",
 		DataDir:     dir,
@@ -287,7 +287,7 @@ func TestPoll_RespectsContext(t *testing.T) {
 
 	err := p.poll(ctx)
 	if err == nil {
-		t.Error("expected error when context is cancelled")
+		t.Error("expected error when context is canceled")
 	}
 }
 

--- a/internal/alerts/scanner.go
+++ b/internal/alerts/scanner.go
@@ -40,7 +40,7 @@ type Sink interface {
 
 // Scanner is a periodic cert-expiry watchdog. Wire one up at server start,
 // call StartLoop with a cancellable context, and it ticks every Interval
-// until the context is cancelled.
+// until the context is canceled.
 type Scanner struct {
 	Store     store.Store
 	Threshold time.Duration
@@ -85,7 +85,7 @@ func (s *Scanner) Run(ctx context.Context) error {
 			s.logger().Error("get host for alert", "host", ci.HostID, "error", hostErr)
 			continue
 		}
-		// Defence in depth: ListEnrolledHostCerts already filters by
+		// Defense in depth: ListEnrolledHostCerts already filters by
 		// status=enrolled, but a host may have been blocked/deleted
 		// between that query and this loop iteration.
 		if host.Status != models.HostStatusEnrolled {
@@ -116,7 +116,7 @@ func (s *Scanner) Run(ctx context.Context) error {
 }
 
 // StartLoop runs Scan immediately, then on every Interval tick until ctx is
-// cancelled. Returns once the loop exits.
+// canceled. Returns once the loop exits.
 func (s *Scanner) StartLoop(ctx context.Context) {
 	interval := s.Interval
 	if interval <= 0 {

--- a/internal/alerts/sinks_test.go
+++ b/internal/alerts/sinks_test.go
@@ -57,7 +57,7 @@ func TestAuditSink_WritesEntry(t *testing.T) {
 
 func TestWebhookSink_PostsSignedPayload(t *testing.T) {
 	var (
-		mu     sync.Mutex
+		mu      sync.Mutex
 		gotBody []byte
 		gotSig  string
 	)

--- a/internal/api/audit_authz_test.go
+++ b/internal/api/audit_authz_test.go
@@ -10,7 +10,7 @@ func TestGetAuditLog_RequiresAdminRole(t *testing.T) {
 	srv, _ := newTestServer(t)
 	userKey := createUserWithAPIKey(t, srv, "user")
 
-	req := httptest.NewRequest("GET", "/api/v1/audit-log", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit-log", nil)
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -23,7 +23,7 @@ func TestGetAuditLog_AdminSucceeds(t *testing.T) {
 	srv, _ := newTestServer(t)
 	adminKey := createUserWithAPIKey(t, srv, "admin")
 
-	req := httptest.NewRequest("GET", "/api/v1/audit-log", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit-log", nil)
 	req.Header.Set("Authorization", "Bearer "+adminKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)

--- a/internal/api/authz_test.go
+++ b/internal/api/authz_test.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // createOperatorWithCA creates a non-admin operator with an API key and a CA owned by that operator.

--- a/internal/api/ca_for_host.go
+++ b/internal/api/ca_for_host.go
@@ -20,4 +20,3 @@ func (s *Server) caForHost(ctx context.Context, host *models.Host) (*pki.CAManag
 	}
 	return s.caResolver.LoadByID(ctx, host.CAID)
 }
-

--- a/internal/api/cas.go
+++ b/internal/api/cas.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"

--- a/internal/api/cas_test.go
+++ b/internal/api/cas_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
@@ -61,7 +62,7 @@ func TestCreateCA_OperatorCanCreate(t *testing.T) {
 	srv, opKey := newServerWithMaster(t)
 
 	body, _ := json.Marshal(map[string]string{"name": "tenant-a"})
-	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cas", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -87,7 +88,7 @@ func TestCreateCA_PrivateKeyEncryptedAtRest(t *testing.T) {
 	srv, opKey := newServerWithMaster(t)
 
 	body, _ := json.Marshal(map[string]string{"name": "rest-check"})
-	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cas", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -149,7 +150,7 @@ func TestListCAs_ScopedToOwner(t *testing.T) {
 
 	// A creates a CA
 	body, _ := json.Marshal(map[string]string{"name": "tenant-a"})
-	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cas", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+keyA)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -160,7 +161,7 @@ func TestListCAs_ScopedToOwner(t *testing.T) {
 	_ = json.NewDecoder(rec.Body).Decode(&caA)
 
 	// B lists — should not see A's CA
-	req = httptest.NewRequest("GET", "/api/v1/cas", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/cas", nil)
 	req.Header.Set("Authorization", "Bearer "+keyB)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -176,7 +177,7 @@ func TestListCAs_ScopedToOwner(t *testing.T) {
 	}
 
 	// B GETs A's CA by id — 403
-	req = httptest.NewRequest("GET", "/api/v1/cas/"+caA.ID, nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/cas/"+caA.ID, nil)
 	req.Header.Set("Authorization", "Bearer "+keyB)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -185,7 +186,7 @@ func TestListCAs_ScopedToOwner(t *testing.T) {
 	}
 
 	// B DELETEs A's CA — 403
-	req = httptest.NewRequest("DELETE", "/api/v1/cas/"+caA.ID, nil)
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/cas/"+caA.ID, nil)
 	req.Header.Set("Authorization", "Bearer "+keyB)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -198,7 +199,7 @@ func TestAuditLog_RecordsCACreate(t *testing.T) {
 	srv, opKey := newServerWithMaster(t)
 
 	body, _ := json.Marshal(map[string]string{"name": "audited"})
-	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cas", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -226,7 +227,7 @@ func TestRotateCA_Success(t *testing.T) {
 
 	// Create initial CA
 	body, _ := json.Marshal(map[string]string{"name": "test-ca"})
-	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cas", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -241,7 +242,7 @@ func TestRotateCA_Success(t *testing.T) {
 	ca1ID := ca1.ID
 
 	// Rotate the CA
-	req = httptest.NewRequest("POST", "/api/v1/cas/"+ca1ID+"/rotate", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/cas/"+ca1ID+"/rotate", nil)
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -297,7 +298,7 @@ func TestRotateCA_Forbidden_NonOwner(t *testing.T) {
 	// Create CA with admin key
 	adminKey := createAdminKey(t, srv)
 	body, _ := json.Marshal(map[string]string{"name": "test-ca"})
-	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cas", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+adminKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -329,7 +330,7 @@ func TestRotateCA_Forbidden_NonOwner(t *testing.T) {
 	}
 
 	// Non-owner tries to rotate
-	req = httptest.NewRequest("POST", "/api/v1/cas/"+ca.ID+"/rotate", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/cas/"+ca.ID+"/rotate", nil)
 	req.Header.Set("Authorization", "Bearer "+nonAdminKey)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -341,7 +342,7 @@ func TestRotateCA_Forbidden_NonOwner(t *testing.T) {
 func TestRotateCA_NotFound(t *testing.T) {
 	srv, opKey := newServerWithMaster(t)
 
-	req := httptest.NewRequest("POST", "/api/v1/cas/nonexistent/rotate", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cas/nonexistent/rotate", nil)
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -355,7 +356,7 @@ func TestRotateCA_Idempotent_ReturnsExistingSuccessor(t *testing.T) {
 
 	// Create initial CA
 	body, _ := json.Marshal(map[string]string{"name": "test-ca"})
-	req := httptest.NewRequest("POST", "/api/v1/cas", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cas", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -369,7 +370,7 @@ func TestRotateCA_Idempotent_ReturnsExistingSuccessor(t *testing.T) {
 	}
 
 	// Rotate first time
-	req = httptest.NewRequest("POST", "/api/v1/cas/"+ca1.ID+"/rotate", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/cas/"+ca1.ID+"/rotate", nil)
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -384,7 +385,7 @@ func TestRotateCA_Idempotent_ReturnsExistingSuccessor(t *testing.T) {
 	ca2ID := ca2.ID
 
 	// Rotate second time (should return same successor)
-	req = httptest.NewRequest("POST", "/api/v1/cas/"+ca1.ID+"/rotate", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/cas/"+ca1.ID+"/rotate", nil)
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -8,11 +8,12 @@ import (
 	"net/http"
 	"net/netip"
 
+	"github.com/slackhq/nebula/cert"
+
 	"github.com/juev/nebula-mesh/internal/configgen"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/store"
-	"github.com/slackhq/nebula/cert"
 )
 
 type enrollRequest struct {

--- a/internal/api/firewall.go
+++ b/internal/api/firewall.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/juev/nebula-mesh/internal/store"
 )
 

--- a/internal/api/firewall_authz_test.go
+++ b/internal/api/firewall_authz_test.go
@@ -9,9 +9,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/juev/nebula-mesh/internal/models"
 )
 
 // TestGetFirewall_RequiresOwnership verifies that a non-owner cannot read
@@ -30,7 +31,7 @@ func TestGetFirewall_RequiresOwnership(t *testing.T) {
 	}
 	require.NoError(t, testDB.CreateNetwork(context.Background(), net1))
 
-	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/networks/%s/firewall", net1.ID), nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/networks/%s/firewall", net1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -62,7 +63,7 @@ func TestUpdateFirewall_RequiresOwnership(t *testing.T) {
 			{"port": "any", "proto": "any", "group": "any"},
 		},
 	})
-	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/networks/%s/firewall", net1.ID), bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/networks/%s/firewall", net1.ID), bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -85,7 +86,7 @@ func TestGetFirewall_OwnerSucceeds(t *testing.T) {
 	}
 	require.NoError(t, testDB.CreateNetwork(context.Background(), net1))
 
-	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/networks/%s/firewall", net1.ID), nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/networks/%s/firewall", net1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op1Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -115,7 +116,7 @@ func TestUpdateFirewall_OwnerSucceeds(t *testing.T) {
 			{"port": "any", "proto": "any", "group": "any"},
 		},
 	})
-	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/networks/%s/firewall", net1.ID), bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/networks/%s/firewall", net1.ID), bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+op1Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -4,9 +4,10 @@ import (
 	"net/netip"
 	"testing"
 
-	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/juev/nebula-mesh/internal/models"
 )
 
 func TestBuildHostPrefix(t *testing.T) {

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
 )

--- a/internal/api/hosts_authz_test.go
+++ b/internal/api/hosts_authz_test.go
@@ -39,7 +39,7 @@ func TestCreateHost_RequiresNetworkOwnership(t *testing.T) {
 		NebulaIPs: []string{"10.0.0.5"},
 	}
 	body, _ := json.Marshal(reqBody)
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -77,7 +77,7 @@ func TestCreateHost_OwnerSucceeds(t *testing.T) {
 		NebulaIPs: []string{"10.0.0.5"},
 	}
 	body, _ := json.Marshal(reqBody)
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -116,7 +116,7 @@ func TestRotateCert_RequiresOwnership(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
 	// new_key=true (pending_rekey path)
-	reqPending := httptest.NewRequest("POST",
+	reqPending := httptest.NewRequest(http.MethodPost,
 		fmt.Sprintf("/api/v1/hosts/%s/rotate-cert?new_key=true", host1.ID), nil)
 	reqPending.Header.Set("Authorization", "Bearer "+op2Key)
 	wPending := httptest.NewRecorder()
@@ -125,7 +125,7 @@ func TestRotateCert_RequiresOwnership(t *testing.T) {
 		"non-owner should not set pending_rekey on foreign host")
 
 	// new_key=false (immediate re-sign path)
-	reqResign := httptest.NewRequest("POST",
+	reqResign := httptest.NewRequest(http.MethodPost,
 		fmt.Sprintf("/api/v1/hosts/%s/rotate-cert?new_key=false", host1.ID), nil)
 	reqResign.Header.Set("Authorization", "Bearer "+op2Key)
 	wResign := httptest.NewRecorder()
@@ -159,7 +159,7 @@ func TestGetHost_OwnerSucceeds(t *testing.T) {
 	}
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
-	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/hosts/%s", host1.ID), nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/hosts/%s", host1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op1Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -194,7 +194,7 @@ func TestGetHost_RequiresOwnership(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
 	// op2 tries to GET op1's host → should fail with 403
-	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/hosts/%s", host1.ID), nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/hosts/%s", host1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -233,7 +233,7 @@ func TestUpdateHost_RequiresOwnership(t *testing.T) {
 	name := "renamed"
 	reqBody := updateHostRequest{Name: &name}
 	body, _ := json.Marshal(reqBody)
-	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/hosts/%s", host1.ID), bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/hosts/%s", host1.ID), bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -270,7 +270,7 @@ func TestDeleteHost_RequiresOwnership(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
 	// op2 tries to DELETE op1's host → should fail with 403
-	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/hosts/%s", host1.ID), nil)
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/hosts/%s", host1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -306,7 +306,7 @@ func TestBlockHost_RequiresOwnership(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
 	// op2 tries to BLOCK op1's host → should fail with 403
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/hosts/%s/block", host1.ID), nil)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/hosts/%s/block", host1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -343,7 +343,7 @@ func TestUnblockHost_RequiresOwnership(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
 	// op2 tries to UNBLOCK op1's host → should fail with 403
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/hosts/%s/unblock", host1.ID), nil)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/hosts/%s/unblock", host1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -380,7 +380,7 @@ func TestReenroll_OwnershipAuthz(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
 	// op2 tries to REENROLL op1's host → should fail with 403
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/hosts/%s/reenroll", host1.ID), nil)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/hosts/%s/reenroll", host1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -416,7 +416,7 @@ func TestRegenerateEnrollmentToken_OwnershipAuthz(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
 	// op2 tries to REGENERATE enrollment token for op1's host → should fail with 403
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/hosts/%s/enrollment-token", host1.ID), nil)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/hosts/%s/enrollment-token", host1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -472,7 +472,7 @@ func TestListHosts_ScopedToOwnedCAs(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), hostB))
 
 	// Operator A lists hosts with their token
-	req := httptest.NewRequest("GET", "/api/v1/hosts", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts", nil)
 	req.Header.Set("Authorization", "Bearer "+opAKey)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -494,7 +494,7 @@ func TestListHosts_ScopedToOwnedCAs(t *testing.T) {
 	assert.NotContains(t, hostIDs, hostB.ID, "operator A should not see operator B's host")
 
 	// Operator B lists hosts with their token
-	req = httptest.NewRequest("GET", "/api/v1/hosts", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/hosts", nil)
 	req.Header.Set("Authorization", "Bearer "+opBKey)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/hosts_reenroll_test.go
+++ b/internal/api/hosts_reenroll_test.go
@@ -21,7 +21,7 @@ func TestReenroll_MintsTokenAndPreservesHost(t *testing.T) {
 		NebulaIPs: []string{"192.168.100.42"},
 		Groups:    []string{"g1"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -37,7 +37,7 @@ func TestReenroll_MintsTokenAndPreservesHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req = httptest.NewRequest("POST", "/api/v1/hosts/"+initial.Host.ID+"/reenroll", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+initial.Host.ID+"/reenroll", nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -73,7 +73,7 @@ func TestReenroll_MintsTokenAndPreservesHost(t *testing.T) {
 
 func TestReenroll_HostNotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("POST", "/api/v1/hosts/missing/reenroll", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/missing/reenroll", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -84,7 +84,7 @@ func TestReenroll_HostNotFound(t *testing.T) {
 
 func TestReenroll_RequiresAuth(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("POST", "/api/v1/hosts/anything/reenroll", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/anything/reenroll", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {

--- a/internal/api/hosts_role_reachability_test.go
+++ b/internal/api/hosts_role_reachability_test.go
@@ -87,12 +87,12 @@ func TestCreateHost_RoleReachability(t *testing.T) {
 			body, _ := json.Marshal(createHostRequest{
 				NetworkID:  netID,
 				Name:       "h-" + strings.ReplaceAll(tc.name, " ", "-"),
-				NebulaIPs: []string{tc.nebulaIP},
+				NebulaIPs:  []string{tc.nebulaIP},
 				Role:       tc.role,
 				PublicIP:   tc.publicIP,
 				ListenPort: tc.listenPort,
 			})
-			req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 			authRequest(req)
 			w := httptest.NewRecorder()
 			srv.ServeHTTP(w, req)

--- a/internal/api/hosts_rotate_cert_test.go
+++ b/internal/api/hosts_rotate_cert_test.go
@@ -25,7 +25,7 @@ func TestRotateCert_SameKey(t *testing.T) {
 	}
 	beforeFP := host.CertFingerprint
 
-	req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=false", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=false", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -57,7 +57,7 @@ func TestRotateCert_NewKey_SetsPending(t *testing.T) {
 	agent := enrolledFixture(t, srv)
 	host, _ := st.GetHostByFingerprint(context.Background(), agent.fingerprint)
 
-	req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=true", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=true", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -77,7 +77,7 @@ func TestRotateCert_NewKey_ConflictOnSecond(t *testing.T) {
 	host, _ := st.GetHostByFingerprint(context.Background(), agent.fingerprint)
 
 	for i := 0; i < 2; i++ {
-		req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=true", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+host.ID+"/rotate-cert?new_key=true", nil)
 		authRequest(req)
 		w := httptest.NewRecorder()
 		srv.ServeHTTP(w, req)
@@ -92,7 +92,7 @@ func TestRotateCert_NewKey_ConflictOnSecond(t *testing.T) {
 
 func TestRotateCert_HostNotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("POST", "/api/v1/hosts/missing/rotate-cert", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/missing/rotate-cert", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -103,7 +103,7 @@ func TestRotateCert_HostNotFound(t *testing.T) {
 
 func TestRotateCert_RequiresAuth(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("POST", "/api/v1/hosts/anything/rotate-cert", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/anything/rotate-cert", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
@@ -119,7 +119,7 @@ func TestPoll_EmitsRekeyToken_WhenPending(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/hosts_token_ttl_test.go
+++ b/internal/api/hosts_token_ttl_test.go
@@ -24,7 +24,7 @@ func TestCreateHost_UsesServerDefaultTTL(t *testing.T) {
 		Name:      "h1",
 		NebulaIPs: []string{"192.168.100.10"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	before := time.Now()
@@ -50,7 +50,7 @@ func TestCreateHost_UsesServerDefaultTTL(t *testing.T) {
 	expectedMinExpiry := before.Add(2 * time.Hour).Add(-1 * time.Minute)
 	expectedMaxExpiry := time.Now().Add(2 * time.Hour).Add(1 * time.Minute)
 
-	regReq := httptest.NewRequest("POST", "/api/v1/hosts/"+hostID+"/enrollment-token", nil)
+	regReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+hostID+"/enrollment-token", nil)
 	authRequest(regReq)
 	w2 := httptest.NewRecorder()
 	srv.ServeHTTP(w2, regReq)
@@ -82,7 +82,7 @@ func TestCreateHost_UsesNetworkOverride(t *testing.T) {
 		Name:      "h2",
 		NebulaIPs: []string{"192.168.100.11"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	before := time.Now()
@@ -93,7 +93,7 @@ func TestCreateHost_UsesNetworkOverride(t *testing.T) {
 	var resp createHostResponse
 	_ = json.NewDecoder(w.Body).Decode(&resp)
 
-	regReq := httptest.NewRequest("POST", "/api/v1/hosts/"+resp.Host.ID+"/enrollment-token", nil)
+	regReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+resp.Host.ID+"/enrollment-token", nil)
 	authRequest(regReq)
 	w2 := httptest.NewRecorder()
 	srv.ServeHTTP(w2, regReq)
@@ -121,7 +121,7 @@ func TestRegenerateEnrollmentToken_InvalidatesPrevious(t *testing.T) {
 		Name:      "h3",
 		NebulaIPs: []string{"192.168.100.12"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -131,7 +131,7 @@ func TestRegenerateEnrollmentToken_InvalidatesPrevious(t *testing.T) {
 	var initial createHostResponse
 	_ = json.NewDecoder(w.Body).Decode(&initial)
 
-	regReq := httptest.NewRequest("POST", "/api/v1/hosts/"+initial.Host.ID+"/enrollment-token", nil)
+	regReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+initial.Host.ID+"/enrollment-token", nil)
 	authRequest(regReq)
 	w2 := httptest.NewRecorder()
 	srv.ServeHTTP(w2, regReq)
@@ -158,7 +158,7 @@ func TestRegenerateEnrollmentToken_InvalidatesPrevious(t *testing.T) {
 // auth, like every other host-CRUD route.
 func TestRegenerateEnrollmentToken_RequiresAuth(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("POST", "/api/v1/hosts/anything/enrollment-token", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/anything/enrollment-token", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
@@ -169,7 +169,7 @@ func TestRegenerateEnrollmentToken_RequiresAuth(t *testing.T) {
 // TestRegenerateEnrollmentToken_HostNotFound — 404 for a non-existent host id.
 func TestRegenerateEnrollmentToken_HostNotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("POST", "/api/v1/hosts/missing-host/enrollment-token", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/missing-host/enrollment-token", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/hosts_update_test.go
+++ b/internal/api/hosts_update_test.go
@@ -8,9 +8,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateHost_RouteRegistered(t *testing.T) {
@@ -25,7 +26,7 @@ func TestUpdateHost_RouteRegistered(t *testing.T) {
 		Groups:    []string{"test"},
 		Role:      "host",
 	})
-	hostReq := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(hostBody))
+	hostReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(hostBody))
 	authRequest(hostReq)
 	hostRec := httptest.NewRecorder()
 	srv.ServeHTTP(hostRec, hostReq)
@@ -46,7 +47,7 @@ func TestUpdateHost_RouteRegistered(t *testing.T) {
 		"name": "updated-name",
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+hostID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+hostID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 
@@ -72,7 +73,7 @@ func createHostHelper(t *testing.T, srv *Server, netID string, name, nebulaIP st
 		Role:      "host",
 		Advanced:  adv,
 	})
-	hostReq := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(hostBody))
+	hostReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(hostBody))
 	authRequest(hostReq)
 	hostRec := httptest.NewRecorder()
 	srv.ServeHTTP(hostRec, hostReq)
@@ -106,7 +107,7 @@ func TestUpdateHost_HappyPath_Advanced(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -144,7 +145,7 @@ func TestUpdateHost_HappyPath_Rename(t *testing.T) {
 		Name: &newName,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -185,7 +186,7 @@ func TestUpdateHost_NoChanges_NoAudit_NoRepublish(t *testing.T) {
 		Name: &host.Name,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -219,7 +220,7 @@ func TestUpdateHost_SameIPNotDuplicate(t *testing.T) {
 		NebulaIPs: &sameIPList,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -241,7 +242,7 @@ func TestUpdateHost_DuplicateIPRejected(t *testing.T) {
 		NebulaIPs: &dupIPList,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host2.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host2.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -262,7 +263,7 @@ func TestUpdateHost_NebulaIPOutsideCIDR(t *testing.T) {
 		NebulaIPs: &outsideIPList,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -283,7 +284,7 @@ func TestUpdateHost_EmptyName(t *testing.T) {
 		Name: &emptyName,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -305,7 +306,7 @@ func TestUpdateHost_InvalidMTU(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -326,7 +327,7 @@ func TestUpdateHost_InvalidRole(t *testing.T) {
 		Role: &invalidRole,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -347,7 +348,7 @@ func TestUpdateHost_LighthouseWithoutPublicIP(t *testing.T) {
 		Role: &lighthouseRole,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -363,7 +364,7 @@ func TestUpdateHost_HostNotFound(t *testing.T) {
 		Name: stringPtr("newname"),
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/non-existent-id", bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/non-existent-id", bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -381,7 +382,7 @@ func TestUpdateHost_NetworkIDIgnored(t *testing.T) {
 	// Try to send network_id in the body (should be ignored)
 	reqBody := []byte(`{"network_id":"other-network","name":"web-2"}`)
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -422,7 +423,7 @@ func TestUpdateHost_RepublishHostConfig(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -461,7 +462,7 @@ func TestUpdateHost_RoleFlipToLighthouse_BumpsNetwork(t *testing.T) {
 		ListenPort: &listenPort,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -489,13 +490,13 @@ func TestUpdateHost_RoleFlipFromLighthouse_BumpsNetwork(t *testing.T) {
 	hostBody, _ := json.Marshal(createHostRequest{
 		NetworkID:  netID,
 		Name:       "lighthouse-1",
-		NebulaIPs: []string{"192.168.100.1"},
+		NebulaIPs:  []string{"192.168.100.1"},
 		Groups:     []string{},
 		Role:       "lighthouse",
 		PublicIP:   publicIP,
 		ListenPort: listenPort,
 	})
-	hostReq := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(hostBody))
+	hostReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(hostBody))
 	authRequest(hostReq)
 	hostRec := httptest.NewRecorder()
 	srv.ServeHTTP(hostRec, hostReq)
@@ -515,7 +516,7 @@ func TestUpdateHost_RoleFlipFromLighthouse_BumpsNetwork(t *testing.T) {
 		Role: &hostRole,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -550,7 +551,7 @@ func TestUpdateHost_NoRepublishNetworkOnAdvancedChange(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -581,7 +582,7 @@ func TestUpdateHost_RenameSetsPendingRekey(t *testing.T) {
 		Name: &newName,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -617,7 +618,7 @@ func TestUpdateHost_ChangeIPSetsPendingRekey(t *testing.T) {
 		NebulaIPs: &newIPList,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -654,7 +655,7 @@ func TestUpdateHost_AdvancedOnlyNoPendingRekey(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -693,7 +694,7 @@ func TestUpdateHost_IdempotentRekey(t *testing.T) {
 		Name: &newName,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -737,7 +738,7 @@ func TestUpdateHost_HappyPath_RoleFlip(t *testing.T) {
 		ListenPort: &listenPort,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -767,7 +768,7 @@ func TestUpdateHost_HappyPath_ChangeIP(t *testing.T) {
 		NebulaIPs: &newIPList,
 	})
 
-	req := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(reqBody))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -790,7 +791,7 @@ func TestCreateHost_AcceptsNebulaIPs(t *testing.T) {
 		"name":  "dual-net",
 		"cidrs": []string{"10.0.0.0/24", "fd00::/64"},
 	})
-	netReq := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	netReq := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
 	authRequest(netReq)
 	netRec := httptest.NewRecorder()
 	srv.ServeHTTP(netRec, netReq)
@@ -805,7 +806,7 @@ func TestCreateHost_AcceptsNebulaIPs(t *testing.T) {
 		"nebula_ips": []string{"10.0.0.5", "fd00::5"},
 		"role":       "host",
 	})
-	hostReq := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(hostBody))
+	hostReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(hostBody))
 	authRequest(hostReq)
 	hostRec := httptest.NewRecorder()
 	srv.ServeHTTP(hostRec, hostReq)
@@ -827,7 +828,7 @@ func TestCreateHost_RejectsSingularNebulaIP(t *testing.T) {
 
 	// Try to create with old singular field
 	body := `{"network_id":"` + netID + `","name":"bad-host","nebula_ip":"192.168.100.5","role":"host"}`
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBufferString(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBufferString(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -852,7 +853,7 @@ func TestUpdateHost_NebulaIPs_ReplacesList(t *testing.T) {
 		"name":  "dual-net",
 		"cidrs": []string{"10.0.0.0/24", "fd00::/64"},
 	})
-	netReq := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(netBody))
+	netReq := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(netBody))
 	authRequest(netReq)
 	netRec := httptest.NewRecorder()
 	srv.ServeHTTP(netRec, netReq)
@@ -867,7 +868,7 @@ func TestUpdateHost_NebulaIPs_ReplacesList(t *testing.T) {
 		"nebula_ips": []string{"10.0.0.5", "fd00::5"},
 		"role":       "host",
 	})
-	hostReq := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(hostBody))
+	hostReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(hostBody))
 	authRequest(hostReq)
 	hostRec := httptest.NewRecorder()
 	srv.ServeHTTP(hostRec, hostReq)
@@ -881,7 +882,7 @@ func TestUpdateHost_NebulaIPs_ReplacesList(t *testing.T) {
 	patchBody, _ := json.Marshal(map[string]interface{}{
 		"nebula_ips": newIPs,
 	})
-	patchReq := httptest.NewRequest("PATCH", "/api/v1/hosts/"+hostID, bytes.NewBuffer(patchBody))
+	patchReq := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+hostID, bytes.NewBuffer(patchBody))
 	authRequest(patchReq)
 	patchRec := httptest.NewRecorder()
 	srv.ServeHTTP(patchRec, patchReq)
@@ -909,7 +910,7 @@ func TestUpdateHost_OmittedNebulaIPs_Untouched(t *testing.T) {
 	patchBody, _ := json.Marshal(map[string]interface{}{
 		"groups": newGroups,
 	})
-	patchReq := httptest.NewRequest("PATCH", "/api/v1/hosts/"+host.ID, bytes.NewBuffer(patchBody))
+	patchReq := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+host.ID, bytes.NewBuffer(patchBody))
 	authRequest(patchReq)
 	patchRec := httptest.NewRecorder()
 	srv.ServeHTTP(patchRec, patchReq)

--- a/internal/api/lighthouse_test.go
+++ b/internal/api/lighthouse_test.go
@@ -21,9 +21,9 @@ func enrollLighthouse(t *testing.T, srv *Server, networkID, hostID, name, nebula
 		NebulaIPs: []string{nebulaIP}, Groups: []string{},
 		Role: models.HostRoleLighthouse, IsLighthouse: true,
 		PublicIP: publicIP, ListenPort: 4242,
-		Status:    models.HostStatusEnrolled,
+		Status:          models.HostStatusEnrolled,
 		CertFingerprint: fp,
-		CreatedAt: now, UpdatedAt: now,
+		CreatedAt:       now, UpdatedAt: now,
 	}
 	if err := srv.store.CreateHost(ctx, h); err != nil {
 		t.Fatal(err)
@@ -210,12 +210,12 @@ func TestRenderHostConfig_UnsafeRouteFamilyMatch_Pass(t *testing.T) {
 	host := &models.Host{
 		ID: "host_dual", NetworkID: netID, Name: "dual-stack",
 		NebulaIPs: []string{"192.168.100.10", "fd00::10"}, Groups: []string{},
-		Role:      models.HostRoleHost,
-		Status:    models.HostStatusEnrolled,
+		Role:   models.HostRoleHost,
+		Status: models.HostStatusEnrolled,
 		Advanced: &models.HostAdvanced{
 			UnsafeRoutes: []models.UnsafeRoute{
-				{Route: "10.99.0.0/24", Via: "192.168.100.2"},     // IPv4 to IPv4
-				{Route: "fd00:99::/64", Via: "fd00::2"},           // IPv6 to IPv6
+				{Route: "10.99.0.0/24", Via: "192.168.100.2"}, // IPv4 to IPv4
+				{Route: "fd00:99::/64", Via: "fd00::2"},       // IPv6 to IPv6
 			},
 		},
 		CreatedAt: time.Now(), UpdatedAt: time.Now(),
@@ -246,8 +246,8 @@ func TestRenderHostConfig_UnsafeRouteFamilyMismatch(t *testing.T) {
 	host := &models.Host{
 		ID: "host_ipv4_only", NetworkID: netID, Name: "ipv4-only",
 		NebulaIPs: []string{"192.168.100.10"}, Groups: []string{},
-		Role:      models.HostRoleHost,
-		Status:    models.HostStatusEnrolled,
+		Role:   models.HostRoleHost,
+		Status: models.HostStatusEnrolled,
 		Advanced: &models.HostAdvanced{
 			UnsafeRoutes: []models.UnsafeRoute{
 				{Route: "fd00:99::/64", Via: "fd00::1"}, // IPv6 route but no IPv6 host address

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -5,8 +5,9 @@ import (
 	"math"
 	"time"
 
-	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 // Result labels for counters whose terminal outcome falls into one of three
@@ -45,7 +46,7 @@ const (
 )
 
 // Audit action labels: stable identifiers for the audit log entries the API
-// writes. Centralised here so the Prometheus counter, the audit log, and any
+// writes. Centralized here so the Prometheus counter, the audit log, and any
 // future RBAC tooling can share the same vocabulary instead of duplicating
 // string literals.
 const (
@@ -94,14 +95,14 @@ const hostStatusNone = "none"
 // at /metrics. The registry is private to the server instance so test runs
 // don't fight over Prometheus's default registerer global state.
 type metrics struct {
-	reg                *prometheus.Registry
-	httpRequests       *prometheus.CounterVec
-	httpDuration       *prometheus.HistogramVec
-	enrollments        *prometheus.CounterVec
-	certRenewals       *prometheus.CounterVec
-	auditEntries       *prometheus.CounterVec
-	operatorLogins     *prometheus.CounterVec
-	caSignatures       *prometheus.CounterVec
+	reg            *prometheus.Registry
+	httpRequests   *prometheus.CounterVec
+	httpDuration   *prometheus.HistogramVec
+	enrollments    *prometheus.CounterVec
+	certRenewals   *prometheus.CounterVec
+	auditEntries   *prometheus.CounterVec
+	operatorLogins *prometheus.CounterVec
+	caSignatures   *prometheus.CounterVec
 }
 
 // newMetrics builds a fresh metrics bundle bound to an isolated registry and
@@ -252,10 +253,10 @@ func (m *metrics) recordSignature(caID string) {
 // The collector is queried on every Prometheus scrape, so the work is bounded
 // by the scrape cadence (typically 15-60s) and the host/cert table sizes.
 type storeCollector struct {
-	store    store.Store
-	hosts    *prometheus.Desc
-	exp      *prometheus.Desc
-	perHost  *prometheus.Desc
+	store   store.Store
+	hosts   *prometheus.Desc
+	exp     *prometheus.Desc
+	perHost *prometheus.Desc
 }
 
 func newStoreCollector(s store.Store) *storeCollector {

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
+
+	"github.com/juev/nebula-mesh/internal/models"
 )
 
 // TestMetricsEndpoint_PrometheusFormat asserts that /metrics now serves
@@ -25,11 +26,11 @@ func TestMetricsEndpoint_PrometheusFormat(t *testing.T) {
 	// least one sample. Prometheus's text exposition only emits metrics
 	// that have data — pre-seeding zeros for {method, route, status}
 	// would explode cardinality, so we exercise one route instead.
-	wReq := httptest.NewRequest("GET", "/healthz", nil)
+	wReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	wRec := httptest.NewRecorder()
 	srv.ServeHTTP(wRec, wReq)
 
-	req := httptest.NewRequest("GET", "/metrics", nil)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
@@ -67,12 +68,12 @@ func TestMetricsEndpoint_RecordsHTTPRequests(t *testing.T) {
 
 	// Fire a handful of requests we expect to be observed.
 	for i := 0; i < 3; i++ {
-		req := httptest.NewRequest("GET", "/healthz", nil)
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 		w := httptest.NewRecorder()
 		srv.ServeHTTP(w, req)
 	}
 
-	req := httptest.NewRequest("GET", "/metrics", nil)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
@@ -96,7 +97,7 @@ func TestMetricsEndpoint_EnrollmentIncrementsCounter(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "metrics-host", NebulaIPs: []string{"192.168.100.10"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -125,7 +126,7 @@ func TestMetricsEndpoint_EnrollmentIncrementsCounter(t *testing.T) {
 		PublicKeyPEM:  string(pubPEM),
 		SigningPubPEM: signingPEM,
 	})
-	req = httptest.NewRequest("POST", "/api/v1/enroll", bytes.NewBuffer(enrollBody))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/enroll", bytes.NewBuffer(enrollBody))
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -134,7 +135,7 @@ func TestMetricsEndpoint_EnrollmentIncrementsCounter(t *testing.T) {
 
 	// 3. Scrape /metrics and assert that nebula_mgmt_enrollments_total{result="ok"}
 	//    is at least 1.
-	req = httptest.NewRequest("GET", "/metrics", nil)
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -158,14 +159,14 @@ func TestMetricsEndpoint_HostsGauge(t *testing.T) {
 		h := &models.Host{
 			ID: "h_" + string(s), NetworkID: netID, Name: "h-" + string(s),
 			NebulaIPs: []string{"192.168.100." + string(s[0:1]) + "0"},
-			Groups:   []string{}, Role: models.HostRoleHost, Status: s,
+			Groups:    []string{}, Role: models.HostRoleHost, Status: s,
 		}
 		if err := st.CreateHost(req(t).Context(), h); err != nil {
 			t.Fatalf("seed host %s: %v", s, err)
 		}
 	}
 
-	r := httptest.NewRequest("GET", "/metrics", nil)
+	r := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, r)
 	body := w.Body.String()
@@ -179,7 +180,7 @@ func TestMetricsEndpoint_HostsGauge(t *testing.T) {
 // Prometheus exporter takes /metrics.
 func TestExpvarEndpoint_LegacyPath(t *testing.T) {
 	srv, _ := newTestServer(t)
-	r := httptest.NewRequest("GET", "/debug/vars", nil)
+	r := httptest.NewRequest(http.MethodGet, "/debug/vars", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, r)
 	if w.Code != http.StatusOK {
@@ -195,7 +196,7 @@ func TestExpvarEndpoint_LegacyPath(t *testing.T) {
 // req returns a fresh *http.Request used just for its context (test helper).
 func req(t *testing.T) *http.Request {
 	t.Helper()
-	return httptest.NewRequest("GET", "/", nil)
+	return httptest.NewRequest(http.MethodGet, "/", nil)
 }
 
 // newTestServerWithMetrics is like newTestServer but lets the caller decide
@@ -215,14 +216,14 @@ func newTestServerWithMetrics(t *testing.T, enabled bool) (*Server, interface{})
 func TestMetricsEndpoint_DisabledByOption(t *testing.T) {
 	srv, _ := newTestServerWithMetrics(t, false)
 
-	r := httptest.NewRequest("GET", "/metrics", nil)
+	r := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, r)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("disabled /metrics: status = %d, want 404", w.Code)
 	}
 
-	r2 := httptest.NewRequest("GET", "/debug/vars", nil)
+	r2 := httptest.NewRequest(http.MethodGet, "/debug/vars", nil)
 	w2 := httptest.NewRecorder()
 	srv.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/juev/nebula-mesh/internal/ratelimit"
 	"github.com/juev/nebula-mesh/internal/store"
 )

--- a/internal/api/mobile_bundle.go
+++ b/internal/api/mobile_bundle.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/juev/nebula-mesh/internal/mobilebundle"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
@@ -84,7 +85,9 @@ func (s *Server) handleMobileBundle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "0")
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(bundle); err != nil {
+	// Bundle is application/yaml from a trusted server-side builder; XSS is
+	// not a concern on a non-HTML response.
+	if _, err := w.Write(bundle); err != nil { //nolint:gosec // G705: not an HTML response
 		s.logger.Error("write mobile bundle response", "error", err)
 	}
 }

--- a/internal/api/mobile_bundle_authz_test.go
+++ b/internal/api/mobile_bundle_authz_test.go
@@ -9,10 +9,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/juev/nebula-mesh/internal/models"
-	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 // TestMobileBundle_RequiresOwnership verifies that non-owners cannot request
@@ -45,7 +46,7 @@ func TestMobileBundle_RequiresOwnership(t *testing.T) {
 	require.NoError(t, testDB.CreateHost(context.Background(), host1))
 
 	// op2 tries to request mobile bundle for op1's host → 403
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/hosts/%s/mobile-bundle", host1.ID), nil)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/hosts/%s/mobile-bundle", host1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -106,7 +107,7 @@ func TestMobileBundle_AdminCanAccessForeignHost(t *testing.T) {
 	}
 	require.NoError(t, testDB.CreateHost(context.Background(), host))
 
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/hosts/%s/mobile-bundle", host.ID), nil)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/hosts/%s/mobile-bundle", host.ID), nil)
 	authRequest(req) // admin (testAPIKey)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -161,7 +162,7 @@ func TestMobileBundle_OwningNonAdminCanAccess(t *testing.T) {
 	}
 	require.NoError(t, testDB.CreateHost(context.Background(), host))
 
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/hosts/%s/mobile-bundle", host.ID), nil)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/hosts/%s/mobile-bundle", host.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+opKey)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/mobile_bundle_test.go
+++ b/internal/api/mobile_bundle_test.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/juev/nebula-mesh/internal/models"
 	"gopkg.in/yaml.v3"
+
+	"github.com/juev/nebula-mesh/internal/models"
 )
 
 // TestHandleMobileBundle_Success verifies the handler generates a mobile bundle
@@ -38,7 +39,7 @@ func TestHandleMobileBundle_Success(t *testing.T) {
 		t.Fatalf("create mobile host: %v", err)
 	}
 
-	req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/mobile-bundle", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+host.ID+"/mobile-bundle", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -108,7 +109,7 @@ func TestHandleMobileBundle_RejectsNonMobile(t *testing.T) {
 		t.Fatalf("create agent host: %v", err)
 	}
 
-	req := httptest.NewRequest("POST", "/api/v1/hosts/"+host.ID+"/mobile-bundle", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+host.ID+"/mobile-bundle", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -130,7 +131,7 @@ func TestHandleMobileBundle_RejectsNonMobile(t *testing.T) {
 func TestHandleMobileBundle_NotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
 
-	req := httptest.NewRequest("POST", "/api/v1/hosts/nonexistent/mobile-bundle", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/nonexistent/mobile-bundle", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -144,7 +145,7 @@ func TestHandleMobileBundle_NotFound(t *testing.T) {
 func TestHandleMobileBundle_Unauthorized(t *testing.T) {
 	srv, _ := newTestServer(t)
 
-	req := httptest.NewRequest("POST", "/api/v1/hosts/anything/mobile-bundle", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/anything/mobile-bundle", nil)
 	// Note: no authRequest call — missing Authorization header
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/networks.go
+++ b/internal/api/networks.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
 )

--- a/internal/api/networks_authz_test.go
+++ b/internal/api/networks_authz_test.go
@@ -9,9 +9,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/juev/nebula-mesh/internal/models"
 )
 
 // TestCreateNetwork_RequiresAdmin verifies that handleCreateNetwork is
@@ -25,7 +26,7 @@ func TestCreateNetwork_RequiresAdmin(t *testing.T) {
 		"name":  "n",
 		"cidrs": []string{"10.0.0.0/8"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -49,7 +50,7 @@ func TestGetNetwork_RequiresOwnership(t *testing.T) {
 	}
 	require.NoError(t, testDB.CreateNetwork(context.Background(), net1))
 
-	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/networks/%s", net1.ID), nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/networks/%s", net1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op2Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -72,7 +73,7 @@ func TestGetNetwork_OwnerSucceeds(t *testing.T) {
 	}
 	require.NoError(t, testDB.CreateNetwork(context.Background(), net1))
 
-	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/networks/%s", net1.ID), nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/networks/%s", net1.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+op1Key)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -90,7 +91,7 @@ func TestCreateNetwork_AdminSucceeds(t *testing.T) {
 		"name":  "admin-created-net",
 		"cidrs": []string{"10.99.0.0/16"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+adminKey)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -121,7 +122,7 @@ func TestListNetworks_ScopedToOwnedCAs(t *testing.T) {
 	require.NoError(t, testDB.CreateNetwork(context.Background(), netA))
 	require.NoError(t, testDB.CreateNetwork(context.Background(), netB))
 
-	req := httptest.NewRequest("GET", "/api/v1/networks", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/networks", nil)
 	req.Header.Set("Authorization", "Bearer "+keyA)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/networks_test.go
+++ b/internal/api/networks_test.go
@@ -18,7 +18,7 @@ func TestCreateNetwork_AcceptsCIDRs(t *testing.T) {
 		"name":  "dual-stack-net",
 		"cidrs": []string{"10.0.0.0/24", "fd00::/64"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -47,7 +47,7 @@ func TestCreateNetwork_RejectsSingularCIDR(t *testing.T) {
 	srv, _ := newTestServer(t)
 
 	body := `{"name":"test-net","cidr":"10.0.0.0/24"}`
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBufferString(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBufferString(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -81,7 +81,7 @@ func TestCreateNetwork_EmptyCIDRs(t *testing.T) {
 		"name":  "empty-net",
 		"cidrs": []string{},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -98,7 +98,7 @@ func TestCreateNetwork_RejectsOverlappingCIDRs(t *testing.T) {
 		"name":  "overlap-net",
 		"cidrs": []string{"10.0.0.0/16", "10.0.0.0/24"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -118,7 +118,7 @@ func TestCreateNetwork_RejectsDuplicateCIDRs(t *testing.T) {
 		"name":  "dup-net",
 		"cidrs": []string{"10.0.0.0/24", "10.0.0.0/24"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/operators.go
+++ b/internal/api/operators.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"golang.org/x/crypto/bcrypt"
 )
 
 type createOperatorRequest struct {
@@ -123,8 +124,8 @@ type createAPIKeyRequest struct {
 }
 
 type createAPIKeyResponse struct {
-	Key   string                  `json:"key"`   // shown once
-	Entry *models.OperatorAPIKey  `json:"entry"`
+	Key   string                 `json:"key"` // shown once
+	Entry *models.OperatorAPIKey `json:"entry"`
 }
 
 func (s *Server) handleCreateOperatorAPIKey(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/operators_admin_test.go
+++ b/internal/api/operators_admin_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+
 	"github.com/juev/nebula-mesh/internal/models"
 )
 
@@ -43,7 +44,7 @@ func TestCreateOperator_RequiresAdminRole(t *testing.T) {
 	userKey := createUserWithAPIKey(t, srv, "user")
 
 	body, _ := json.Marshal(map[string]string{"username": "bob", "password": "pw"})
-	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -57,7 +58,7 @@ func TestCreateOperator_AdminCanCreate(t *testing.T) {
 	adminKey := createUserWithAPIKey(t, srv, "admin")
 
 	body, _ := json.Marshal(map[string]string{"username": "carol", "password": "pw"})
-	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+adminKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -70,7 +71,7 @@ func TestListOperators_RequiresAdminRole(t *testing.T) {
 	srv, _ := newTestServer(t)
 	userKey := createUserWithAPIKey(t, srv, "user")
 
-	req := httptest.NewRequest("GET", "/api/v1/operators", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/operators", nil)
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -86,7 +87,7 @@ func TestGetBlocklist_RequiresAdminRole(t *testing.T) {
 	srv, _ := newTestServer(t)
 	userKey := createUserWithAPIKey(t, srv, "user")
 
-	req := httptest.NewRequest("GET", "/api/v1/blocklist", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/blocklist", nil)
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -108,7 +109,7 @@ func TestDisableOperator_RequiresAdminRole(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("POST", "/api/v1/operators/"+targetOp.ID+"/disable", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators/"+targetOp.ID+"/disable", nil)
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -130,7 +131,7 @@ func TestEnableOperator_RequiresAdminRole(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("POST", "/api/v1/operators/"+targetOp.ID+"/enable", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators/"+targetOp.ID+"/enable", nil)
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -145,7 +146,7 @@ func TestCreateOperatorAPIKey_RequiresAdminRole(t *testing.T) {
 	targetID := createUserWithAPIKey(t, srv, "user")
 
 	body, _ := json.Marshal(map[string]string{"name": "evil-key"})
-	req := httptest.NewRequest("POST", "/api/v1/operators/"+targetID+"/api-keys", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators/"+targetID+"/api-keys", bytes.NewBuffer(body))
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -160,7 +161,7 @@ func TestRevokeOperatorAPIKey_RequiresAdminRole(t *testing.T) {
 	targetID := createUserWithAPIKey(t, srv, "user")
 	keyID := uuid.New().String()
 
-	req := httptest.NewRequest("DELETE", "/api/v1/operators/"+targetID+"/api-keys/"+keyID, nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/operators/"+targetID+"/api-keys/"+keyID, nil)
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -174,7 +175,7 @@ func TestListOperatorAPIKeys_RequiresAdminRole(t *testing.T) {
 	userKey := createUserWithAPIKey(t, srv, "user")
 	targetID := createUserWithAPIKey(t, srv, "user")
 
-	req := httptest.NewRequest("GET", "/api/v1/operators/"+targetID+"/api-keys", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/operators/"+targetID+"/api-keys", nil)
 	req.Header.Set("Authorization", "Bearer "+userKey)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)

--- a/internal/api/operators_test.go
+++ b/internal/api/operators_test.go
@@ -19,7 +19,7 @@ func TestOperatorLifecycle_CreateListDisable(t *testing.T) {
 	body, _ := json.Marshal(map[string]string{
 		"username": "bob", "password": "supersecret", "display_name": "Bob",
 	})
-	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators", bytes.NewBuffer(body))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -35,7 +35,7 @@ func TestOperatorLifecycle_CreateListDisable(t *testing.T) {
 	}
 
 	// List should include bob
-	req = httptest.NewRequest("GET", "/api/v1/operators", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/operators", nil)
 	authRequest(req)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -57,7 +57,7 @@ func TestOperatorLifecycle_CreateListDisable(t *testing.T) {
 	}
 
 	// Disable bob
-	req = httptest.NewRequest("POST", "/api/v1/operators/"+created.ID+"/disable", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/operators/"+created.ID+"/disable", nil)
 	authRequest(req)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -76,7 +76,7 @@ func TestOperatorAPIKey_CreateAndUse(t *testing.T) {
 	body, _ := json.Marshal(map[string]string{
 		"username": "carol", "password": "secret123",
 	})
-	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators", bytes.NewBuffer(body))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -89,7 +89,7 @@ func TestOperatorAPIKey_CreateAndUse(t *testing.T) {
 	}
 
 	// Create API key
-	req = httptest.NewRequest("POST", "/api/v1/operators/"+op.ID+"/api-keys", bytes.NewBufferString(`{"name":"cli"}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/operators/"+op.ID+"/api-keys", bytes.NewBufferString(`{"name":"cli"}`))
 	authRequest(req)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -109,7 +109,7 @@ func TestOperatorAPIKey_CreateAndUse(t *testing.T) {
 	}
 
 	// Use the new key to access a protected endpoint
-	req = httptest.NewRequest("GET", "/api/v1/operators", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/operators", nil)
 	req.Header.Set("Authorization", "Bearer "+keyResp.Key)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -118,7 +118,7 @@ func TestOperatorAPIKey_CreateAndUse(t *testing.T) {
 	}
 
 	// Revoke it
-	req = httptest.NewRequest("DELETE", "/api/v1/operators/"+op.ID+"/api-keys/"+keyResp.Entry.ID, nil)
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/operators/"+op.ID+"/api-keys/"+keyResp.Entry.ID, nil)
 	authRequest(req)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -127,7 +127,7 @@ func TestOperatorAPIKey_CreateAndUse(t *testing.T) {
 	}
 
 	// Now the key should not authenticate
-	req = httptest.NewRequest("GET", "/api/v1/operators", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/operators", nil)
 	req.Header.Set("Authorization", "Bearer "+keyResp.Key)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -141,14 +141,14 @@ func TestDisableOperator_InvalidatesAPIKey(t *testing.T) {
 
 	// Create operator
 	body, _ := json.Marshal(map[string]string{"username": "dan", "password": "p"})
-	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators", bytes.NewBuffer(body))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	var op models.Operator
 	_ = json.NewDecoder(rec.Body).Decode(&op)
 
-	req = httptest.NewRequest("POST", "/api/v1/operators/"+op.ID+"/api-keys", bytes.NewBufferString(`{}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/operators/"+op.ID+"/api-keys", bytes.NewBufferString(`{}`))
 	authRequest(req)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -161,7 +161,7 @@ func TestDisableOperator_InvalidatesAPIKey(t *testing.T) {
 	}
 
 	// Key should no longer authenticate
-	req = httptest.NewRequest("GET", "/api/v1/operators", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/operators", nil)
 	req.Header.Set("Authorization", "Bearer "+keyResp.Key)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -174,7 +174,7 @@ func TestAuditLogActorIsRecorded(t *testing.T) {
 	srv, st := newTestServer(t)
 
 	body, _ := json.Marshal(map[string]string{"username": "eve", "password": "p"})
-	req := httptest.NewRequest("POST", "/api/v1/operators", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators", bytes.NewBuffer(body))
 	authRequest(req)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)

--- a/internal/api/pop/nonce.go
+++ b/internal/api/pop/nonce.go
@@ -69,15 +69,14 @@ func (c *NonceCache) SeenOrAdd(hostID, nonce string) bool {
 	now := c.now()
 	if el, ok := c.items[key]; ok {
 		entry := el.Value.(*nonceEntry)
-		if now.Sub(entry.lastSeen) >= c.idleTTL {
-			c.removeEl(el)
-		} else {
+		if now.Sub(entry.lastSeen) < c.idleTTL {
 			// Live duplicate: replay. Bump recency to defeat
 			// flood-then-replay tactics.
 			entry.lastSeen = now
 			c.order.MoveToFront(el)
 			return false
 		}
+		c.removeEl(el)
 	}
 
 	entry := &nonceEntry{key: key, lastSeen: now}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	poppkg "github.com/juev/nebula-mesh/internal/api/pop"
 	"github.com/juev/nebula-mesh/internal/auth"
 	"github.com/juev/nebula-mesh/internal/configgen"
@@ -17,19 +19,18 @@ import (
 	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/ratelimit"
 	"github.com/juev/nebula-mesh/internal/store"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Server is the HTTP API server.
 type Server struct {
-	router         chi.Router
-	store          store.Store
-	caResolver     *pki.CAResolver // resolves CAs by id from the store (multi-CA)
-	master         *keystore.Master
-	defaultCAID    string // id of the seeded default CA (when imported)
-	logger         *slog.Logger
-	metrics        *metrics
-	metricsEnabled bool
+	router             chi.Router
+	store              store.Store
+	caResolver         *pki.CAResolver // resolves CAs by id from the store (multi-CA)
+	master             *keystore.Master
+	defaultCAID        string // id of the seeded default CA (when imported)
+	logger             *slog.Logger
+	metrics            *metrics
+	metricsEnabled     bool
 	hostSeen           HostSeenEmitter
 	limiter            *ratelimit.Limiter
 	passwordPolicy     auth.Policy

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -98,7 +98,7 @@ func authRequest(req *http.Request) {
 
 func TestHealth(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/health", nil)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
@@ -117,7 +117,7 @@ func TestHealth(t *testing.T) {
 
 func TestHealthz(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/healthz", nil)
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -127,7 +127,7 @@ func TestHealthz(t *testing.T) {
 
 func TestReadyz_DBHealthy(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/readyz", nil)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -140,7 +140,7 @@ func TestReadyz_DBClosed(t *testing.T) {
 	if err := st.Close(); err != nil {
 		t.Fatal(err)
 	}
-	req := httptest.NewRequest("GET", "/readyz", nil)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusServiceUnavailable {
@@ -150,7 +150,7 @@ func TestReadyz_DBClosed(t *testing.T) {
 
 func TestMetrics(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/metrics", nil)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -167,7 +167,7 @@ func TestMetrics(t *testing.T) {
 
 func TestAuthMiddleware_NoHeader(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/api/v1/hosts", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
@@ -178,7 +178,7 @@ func TestAuthMiddleware_NoHeader(t *testing.T) {
 
 func TestAuthMiddleware_InvalidKey(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/api/v1/hosts", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts", nil)
 	req.Header.Set("Authorization", "Bearer wrong-key")
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -190,7 +190,7 @@ func TestAuthMiddleware_InvalidKey(t *testing.T) {
 
 func TestAuthMiddleware_ValidKey(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/api/v1/hosts", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -206,7 +206,7 @@ func TestCreateAndListNetworks(t *testing.T) {
 	srv, _ := newTestServer(t)
 
 	body := `{"name":"test-net","cidrs":["192.168.100.0/24"]}`
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBufferString(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBufferString(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -224,7 +224,7 @@ func TestCreateAndListNetworks(t *testing.T) {
 	}
 
 	// List
-	req = httptest.NewRequest("GET", "/api/v1/networks", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/networks", nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -247,7 +247,7 @@ func TestCreateAndListNetworks(t *testing.T) {
 func createNetwork(t *testing.T, srv *Server) string {
 	t.Helper()
 	body := `{"name":"test-net","cidrs":["192.168.100.0/24"]}`
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBufferString(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBufferString(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -268,7 +268,7 @@ func TestCreateHost_InvalidRole(t *testing.T) {
 		NebulaIPs: []string{"192.168.100.10"},
 		Role:      "invalid",
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -288,7 +288,7 @@ func TestCreateAndGetHost(t *testing.T) {
 		NebulaIPs: []string{"192.168.100.10"},
 		Groups:    []string{"web"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -309,7 +309,7 @@ func TestCreateAndGetHost(t *testing.T) {
 	}
 
 	// Get host
-	req = httptest.NewRequest("GET", "/api/v1/hosts/"+resp.Host.ID, nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/hosts/"+resp.Host.ID, nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -326,7 +326,7 @@ func TestDeleteHost(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "to-delete", NebulaIPs: []string{"192.168.100.20"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -336,7 +336,7 @@ func TestDeleteHost(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 
-	req = httptest.NewRequest("DELETE", "/api/v1/hosts/"+resp.Host.ID, nil)
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/hosts/"+resp.Host.ID, nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -346,7 +346,7 @@ func TestDeleteHost(t *testing.T) {
 	}
 
 	// Verify deleted
-	req = httptest.NewRequest("GET", "/api/v1/hosts/"+resp.Host.ID, nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/hosts/"+resp.Host.ID, nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -363,7 +363,7 @@ func TestBlockAndUnblockHost(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "block-cycle", NebulaIPs: []string{"192.168.100.50"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -374,7 +374,7 @@ func TestBlockAndUnblockHost(t *testing.T) {
 	}
 
 	// Block
-	req = httptest.NewRequest("POST", "/api/v1/hosts/"+resp.Host.ID+"/block", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+resp.Host.ID+"/block", nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -392,7 +392,7 @@ func TestBlockAndUnblockHost(t *testing.T) {
 	}
 
 	// Unblock
-	req = httptest.NewRequest("POST", "/api/v1/hosts/"+resp.Host.ID+"/unblock", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+resp.Host.ID+"/unblock", nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -411,7 +411,7 @@ func TestBlockAndUnblockHost(t *testing.T) {
 
 func TestUnblockHost_NotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("POST", "/api/v1/hosts/nonexistent/unblock", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/nonexistent/unblock", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -427,7 +427,7 @@ func TestDeleteHost_WithCertBlocklisted(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "enrolled-host", NebulaIPs: []string{"192.168.100.30"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -446,7 +446,7 @@ func TestDeleteHost_WithCertBlocklisted(t *testing.T) {
 	}
 
 	// Delete should add to blocklist
-	req = httptest.NewRequest("DELETE", "/api/v1/hosts/"+host.ID, nil)
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/hosts/"+host.ID, nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -476,7 +476,7 @@ func TestCreateNetwork_InvalidCIDR(t *testing.T) {
 	srv, _ := newTestServer(t)
 
 	body := `{"name":"bad-net","cidr":"invalid/33"}`
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBufferString(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBufferString(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -493,7 +493,7 @@ func TestCreateHost_InvalidIP(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "bad-host", NebulaIPs: []string{"not-an-ip"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -511,10 +511,10 @@ func TestCreateHost_InvalidPort(t *testing.T) {
 		body, _ := json.Marshal(createHostRequest{
 			NetworkID:  netID,
 			Name:       "bad-port",
-			NebulaIPs: []string{"192.168.100.10"},
+			NebulaIPs:  []string{"192.168.100.10"},
 			ListenPort: port,
 		})
-		req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 		authRequest(req)
 		w := httptest.NewRecorder()
 		srv.ServeHTTP(w, req)
@@ -536,7 +536,7 @@ func TestCreateHost_ValidPort(t *testing.T) {
 			NebulaIPs:  []string{fmt.Sprintf("192.168.100.%d", 10+port%200)},
 			ListenPort: port,
 		})
-		req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 		authRequest(req)
 		w := httptest.NewRecorder()
 		srv.ServeHTTP(w, req)
@@ -562,7 +562,7 @@ func TestCreateHost_EmptyGroup(t *testing.T) {
 			NebulaIPs: []string{"192.168.100.10"},
 			Groups:    groups,
 		})
-		req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 		authRequest(req)
 		w := httptest.NewRecorder()
 		srv.ServeHTTP(w, req)
@@ -583,7 +583,7 @@ func TestCreateHost_ValidGroups(t *testing.T) {
 		NebulaIPs: []string{"192.168.100.10"},
 		Groups:    []string{"web", "prod"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -598,7 +598,7 @@ func TestFirewallRules_DefaultAndCRUD(t *testing.T) {
 	netID := createNetwork(t, srv)
 
 	// GET returns defaults
-	req := httptest.NewRequest("GET", "/api/v1/networks/"+netID+"/firewall", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/networks/"+netID+"/firewall", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -616,7 +616,7 @@ func TestFirewallRules_DefaultAndCRUD(t *testing.T) {
 
 	// PUT custom rules
 	customRules := `{"inbound":[{"port":"443","proto":"tcp","group":"web"}],"outbound":[{"port":"any","proto":"any","group":"any"}]}`
-	req = httptest.NewRequest("PUT", "/api/v1/networks/"+netID+"/firewall", bytes.NewBufferString(customRules))
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/networks/"+netID+"/firewall", bytes.NewBufferString(customRules))
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -625,7 +625,7 @@ func TestFirewallRules_DefaultAndCRUD(t *testing.T) {
 	}
 
 	// GET returns stored rules
-	req = httptest.NewRequest("GET", "/api/v1/networks/"+netID+"/firewall", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/networks/"+netID+"/firewall", nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -643,7 +643,7 @@ func TestFirewallRules_ValidationEmptyProto(t *testing.T) {
 	netID := createNetwork(t, srv)
 
 	invalidRules := `{"inbound":[{"port":"443","proto":"","group":"web"}],"outbound":[]}`
-	req := httptest.NewRequest("PUT", "/api/v1/networks/"+netID+"/firewall", bytes.NewBufferString(invalidRules))
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/networks/"+netID+"/firewall", bytes.NewBufferString(invalidRules))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -658,7 +658,7 @@ func TestFirewallRules_ValidationEmptyPort(t *testing.T) {
 	netID := createNetwork(t, srv)
 
 	invalidRules := `{"inbound":[],"outbound":[{"port":"","proto":"tcp","group":"any"}]}`
-	req := httptest.NewRequest("PUT", "/api/v1/networks/"+netID+"/firewall", bytes.NewBufferString(invalidRules))
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/networks/"+netID+"/firewall", bytes.NewBufferString(invalidRules))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -677,7 +677,7 @@ func TestFirewallRules_CorruptedJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/api/v1/networks/"+netID+"/firewall", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/networks/"+netID+"/firewall", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -691,7 +691,7 @@ func TestGetAuditLog_LimitBounds(t *testing.T) {
 	srv, _ := newTestServer(t)
 
 	// limit > 1000 → should be capped to 1000 (still OK)
-	req := httptest.NewRequest("GET", "/api/v1/audit-log?limit=5000", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit-log?limit=5000", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -700,7 +700,7 @@ func TestGetAuditLog_LimitBounds(t *testing.T) {
 	}
 
 	// limit = "abc" → bad request
-	req = httptest.NewRequest("GET", "/api/v1/audit-log?limit=abc", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/audit-log?limit=abc", nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -709,7 +709,7 @@ func TestGetAuditLog_LimitBounds(t *testing.T) {
 	}
 
 	// limit = -5 → bad request
-	req = httptest.NewRequest("GET", "/api/v1/audit-log?limit=-5", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/audit-log?limit=-5", nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -718,7 +718,7 @@ func TestGetAuditLog_LimitBounds(t *testing.T) {
 	}
 
 	// no limit → uses explicit default, returns OK
-	req = httptest.NewRequest("GET", "/api/v1/audit-log", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/audit-log", nil)
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -746,7 +746,7 @@ func TestMaxBytesReader(t *testing.T) {
 	bigStr := string(bytes.Repeat([]byte("x"), 1<<20+1))
 	body, _ := json.Marshal(map[string]string{"name": bigStr, "cidr": "10.0.0.0/24"})
 
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewReader(body))
 	authRequest(req)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -766,7 +766,7 @@ func TestEnroll_HostDeletedAfterTokenCreated(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "doomed", NebulaIPs: []string{"192.168.100.50"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -797,7 +797,7 @@ func TestEnroll_HostDeletedAfterTokenCreated(t *testing.T) {
 		PublicKeyPEM:  "dummy-key",
 		SigningPubPEM: signingPEM,
 	})
-	req = httptest.NewRequest("POST", "/api/v1/enroll", bytes.NewBuffer(enrollBody))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/enroll", bytes.NewBuffer(enrollBody))
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
@@ -817,7 +817,7 @@ func TestEnroll_HostDeletedAfterTokenCreated(t *testing.T) {
 
 func TestHostNotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/api/v1/hosts/nonexistent", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts/nonexistent", nil)
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -7,13 +7,14 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/juev/nebula-mesh/internal/models"
-	"github.com/juev/nebula-mesh/internal/pki"
-	apipop "github.com/juev/nebula-mesh/internal/api/pop"
-	corepop "github.com/juev/nebula-mesh/internal/pop"
-	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/google/uuid"
 	"github.com/slackhq/nebula/cert"
+
+	apipop "github.com/juev/nebula-mesh/internal/api/pop"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	corepop "github.com/juev/nebula-mesh/internal/pop"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 type agentUpdatesResponse struct {

--- a/internal/api/updates_revocation_test.go
+++ b/internal/api/updates_revocation_test.go
@@ -23,7 +23,7 @@ func TestPoll_RespondsForbidden_WhenHostBlocked(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -57,7 +57,7 @@ func TestPoll_RespondsGone_WhenHostDeletedButBlocklisted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -89,7 +89,7 @@ func TestPoll_UnknownStatusStillSucceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/updates_rotation_overlap_test.go
+++ b/internal/api/updates_rotation_overlap_test.go
@@ -30,7 +30,7 @@ func TestPoll_AcceptsPrevFingerprintDuringOverlap(t *testing.T) {
 	}
 
 	// Agent still polls under the old fingerprint — must succeed.
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -53,7 +53,7 @@ func TestPoll_ClearsPrevFingerprintAfterAgentUpgrades(t *testing.T) {
 	}
 
 	// Poll under the *current* fingerprint with prev still populated.
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -92,7 +92,7 @@ func TestPoll_RejectsStalePrevFingerprintAfterTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/updates_signed_poll_test.go
+++ b/internal/api/updates_signed_poll_test.go
@@ -14,10 +14,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juev/nebula-mesh/internal/models"
-	corepop "github.com/juev/nebula-mesh/internal/pop"
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	corepop "github.com/juev/nebula-mesh/internal/pop"
 )
 
 // enrolledAgent represents a fully enrolled host fixture in the
@@ -41,7 +42,7 @@ func enrolledFixture(t *testing.T, srv *Server) enrolledAgent {
 		Name:      "signed-host",
 		NebulaIPs: []string{"192.168.100.30"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -74,7 +75,7 @@ func enrolledFixture(t *testing.T, srv *Server) enrolledAgent {
 		PublicKeyPEM:  string(pubKeyPEM),
 		SigningPubPEM: string(signingPubPEM),
 	})
-	er := httptest.NewRequest("POST", "/api/v1/enroll", bytes.NewBuffer(enrollBody))
+	er := httptest.NewRequest(http.MethodPost, "/api/v1/enroll", bytes.NewBuffer(enrollBody))
 	ew := httptest.NewRecorder()
 	srv.ServeHTTP(ew, er)
 	if ew.Code != http.StatusOK {
@@ -157,7 +158,7 @@ func errBody(t *testing.T, resp *http.Response) string {
 
 func TestPoll_RejectsMissingHeaders(t *testing.T) {
 	srv, _ := newTestServer(t)
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
@@ -173,7 +174,7 @@ func TestPoll_RejectsUnknownFingerprint(t *testing.T) {
 	agent := enrolledFixture(t, srv)
 	// Swap fingerprint to an unknown value.
 	bogus := enrolledAgent{fingerprint: "deadbeef", signingPub: agent.signingPub, signingPriv: agent.signingPriv}
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, bogus)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -190,7 +191,7 @@ func TestPoll_RejectsBadSignature(t *testing.T) {
 	agent := enrolledFixture(t, srv)
 	// Sign with a different keypair.
 	_, otherPriv, _ := ed25519.GenerateKey(rand.Reader)
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent, withPrivateKey(otherPriv))
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -207,7 +208,7 @@ func TestPoll_RejectsSkewedTimestamp(t *testing.T) {
 	agent := enrolledFixture(t, srv)
 	// 10 minutes in the past — outside ±5 min window.
 	past := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent, withTimestamp(past))
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -225,7 +226,7 @@ func TestPoll_RejectsReplayedNonce(t *testing.T) {
 
 	nonce := "fixed-nonce-12345678"
 	for i := 0; i < 2; i++ {
-		req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 		signPoll(t, req, agent, withNonce(nonce))
 		w := httptest.NewRecorder()
 		srv.ServeHTTP(w, req)
@@ -246,7 +247,7 @@ func TestPoll_RejectsReplayedNonce(t *testing.T) {
 func TestPoll_HappyPath(t *testing.T) {
 	srv, _ := newTestServer(t)
 	agent := enrolledFixture(t, srv)
-	req := httptest.NewRequest("GET", "/api/v1/agent/updates", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
 	signPoll(t, req, agent)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/api/updates_test.go
+++ b/internal/api/updates_test.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"strings"
@@ -88,11 +89,10 @@ func TestTrustBundleLogic_NoSuccessor(t *testing.T) {
 
 	// Test: FindCAByPredecessor returns ErrNotFound for CA without successor
 	found, err := st.FindCAByPredecessor(ctx, ca.ID)
-	if err != store.ErrNotFound {
+	if !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("FindCAByPredecessor err = %v, want ErrNotFound", err)
 	}
 	if found != nil {
 		t.Errorf("FindCAByPredecessor returned CA=%+v, want nil", found)
 	}
 }
-

--- a/internal/api/validate_ip.go
+++ b/internal/api/validate_ip.go
@@ -35,7 +35,6 @@ func newHostIPValidationError(msg string) error {
 	return &hostIPValidationError{msg: msg}
 }
 
-
 var _ = models.HostStatusBlocked
 
 // forbiddenIPv4Reserved reports whether addr is the network or broadcast

--- a/internal/api/validate_ip_test.go
+++ b/internal/api/validate_ip_test.go
@@ -19,7 +19,7 @@ func TestCreateHost_FriendlyNebulaIPError(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "garbage", NebulaIPs: []string{"10.42.0.22.333"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -43,7 +43,7 @@ func TestCreateHost_FriendlyPublicIPError(t *testing.T) {
 		NetworkID: netID, Name: "lh", NebulaIPs: []string{"192.168.100.10"},
 		Role: "lighthouse", PublicIP: "203.0.113.999", ListenPort: 4242,
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -62,7 +62,7 @@ func TestCreateHost_FriendlyPublicIPError(t *testing.T) {
 func TestCreateNetwork_FriendlyCIDRError(t *testing.T) {
 	srv, _ := newTestServer(t)
 	body := []byte(`{"name":"n","cidrs":["not-a-cidr"]}`)
-	req := httptest.NewRequest("POST", "/api/v1/networks", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -86,7 +86,7 @@ func TestCreateHost_FriendlyAdvancedListenHostError(t *testing.T) {
 		NetworkID: netID, Name: "adv", NebulaIPs: []string{"192.168.100.20"},
 		Advanced: &models.HostAdvanced{ListenHost: "not-an-ip"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -112,7 +112,7 @@ func TestCreateHost_FriendlyUnsafeRouteError(t *testing.T) {
 			UnsafeRoutes: []models.UnsafeRoute{{Route: "bad/cidr", Via: "10.0.0.1"}},
 		},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -135,7 +135,7 @@ func TestCreateHost_RejectsIPOutsideCIDR(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "wrong-net", NebulaIPs: []string{"10.0.0.1"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -151,7 +151,7 @@ func TestCreateHost_RejectsDuplicateIPInSameNetwork(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "h1", NebulaIPs: []string{"192.168.100.10"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -162,7 +162,7 @@ func TestCreateHost_RejectsDuplicateIPInSameNetwork(t *testing.T) {
 	body, _ = json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "h2", NebulaIPs: []string{"192.168.100.10"},
 	})
-	req = httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -178,7 +178,7 @@ func TestCreateHost_RejectsIPv4NetworkAddress(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "net-addr", NebulaIPs: []string{"192.168.100.0"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -194,7 +194,7 @@ func TestCreateHost_RejectsIPv4BroadcastAddress(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "broadcast", NebulaIPs: []string{"192.168.100.255"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -217,7 +217,7 @@ func TestCreateHost_AllowsDuplicateIPAcrossDifferentNetworks(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: net1, Name: "h1", NebulaIPs: []string{"192.168.100.10"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -228,7 +228,7 @@ func TestCreateHost_AllowsDuplicateIPAcrossDifferentNetworks(t *testing.T) {
 	body, _ = json.Marshal(createHostRequest{
 		NetworkID: "net-other", Name: "h2", NebulaIPs: []string{"10.20.0.10"},
 	})
-	req = httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -244,7 +244,7 @@ func TestValidateHostIP_BlockedHostStillHoldsItsAddress(t *testing.T) {
 	body, _ := json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "h1", NebulaIPs: []string{"192.168.100.10"},
 	})
-	req := httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
@@ -266,7 +266,7 @@ func TestValidateHostIP_BlockedHostStillHoldsItsAddress(t *testing.T) {
 	body, _ = json.Marshal(createHostRequest{
 		NetworkID: netID, Name: "h2", NebulaIPs: []string{"192.168.100.10"},
 	})
-	req = httptest.NewRequest("POST", "/api/v1/hosts", bytes.NewBuffer(body))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
 	authRequest(req)
 	w = httptest.NewRecorder()
 	srv.ServeHTTP(w, req)

--- a/internal/cawatch/scanner.go
+++ b/internal/cawatch/scanner.go
@@ -17,7 +17,7 @@ import (
 
 // Scanner is a periodic CA auto-rotation watchdog. Wire one up at server start,
 // call StartLoop with a cancellable context, and it ticks every Interval
-// until the context is cancelled.
+// until the context is canceled.
 type Scanner struct {
 	Store     store.Store
 	Master    *keystore.Master
@@ -59,7 +59,7 @@ func (s *Scanner) Run(ctx context.Context) error {
 }
 
 // StartLoop runs Run() immediately, then on every Interval tick until ctx is
-// cancelled. Returns once the loop exits.
+// canceled. Returns once the loop exits.
 func (s *Scanner) StartLoop(ctx context.Context) {
 	interval := s.Interval
 	if interval <= 0 {

--- a/internal/cawatch/scanner_test.go
+++ b/internal/cawatch/scanner_test.go
@@ -3,6 +3,7 @@ package cawatch
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -70,7 +71,7 @@ func TestScanner_Run_RotatesApproachingExpiry(t *testing.T) {
 		OwnerOperatorID:      opID,
 		Fingerprint:          "fp_approaching",
 		Status:               models.CAStatusActive,
-		NotBefore:            now.AddDate(-10, 0, 0),           // 10 years old
+		NotBefore:            now.AddDate(-10, 0, 0),            // 10 years old
 		NotAfter:             now.Add(365 * 24 * time.Hour * 2), // ~2 years left = 20% of 10-year lifetime
 		CertPEM:              "-----BEGIN NEBULA CERTIFICATE-----\napproaching\n-----END NEBULA CERTIFICATE-----\n",
 		EncryptedKeyDEK:      []byte("key"),
@@ -117,7 +118,7 @@ func TestScanner_Run_RotatesApproachingExpiry(t *testing.T) {
 
 	// Verify fresh CA was NOT rotated (no successor)
 	freshSuccessor, err := st.FindCAByPredecessor(ctx, fresh.ID)
-	if err != store.ErrNotFound {
+	if !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("fresh CA should have no successor, got err=%v", err)
 	}
 	if freshSuccessor != nil {

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // DefaultAdminUsername is the username assigned to the auto-seeded admin operator.

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,7 +38,7 @@ func CACreate(serverURL, apiKey, name, duration string) error {
 		return fmt.Errorf("--name is required")
 	}
 	body, _ := json.Marshal(caCreateRequest{Name: name, Duration: duration})
-	req, err := http.NewRequest("POST", serverURL+"/api/v1/cas", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/cas", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -68,7 +69,7 @@ func CACreate(serverURL, apiKey, name, duration string) error {
 
 // CAList prints the CAs visible to the caller.
 func CAList(serverURL, apiKey string) error {
-	req, err := http.NewRequest("GET", serverURL+"/api/v1/cas", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL+"/api/v1/cas", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -112,7 +113,7 @@ func CARotate(serverURL, apiKey, id string) error {
 	if apiKey == "" {
 		return fmt.Errorf("--api-key is required")
 	}
-	req, err := http.NewRequest("POST", serverURL+"/api/v1/cas/"+id+"/rotate", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/cas/"+id+"/rotate", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/internal/cli/ca_test.go
+++ b/internal/cli/ca_test.go
@@ -25,11 +25,11 @@ func TestCARotate_BuildsCorrectRequest(t *testing.T) {
 		// Return mock response
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]any{
-			"id":              "new-ca-id",
-			"name":            "ca-name-rotated",
-			"predecessor_id":  "ca-123",
-			"fingerprint":     "abc123def456",
-			"status":          "active",
+			"id":             "new-ca-id",
+			"name":           "ca-name-rotated",
+			"predecessor_id": "ca-123",
+			"fingerprint":    "abc123def456",
+			"status":         "active",
 		})
 	}))
 	defer server.Close()

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,11 +21,11 @@ func HostCreate(serverURL, apiKey, networkID, name, nebulaIP, role string, group
 	}
 
 	body := map[string]any{
-		"network_id":  networkID,
-		"name":        name,
-		"nebula_ips":  nebullaIPs,
-		"role":        role,
-		"groups":      groups,
+		"network_id": networkID,
+		"name":       name,
+		"nebula_ips": nebullaIPs,
+		"role":       role,
+		"groups":     groups,
 	}
 	if publicIP != "" {
 		body["public_ip"] = publicIP
@@ -37,7 +38,7 @@ func HostCreate(serverURL, apiKey, networkID, name, nebulaIP, role string, group
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
 	}
-	req, err := http.NewRequest("POST", serverURL+"/api/v1/hosts", bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/hosts", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -102,7 +103,7 @@ func doHostAction(serverURL, apiKey, method, path string, wantStatus int, verb s
 		return fmt.Errorf("--server is required")
 	}
 
-	req, err := http.NewRequest(method, serverURL+path, nil)
+	req, err := http.NewRequestWithContext(context.Background(), method, serverURL+path, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -134,7 +135,7 @@ func HostList(serverURL, apiKey, networkID string) error {
 		u += "?network_id=" + url.QueryEscape(networkID)
 	}
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -96,9 +96,9 @@ func Init(configPath string) error {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	ca, minted, err := pki.MintAndStoreCA(migrateCtx, s, master, logger,
 		pki.MintRequest{
-			Operator: adminOp,
-			Name:     DefaultAdminUsername + "-default",
-			Duration: 10 * 365 * 24 * time.Hour,
+			Operator:     adminOp,
+			Name:         DefaultAdminUsername + "-default",
+			Duration:     10 * 365 * 24 * time.Hour,
 			SkipIfActive: true,
 		})
 	if err != nil {

--- a/internal/cli/network.go
+++ b/internal/cli/network.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,7 +27,7 @@ func NetworkCreate(serverURL, apiKey, name, cidr string) error {
 		return fmt.Errorf("marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", serverURL+"/api/v1/networks", bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/networks", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -66,7 +67,7 @@ func NetworkCreate(serverURL, apiKey, name, cidr string) error {
 
 // NetworkList lists networks via the API.
 func NetworkList(serverURL, apiKey string) error {
-	req, err := http.NewRequest("GET", serverURL+"/api/v1/networks", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL+"/api/v1/networks", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -15,9 +15,9 @@ import (
 	"github.com/juev/nebula-mesh/internal/auth"
 	"github.com/juev/nebula-mesh/internal/cawatch"
 	"github.com/juev/nebula-mesh/internal/config"
-	"github.com/juev/nebula-mesh/internal/ratelimit"
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/ratelimit"
 	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/juev/nebula-mesh/internal/web"
 )

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -65,7 +65,7 @@ func TestBuildMux_RoutesPerIssue69(t *testing.T) {
 }
 
 func TestBuildMux_UnknownApiPathDoesNotFallThroughToUI(t *testing.T) {
-	// API stub mimics chi's NotFound behaviour: returns 404 with a distinctive body.
+	// API stub mimics chi's NotFound behavior: returns 404 with a distinctive body.
 	apiSrv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("api-not-found"))

--- a/internal/cli/user.go
+++ b/internal/cli/user.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -29,13 +30,15 @@ func UserCreate(serverURL, apiKey, username, password, displayName, role string)
 	if username == "" || password == "" {
 		return fmt.Errorf("--username and --password are required")
 	}
-	body, err := json.Marshal(userCreateRequest{
+	// userCreateRequest intentionally carries the plaintext password to the
+	// server, which hashes it before storage.
+	body, err := json.Marshal(userCreateRequest{ //nolint:gosec // G117: intentional secret in transport DTO
 		Username: username, Password: password, DisplayName: displayName, Role: role,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
 	}
-	req, err := http.NewRequest("POST", serverURL+"/api/v1/operators", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/operators", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -65,7 +68,7 @@ func UserCreate(serverURL, apiKey, username, password, displayName, role string)
 
 // UserList lists operators via the API.
 func UserList(serverURL, apiKey string) error {
-	req, err := http.NewRequest("GET", serverURL+"/api/v1/operators", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL+"/api/v1/operators", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -118,7 +121,7 @@ type apiKeyCreateResponse struct {
 // printed once.
 func APIKeyCreate(serverURL, apiKey, operatorID, name string) error {
 	body, _ := json.Marshal(map[string]string{"name": name})
-	req, err := http.NewRequest("POST", serverURL+"/api/v1/operators/"+operatorID+"/api-keys", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/operators/"+operatorID+"/api-keys", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -129,8 +129,8 @@ type RateLimitConfig struct {
 	// Enabled is a pointer so an absent YAML block defaults to "true"
 	// (issue #52 requires on-by-default) while still allowing a
 	// `rate_limit: { enabled: false }` to disable it.
-	Enabled          *bool                          `yaml:"enabled,omitempty"`
-	TrustProxyHeader bool                           `yaml:"trust_proxy_header,omitempty"`
+	Enabled          *bool                           `yaml:"enabled,omitempty"`
+	TrustProxyHeader bool                            `yaml:"trust_proxy_header,omitempty"`
 	Groups           map[string]RateLimitGroupConfig `yaml:"groups,omitempty"`
 }
 
@@ -289,7 +289,9 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 // SaveServerConfig writes the config to path atomically (temp file + rename).
 // Existing comments and unknown fields in the file are not preserved.
 func SaveServerConfig(path string, cfg *ServerConfig) error {
-	data, err := yaml.Marshal(cfg)
+	// The server config legitimately contains secrets (OIDC client secret,
+	// API keys); they live in this file by design.
+	data, err := yaml.Marshal(cfg) //nolint:gosec // G117: secrets are an expected part of the config
 	if err != nil {
 		return fmt.Errorf("marshal config: %w", err)
 	}

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -233,11 +233,11 @@ func TestLoadServerConfig_RejectsCAAutoRotateBadThreshold(t *testing.T) {
 		threshold float64
 		wantErr   bool
 	}{
-		{"threshold=0", 0, false},          // 0 = unset, OK, will apply default
-		{"threshold=-0.1", -0.1, true},     // negative, not allowed
-		{"threshold=1.0", 1.0, true},       // >= 1.0, not allowed
-		{"threshold=1.5", 1.5, true},       // > 1.0, not allowed
-		{"threshold=0.5", 0.5, false},      // valid
+		{"threshold=0", 0, false},      // 0 = unset, OK, will apply default
+		{"threshold=-0.1", -0.1, true}, // negative, not allowed
+		{"threshold=1.0", 1.0, true},   // >= 1.0, not allowed
+		{"threshold=1.5", 1.5, true},   // > 1.0, not allowed
+		{"threshold=0.5", 0.5, false},  // valid
 	}
 
 	for _, tt := range tests {

--- a/internal/configgen/generator.go
+++ b/internal/configgen/generator.go
@@ -42,11 +42,11 @@ type GeneratorInput struct {
 	FirewallOutbound []FirewallRule
 
 	// Optional per-host overrides. Zero values mean "use the default".
-	PunchyOverride   *bool
-	ListenHost       string
-	MTU              int
-	TunDevice        string
-	UnsafeRoutes     []AdvancedUnsafeRoute
+	PunchyOverride *bool
+	ListenHost     string
+	MTU            int
+	TunDevice      string
+	UnsafeRoutes   []AdvancedUnsafeRoute
 
 	// Optional: if set, override the path-based pki section with inline PEM blocks.
 	// Used for Mobile Nebula clients which import a self-contained YAML config.

--- a/internal/configgen/generator_test.go
+++ b/internal/configgen/generator_test.go
@@ -6,21 +6,22 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/slackhq/nebula/cert"
 	"gopkg.in/yaml.v3"
+
+	"github.com/juev/nebula-mesh/internal/pki"
 )
 
 func TestGenerate_RegularHost(t *testing.T) {
 	input := GeneratorInput{
-		HostName:    "web-1",
-		NebulaIPs:   []string{"192.168.100.10"},
+		HostName:     "web-1",
+		NebulaIPs:    []string{"192.168.100.10"},
 		IsLighthouse: false,
-		IsRelay:     false,
-		CACertPath:  "/etc/nebula/ca.crt",
-		CertPath:    "/etc/nebula/host.crt",
-		KeyPath:     "/etc/nebula/host.key",
-		ListenPort:  0,
+		IsRelay:      false,
+		CACertPath:   "/etc/nebula/ca.crt",
+		CertPath:     "/etc/nebula/host.crt",
+		KeyPath:      "/etc/nebula/host.key",
+		ListenPort:   0,
 		Lighthouses: []LighthouseInfo{
 			{NebulaIPs: []string{"192.168.100.1"}, PublicAddr: "203.0.113.10:4242"},
 		},
@@ -99,13 +100,13 @@ func TestGenerate_Lighthouse(t *testing.T) {
 
 func TestGenerate_Relay(t *testing.T) {
 	input := GeneratorInput{
-		HostName:    "relay-1",
-		NebulaIPs:   []string{"192.168.100.2"},
-		IsRelay:     true,
-		CACertPath:  "/etc/nebula/ca.crt",
-		CertPath:    "/etc/nebula/host.crt",
-		KeyPath:     "/etc/nebula/host.key",
-		ListenPort:  4242,
+		HostName:   "relay-1",
+		NebulaIPs:  []string{"192.168.100.2"},
+		IsRelay:    true,
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+		ListenPort: 4242,
 		Lighthouses: []LighthouseInfo{
 			{NebulaIPs: []string{"192.168.100.1"}, PublicAddr: "203.0.113.10:4242"},
 		},
@@ -256,14 +257,14 @@ KEY...KEY...KEY
 
 func TestGenerate_StaticHostMap_PerAddress(t *testing.T) {
 	input := GeneratorInput{
-		HostName:    "web-1",
-		NebulaIPs:   []string{"10.0.0.5", "fd00::5"},
+		HostName:     "web-1",
+		NebulaIPs:    []string{"10.0.0.5", "fd00::5"},
 		IsLighthouse: false,
-		IsRelay:     false,
-		CACertPath:  "/etc/nebula/ca.crt",
-		CertPath:    "/etc/nebula/host.crt",
-		KeyPath:     "/etc/nebula/host.key",
-		ListenPort:  0,
+		IsRelay:      false,
+		CACertPath:   "/etc/nebula/ca.crt",
+		CertPath:     "/etc/nebula/host.crt",
+		KeyPath:      "/etc/nebula/host.key",
+		ListenPort:   0,
 		Lighthouses: []LighthouseInfo{
 			{NebulaIPs: []string{"10.0.0.1", "fd00::1"}, PublicAddr: "1.2.3.4:4242"},
 		},
@@ -292,14 +293,14 @@ func TestGenerate_StaticHostMap_PerAddress(t *testing.T) {
 
 func TestGenerate_LighthouseHosts_AllAddresses(t *testing.T) {
 	input := GeneratorInput{
-		HostName:    "web-1",
-		NebulaIPs:   []string{"10.0.0.5"},
+		HostName:     "web-1",
+		NebulaIPs:    []string{"10.0.0.5"},
 		IsLighthouse: false,
-		IsRelay:     false,
-		CACertPath:  "/etc/nebula/ca.crt",
-		CertPath:    "/etc/nebula/host.crt",
-		KeyPath:     "/etc/nebula/host.key",
-		ListenPort:  0,
+		IsRelay:      false,
+		CACertPath:   "/etc/nebula/ca.crt",
+		CertPath:     "/etc/nebula/host.crt",
+		KeyPath:      "/etc/nebula/host.key",
+		ListenPort:   0,
 		Lighthouses: []LighthouseInfo{
 			{NebulaIPs: []string{"10.0.0.1", "fd00::1"}, PublicAddr: "1.2.3.4:4242"},
 		},
@@ -328,14 +329,14 @@ func TestGenerate_LighthouseHosts_AllAddresses(t *testing.T) {
 
 func TestGenerate_MultipleLighthousesEachMulti(t *testing.T) {
 	input := GeneratorInput{
-		HostName:    "web-1",
-		NebulaIPs:   []string{"10.0.0.5"},
+		HostName:     "web-1",
+		NebulaIPs:    []string{"10.0.0.5"},
 		IsLighthouse: false,
-		IsRelay:     false,
-		CACertPath:  "/etc/nebula/ca.crt",
-		CertPath:    "/etc/nebula/host.crt",
-		KeyPath:     "/etc/nebula/host.key",
-		ListenPort:  0,
+		IsRelay:      false,
+		CACertPath:   "/etc/nebula/ca.crt",
+		CertPath:     "/etc/nebula/host.crt",
+		KeyPath:      "/etc/nebula/host.key",
+		ListenPort:   0,
 		Lighthouses: []LighthouseInfo{
 			{NebulaIPs: []string{"10.0.0.1", "fd00::1"}, PublicAddr: "1.2.3.4:4242"},
 			{NebulaIPs: []string{"10.0.0.2", "fd00::2"}, PublicAddr: "5.6.7.8:4242"},

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -42,7 +42,7 @@ func NewMasterFromBase64(b64 string) (*Master, error) {
 	}
 	raw, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidMasterKey, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidMasterKey, err)
 	}
 	return NewMaster(raw)
 }

--- a/internal/mobilebundle/builder.go
+++ b/internal/mobilebundle/builder.go
@@ -9,12 +9,13 @@ import (
 	"net/netip"
 	"strconv"
 
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+
 	"github.com/juev/nebula-mesh/internal/configgen"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/store"
-	"github.com/slackhq/nebula/cert"
-	"golang.org/x/crypto/curve25519"
 )
 
 var ErrNotMobile = errors.New("mobilebundle: host is not a mobile host")
@@ -23,7 +24,9 @@ var ErrNotMobile = errors.New("mobilebundle: host is not a mobile host")
 // cert via store, and returns a self-contained Nebula YAML bundle with
 // inline PEM for ca/cert/key. The private key is not persisted server-side
 // — it lives only in the returned bytes.
-func Build(ctx context.Context, s store.Store, resolver interface{ LoadByID(context.Context, string) (*pki.CAManager, error) }, host *models.Host) ([]byte, error) {
+func Build(ctx context.Context, s store.Store, resolver interface {
+	LoadByID(context.Context, string) (*pki.CAManager, error)
+}, host *models.Host) ([]byte, error) {
 	if host.Kind != models.HostKindMobile {
 		return nil, ErrNotMobile
 	}

--- a/internal/mobilebundle/builder_test.go
+++ b/internal/mobilebundle/builder_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/slackhq/nebula/cert"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/store"
-	"github.com/slackhq/nebula/cert"
 )
 
 func TestBuild_RoundTrip(t *testing.T) {

--- a/internal/models/host_test.go
+++ b/internal/models/host_test.go
@@ -16,7 +16,7 @@ func TestValidRole(t *testing.T) {
 		{HostRoleHost, true},
 		{HostRoleLighthouse, true},
 		{HostRoleRelay, true},
-		{"", true},       // empty = use default in handler
+		{"", true}, // empty = use default in handler
 		{"invalid", false},
 		{"admin", false},
 		{"HOST", false}, // case-sensitive
@@ -90,8 +90,8 @@ func TestValidKind(t *testing.T) {
 
 func TestValidVariant(t *testing.T) {
 	tests := []struct {
-		name    string
-		variant HostVariant
+		name     string
+		variant  HostVariant
 		expected bool
 	}{
 		{name: "none (empty)", variant: HostVariantNone, expected: true},

--- a/internal/models/hostdiff_test.go
+++ b/internal/models/hostdiff_test.go
@@ -81,10 +81,10 @@ func TestHostDiff_NameChanged(t *testing.T) {
 	}
 
 	nameChange := result["name"]
-	if before_val, ok := nameChange["before"]; !ok || before_val != "web-1" {
+	if beforeVal, ok := nameChange["before"]; !ok || beforeVal != "web-1" {
 		t.Fatalf("expected before='web-1', got %v", nameChange)
 	}
-	if after_val, ok := nameChange["after"]; !ok || after_val != "web-2" {
+	if afterVal, ok := nameChange["after"]; !ok || afterVal != "web-2" {
 		t.Fatalf("expected after='web-2', got %v", nameChange)
 	}
 }
@@ -290,19 +290,19 @@ func TestHostDiff_DeterministicKeyOrder(t *testing.T) {
 func TestHostDiff_PunchyTriState(t *testing.T) {
 	falseVal := false
 	before := &Host{
-		Name:       "web-1",
-		NebulaIPs:  []string{"192.168.100.1"},
-		Groups:     []string{},
-		Role:       HostRoleHost,
+		Name:      "web-1",
+		NebulaIPs: []string{"192.168.100.1"},
+		Groups:    []string{},
+		Role:      HostRoleHost,
 		Advanced: &HostAdvanced{
 			Punchy: nil,
 		},
 	}
 	after := &Host{
-		Name:       "web-1",
-		NebulaIPs:  []string{"192.168.100.1"},
-		Groups:     []string{},
-		Role:       HostRoleHost,
+		Name:      "web-1",
+		NebulaIPs: []string{"192.168.100.1"},
+		Groups:    []string{},
+		Role:      HostRoleHost,
 		Advanced: &HostAdvanced{
 			Punchy: &falseVal,
 		},
@@ -326,7 +326,7 @@ func TestHostDiff_PunchyTriState(t *testing.T) {
 	}
 	punchyChange := result["advanced.punchy"]
 	// nil → false
-	if punchyChange["after"] != false {
+	if got, _ := punchyChange["after"].(bool); got {
 		t.Fatalf("expected after=false, got %v", punchyChange["after"])
 	}
 }
@@ -335,20 +335,20 @@ func TestHostDiff_PunchyTriState(t *testing.T) {
 func TestHostDiff_MultipleAdvancedChanges(t *testing.T) {
 	trueVal := true
 	before := &Host{
-		Name:       "web-1",
-		NebulaIPs:  []string{"192.168.100.1"},
-		Groups:     []string{},
-		Role:       HostRoleHost,
+		Name:      "web-1",
+		NebulaIPs: []string{"192.168.100.1"},
+		Groups:    []string{},
+		Role:      HostRoleHost,
 		Advanced: &HostAdvanced{
 			MTU:    1300,
 			Punchy: &trueVal,
 		},
 	}
 	after := &Host{
-		Name:       "web-1",
-		NebulaIPs:  []string{"192.168.100.1"},
-		Groups:     []string{},
-		Role:       HostRoleHost,
+		Name:      "web-1",
+		NebulaIPs: []string{"192.168.100.1"},
+		Groups:    []string{},
+		Role:      HostRoleHost,
 		Advanced: &HostAdvanced{
 			MTU:    1280,
 			Punchy: &trueVal,

--- a/internal/models/operator.go
+++ b/internal/models/operator.go
@@ -20,20 +20,20 @@ const (
 
 // Operator is an administrative user of the management server.
 type Operator struct {
-	ID            string               `json:"id"`
-	Username      string               `json:"username"`
-	DisplayName   string               `json:"display_name"`
-	PasswordHash  string               `json:"-"`
-	AuthProvider  OperatorAuthProvider `json:"auth_provider"`
-	Status        OperatorStatus       `json:"status"`
-	Role          string               `json:"role"`
-	TOTPSecret    string               `json:"-"`
-	TOTPEnabled   bool                 `json:"totp_enabled"`
-	OIDCIssuer    string               `json:"oidc_issuer,omitempty"`
-	OIDCSubject   string               `json:"oidc_subject,omitempty"`
-	CreatedAt     time.Time            `json:"created_at"`
-	UpdatedAt     time.Time            `json:"updated_at"`
-	LastLoginAt   *time.Time           `json:"last_login_at,omitempty"`
+	ID           string               `json:"id"`
+	Username     string               `json:"username"`
+	DisplayName  string               `json:"display_name"`
+	PasswordHash string               `json:"-"`
+	AuthProvider OperatorAuthProvider `json:"auth_provider"`
+	Status       OperatorStatus       `json:"status"`
+	Role         string               `json:"role"`
+	TOTPSecret   string               `json:"-"`
+	TOTPEnabled  bool                 `json:"totp_enabled"`
+	OIDCIssuer   string               `json:"oidc_issuer,omitempty"`
+	OIDCSubject  string               `json:"oidc_subject,omitempty"`
+	CreatedAt    time.Time            `json:"created_at"`
+	UpdatedAt    time.Time            `json:"updated_at"`
+	LastLoginAt  *time.Time           `json:"last_login_at,omitempty"`
 }
 
 // OperatorAPIKey is a per-operator API key. Only the hash is stored.

--- a/internal/models/validate_ip_test.go
+++ b/internal/models/validate_ip_test.go
@@ -134,7 +134,7 @@ func TestValidateHostAdvanced_TunDeviceInjection(t *testing.T) {
 		{"colon_separator", "tun:value"},
 		{"open_brace", "nebula{"},
 		{"open_bracket", "nebula["},
-		{"too_long_16", "0123456789abcdef"},     // 16 chars > IFNAMSIZ-1
+		{"too_long_16", "0123456789abcdef"},      // 16 chars > IFNAMSIZ-1
 		{"too_long_32", strings.Repeat("a", 32)}, // previous limit
 		{"original_space", "nebula 0"},
 		{"original_tab", "nebula\t0"},

--- a/internal/pki/autoprovision.go
+++ b/internal/pki/autoprovision.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/models"
 )
@@ -33,7 +34,7 @@ type MintRequest struct {
 	// Duration is the validity period for the cert (e.g. 10 * 365 * 24 * time.Hour).
 	Duration time.Duration
 	// SkipIfActive, when true, causes the function to return an existing active CA
-	// for the operator instead of minting a new one (idempotent behaviour).
+	// for the operator instead of minting a new one (idempotent behavior).
 	SkipIfActive bool
 }
 

--- a/internal/pki/ca.go
+++ b/internal/pki/ca.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/slackhq/nebula/cert"
+
+	"github.com/juev/nebula-mesh/internal/keystore"
 )
 
 // CAManager holds a loaded CA certificate and its signing key in memory.

--- a/internal/pki/renewal_test.go
+++ b/internal/pki/renewal_test.go
@@ -61,9 +61,9 @@ func TestFindHostsForRenewal(t *testing.T) {
 	now := time.Now()
 
 	hosts := []HostCertInfo{
-		{HostID: "h1", NotBefore: now.Add(-17 * 24 * time.Hour), NotAfter: now.Add(3 * 24 * time.Hour)},  // 15% — renew
-		{HostID: "h2", NotBefore: now.Add(-5 * 24 * time.Hour), NotAfter: now.Add(5 * 24 * time.Hour)},    // 50% — skip
-		{HostID: "h3", NotBefore: now.Add(-19 * 24 * time.Hour), NotAfter: now.Add(1 * 24 * time.Hour)},   // 5% — renew
+		{HostID: "h1", NotBefore: now.Add(-17 * 24 * time.Hour), NotAfter: now.Add(3 * 24 * time.Hour)}, // 15% — renew
+		{HostID: "h2", NotBefore: now.Add(-5 * 24 * time.Hour), NotAfter: now.Add(5 * 24 * time.Hour)},  // 50% — skip
+		{HostID: "h3", NotBefore: now.Add(-19 * 24 * time.Hour), NotAfter: now.Add(1 * 24 * time.Hour)}, // 5% — renew
 	}
 
 	needRenewal := FindHostsForRenewal(hosts)

--- a/internal/pki/rotate.go
+++ b/internal/pki/rotate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"

--- a/internal/pki/rotate_test.go
+++ b/internal/pki/rotate_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/store"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRotateAndStoreCA_HappyPath(t *testing.T) {
@@ -90,9 +91,9 @@ func TestRotateAndStoreCA_IdempotentExistingSuccessor(t *testing.T) {
 	require.NotNil(t, ca2)
 
 	// Rotate again (idempotence): should return CA2 without creating CA3.
-	ca2_again, err := pki.RotateAndStoreCA(context.Background(), s, master, logger, ca1)
+	ca2Again, err := pki.RotateAndStoreCA(context.Background(), s, master, logger, ca1)
 	require.NoError(t, err)
-	assert.Equal(t, ca2_again.ID, ca2.ID)
+	assert.Equal(t, ca2Again.ID, ca2.ID)
 
 	// Verify DB has exactly 2 CAs.
 	all, err := s.ListCAsByOwner(context.Background(), op.ID)

--- a/internal/pki/signer_test.go
+++ b/internal/pki/signer_test.go
@@ -37,11 +37,11 @@ func TestSign(t *testing.T) {
 	pub, _ := generateHostKeypair(t)
 
 	req := SignRequest{
-		Name:     "host1",
+		Name:      "host1",
 		PublicKey: pub,
-		Networks: []netip.Prefix{netip.MustParsePrefix("192.168.100.5/24")},
-		Groups:   []string{"web", "workers"},
-		Duration: 8 * time.Hour,
+		Networks:  []netip.Prefix{netip.MustParsePrefix("192.168.100.5/24")},
+		Groups:    []string{"web", "workers"},
+		Duration:  8 * time.Hour,
 	}
 
 	hostCert, err := ca.Sign(req)

--- a/internal/pop/canonical_test.go
+++ b/internal/pop/canonical_test.go
@@ -12,7 +12,7 @@ func TestCanonicalString_Format(t *testing.T) {
 
 func TestCanonicalString_FieldsAreLineSeparated(t *testing.T) {
 	// Embedded newlines in any field would let an attacker hide bytes from
-	// the verifier. We don't sanitise the input here — the API layer feeds
+	// the verifier. We don't sanitize the input here — the API layer feeds
 	// trusted, fixed-shape values — but the canonical helper must still
 	// produce exactly four \n separators.
 	got := CanonicalString("GET", "/p", "h", "t", "n")

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -177,8 +177,8 @@ type entry struct {
 	lim *rate.Limiter
 }
 
-func newShard(max int) *shard {
-	return &shard{max: max, lookup: make(map[string]*list.Element), lru: list.New()}
+func newShard(maxEntries int) *shard {
+	return &shard{max: maxEntries, lookup: make(map[string]*list.Element), lru: list.New()}
 }
 
 func (s *shard) get(key string, gc GroupConfig) *rate.Limiter {

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -106,10 +106,10 @@ func TestClientIP_IPv6(t *testing.T) {
 
 func TestMaskIP(t *testing.T) {
 	tests := map[string]string{
-		"203.0.113.42":         "203.0.113.0/24",
-		"10.0.0.1":             "10.0.0.0/24",
+		"203.0.113.42":          "203.0.113.0/24",
+		"10.0.0.1":              "10.0.0.0/24",
 		"2001:db8:1234:5678::1": "2001:db8:1234:5678::/64",
-		"not-an-ip":            "not-an-ip",
+		"not-an-ip":             "not-an-ip",
 	}
 	for in, want := range tests {
 		if got := MaskIP(in); got != want {

--- a/internal/store/migration_repro_test.go
+++ b/internal/store/migration_repro_test.go
@@ -43,7 +43,7 @@ func TestMigration_StableAcrossRestarts(t *testing.T) {
 }
 
 // TestMigration_HealsLegacyMissingCAID exercises the repair path for
-// databases that were initialised by the pre-#37 loader and ended up
+// databases that were initialized by the pre-#37 loader and ended up
 // without `blocklist.ca_id`. After Migrate(), the column and its index
 // must be back.
 func TestMigration_HealsLegacyMissingCAID(t *testing.T) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store/migrations"
 
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // database/sql driver registration
 )
 
 var (
@@ -44,12 +44,13 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		db.SetMaxOpenConns(1)
 	}
 
-	// Enable WAL mode and foreign keys
+	// Enable WAL mode and foreign keys. Setup runs at process start without
+	// an inherited context, so background is acceptable here.
 	for _, pragma := range []string{
 		"PRAGMA journal_mode=WAL",
 		"PRAGMA foreign_keys=ON",
 	} {
-		if _, err := db.Exec(pragma); err != nil {
+		if _, err := db.ExecContext(context.Background(), pragma); err != nil {
 			if closeErr := db.Close(); closeErr != nil {
 				slog.Error("close db after pragma failure", "error", closeErr)
 			}
@@ -74,7 +75,7 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 //     boundaries and Exec one statement at a time.
 //
 // See https://github.com/juev/nebula-mesh/issues/37.
-func (s *SQLiteStore) Migrate(_ context.Context) error {
+func (s *SQLiteStore) Migrate(ctx context.Context) error {
 	migrationFiles := []string{
 		"001_initial.up.sql",
 		"002_config_version.up.sql",
@@ -95,7 +96,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 	}
 
 	// Tracking table. Created once; idempotent on subsequent starts.
-	if _, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+	if _, err := s.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
 		name        TEXT PRIMARY KEY,
 		applied_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	)`); err != nil {
@@ -103,7 +104,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 	}
 
 	for _, f := range migrationFiles {
-		applied, err := s.migrationApplied(f)
+		applied, err := s.migrationApplied(ctx, f)
 		if err != nil {
 			return fmt.Errorf("check migration %s: %w", f, err)
 		}
@@ -115,7 +116,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 			return fmt.Errorf("read migration %s: %w", f, err)
 		}
 		for _, stmt := range splitSQLStatements(string(sqlBytes)) {
-			if _, err := s.db.Exec(stmt); err != nil {
+			if _, err := s.db.ExecContext(ctx, stmt); err != nil {
 				if isDuplicateColumnErr(err) {
 					// Tolerated for backward compatibility with DBs that
 					// partially applied a buggy earlier version of this
@@ -125,7 +126,7 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 				return fmt.Errorf("apply migration %s stmt %q: %w", f, firstLine(stmt), err)
 			}
 		}
-		if _, err := s.db.Exec(`INSERT OR REPLACE INTO schema_migrations(name) VALUES (?)`, f); err != nil {
+		if _, err := s.db.ExecContext(ctx, `INSERT OR REPLACE INTO schema_migrations(name) VALUES (?)`, f); err != nil {
 			return fmt.Errorf("record migration %s: %w", f, err)
 		}
 	}
@@ -135,15 +136,15 @@ func (s *SQLiteStore) Migrate(_ context.Context) error {
 	// migration is now flagged as applied. Re-run the affected ALTER
 	// outside the normal migration flow so existing installs heal on the
 	// next start.
-	if err := s.repairBlocklistCAID(); err != nil {
+	if err := s.repairBlocklistCAID(ctx); err != nil {
 		return fmt.Errorf("repair blocklist ca_id: %w", err)
 	}
 	return nil
 }
 
-func (s *SQLiteStore) migrationApplied(name string) (bool, error) {
+func (s *SQLiteStore) migrationApplied(ctx context.Context, name string) (bool, error) {
 	var got string
-	row := s.db.QueryRow(`SELECT name FROM schema_migrations WHERE name = ?`, name)
+	row := s.db.QueryRowContext(ctx, `SELECT name FROM schema_migrations WHERE name = ?`, name)
 	if err := row.Scan(&got); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
@@ -156,8 +157,8 @@ func (s *SQLiteStore) migrationApplied(name string) (bool, error) {
 // repairBlocklistCAID heals databases that ran the buggy multi-statement
 // migration loader before issue #37 was fixed. If `blocklist.ca_id` is
 // absent, add it (together with its index) so multi-CA logic works.
-func (s *SQLiteStore) repairBlocklistCAID() error {
-	row := s.db.QueryRow(`SELECT COUNT(1) FROM pragma_table_info('blocklist') WHERE name = 'ca_id'`)
+func (s *SQLiteStore) repairBlocklistCAID(ctx context.Context) error {
+	row := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM pragma_table_info('blocklist') WHERE name = 'ca_id'`)
 	var n int
 	if err := row.Scan(&n); err != nil {
 		return err
@@ -165,12 +166,12 @@ func (s *SQLiteStore) repairBlocklistCAID() error {
 	if n > 0 {
 		return nil
 	}
-	if _, err := s.db.Exec(`ALTER TABLE blocklist ADD COLUMN ca_id TEXT NOT NULL DEFAULT ''`); err != nil {
+	if _, err := s.db.ExecContext(ctx, `ALTER TABLE blocklist ADD COLUMN ca_id TEXT NOT NULL DEFAULT ''`); err != nil {
 		if !isDuplicateColumnErr(err) {
 			return err
 		}
 	}
-	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_blocklist_ca ON blocklist(ca_id)`); err != nil {
+	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_blocklist_ca ON blocklist(ca_id)`); err != nil {
 		return err
 	}
 	return nil
@@ -380,7 +381,7 @@ func (s *SQLiteStore) UpdateNetwork(ctx context.Context, n *models.Network) erro
 
 func (s *SQLiteStore) GetNetwork(ctx context.Context, id string) (*models.Network, error) {
 	n := &models.Network{}
-	err := s.db.QueryRow(
+	err := s.db.QueryRowContext(ctx,
 		`SELECT id, name, created_at, ca_id FROM networks WHERE id = ?`, id,
 	).Scan(&n.ID, &n.Name, &n.CreatedAt, &n.CAID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -407,16 +408,18 @@ func (s *SQLiteStore) ListNetworks(ctx context.Context) ([]*models.Network, erro
 
 	// Scan all networks first before querying for CIDRs.
 	// This avoids nested queries on SQLite which can cause deadlocks.
+	// `rows` is closed explicitly (not via defer) so loadNetworkCIDRs below
+	// can run on the same connection.
 	result := make([]*models.Network, 0)
 	for rows.Next() {
 		n := &models.Network{}
 		if err := rows.Scan(&n.ID, &n.Name, &n.CreatedAt, &n.CAID); err != nil {
-			_ = rows.Close()
+			_ = rows.Close() //nolint:sqlclosecheck // see comment above
 			return nil, fmt.Errorf("scan network: %w", err)
 		}
 		result = append(result, n)
 	}
-	_ = rows.Close()
+	_ = rows.Close() //nolint:sqlclosecheck // see comment above
 
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -607,7 +610,7 @@ func (s *SQLiteStore) scanHost(scanner interface {
 const hostColumns = `id, network_id, name, groups_json, role, is_lighthouse, is_relay, public_ip, listen_port, status, cert_fingerprint, cert_expires_at, last_seen_at, created_at, updated_at, advanced_json, ca_id, prev_cert_fingerprint, cert_rotated_at, pending_rekey, signing_pub_pem, kind, variant`
 
 func (s *SQLiteStore) GetHost(ctx context.Context, id string) (*models.Host, error) {
-	row := s.db.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
 	h, err := s.scanHost(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -634,7 +637,7 @@ func (s *SQLiteStore) GetHost(ctx context.Context, id string) (*models.Host, err
 // value; callers that need to know which fingerprint matched can compare
 // against the input.
 func (s *SQLiteStore) GetHostByFingerprint(ctx context.Context, fingerprint string) (*models.Host, error) {
-	row := s.db.QueryRow(
+	row := s.db.QueryRowContext(ctx,
 		`SELECT `+hostColumns+` FROM hosts WHERE cert_fingerprint = ? OR prev_cert_fingerprint = ?`,
 		fingerprint, fingerprint,
 	)
@@ -687,16 +690,18 @@ func (s *SQLiteStore) ListHosts(ctx context.Context, filter HostFilter) ([]*mode
 
 	// Scan all hosts first before querying for addresses.
 	// This avoids nested queries on SQLite which can cause deadlocks.
+	// `rows` is closed explicitly (not via defer) so loadHostAddresses below
+	// can run on the same connection.
 	result := make([]*models.Host, 0)
 	for rows.Next() {
 		h, err := s.scanHost(rows)
 		if err != nil {
-			_ = rows.Close()
+			_ = rows.Close() //nolint:sqlclosecheck // see comment above
 			return nil, fmt.Errorf("scan host: %w", err)
 		}
 		result = append(result, h)
 	}
-	_ = rows.Close()
+	_ = rows.Close() //nolint:sqlclosecheck // see comment above
 
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -767,8 +772,8 @@ func (s *SQLiteStore) UpdateHost(ctx context.Context, h *models.Host) error {
 	return nil
 }
 
-func (s *SQLiteStore) UpdateHostLastSeen(_ context.Context, id string, t time.Time) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) UpdateHostLastSeen(ctx context.Context, id string, t time.Time) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET last_seen_at=?, updated_at=? WHERE id=?`,
 		t, time.Now(), id,
 	)
@@ -785,8 +790,8 @@ func (s *SQLiteStore) UpdateHostLastSeen(_ context.Context, id string, t time.Ti
 	return nil
 }
 
-func (s *SQLiteStore) UpdateHostCert(_ context.Context, id, fingerprint string, expiresAt time.Time) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) UpdateHostCert(ctx context.Context, id, fingerprint string, expiresAt time.Time) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET cert_fingerprint=?, cert_expires_at=?, updated_at=? WHERE id=?`,
 		fingerprint, expiresAt, time.Now(), id,
 	)
@@ -803,8 +808,8 @@ func (s *SQLiteStore) UpdateHostCert(_ context.Context, id, fingerprint string, 
 	return nil
 }
 
-func (s *SQLiteStore) UpdateHostStatus(_ context.Context, id string, status models.HostStatus) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) UpdateHostStatus(ctx context.Context, id string, status models.HostStatus) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET status=?, updated_at=? WHERE id=?`,
 		status, time.Now(), id,
 	)
@@ -821,8 +826,8 @@ func (s *SQLiteStore) UpdateHostStatus(_ context.Context, id string, status mode
 	return nil
 }
 
-func (s *SQLiteStore) DeleteHost(_ context.Context, id string) error {
-	result, err := s.db.Exec(`DELETE FROM hosts WHERE id = ?`, id)
+func (s *SQLiteStore) DeleteHost(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM hosts WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("delete host: %w", err)
 	}
@@ -839,8 +844,8 @@ func (s *SQLiteStore) DeleteHost(_ context.Context, id string) error {
 // BlockHostAndAddToBlocklist atomically blocks a host and adds its cert to the blocklist.
 // If the blocked host was an enrolled lighthouse, the network's config_version is
 // bumped so peers stop directing traffic at it on their next poll.
-func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason string) (*models.Host, error) {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) BlockHostAndAddToBlocklist(ctx context.Context, id, reason string) (*models.Host, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
@@ -850,7 +855,7 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason s
 		}
 	}()
 
-	row := tx.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
+	row := tx.QueryRowContext(ctx, `SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
 	h, err := s.scanHost(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -861,7 +866,7 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason s
 
 	if h.CertFingerprint != "" {
 		var hostIDVal any = id
-		_, err = tx.Exec(
+		_, err = tx.ExecContext(ctx,
 			`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at) VALUES (?, ?, ?, ?)`,
 			h.CertFingerprint, hostIDVal, reason, time.Now(),
 		)
@@ -872,7 +877,7 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason s
 
 	wasEnrolledLighthouse := h.IsLighthouse && h.Status == models.HostStatusEnrolled
 
-	result, err := tx.Exec(
+	result, err := tx.ExecContext(ctx,
 		`UPDATE hosts SET status=?, updated_at=? WHERE id=?`,
 		models.HostStatusBlocked, time.Now(), id,
 	)
@@ -888,7 +893,7 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason s
 	}
 
 	if wasEnrolledLighthouse {
-		if _, err := tx.Exec(
+		if _, err := tx.ExecContext(ctx,
 			`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`,
 			h.NetworkID,
 		); err != nil {
@@ -907,8 +912,8 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(_ context.Context, id, reason s
 // UnblockHostAndRemoveFromBlocklist atomically marks a blocked host as pending
 // and removes its certificate fingerprint from the blocklist. The host must
 // re-enroll to obtain a new certificate after unblocking.
-func (s *SQLiteStore) UnblockHostAndRemoveFromBlocklist(_ context.Context, id string) (*models.Host, error) {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) UnblockHostAndRemoveFromBlocklist(ctx context.Context, id string) (*models.Host, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
@@ -918,7 +923,7 @@ func (s *SQLiteStore) UnblockHostAndRemoveFromBlocklist(_ context.Context, id st
 		}
 	}()
 
-	row := tx.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
+	row := tx.QueryRowContext(ctx, `SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
 	h, err := s.scanHost(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -928,12 +933,12 @@ func (s *SQLiteStore) UnblockHostAndRemoveFromBlocklist(_ context.Context, id st
 	}
 
 	if h.CertFingerprint != "" {
-		if _, err := tx.Exec(`DELETE FROM blocklist WHERE fingerprint = ?`, h.CertFingerprint); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM blocklist WHERE fingerprint = ?`, h.CertFingerprint); err != nil {
 			return nil, fmt.Errorf("remove from blocklist: %w", err)
 		}
 	}
 
-	result, err := tx.Exec(
+	result, err := tx.ExecContext(ctx,
 		`UPDATE hosts SET status=?, updated_at=? WHERE id=?`,
 		models.HostStatusPending, time.Now(), id,
 	)
@@ -959,8 +964,8 @@ func (s *SQLiteStore) UnblockHostAndRemoveFromBlocklist(_ context.Context, id st
 // DeleteHostAndBlockCert atomically deletes a host and adds its cert to the blocklist.
 // If the deleted host was an enrolled lighthouse, the network's config_version is
 // bumped so peers stop directing traffic at it on their next poll.
-func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason string) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) DeleteHostAndBlockCert(ctx context.Context, id, reason string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -970,7 +975,7 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason strin
 		}
 	}()
 
-	row := tx.QueryRow(`SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
+	row := tx.QueryRowContext(ctx, `SELECT `+hostColumns+` FROM hosts WHERE id = ?`, id)
 	h, err := s.scanHost(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrNotFound
@@ -981,7 +986,7 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason strin
 
 	if h.CertFingerprint != "" {
 		var hostIDVal any = id
-		_, err = tx.Exec(
+		_, err = tx.ExecContext(ctx,
 			`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at) VALUES (?, ?, ?, ?)`,
 			h.CertFingerprint, hostIDVal, reason, time.Now(),
 		)
@@ -992,7 +997,7 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason strin
 
 	wasEnrolledLighthouse := h.IsLighthouse && h.Status == models.HostStatusEnrolled
 
-	result, err := tx.Exec(`DELETE FROM hosts WHERE id = ?`, id)
+	result, err := tx.ExecContext(ctx, `DELETE FROM hosts WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("delete host: %w", err)
 	}
@@ -1005,7 +1010,7 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason strin
 	}
 
 	if wasEnrolledLighthouse {
-		if _, err := tx.Exec(
+		if _, err := tx.ExecContext(ctx,
 			`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`,
 			h.NetworkID,
 		); err != nil {
@@ -1024,8 +1029,8 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(_ context.Context, id, reason strin
 // SetPrevFingerprint records the previous cert fingerprint and the rotation
 // timestamp on the host row. Called from SaveCertificateAndUpdateHostCert
 // before the new fingerprint is written so the overlap window is preserved.
-func (s *SQLiteStore) SetPrevFingerprint(_ context.Context, hostID, prev string, rotatedAt time.Time) error {
-	res, err := s.db.Exec(
+func (s *SQLiteStore) SetPrevFingerprint(ctx context.Context, hostID, prev string, rotatedAt time.Time) error {
+	res, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET prev_cert_fingerprint = ?, cert_rotated_at = ?, updated_at = ? WHERE id = ?`,
 		prev, rotatedAt, time.Now(), hostID,
 	)
@@ -1045,8 +1050,8 @@ func (s *SQLiteStore) SetPrevFingerprint(_ context.Context, hostID, prev string,
 // ClearPrevFingerprint drops the rotation overlap state once the agent has
 // successfully polled under the new fingerprint or the wall-clock window
 // expired.
-func (s *SQLiteStore) ClearPrevFingerprint(_ context.Context, hostID string) error {
-	res, err := s.db.Exec(
+func (s *SQLiteStore) ClearPrevFingerprint(ctx context.Context, hostID string) error {
+	res, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET prev_cert_fingerprint = NULL, cert_rotated_at = NULL, updated_at = ? WHERE id = ?`,
 		time.Now(), hostID,
 	)
@@ -1066,8 +1071,8 @@ func (s *SQLiteStore) ClearPrevFingerprint(_ context.Context, hostID string) err
 // SetPendingRekey flips the pending_rekey flag atomically. If the flag is
 // already set on this host the call returns ErrRekeyAlreadyPending so a
 // duplicate force-rotate request can be rejected with 409.
-func (s *SQLiteStore) SetPendingRekey(_ context.Context, hostID string) error {
-	res, err := s.db.Exec(
+func (s *SQLiteStore) SetPendingRekey(ctx context.Context, hostID string) error {
+	res, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET pending_rekey = 1, updated_at = ? WHERE id = ? AND pending_rekey = 0`,
 		time.Now(), hostID,
 	)
@@ -1082,7 +1087,7 @@ func (s *SQLiteStore) SetPendingRekey(_ context.Context, hostID string) error {
 		// Either the host does not exist or pending_rekey is already 1.
 		// Distinguish by re-reading the row.
 		var exists int
-		row := s.db.QueryRow(`SELECT 1 FROM hosts WHERE id = ?`, hostID)
+		row := s.db.QueryRowContext(ctx, `SELECT 1 FROM hosts WHERE id = ?`, hostID)
 		if err := row.Scan(&exists); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
@@ -1097,8 +1102,8 @@ func (s *SQLiteStore) SetPendingRekey(_ context.Context, hostID string) error {
 // ClearPendingRekey resets the pending_rekey flag, typically after the agent
 // has redeemed the rekey token and the new keypair has been bound to the
 // existing host row.
-func (s *SQLiteStore) ClearPendingRekey(_ context.Context, hostID string) error {
-	res, err := s.db.Exec(
+func (s *SQLiteStore) ClearPendingRekey(ctx context.Context, hostID string) error {
+	res, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET pending_rekey = 0, updated_at = ? WHERE id = ?`,
 		time.Now(), hostID,
 	)
@@ -1117,8 +1122,8 @@ func (s *SQLiteStore) ClearPendingRekey(_ context.Context, hostID string) error 
 
 // UpdateHostSigningPub stores the Ed25519 PEM public key bound to the host's
 // signing identity at enrollment / re-enrollment time.
-func (s *SQLiteStore) UpdateHostSigningPub(_ context.Context, hostID, signingPubPEM string) error {
-	res, err := s.db.Exec(
+func (s *SQLiteStore) UpdateHostSigningPub(ctx context.Context, hostID, signingPubPEM string) error {
+	res, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET signing_pub_pem = ?, updated_at = ? WHERE id = ?`,
 		signingPubPEM, time.Now(), hostID,
 	)
@@ -1188,8 +1193,8 @@ func (s *SQLiteStore) CreateHostAndToken(ctx context.Context, h *models.Host, t 
 	return nil
 }
 
-func (s *SQLiteStore) CreateToken(_ context.Context, t *models.EnrollmentToken) error {
-	_, err := s.db.Exec(
+func (s *SQLiteStore) CreateToken(ctx context.Context, t *models.EnrollmentToken) error {
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO enrollment_tokens (id, host_id, token_hash, used, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
 		t.ID, t.HostID, t.TokenHash, false, t.ExpiresAt, t.CreatedAt,
 	)
@@ -1204,8 +1209,8 @@ func (s *SQLiteStore) CreateToken(_ context.Context, t *models.EnrollmentToken) 
 // reenroll, and rekey flows (ADR 0004) where the host row must be preserved.
 // The `token` argument is the raw value handed back to the caller; the store
 // only ever persists its SHA-256 hex (GHSA-ghmh-jhmj-wcmf).
-func (s *SQLiteStore) CreateTokenForHost(_ context.Context, hostID, token string, expiresAt time.Time) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) CreateTokenForHost(ctx context.Context, hostID, token string, expiresAt time.Time) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -1215,12 +1220,12 @@ func (s *SQLiteStore) CreateTokenForHost(_ context.Context, hostID, token string
 		}
 	}()
 
-	if _, err := tx.Exec(`DELETE FROM enrollment_tokens WHERE host_id = ? AND used = 0`, hostID); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM enrollment_tokens WHERE host_id = ? AND used = 0`, hostID); err != nil {
 		return fmt.Errorf("delete previous tokens: %w", err)
 	}
 	now := time.Now()
 	id := fmt.Sprintf("etok_%d", now.UnixNano())
-	if _, err := tx.Exec(
+	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO enrollment_tokens (id, host_id, token_hash, used, expires_at, created_at) VALUES (?, ?, ?, 0, ?, ?)`,
 		id, hostID, models.HashEnrollmentToken(token), expiresAt, now,
 	); err != nil {
@@ -1234,8 +1239,8 @@ func (s *SQLiteStore) CreateTokenForHost(_ context.Context, hostID, token string
 
 // ConsumeToken accepts the raw token from the caller, hashes it, and
 // looks up by SHA-256 hex. Marks the row used on success. GHSA-ghmh-jhmj-wcmf.
-func (s *SQLiteStore) ConsumeToken(_ context.Context, token string) (*models.EnrollmentToken, error) {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) ConsumeToken(ctx context.Context, token string) (*models.EnrollmentToken, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
@@ -1246,7 +1251,7 @@ func (s *SQLiteStore) ConsumeToken(_ context.Context, token string) (*models.Enr
 	}()
 
 	t := &models.EnrollmentToken{}
-	err = tx.QueryRow(
+	err = tx.QueryRowContext(ctx,
 		`SELECT id, host_id, token_hash, used, expires_at, created_at FROM enrollment_tokens WHERE token_hash = ?`,
 		models.HashEnrollmentToken(token),
 	).Scan(&t.ID, &t.HostID, &t.TokenHash, &t.Used, &t.ExpiresAt, &t.CreatedAt)
@@ -1265,7 +1270,7 @@ func (s *SQLiteStore) ConsumeToken(_ context.Context, token string) (*models.Enr
 	}
 
 	now := time.Now()
-	_, err = tx.Exec(`UPDATE enrollment_tokens SET used = 1, used_at = ? WHERE id = ?`, now, t.ID)
+	_, err = tx.ExecContext(ctx, `UPDATE enrollment_tokens SET used = 1, used_at = ? WHERE id = ?`, now, t.ID)
 	if err != nil {
 		return nil, fmt.Errorf("consume token: %w", err)
 	}
@@ -1281,8 +1286,8 @@ func (s *SQLiteStore) ConsumeToken(_ context.Context, token string) (*models.Enr
 
 // --- Certificates ---
 
-func (s *SQLiteStore) SaveCertificate(_ context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) SaveCertificate(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -1292,7 +1297,7 @@ func (s *SQLiteStore) SaveCertificate(_ context.Context, hostID string, certPEM 
 		}
 	}()
 
-	if err := s.saveCertificateInTx(tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
+	if err := s.saveCertificateInTx(ctx, tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
 		return err
 	}
 
@@ -1305,8 +1310,8 @@ func (s *SQLiteStore) SaveCertificate(_ context.Context, hostID string, certPEM 
 // SaveCertificateAndEnrollHost atomically saves a certificate and marks the host as enrolled.
 // If the host has role=lighthouse, the network's config_version is bumped so peer
 // agents pick up the new lighthouse on their next poll.
-func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) SaveCertificateAndEnrollHost(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -1318,7 +1323,7 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID str
 
 	var isLighthouse bool
 	var networkID string
-	err = tx.QueryRow(
+	err = tx.QueryRowContext(ctx,
 		`SELECT is_lighthouse, network_id FROM hosts WHERE id = ?`, hostID,
 	).Scan(&isLighthouse, &networkID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1328,12 +1333,12 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID str
 		return fmt.Errorf("get host role: %w", err)
 	}
 
-	if err := s.saveCertificateInTx(tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
+	if err := s.saveCertificateInTx(ctx, tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
 		return err
 	}
 
 	// Update host: status=enrolled, cert_fingerprint, cert_expires_at
-	result, err := tx.Exec(
+	result, err := tx.ExecContext(ctx,
 		`UPDATE hosts SET status=?, cert_fingerprint=?, cert_expires_at=?, updated_at=? WHERE id=?`,
 		models.HostStatusEnrolled, fp, notAfter, time.Now(), hostID,
 	)
@@ -1349,7 +1354,7 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID str
 	}
 
 	if isLighthouse {
-		if _, err := tx.Exec(
+		if _, err := tx.ExecContext(ctx,
 			`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`,
 			networkID,
 		); err != nil {
@@ -1368,8 +1373,8 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(_ context.Context, hostID str
 // is parked in prev_cert_fingerprint with cert_rotated_at = now() so the
 // poll handler can accept either fingerprint during the rotation overlap
 // window (ADR 0004 §7.1).
-func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(_ context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -1379,7 +1384,7 @@ func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(_ context.Context, hostID
 		}
 	}()
 
-	if err := s.saveCertificateInTx(tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
+	if err := s.saveCertificateInTx(ctx, tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
 		return err
 	}
 
@@ -1388,7 +1393,7 @@ func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(_ context.Context, hostID
 	// new one). Same-key rotation handing back the same fingerprint should
 	// not populate prev_cert_fingerprint; the agent's poll continues to
 	// match on cert_fingerprint.
-	result, err := tx.Exec(
+	result, err := tx.ExecContext(ctx,
 		`UPDATE hosts SET
 			prev_cert_fingerprint = CASE
 				WHEN cert_fingerprint IS NULL OR cert_fingerprint = '' OR cert_fingerprint = ? THEN prev_cert_fingerprint
@@ -1422,17 +1427,17 @@ func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(_ context.Context, hostID
 }
 
 // saveCertificateInTx saves a certificate within an existing transaction.
-func (s *SQLiteStore) saveCertificateInTx(tx *sql.Tx, hostID, fp string, certPEM []byte, notBefore, notAfter time.Time) error {
-	_, err := tx.Exec(`UPDATE certificates SET is_current = 0 WHERE host_id = ?`, hostID)
+func (s *SQLiteStore) saveCertificateInTx(ctx context.Context, tx *sql.Tx, hostID, fp string, certPEM []byte, notBefore, notAfter time.Time) error {
+	_, err := tx.ExecContext(ctx, `UPDATE certificates SET is_current = 0 WHERE host_id = ?`, hostID)
 	if err != nil {
 		return fmt.Errorf("unmark current: %w", err)
 	}
 
 	// Inherit ca_id from the host so the startup invariant (no empty ca_id
-	// rows across networks/hosts/certificates/blocklist) holds after enrol /
+	// rows across networks/hosts/certificates/blocklist) holds after enroll /
 	// rotate / mobile-bundle paths complete.
 	var caID string
-	if err := tx.QueryRow(`SELECT ca_id FROM hosts WHERE id = ?`, hostID).Scan(&caID); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT ca_id FROM hosts WHERE id = ?`, hostID).Scan(&caID); err != nil {
 		return fmt.Errorf("get host ca_id for cert insert: %w", err)
 	}
 
@@ -1441,7 +1446,7 @@ func (s *SQLiteStore) saveCertificateInTx(tx *sql.Tx, hostID, fp string, certPEM
 		prefix = prefix[:8]
 	}
 	id := fmt.Sprintf("cert_%s_%d", prefix, time.Now().UnixNano())
-	_, err = tx.Exec(
+	_, err = tx.ExecContext(ctx,
 		`INSERT INTO certificates (id, host_id, ca_id, fingerprint, pem, not_before, not_after, is_current, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)`,
 		id, hostID, caID, fp, string(certPEM), notBefore, notAfter, time.Now(),
@@ -1452,9 +1457,9 @@ func (s *SQLiteStore) saveCertificateInTx(tx *sql.Tx, hostID, fp string, certPEM
 	return nil
 }
 
-func (s *SQLiteStore) GetCurrentCertificate(_ context.Context, hostID string) ([]byte, error) {
+func (s *SQLiteStore) GetCurrentCertificate(ctx context.Context, hostID string) ([]byte, error) {
 	var pem string
-	err := s.db.QueryRow(
+	err := s.db.QueryRowContext(ctx,
 		`SELECT pem FROM certificates WHERE host_id = ? AND is_current = 1`, hostID,
 	).Scan(&pem)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1466,9 +1471,9 @@ func (s *SQLiteStore) GetCurrentCertificate(_ context.Context, hostID string) ([
 	return []byte(pem), nil
 }
 
-func (s *SQLiteStore) GetCertificateInfo(_ context.Context, hostID string) (*models.CertificateInfo, error) {
+func (s *SQLiteStore) GetCertificateInfo(ctx context.Context, hostID string) (*models.CertificateInfo, error) {
 	ci := &models.CertificateInfo{}
-	err := s.db.QueryRow(
+	err := s.db.QueryRowContext(ctx,
 		`SELECT id, host_id, fingerprint, pem, not_before, not_after, is_current, created_at
 		 FROM certificates WHERE host_id = ? AND is_current = 1`, hostID,
 	).Scan(&ci.ID, &ci.HostID, &ci.Fingerprint, &ci.PEM, &ci.NotBefore, &ci.NotAfter, &ci.IsCurrent, &ci.CreatedAt)
@@ -1481,8 +1486,8 @@ func (s *SQLiteStore) GetCertificateInfo(_ context.Context, hostID string) (*mod
 	return ci, nil
 }
 
-func (s *SQLiteStore) ListEnrolledHostCerts(_ context.Context) ([]*models.CertificateInfo, error) {
-	rows, err := s.db.Query(
+func (s *SQLiteStore) ListEnrolledHostCerts(ctx context.Context) ([]*models.CertificateInfo, error) {
+	rows, err := s.db.QueryContext(ctx,
 		`SELECT c.id, c.host_id, c.fingerprint, c.pem, c.not_before, c.not_after, c.is_current, c.created_at
 		 FROM certificates c
 		 JOIN hosts h ON h.id = c.host_id
@@ -1509,12 +1514,12 @@ func (s *SQLiteStore) ListEnrolledHostCerts(_ context.Context) ([]*models.Certif
 
 // --- Blocklist ---
 
-func (s *SQLiteStore) AddToBlocklist(_ context.Context, fingerprint, hostID, reason string) error {
+func (s *SQLiteStore) AddToBlocklist(ctx context.Context, fingerprint, hostID, reason string) error {
 	var hostIDVal any
 	if hostID != "" {
 		hostIDVal = hostID
 	}
-	_, err := s.db.Exec(
+	_, err := s.db.ExecContext(ctx,
 		`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at) VALUES (?, ?, ?, ?)`,
 		fingerprint, hostIDVal, reason, time.Now(),
 	)
@@ -1524,16 +1529,16 @@ func (s *SQLiteStore) AddToBlocklist(_ context.Context, fingerprint, hostID, rea
 	return nil
 }
 
-func (s *SQLiteStore) RemoveFromBlocklist(_ context.Context, fingerprint string) error {
-	_, err := s.db.Exec(`DELETE FROM blocklist WHERE fingerprint = ?`, fingerprint)
+func (s *SQLiteStore) RemoveFromBlocklist(ctx context.Context, fingerprint string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM blocklist WHERE fingerprint = ?`, fingerprint)
 	if err != nil {
 		return fmt.Errorf("remove from blocklist: %w", err)
 	}
 	return nil
 }
 
-func (s *SQLiteStore) GetBlocklist(_ context.Context) ([]string, error) {
-	rows, err := s.db.Query(`SELECT fingerprint FROM blocklist ORDER BY fingerprint`)
+func (s *SQLiteStore) GetBlocklist(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT fingerprint FROM blocklist ORDER BY fingerprint`)
 	if err != nil {
 		return nil, fmt.Errorf("get blocklist: %w", err)
 	}
@@ -1559,8 +1564,8 @@ func (s *SQLiteStore) GetBlocklist(_ context.Context) ([]string, error) {
 // RecordCertAlert upserts the (host_id, alerted_not_after) tuple so subsequent
 // scans for the same cert do not re-emit the alert. Update alerted_at to now
 // on every call so dashboards can show "last fired" times.
-func (s *SQLiteStore) RecordCertAlert(_ context.Context, hostID string, alertedNotAfter time.Time) error {
-	_, err := s.db.Exec(
+func (s *SQLiteStore) RecordCertAlert(ctx context.Context, hostID string, alertedNotAfter time.Time) error {
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO cert_alerts (host_id, alerted_not_after, alerted_at) VALUES (?, ?, ?)
 		 ON CONFLICT(host_id) DO UPDATE SET alerted_not_after = excluded.alerted_not_after, alerted_at = excluded.alerted_at`,
 		hostID, alertedNotAfter, time.Now(),
@@ -1573,9 +1578,9 @@ func (s *SQLiteStore) RecordCertAlert(_ context.Context, hostID string, alertedN
 
 // GetCertAlert returns the alerted_not_after recorded for hostID, or
 // ErrNotFound when no alert has been recorded yet.
-func (s *SQLiteStore) GetCertAlert(_ context.Context, hostID string) (time.Time, error) {
+func (s *SQLiteStore) GetCertAlert(ctx context.Context, hostID string) (time.Time, error) {
 	var t time.Time
-	err := s.db.QueryRow(`SELECT alerted_not_after FROM cert_alerts WHERE host_id = ?`, hostID).Scan(&t)
+	err := s.db.QueryRowContext(ctx, `SELECT alerted_not_after FROM cert_alerts WHERE host_id = ?`, hostID).Scan(&t)
 	if errors.Is(err, sql.ErrNoRows) {
 		return time.Time{}, ErrNotFound
 	}
@@ -1589,9 +1594,9 @@ func (s *SQLiteStore) GetCertAlert(_ context.Context, hostID string) (time.Time,
 
 // GetServerSetting returns the stored value for key, or "" + ErrNotFound
 // when the key has never been set.
-func (s *SQLiteStore) GetServerSetting(_ context.Context, key string) (string, error) {
+func (s *SQLiteStore) GetServerSetting(ctx context.Context, key string) (string, error) {
 	var value string
-	err := s.db.QueryRow(`SELECT value FROM server_settings WHERE key = ?`, key).Scan(&value)
+	err := s.db.QueryRowContext(ctx, `SELECT value FROM server_settings WHERE key = ?`, key).Scan(&value)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", ErrNotFound
 	}
@@ -1602,8 +1607,8 @@ func (s *SQLiteStore) GetServerSetting(_ context.Context, key string) (string, e
 }
 
 // SetServerSetting upserts a key/value pair into server_settings.
-func (s *SQLiteStore) SetServerSetting(_ context.Context, key, value string) error {
-	_, err := s.db.Exec(
+func (s *SQLiteStore) SetServerSetting(ctx context.Context, key, value string) error {
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO server_settings (key, value) VALUES (?, ?)
 		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
 		key, value,
@@ -1616,17 +1621,17 @@ func (s *SQLiteStore) SetServerSetting(_ context.Context, key, value string) err
 
 // --- Config Versioning ---
 
-func (s *SQLiteStore) BumpNetworkConfigVersion(_ context.Context, networkID string) error {
-	_, err := s.db.Exec(`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`, networkID)
+func (s *SQLiteStore) BumpNetworkConfigVersion(ctx context.Context, networkID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE networks SET config_version = config_version + 1 WHERE id = ?`, networkID)
 	if err != nil {
 		return fmt.Errorf("bump config version: %w", err)
 	}
 	return nil
 }
 
-func (s *SQLiteStore) GetNetworkConfigVersion(_ context.Context, networkID string) (int, error) {
+func (s *SQLiteStore) GetNetworkConfigVersion(ctx context.Context, networkID string) (int, error) {
 	var version int
-	err := s.db.QueryRow(`SELECT config_version FROM networks WHERE id = ?`, networkID).Scan(&version)
+	err := s.db.QueryRowContext(ctx, `SELECT config_version FROM networks WHERE id = ?`, networkID).Scan(&version)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, ErrNotFound
 	}
@@ -1636,9 +1641,9 @@ func (s *SQLiteStore) GetNetworkConfigVersion(_ context.Context, networkID strin
 	return version, nil
 }
 
-func (s *SQLiteStore) GetHostConfigVersion(_ context.Context, hostID string) (int, error) {
+func (s *SQLiteStore) GetHostConfigVersion(ctx context.Context, hostID string) (int, error) {
 	var version int
-	err := s.db.QueryRow(`SELECT config_version FROM hosts WHERE id = ?`, hostID).Scan(&version)
+	err := s.db.QueryRowContext(ctx, `SELECT config_version FROM hosts WHERE id = ?`, hostID).Scan(&version)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, ErrNotFound
 	}
@@ -1648,8 +1653,8 @@ func (s *SQLiteStore) GetHostConfigVersion(_ context.Context, hostID string) (in
 	return version, nil
 }
 
-func (s *SQLiteStore) UpdateHostConfigVersion(_ context.Context, hostID string, version int) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) UpdateHostConfigVersion(ctx context.Context, hostID string, version int) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE hosts SET config_version=?, updated_at=? WHERE id=?`,
 		version, time.Now(), hostID,
 	)
@@ -1668,9 +1673,9 @@ func (s *SQLiteStore) UpdateHostConfigVersion(_ context.Context, hostID string, 
 
 // --- Network Config ---
 
-func (s *SQLiteStore) GetNetworkConfig(_ context.Context, networkID, key string) (string, error) {
+func (s *SQLiteStore) GetNetworkConfig(ctx context.Context, networkID, key string) (string, error) {
 	var value string
-	err := s.db.QueryRow(
+	err := s.db.QueryRowContext(ctx,
 		`SELECT value FROM network_config WHERE network_id = ? AND key = ?`, networkID, key,
 	).Scan(&value)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1682,8 +1687,8 @@ func (s *SQLiteStore) GetNetworkConfig(_ context.Context, networkID, key string)
 	return value, nil
 }
 
-func (s *SQLiteStore) SetNetworkConfig(_ context.Context, networkID, key, value string) error {
-	_, err := s.db.Exec(
+func (s *SQLiteStore) SetNetworkConfig(ctx context.Context, networkID, key, value string) error {
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO network_config (network_id, key, value) VALUES (?, ?, ?)
 		 ON CONFLICT(network_id, key) DO UPDATE SET value = excluded.value`,
 		networkID, key, value,
@@ -1695,8 +1700,8 @@ func (s *SQLiteStore) SetNetworkConfig(_ context.Context, networkID, key, value 
 }
 
 // SetNetworkConfigAndBumpVersion atomically sets a config value and bumps the config version.
-func (s *SQLiteStore) SetNetworkConfigAndBumpVersion(_ context.Context, networkID, key, value string) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) SetNetworkConfigAndBumpVersion(ctx context.Context, networkID, key, value string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -1706,7 +1711,7 @@ func (s *SQLiteStore) SetNetworkConfigAndBumpVersion(_ context.Context, networkI
 		}
 	}()
 
-	_, err = tx.Exec(
+	_, err = tx.ExecContext(ctx,
 		`INSERT INTO network_config (network_id, key, value) VALUES (?, ?, ?)
 		 ON CONFLICT(network_id, key) DO UPDATE SET value = excluded.value`,
 		networkID, key, value,
@@ -1715,7 +1720,7 @@ func (s *SQLiteStore) SetNetworkConfigAndBumpVersion(_ context.Context, networkI
 		return fmt.Errorf("set network config: %w", err)
 	}
 
-	_, err = tx.Exec(`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`, networkID)
+	_, err = tx.ExecContext(ctx, `UPDATE networks SET config_version = config_version + 1 WHERE id = ?`, networkID)
 	if err != nil {
 		return fmt.Errorf("bump config version: %w", err)
 	}
@@ -1728,9 +1733,9 @@ func (s *SQLiteStore) SetNetworkConfigAndBumpVersion(_ context.Context, networkI
 
 // --- Audit Log ---
 
-func (s *SQLiteStore) AddAuditEntry(_ context.Context, actor, action, resource, details string) error {
+func (s *SQLiteStore) AddAuditEntry(ctx context.Context, actor, action, resource, details string) error {
 	id := fmt.Sprintf("audit_%d", time.Now().UnixNano())
-	_, err := s.db.Exec(
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO audit_log (id, actor, action, resource, details) VALUES (?, ?, ?, ?, ?)`,
 		id, actor, action, resource, details,
 	)
@@ -1740,7 +1745,7 @@ func (s *SQLiteStore) AddAuditEntry(_ context.Context, actor, action, resource, 
 	return nil
 }
 
-func (s *SQLiteStore) ListAuditEntries(_ context.Context, filter AuditFilter) ([]*models.AuditEntry, error) {
+func (s *SQLiteStore) ListAuditEntries(ctx context.Context, filter AuditFilter) ([]*models.AuditEntry, error) {
 	query := `SELECT id, timestamp, actor, action, resource, COALESCE(details, '') FROM audit_log WHERE 1=1`
 	var args []any
 
@@ -1757,7 +1762,7 @@ func (s *SQLiteStore) ListAuditEntries(_ context.Context, filter AuditFilter) ([
 	query += ` LIMIT ?`
 	args = append(args, limit)
 
-	rows, err := s.db.Query(query, args...)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list audit entries: %w", err)
 	}

--- a/internal/store/sqlite_cas.go
+++ b/internal/store/sqlite_cas.go
@@ -33,7 +33,7 @@ func scanCA(scanner interface {
 	return &c, nil
 }
 
-func (s *SQLiteStore) CreateCA(_ context.Context, c *models.CA) error {
+func (s *SQLiteStore) CreateCA(ctx context.Context, c *models.CA) error {
 	if c.ID == "" || c.Name == "" || c.OwnerOperatorID == "" || c.Fingerprint == "" {
 		return fmt.Errorf("CA id, name, owner_operator_id, fingerprint are required")
 	}
@@ -47,7 +47,7 @@ func (s *SQLiteStore) CreateCA(_ context.Context, c *models.CA) error {
 	if c.UpdatedAt.IsZero() {
 		c.UpdatedAt = now
 	}
-	_, err := s.db.Exec(
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO cas (`+caColumns+`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		c.ID, c.Name, c.OwnerOperatorID, c.CertPEM, c.Fingerprint,
 		c.NotBefore, c.NotAfter, c.Status, c.PredecessorID,
@@ -61,8 +61,8 @@ func (s *SQLiteStore) CreateCA(_ context.Context, c *models.CA) error {
 	return nil
 }
 
-func (s *SQLiteStore) GetCA(_ context.Context, id string) (*models.CA, error) {
-	row := s.db.QueryRow(`SELECT `+caColumns+` FROM cas WHERE id = ?`, id)
+func (s *SQLiteStore) GetCA(ctx context.Context, id string) (*models.CA, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+caColumns+` FROM cas WHERE id = ?`, id)
 	c, err := scanCA(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -73,8 +73,8 @@ func (s *SQLiteStore) GetCA(_ context.Context, id string) (*models.CA, error) {
 	return c, nil
 }
 
-func (s *SQLiteStore) GetCAByFingerprint(_ context.Context, fp string) (*models.CA, error) {
-	row := s.db.QueryRow(`SELECT `+caColumns+` FROM cas WHERE fingerprint = ?`, fp)
+func (s *SQLiteStore) GetCAByFingerprint(ctx context.Context, fp string) (*models.CA, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+caColumns+` FROM cas WHERE fingerprint = ?`, fp)
 	c, err := scanCA(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -85,8 +85,8 @@ func (s *SQLiteStore) GetCAByFingerprint(_ context.Context, fp string) (*models.
 	return c, nil
 }
 
-func (s *SQLiteStore) ListCAs(_ context.Context) ([]*models.CA, error) {
-	rows, err := s.db.Query(`SELECT ` + caColumns + ` FROM cas ORDER BY name`)
+func (s *SQLiteStore) ListCAs(ctx context.Context) ([]*models.CA, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+caColumns+` FROM cas ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("list CAs: %w", err)
 	}
@@ -106,8 +106,8 @@ func (s *SQLiteStore) ListCAs(_ context.Context) ([]*models.CA, error) {
 	return out, rows.Err()
 }
 
-func (s *SQLiteStore) ListCAsByOwner(_ context.Context, ownerID string) ([]*models.CA, error) {
-	rows, err := s.db.Query(`SELECT `+caColumns+` FROM cas WHERE owner_operator_id = ? ORDER BY name`, ownerID)
+func (s *SQLiteStore) ListCAsByOwner(ctx context.Context, ownerID string) ([]*models.CA, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+caColumns+` FROM cas WHERE owner_operator_id = ? ORDER BY name`, ownerID)
 	if err != nil {
 		return nil, fmt.Errorf("list CAs by owner: %w", err)
 	}
@@ -127,12 +127,12 @@ func (s *SQLiteStore) ListCAsByOwner(_ context.Context, ownerID string) ([]*mode
 	return out, rows.Err()
 }
 
-func (s *SQLiteStore) ListCAsApproachingExpiry(_ context.Context, thresholdRatio float64) ([]*models.CA, error) {
+func (s *SQLiteStore) ListCAsApproachingExpiry(ctx context.Context, thresholdRatio float64) ([]*models.CA, error) {
 	// Query for active CAs where remaining lifetime <= threshold * total lifetime.
 	// SQLite stores times as RFC3339 strings, so we extract just the date portion (YYYY-MM-DD)
 	// and use julianday() for date arithmetic.
 	// Calculation: (not_after_days - now_days) / (not_after_days - not_before_days) <= threshold
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+caColumns+` FROM cas
 		WHERE status = ?
 		  AND (julianday(SUBSTR(not_after, 1, 10)) - julianday(SUBSTR(datetime('now'), 1, 10))) /
@@ -158,8 +158,8 @@ func (s *SQLiteStore) ListCAsApproachingExpiry(_ context.Context, thresholdRatio
 	return out, rows.Err()
 }
 
-func (s *SQLiteStore) FindCAByPredecessor(_ context.Context, predecessorID string) (*models.CA, error) {
-	row := s.db.QueryRow(`SELECT `+caColumns+` FROM cas WHERE predecessor_id = ? AND status = ? LIMIT 1`, predecessorID, models.CAStatusActive)
+func (s *SQLiteStore) FindCAByPredecessor(ctx context.Context, predecessorID string) (*models.CA, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+caColumns+` FROM cas WHERE predecessor_id = ? AND status = ? LIMIT 1`, predecessorID, models.CAStatusActive)
 	c, err := scanCA(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -170,8 +170,8 @@ func (s *SQLiteStore) FindCAByPredecessor(_ context.Context, predecessorID strin
 	return c, nil
 }
 
-func (s *SQLiteStore) UpdateCAStatus(_ context.Context, id string, status models.CAStatus) error {
-	result, err := s.db.Exec(`UPDATE cas SET status=?, updated_at=? WHERE id=?`, status, time.Now(), id)
+func (s *SQLiteStore) UpdateCAStatus(ctx context.Context, id string, status models.CAStatus) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE cas SET status=?, updated_at=? WHERE id=?`, status, time.Now(), id)
 	if err != nil {
 		return fmt.Errorf("update CA status: %w", err)
 	}
@@ -190,7 +190,7 @@ func (s *SQLiteStore) UpdateCAStatus(_ context.Context, id string, status models
 // the call returns an error if networks still reference the CA, so the
 // operator must retire / move networks first.
 func (s *SQLiteStore) DeleteCA(ctx context.Context, id string) error {
-	row := s.db.QueryRow(`SELECT COUNT(1) FROM networks WHERE ca_id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM networks WHERE ca_id = ?`, id)
 	var n int
 	if err := row.Scan(&n); err != nil {
 		return fmt.Errorf("check CA references: %w", err)
@@ -198,7 +198,7 @@ func (s *SQLiteStore) DeleteCA(ctx context.Context, id string) error {
 	if n > 0 {
 		return fmt.Errorf("CA still has %d network(s); detach them first", n)
 	}
-	result, err := s.db.Exec(`DELETE FROM cas WHERE id = ?`, id)
+	result, err := s.db.ExecContext(ctx, `DELETE FROM cas WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("delete CA: %w", err)
 	}

--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -39,7 +39,7 @@ func scanOperator(scanner interface {
 }
 
 // CreateOperator inserts a new operator. Caller fills in PasswordHash.
-func (s *SQLiteStore) CreateOperator(_ context.Context, op *models.Operator) error {
+func (s *SQLiteStore) CreateOperator(ctx context.Context, op *models.Operator) error {
 	if op.ID == "" || op.Username == "" || op.PasswordHash == "" {
 		return fmt.Errorf("operator id, username, password_hash are required")
 	}
@@ -59,7 +59,7 @@ func (s *SQLiteStore) CreateOperator(_ context.Context, op *models.Operator) err
 	if op.Role == "" {
 		op.Role = "admin"
 	}
-	_, err := s.db.Exec(
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO operators (id, username, display_name, password_hash, auth_provider, status, role, oidc_issuer, oidc_subject, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		op.ID, op.Username, op.DisplayName, op.PasswordHash,
 		op.AuthProvider, op.Status, op.Role,
@@ -74,8 +74,8 @@ func (s *SQLiteStore) CreateOperator(_ context.Context, op *models.Operator) err
 
 // GetOperatorByOIDC returns the operator matching the issuer+subject pair, if
 // any. Used to look up federated operators after a successful OIDC callback.
-func (s *SQLiteStore) GetOperatorByOIDC(_ context.Context, issuer, subject string) (*models.Operator, error) {
-	row := s.db.QueryRow(
+func (s *SQLiteStore) GetOperatorByOIDC(ctx context.Context, issuer, subject string) (*models.Operator, error) {
+	row := s.db.QueryRowContext(ctx,
 		`SELECT `+operatorColumns+` FROM operators WHERE oidc_issuer = ? AND oidc_subject = ?`,
 		issuer, subject,
 	)
@@ -89,8 +89,8 @@ func (s *SQLiteStore) GetOperatorByOIDC(_ context.Context, issuer, subject strin
 	return op, nil
 }
 
-func (s *SQLiteStore) GetOperator(_ context.Context, id string) (*models.Operator, error) {
-	row := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE id = ?`, id)
+func (s *SQLiteStore) GetOperator(ctx context.Context, id string) (*models.Operator, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+operatorColumns+` FROM operators WHERE id = ?`, id)
 	op, err := scanOperator(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -101,8 +101,8 @@ func (s *SQLiteStore) GetOperator(_ context.Context, id string) (*models.Operato
 	return op, nil
 }
 
-func (s *SQLiteStore) GetOperatorByUsername(_ context.Context, username string) (*models.Operator, error) {
-	row := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE username = ?`, username)
+func (s *SQLiteStore) GetOperatorByUsername(ctx context.Context, username string) (*models.Operator, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+operatorColumns+` FROM operators WHERE username = ?`, username)
 	op, err := scanOperator(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -113,8 +113,8 @@ func (s *SQLiteStore) GetOperatorByUsername(_ context.Context, username string) 
 	return op, nil
 }
 
-func (s *SQLiteStore) ListOperators(_ context.Context) ([]*models.Operator, error) {
-	rows, err := s.db.Query(`SELECT ` + operatorColumns + ` FROM operators ORDER BY username`)
+func (s *SQLiteStore) ListOperators(ctx context.Context) ([]*models.Operator, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+operatorColumns+` FROM operators ORDER BY username`)
 	if err != nil {
 		return nil, fmt.Errorf("list operators: %w", err)
 	}
@@ -134,8 +134,8 @@ func (s *SQLiteStore) ListOperators(_ context.Context) ([]*models.Operator, erro
 	return out, rows.Err()
 }
 
-func (s *SQLiteStore) UpdateOperatorPassword(_ context.Context, id, passwordHash string) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) UpdateOperatorPassword(ctx context.Context, id, passwordHash string) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE operators SET password_hash=?, updated_at=? WHERE id=?`,
 		passwordHash, time.Now(), id,
 	)
@@ -152,8 +152,8 @@ func (s *SQLiteStore) UpdateOperatorPassword(_ context.Context, id, passwordHash
 	return nil
 }
 
-func (s *SQLiteStore) UpdateOperatorLastLogin(_ context.Context, id string, t time.Time) error {
-	_, err := s.db.Exec(`UPDATE operators SET last_login_at=?, updated_at=? WHERE id=?`, t, t, id)
+func (s *SQLiteStore) UpdateOperatorLastLogin(ctx context.Context, id string, t time.Time) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE operators SET last_login_at=?, updated_at=? WHERE id=?`, t, t, id)
 	if err != nil {
 		return fmt.Errorf("update last_login_at: %w", err)
 	}
@@ -162,8 +162,8 @@ func (s *SQLiteStore) UpdateOperatorLastLogin(_ context.Context, id string, t ti
 
 // DisableOperator marks operator as disabled and atomically deletes their
 // sessions and revokes all of their non-revoked API keys.
-func (s *SQLiteStore) DisableOperator(_ context.Context, id string) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) DisableOperator(ctx context.Context, id string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -174,7 +174,7 @@ func (s *SQLiteStore) DisableOperator(_ context.Context, id string) error {
 	}()
 
 	now := time.Now()
-	result, err := tx.Exec(
+	result, err := tx.ExecContext(ctx,
 		`UPDATE operators SET status=?, updated_at=? WHERE id=?`,
 		models.OperatorStatusDisabled, now, id,
 	)
@@ -189,10 +189,10 @@ func (s *SQLiteStore) DisableOperator(_ context.Context, id string) error {
 		return ErrNotFound
 	}
 
-	if _, err := tx.Exec(`DELETE FROM operator_sessions WHERE operator_id=?`, id); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM operator_sessions WHERE operator_id=?`, id); err != nil {
 		return fmt.Errorf("delete operator sessions: %w", err)
 	}
-	if _, err := tx.Exec(
+	if _, err := tx.ExecContext(ctx,
 		`UPDATE operator_api_keys SET revoked_at=? WHERE operator_id=? AND revoked_at IS NULL`,
 		now, id,
 	); err != nil {
@@ -202,8 +202,8 @@ func (s *SQLiteStore) DisableOperator(_ context.Context, id string) error {
 	return tx.Commit()
 }
 
-func (s *SQLiteStore) EnableOperator(_ context.Context, id string) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) EnableOperator(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE operators SET status=?, updated_at=? WHERE id=?`,
 		models.OperatorStatusActive, time.Now(), id,
 	)
@@ -224,8 +224,8 @@ func (s *SQLiteStore) EnableOperator(_ context.Context, id string) error {
 
 // SetOperatorTOTP records the operator's TOTP secret and enabled flag.
 // Passing enabled=false with secret="" clears 2FA entirely.
-func (s *SQLiteStore) SetOperatorTOTP(_ context.Context, id, secret string, enabled bool) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) SetOperatorTOTP(ctx context.Context, id, secret string, enabled bool) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -238,7 +238,7 @@ func (s *SQLiteStore) SetOperatorTOTP(_ context.Context, id, secret string, enab
 	if enabled {
 		enabledInt = 1
 	}
-	result, err := tx.Exec(
+	result, err := tx.ExecContext(ctx,
 		`UPDATE operators SET totp_secret=?, totp_enabled=?, updated_at=? WHERE id=?`,
 		secret, enabledInt, time.Now(), id,
 	)
@@ -253,7 +253,7 @@ func (s *SQLiteStore) SetOperatorTOTP(_ context.Context, id, secret string, enab
 		return ErrNotFound
 	}
 	if !enabled {
-		if _, err := tx.Exec(`DELETE FROM operator_recovery_codes WHERE operator_id=?`, id); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM operator_recovery_codes WHERE operator_id=?`, id); err != nil {
 			return fmt.Errorf("clear recovery codes: %w", err)
 		}
 	}
@@ -262,8 +262,8 @@ func (s *SQLiteStore) SetOperatorTOTP(_ context.Context, id, secret string, enab
 
 // ReplaceOperatorRecoveryCodes deletes any existing codes for the operator
 // and inserts the provided list of hashes (atomic).
-func (s *SQLiteStore) ReplaceOperatorRecoveryCodes(_ context.Context, id string, codeHashes []string) error {
-	tx, err := s.db.Begin()
+func (s *SQLiteStore) ReplaceOperatorRecoveryCodes(ctx context.Context, id string, codeHashes []string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
@@ -272,11 +272,11 @@ func (s *SQLiteStore) ReplaceOperatorRecoveryCodes(_ context.Context, id string,
 			slog.Error("rollback", "error", err)
 		}
 	}()
-	if _, err := tx.Exec(`DELETE FROM operator_recovery_codes WHERE operator_id=?`, id); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM operator_recovery_codes WHERE operator_id=?`, id); err != nil {
 		return fmt.Errorf("delete recovery codes: %w", err)
 	}
 	for _, h := range codeHashes {
-		if _, err := tx.Exec(
+		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO operator_recovery_codes (operator_id, code_hash) VALUES (?, ?)`,
 			id, h,
 		); err != nil {
@@ -288,8 +288,8 @@ func (s *SQLiteStore) ReplaceOperatorRecoveryCodes(_ context.Context, id string,
 
 // ConsumeOperatorRecoveryCode marks the given hash as consumed if it exists
 // and is unused. Returns ErrNotFound otherwise.
-func (s *SQLiteStore) ConsumeOperatorRecoveryCode(_ context.Context, id, codeHash string) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) ConsumeOperatorRecoveryCode(ctx context.Context, id, codeHash string) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE operator_recovery_codes SET consumed_at=? WHERE operator_id=? AND code_hash=? AND consumed_at IS NULL`,
 		time.Now(), id, codeHash,
 	)
@@ -308,8 +308,8 @@ func (s *SQLiteStore) ConsumeOperatorRecoveryCode(_ context.Context, id, codeHas
 
 // ListOperatorRecoveryCodes returns the hashes of all non-consumed recovery
 // codes for the operator. Used by tests and integrity checks.
-func (s *SQLiteStore) ListOperatorRecoveryCodes(_ context.Context, id string) ([]string, error) {
-	rows, err := s.db.Query(
+func (s *SQLiteStore) ListOperatorRecoveryCodes(ctx context.Context, id string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
 		`SELECT code_hash FROM operator_recovery_codes WHERE operator_id=? AND consumed_at IS NULL`,
 		id,
 	)
@@ -334,14 +334,14 @@ func (s *SQLiteStore) ListOperatorRecoveryCodes(_ context.Context, id string) ([
 
 // --- API keys ---
 
-func (s *SQLiteStore) CreateOperatorAPIKey(_ context.Context, k *models.OperatorAPIKey) error {
+func (s *SQLiteStore) CreateOperatorAPIKey(ctx context.Context, k *models.OperatorAPIKey) error {
 	if k.ID == "" || k.OperatorID == "" || k.KeyHash == "" {
 		return fmt.Errorf("api key id, operator_id, key_hash are required")
 	}
 	if k.CreatedAt.IsZero() {
 		k.CreatedAt = time.Now()
 	}
-	_, err := s.db.Exec(
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO operator_api_keys (id, operator_id, name, key_hash, created_at) VALUES (?, ?, ?, ?, ?)`,
 		k.ID, k.OperatorID, k.Name, k.KeyHash, k.CreatedAt,
 	)
@@ -353,13 +353,13 @@ func (s *SQLiteStore) CreateOperatorAPIKey(_ context.Context, k *models.Operator
 
 // GetOperatorByAPIKeyHash returns the operator associated with a non-revoked
 // API key, ensuring the operator is active.
-func (s *SQLiteStore) GetOperatorByAPIKeyHash(_ context.Context, keyHash string) (*models.Operator, *models.OperatorAPIKey, error) {
+func (s *SQLiteStore) GetOperatorByAPIKeyHash(ctx context.Context, keyHash string) (*models.Operator, *models.OperatorAPIKey, error) {
 	var (
-		k          models.OperatorAPIKey
-		lastUsed   sql.NullTime
-		revokedAt  sql.NullTime
+		k         models.OperatorAPIKey
+		lastUsed  sql.NullTime
+		revokedAt sql.NullTime
 	)
-	row := s.db.QueryRow(
+	row := s.db.QueryRowContext(ctx,
 		`SELECT id, operator_id, name, key_hash, created_at, last_used_at, revoked_at FROM operator_api_keys WHERE key_hash=? AND revoked_at IS NULL`,
 		keyHash,
 	)
@@ -374,7 +374,7 @@ func (s *SQLiteStore) GetOperatorByAPIKeyHash(_ context.Context, keyHash string)
 		k.LastUsedAt = &t
 	}
 
-	opRow := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE id = ?`, k.OperatorID)
+	opRow := s.db.QueryRowContext(ctx, `SELECT `+operatorColumns+` FROM operators WHERE id = ?`, k.OperatorID)
 	op, err := scanOperator(opRow)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil, ErrNotFound
@@ -388,8 +388,8 @@ func (s *SQLiteStore) GetOperatorByAPIKeyHash(_ context.Context, keyHash string)
 	return op, &k, nil
 }
 
-func (s *SQLiteStore) ListOperatorAPIKeys(_ context.Context, operatorID string) ([]*models.OperatorAPIKey, error) {
-	rows, err := s.db.Query(
+func (s *SQLiteStore) ListOperatorAPIKeys(ctx context.Context, operatorID string) ([]*models.OperatorAPIKey, error) {
+	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, operator_id, name, key_hash, created_at, last_used_at, revoked_at FROM operator_api_keys WHERE operator_id=? ORDER BY created_at DESC`,
 		operatorID,
 	)
@@ -424,8 +424,8 @@ func (s *SQLiteStore) ListOperatorAPIKeys(_ context.Context, operatorID string) 
 	return out, rows.Err()
 }
 
-func (s *SQLiteStore) RevokeOperatorAPIKey(_ context.Context, keyID string) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) RevokeOperatorAPIKey(ctx context.Context, keyID string) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE operator_api_keys SET revoked_at=? WHERE id=? AND revoked_at IS NULL`,
 		time.Now(), keyID,
 	)
@@ -442,8 +442,8 @@ func (s *SQLiteStore) RevokeOperatorAPIKey(_ context.Context, keyID string) erro
 	return nil
 }
 
-func (s *SQLiteStore) TouchOperatorAPIKey(_ context.Context, keyID string, t time.Time) error {
-	_, err := s.db.Exec(`UPDATE operator_api_keys SET last_used_at=? WHERE id=?`, t, keyID)
+func (s *SQLiteStore) TouchOperatorAPIKey(ctx context.Context, keyID string, t time.Time) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE operator_api_keys SET last_used_at=? WHERE id=?`, t, keyID)
 	if err != nil {
 		return fmt.Errorf("touch api key: %w", err)
 	}
@@ -452,7 +452,7 @@ func (s *SQLiteStore) TouchOperatorAPIKey(_ context.Context, keyID string, t tim
 
 // --- Sessions ---
 
-func (s *SQLiteStore) CreateOperatorSession(_ context.Context, sess *models.OperatorSession) error {
+func (s *SQLiteStore) CreateOperatorSession(ctx context.Context, sess *models.OperatorSession) error {
 	if sess.Token == "" || sess.OperatorID == "" {
 		return fmt.Errorf("session token and operator_id are required")
 	}
@@ -463,7 +463,7 @@ func (s *SQLiteStore) CreateOperatorSession(_ context.Context, sess *models.Oper
 	if state == "" {
 		state = models.SessionStateAuthenticated
 	}
-	_, err := s.db.Exec(
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO operator_sessions (token, operator_id, expires_at, created_at, state) VALUES (?, ?, ?, ?, ?)`,
 		sess.Token, sess.OperatorID, sess.ExpiresAt, sess.CreatedAt, state,
 	)
@@ -476,8 +476,8 @@ func (s *SQLiteStore) CreateOperatorSession(_ context.Context, sess *models.Oper
 // GetOperatorBySession returns the operator associated with a non-expired,
 // fully-authenticated session whose operator is still active. Sessions in
 // pending_totp state are NOT returned here.
-func (s *SQLiteStore) GetOperatorBySession(_ context.Context, token string) (*models.Operator, error) {
-	row := s.db.QueryRow(
+func (s *SQLiteStore) GetOperatorBySession(ctx context.Context, token string) (*models.Operator, error) {
+	row := s.db.QueryRowContext(ctx,
 		`SELECT operator_id, expires_at, state FROM operator_sessions WHERE token=?`,
 		token,
 	)
@@ -498,7 +498,7 @@ func (s *SQLiteStore) GetOperatorBySession(_ context.Context, token string) (*mo
 	if time.Now().After(expiresAt) {
 		return nil, ErrNotFound
 	}
-	opRow := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE id=?`, operatorID)
+	opRow := s.db.QueryRowContext(ctx, `SELECT `+operatorColumns+` FROM operators WHERE id=?`, operatorID)
 	op, err := scanOperator(opRow)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -515,8 +515,8 @@ func (s *SQLiteStore) GetOperatorBySession(_ context.Context, token string) (*mo
 // GetPendingTwoFactorOperator returns the operator associated with a session
 // that is awaiting a second factor (`pending_totp`). The operator must still
 // be active. Sessions already authenticated are not returned.
-func (s *SQLiteStore) GetPendingTwoFactorOperator(_ context.Context, token string) (*models.Operator, error) {
-	row := s.db.QueryRow(
+func (s *SQLiteStore) GetPendingTwoFactorOperator(ctx context.Context, token string) (*models.Operator, error) {
+	row := s.db.QueryRowContext(ctx,
 		`SELECT operator_id, expires_at, state FROM operator_sessions WHERE token=?`,
 		token,
 	)
@@ -537,7 +537,7 @@ func (s *SQLiteStore) GetPendingTwoFactorOperator(_ context.Context, token strin
 	if time.Now().After(expiresAt) {
 		return nil, ErrNotFound
 	}
-	opRow := s.db.QueryRow(`SELECT `+operatorColumns+` FROM operators WHERE id=?`, operatorID)
+	opRow := s.db.QueryRowContext(ctx, `SELECT `+operatorColumns+` FROM operators WHERE id=?`, operatorID)
 	op, err := scanOperator(opRow)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -554,8 +554,8 @@ func (s *SQLiteStore) GetPendingTwoFactorOperator(_ context.Context, token strin
 // PromoteOperatorSession upgrades a pending_totp session to authenticated and
 // resets the expiry to a fresh 24h window. Returns ErrNotFound if the session
 // does not exist or is not pending.
-func (s *SQLiteStore) PromoteOperatorSession(_ context.Context, token string, newExpiry time.Time) error {
-	result, err := s.db.Exec(
+func (s *SQLiteStore) PromoteOperatorSession(ctx context.Context, token string, newExpiry time.Time) error {
+	result, err := s.db.ExecContext(ctx,
 		`UPDATE operator_sessions SET state=?, expires_at=? WHERE token=? AND state=?`,
 		models.SessionStateAuthenticated, newExpiry, token, models.SessionStatePendingTOTP,
 	)
@@ -572,24 +572,24 @@ func (s *SQLiteStore) PromoteOperatorSession(_ context.Context, token string, ne
 	return nil
 }
 
-func (s *SQLiteStore) DeleteOperatorSession(_ context.Context, token string) error {
-	_, err := s.db.Exec(`DELETE FROM operator_sessions WHERE token=?`, token)
+func (s *SQLiteStore) DeleteOperatorSession(ctx context.Context, token string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM operator_sessions WHERE token=?`, token)
 	if err != nil {
 		return fmt.Errorf("delete session: %w", err)
 	}
 	return nil
 }
 
-func (s *SQLiteStore) DeleteOperatorSessionsByOperator(_ context.Context, operatorID string) error {
-	_, err := s.db.Exec(`DELETE FROM operator_sessions WHERE operator_id=?`, operatorID)
+func (s *SQLiteStore) DeleteOperatorSessionsByOperator(ctx context.Context, operatorID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM operator_sessions WHERE operator_id=?`, operatorID)
 	if err != nil {
 		return fmt.Errorf("delete sessions by operator: %w", err)
 	}
 	return nil
 }
 
-func (s *SQLiteStore) DeleteExpiredOperatorSessions(_ context.Context, before time.Time) error {
-	_, err := s.db.Exec(`DELETE FROM operator_sessions WHERE expires_at < ?`, before)
+func (s *SQLiteStore) DeleteExpiredOperatorSessions(ctx context.Context, before time.Time) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM operator_sessions WHERE expires_at < ?`, before)
 	if err != nil {
 		return fmt.Errorf("delete expired sessions: %w", err)
 	}

--- a/internal/store/sqlite_operators_test.go
+++ b/internal/store/sqlite_operators_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -53,7 +54,7 @@ func TestGetOperatorByUsername(t *testing.T) {
 		t.Errorf("id = %q, want %q", got.ID, op.ID)
 	}
 
-	if _, err := s.GetOperatorByUsername(context.Background(), "nobody"); err != ErrNotFound {
+	if _, err := s.GetOperatorByUsername(context.Background(), "nobody"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -86,7 +87,7 @@ func TestDisableOperator_CascadesSessionsAndAPIKeys(t *testing.T) {
 	}
 
 	// Sessions gone
-	if _, err := s.GetOperatorBySession(ctx, "tok1"); err != ErrNotFound {
+	if _, err := s.GetOperatorBySession(ctx, "tok1"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("session still valid after disable: %v", err)
 	}
 
@@ -100,7 +101,7 @@ func TestDisableOperator_CascadesSessionsAndAPIKeys(t *testing.T) {
 	}
 
 	// Lookup by hash returns nothing (revoked + operator disabled)
-	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "hash1"); err != ErrNotFound {
+	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "hash1"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("disabled operator's key still resolves: %v", err)
 	}
 }
@@ -126,7 +127,7 @@ func TestGetOperatorByAPIKeyHash_Lookup(t *testing.T) {
 		t.Errorf("key name = %q, want main", gotKey.Name)
 	}
 
-	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "nonexistent"); err != ErrNotFound {
+	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "nonexistent"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -145,11 +146,11 @@ func TestRevokeOperatorAPIKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "eve-hash"); err != ErrNotFound {
+	if _, _, err := s.GetOperatorByAPIKeyHash(ctx, "eve-hash"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("revoked key still resolves: %v", err)
 	}
 
-	if err := s.RevokeOperatorAPIKey(ctx, "k-eve"); err != ErrNotFound {
+	if err := s.RevokeOperatorAPIKey(ctx, "k-eve"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound on second revoke", err)
 	}
 }
@@ -177,7 +178,7 @@ func TestSessionLifecycle(t *testing.T) {
 	if err := s.DeleteOperatorSession(ctx, "frank-tok"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.GetOperatorBySession(ctx, "frank-tok"); err != ErrNotFound {
+	if _, err := s.GetOperatorBySession(ctx, "frank-tok"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("session still valid after delete: %v", err)
 	}
 }
@@ -205,7 +206,7 @@ func TestDeleteExpiredOperatorSessions(t *testing.T) {
 	if _, err := s.GetOperatorBySession(ctx, "fresh"); err != nil {
 		t.Errorf("fresh session removed: %v", err)
 	}
-	if _, err := s.GetOperatorBySession(ctx, "old"); err != ErrNotFound {
+	if _, err := s.GetOperatorBySession(ctx, "old"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("old session still present: %v", err)
 	}
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -121,7 +121,7 @@ func TestCreateAndGetNetwork(t *testing.T) {
 func TestGetNetwork_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	_, err := s.GetNetwork(context.Background(), "nonexistent")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -193,7 +193,7 @@ func TestListHosts_FilterByNetwork(t *testing.T) {
 		h := &models.Host{
 			ID: fmt.Sprintf("host_%d", i), NetworkID: net.ID, Name: name,
 			NebulaIPs: []string{fmt.Sprintf("192.168.100.%d", 10+i)},
-			Groups: []string{}, Role: models.HostRoleHost, Status: models.HostStatusPending,
+			Groups:    []string{}, Role: models.HostRoleHost, Status: models.HostStatusPending,
 			CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		}
 		if err := s.CreateHost(ctx, h); err != nil {
@@ -218,9 +218,9 @@ func TestListHosts_WithLimit(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		h := &models.Host{
 			ID: fmt.Sprintf("host_%d", i), NetworkID: net.ID,
-			Name:     fmt.Sprintf("host-%d", i),
+			Name:      fmt.Sprintf("host-%d", i),
 			NebulaIPs: []string{fmt.Sprintf("192.168.100.%d", 10+i)},
-			Groups:   []string{}, Role: models.HostRoleHost, Status: models.HostStatusPending,
+			Groups:    []string{}, Role: models.HostRoleHost, Status: models.HostStatusPending,
 			CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		}
 		if err := s.CreateHost(ctx, h); err != nil {
@@ -326,7 +326,7 @@ func TestDeleteHost(t *testing.T) {
 	}
 
 	_, err := s.GetHost(ctx, "host_1")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -387,7 +387,7 @@ func TestConsumeToken_AlreadyUsed(t *testing.T) {
 	s.ConsumeToken(ctx, "one-time")
 
 	_, err := s.ConsumeToken(ctx, "one-time")
-	if err != ErrTokenUsed {
+	if !errors.Is(err, ErrTokenUsed) {
 		t.Fatalf("err = %v, want ErrTokenUsed", err)
 	}
 }
@@ -411,7 +411,7 @@ func TestConsumeToken_Expired(t *testing.T) {
 	s.CreateToken(ctx, tok)
 
 	_, err := s.ConsumeToken(ctx, "expired-token")
-	if err != ErrTokenExpired {
+	if !errors.Is(err, ErrTokenExpired) {
 		t.Fatalf("err = %v, want ErrTokenExpired", err)
 	}
 }
@@ -419,7 +419,7 @@ func TestConsumeToken_Expired(t *testing.T) {
 func TestConsumeToken_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	_, err := s.ConsumeToken(context.Background(), "nonexistent")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -528,7 +528,7 @@ func TestUpdateHost_NotFound(t *testing.T) {
 		CreatedAt: time.Now(), UpdatedAt: time.Now(),
 	}
 	err := s.UpdateHost(ctx, h)
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -536,7 +536,7 @@ func TestUpdateHost_NotFound(t *testing.T) {
 func TestDeleteHost_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	err := s.DeleteHost(context.Background(), "nonexistent")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -674,7 +674,7 @@ func TestGetNetworkConfig_NotFound(t *testing.T) {
 	createTestNetwork(t, s)
 
 	_, err := s.GetNetworkConfig(ctx, "net_test1", "nonexistent")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -725,7 +725,7 @@ func TestUpdateHostLastSeen(t *testing.T) {
 func TestUpdateHostLastSeen_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	err := s.UpdateHostLastSeen(context.Background(), "nonexistent", time.Now())
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -760,7 +760,7 @@ func TestUpdateHostCert(t *testing.T) {
 func TestUpdateHostCert_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	err := s.UpdateHostCert(context.Background(), "nonexistent", "fp", time.Now())
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -791,7 +791,7 @@ func TestUpdateHostStatus(t *testing.T) {
 func TestUpdateHostStatus_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	err := s.UpdateHostStatus(context.Background(), "nonexistent", models.HostStatusBlocked)
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -850,7 +850,7 @@ func TestSaveCertificateAndEnrollHost_HostNotFound(t *testing.T) {
 
 	// Verify certificate was NOT saved (rollback)
 	_, err = s.GetCurrentCertificate(ctx, "nonexistent")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected ErrNotFound for cert, got %v", err)
 	}
 }
@@ -911,7 +911,7 @@ func TestSaveCertificateAndUpdateHostCert_HostNotFound(t *testing.T) {
 
 	// Verify certificate was NOT saved (rollback)
 	_, err = s.GetCurrentCertificate(ctx, "nonexistent")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected ErrNotFound for cert, got %v", err)
 	}
 }
@@ -997,7 +997,7 @@ func TestBlockHostAndAddToBlocklist_NoCert(t *testing.T) {
 func TestBlockHostAndAddToBlocklist_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	_, err := s.BlockHostAndAddToBlocklist(context.Background(), "nonexistent", "reason")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -1071,7 +1071,7 @@ func TestUnblockHostAndRemoveFromBlocklist_NoCert(t *testing.T) {
 func TestUnblockHostAndRemoveFromBlocklist_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	_, err := s.UnblockHostAndRemoveFromBlocklist(context.Background(), "nonexistent")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -1103,7 +1103,7 @@ func TestDeleteHostAndBlockCert(t *testing.T) {
 
 	// Host deleted
 	_, err := s.GetHost(ctx, h.ID)
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 
@@ -1141,7 +1141,7 @@ func TestDeleteHostAndBlockCert_NoCert(t *testing.T) {
 
 	// Host deleted
 	_, err := s.GetHost(ctx, h.ID)
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 
@@ -1155,7 +1155,7 @@ func TestDeleteHostAndBlockCert_NoCert(t *testing.T) {
 func TestDeleteHostAndBlockCert_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	err := s.DeleteHostAndBlockCert(context.Background(), "nonexistent", "reason")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -1329,7 +1329,7 @@ func TestUpdateHostConfigVersion(t *testing.T) {
 func TestUpdateHostConfigVersion_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	err := s.UpdateHostConfigVersion(context.Background(), "nonexistent", 1)
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -1337,7 +1337,7 @@ func TestUpdateHostConfigVersion_NotFound(t *testing.T) {
 func TestGetHostConfigVersion_NotFound(t *testing.T) {
 	s := newTestStore(t)
 	_, err := s.GetHostConfigVersion(context.Background(), "nonexistent")
-	if err != ErrNotFound {
+	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
@@ -1529,7 +1529,7 @@ func TestCertAlerts_RecordAndGet(t *testing.T) {
 	}
 
 	// No alert yet → ErrNotFound.
-	if _, err := s.GetCertAlert(ctx, h.ID); err != ErrNotFound {
+	if _, err := s.GetCertAlert(ctx, h.ID); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound before any alert, got %v", err)
 	}
 
@@ -2157,20 +2157,20 @@ func TestCAs_ListApproachingExpiry(t *testing.T) {
 
 	// Create fresh CA (10-year lifetime, just started)
 	freshCA := &models.CA{
-		ID:              "ca_fresh",
-		Name:            "fresh",
-		OwnerOperatorID: op.ID,
-		CertPEM:         "cert",
-		Fingerprint:     "fp_fresh",
-		NotBefore:       now,
-		NotAfter:        now.AddDate(10, 0, 0),
-		Status:          models.CAStatusActive,
-		EncryptedKeyDEK: []byte("key"),
-		NonceDEK:        []byte("nonce"),
+		ID:                   "ca_fresh",
+		Name:                 "fresh",
+		OwnerOperatorID:      op.ID,
+		CertPEM:              "cert",
+		Fingerprint:          "fp_fresh",
+		NotBefore:            now,
+		NotAfter:             now.AddDate(10, 0, 0),
+		Status:               models.CAStatusActive,
+		EncryptedKeyDEK:      []byte("key"),
+		NonceDEK:             []byte("nonce"),
 		EncryptedKeyMaterial: []byte("material"),
-		NonceKey:        []byte("nonce_key"),
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		NonceKey:             []byte("nonce_key"),
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 	if err := s.CreateCA(ctx, freshCA); err != nil {
 		t.Fatal(err)
@@ -2178,20 +2178,20 @@ func TestCAs_ListApproachingExpiry(t *testing.T) {
 
 	// Create mid-life CA (10-year lifetime, 5 years have passed)
 	midLifeCA := &models.CA{
-		ID:              "ca_midlife",
-		Name:            "midlife",
-		OwnerOperatorID: op.ID,
-		CertPEM:         "cert",
-		Fingerprint:     "fp_midlife",
-		NotBefore:       now.AddDate(-5, 0, 0),
-		NotAfter:        now.AddDate(5, 0, 0),
-		Status:          models.CAStatusActive,
-		EncryptedKeyDEK: []byte("key"),
-		NonceDEK:        []byte("nonce"),
+		ID:                   "ca_midlife",
+		Name:                 "midlife",
+		OwnerOperatorID:      op.ID,
+		CertPEM:              "cert",
+		Fingerprint:          "fp_midlife",
+		NotBefore:            now.AddDate(-5, 0, 0),
+		NotAfter:             now.AddDate(5, 0, 0),
+		Status:               models.CAStatusActive,
+		EncryptedKeyDEK:      []byte("key"),
+		NonceDEK:             []byte("nonce"),
 		EncryptedKeyMaterial: []byte("material"),
-		NonceKey:        []byte("nonce_key"),
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		NonceKey:             []byte("nonce_key"),
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 	if err := s.CreateCA(ctx, midLifeCA); err != nil {
 		t.Fatal(err)
@@ -2199,20 +2199,20 @@ func TestCAs_ListApproachingExpiry(t *testing.T) {
 
 	// Create near-expiry CA (10-year lifetime, 8 years have passed, 2 years left = 20%)
 	nearExpiryCA := &models.CA{
-		ID:              "ca_expiring",
-		Name:            "expiring",
-		OwnerOperatorID: op.ID,
-		CertPEM:         "cert",
-		Fingerprint:     "fp_expiring",
-		NotBefore:       now.AddDate(-8, 0, 0),
-		NotAfter:        now.AddDate(2, 0, 0),
-		Status:          models.CAStatusActive,
-		EncryptedKeyDEK: []byte("key"),
-		NonceDEK:        []byte("nonce"),
+		ID:                   "ca_expiring",
+		Name:                 "expiring",
+		OwnerOperatorID:      op.ID,
+		CertPEM:              "cert",
+		Fingerprint:          "fp_expiring",
+		NotBefore:            now.AddDate(-8, 0, 0),
+		NotAfter:             now.AddDate(2, 0, 0),
+		Status:               models.CAStatusActive,
+		EncryptedKeyDEK:      []byte("key"),
+		NonceDEK:             []byte("nonce"),
 		EncryptedKeyMaterial: []byte("material"),
-		NonceKey:        []byte("nonce_key"),
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		NonceKey:             []byte("nonce_key"),
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 	if err := s.CreateCA(ctx, nearExpiryCA); err != nil {
 		t.Fatal(err)
@@ -2220,20 +2220,20 @@ func TestCAs_ListApproachingExpiry(t *testing.T) {
 
 	// Create retired CA (should not be included in results)
 	retiredCA := &models.CA{
-		ID:              "ca_retired",
-		Name:            "retired",
-		OwnerOperatorID: op.ID,
-		CertPEM:         "cert",
-		Fingerprint:     "fp_retired",
-		NotBefore:       now.AddDate(-8, 0, 0),
-		NotAfter:        now.AddDate(2, 0, 0),
-		Status:          models.CAStatusRetired,
-		EncryptedKeyDEK: []byte("key"),
-		NonceDEK:        []byte("nonce"),
+		ID:                   "ca_retired",
+		Name:                 "retired",
+		OwnerOperatorID:      op.ID,
+		CertPEM:              "cert",
+		Fingerprint:          "fp_retired",
+		NotBefore:            now.AddDate(-8, 0, 0),
+		NotAfter:             now.AddDate(2, 0, 0),
+		Status:               models.CAStatusRetired,
+		EncryptedKeyDEK:      []byte("key"),
+		NonceDEK:             []byte("nonce"),
 		EncryptedKeyMaterial: []byte("material"),
-		NonceKey:        []byte("nonce_key"),
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		NonceKey:             []byte("nonce_key"),
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 	if err := s.CreateCA(ctx, retiredCA); err != nil {
 		t.Fatal(err)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -37,7 +37,7 @@ func Print(w io.Writer, name, version, commit, date string) {
 // Resolve returns the version triple, falling back to VCS info from the
 // embedded build info when the input fields are placeholders or empty.
 // Exported for testing.
-func Resolve(version, commit, date string) (string, string, string) {
+func Resolve(version, commit, date string) (resolvedVersion, resolvedCommit, resolvedDate string) {
 	if isPlaceholder(version) || isPlaceholder(commit) || isPlaceholder(date) {
 		if bi, ok := debug.ReadBuildInfo(); ok {
 			if isPlaceholder(version) && bi.Main.Version != "" && bi.Main.Version != "(devel)" {

--- a/internal/web/auto_provision_test.go
+++ b/internal/web/auto_provision_test.go
@@ -357,7 +357,7 @@ func TestHandleCACreate_StillWorks(t *testing.T) {
 	cookie := mintSession(t, s, "frank", "user")
 
 	form := "name=frank-ca&duration=8760h"
-	req := httptest.NewRequest("POST", "/ui/cas", strings.NewReader(form))
+	req := httptest.NewRequest(http.MethodPost, "/ui/cas", strings.NewReader(form))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()

--- a/internal/web/cas.go
+++ b/internal/web/cas.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
@@ -240,10 +241,10 @@ func (w *Web) handleCADetail(rw http.ResponseWriter, r *http.Request) {
 	}
 	isExpiringSoon := pki.ShouldRenew(c.NotBefore, c.NotAfter)
 	w.renderForRequest(rw, r, "ca_detail.html", map[string]any{
-		"Active":            "cas",
-		"CA":                c,
-		"IsExpiringSoon":    isExpiringSoon,
-		"Error":             r.URL.Query().Get("error"),
+		"Active":         "cas",
+		"CA":             c,
+		"IsExpiringSoon": isExpiringSoon,
+		"Error":          r.URL.Query().Get("error"),
 	})
 }
 

--- a/internal/web/cas_test.go
+++ b/internal/web/cas_test.go
@@ -20,13 +20,13 @@ func TestCAs_NonOwner_Forbidden(t *testing.T) {
 	// Bob mints a CA via the store directly so the test stays focused on
 	// the ownership check, not on the master-key plumbing.
 	ca := &models.CA{
-		ID:              "ca-bob",
-		Name:            "bob-ca",
-		OwnerOperatorID: "op-bob",
-		CertPEM:         "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
-		Fingerprint:     "fp-bob",
-		NotBefore:       time.Now(),
-		NotAfter:        time.Now().Add(time.Hour),
+		ID:                   "ca-bob",
+		Name:                 "bob-ca",
+		OwnerOperatorID:      "op-bob",
+		CertPEM:              "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint:          "fp-bob",
+		NotBefore:            time.Now(),
+		NotAfter:             time.Now().Add(time.Hour),
 		Status:               models.CAStatusActive,
 		EncryptedKeyDEK:      []byte("dek"),
 		NonceDEK:             []byte("ndek"),
@@ -66,7 +66,7 @@ func TestCAs_List_FiltersByOwnership(t *testing.T) {
 
 	for _, c := range []models.CA{
 		{ID: "ca1", Name: "alice-ca", OwnerOperatorID: "op-alice", Fingerprint: "fp-alice", NotAfter: time.Now().Add(time.Hour), Status: models.CAStatusActive, EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"), EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"), CreatedAt: time.Now(), UpdatedAt: time.Now()},
-		{ID: "ca2", Name: "bob-ca",   OwnerOperatorID: "op-bob",   Fingerprint: "fp-bob",   NotAfter: time.Now().Add(time.Hour), Status: models.CAStatusActive, EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"), EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: "ca2", Name: "bob-ca", OwnerOperatorID: "op-bob", Fingerprint: "fp-bob", NotAfter: time.Now().Add(time.Hour), Status: models.CAStatusActive, EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"), EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"), CreatedAt: time.Now(), UpdatedAt: time.Now()},
 	} {
 		if err := s.CreateCA(context.Background(), &c); err != nil {
 			t.Fatal(err)
@@ -154,11 +154,11 @@ func TestCAs_List_RendersExpiryWarning(t *testing.T) {
 	now := time.Now()
 	ca := &models.CA{
 		ID: "ca-expiring", Name: "ca-expiring", OwnerOperatorID: "op-bob",
-		CertPEM: "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
-		Fingerprint: "fp-expiring",
-		NotBefore: now.AddDate(-9, 0, 0),
-		NotAfter: now.AddDate(1, 0, 0),
-		Status: models.CAStatusActive,
+		CertPEM:         "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint:     "fp-expiring",
+		NotBefore:       now.AddDate(-9, 0, 0),
+		NotAfter:        now.AddDate(1, 0, 0),
+		Status:          models.CAStatusActive,
 		EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"),
 		EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"),
 		CreatedAt: now, UpdatedAt: now,
@@ -190,11 +190,11 @@ func TestCAs_List_NoWarningForFreshCA(t *testing.T) {
 	now := time.Now()
 	ca := &models.CA{
 		ID: "ca-fresh", Name: "ca-fresh", OwnerOperatorID: "op-bob",
-		CertPEM: "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
-		Fingerprint: "fp-fresh",
-		NotBefore: now,
-		NotAfter: now.AddDate(10, 0, 0),
-		Status: models.CAStatusActive,
+		CertPEM:         "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint:     "fp-fresh",
+		NotBefore:       now,
+		NotAfter:        now.AddDate(10, 0, 0),
+		Status:          models.CAStatusActive,
 		EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"),
 		EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"),
 		CreatedAt: now, UpdatedAt: now,
@@ -225,11 +225,11 @@ func TestCAs_Rotate_CreatesSuccessor(t *testing.T) {
 	now := time.Now()
 	oldCA := &models.CA{
 		ID: "ca-old", Name: "ca-old", OwnerOperatorID: "op-bob",
-		CertPEM: "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
-		Fingerprint: "fp-old",
-		NotBefore: now.AddDate(-5, 0, 0),
-		NotAfter: now.AddDate(5, 0, 0),
-		Status: models.CAStatusActive,
+		CertPEM:         "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint:     "fp-old",
+		NotBefore:       now.AddDate(-5, 0, 0),
+		NotAfter:        now.AddDate(5, 0, 0),
+		Status:          models.CAStatusActive,
 		EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"),
 		EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"),
 		CreatedAt: now, UpdatedAt: now,
@@ -291,11 +291,11 @@ func TestCAs_Rotate_NonOwner_Forbidden(t *testing.T) {
 	now := time.Now()
 	ca := &models.CA{
 		ID: "ca-bob", Name: "ca-bob", OwnerOperatorID: "op-bob",
-		CertPEM: "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
-		Fingerprint: "fp-bob",
-		NotBefore: now.AddDate(-5, 0, 0),
-		NotAfter: now.AddDate(5, 0, 0),
-		Status: models.CAStatusActive,
+		CertPEM:         "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint:     "fp-bob",
+		NotBefore:       now.AddDate(-5, 0, 0),
+		NotAfter:        now.AddDate(5, 0, 0),
+		Status:          models.CAStatusActive,
 		EncryptedKeyDEK: []byte("d"), NonceDEK: []byte("nd"),
 		EncryptedKeyMaterial: []byte("k"), NonceKey: []byte("nk"),
 		CreatedAt: now, UpdatedAt: now,

--- a/internal/web/enforce_2fa_test.go
+++ b/internal/web/enforce_2fa_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"golang.org/x/crypto/bcrypt"
 )
 
 func newEnforceWeb(t *testing.T) (*Web, store.Store) {

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -25,8 +25,8 @@ type HostSeenEvent struct {
 // and stale subscribers get unblocked by dropping the event, never the
 // publisher.
 type EventBus struct {
-	mu      sync.Mutex
-	subs    map[chan HostSeenEvent]struct{}
+	mu   sync.Mutex
+	subs map[chan HostSeenEvent]struct{}
 }
 
 // NewEventBus creates a fresh bus.

--- a/internal/web/form_inline_errors_test.go
+++ b/internal/web/form_inline_errors_test.go
@@ -46,7 +46,7 @@ func TestHostCreate_InlineErrorPreservesForm(t *testing.T) {
 		"groups":          {"web, prod"},
 		"adv_listen_host": {"0.0.0.0"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -101,7 +101,7 @@ func TestHostCreate_InlineErrorPreservesRole(t *testing.T) {
 		"nebula_ips": {"10.0.0.5"},
 		"role":       {"lighthouse"}, // requires public_ip + listen_port → fails
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -131,7 +131,7 @@ func TestNetworkCreate_InlineErrorPreservesForm(t *testing.T) {
 		"name":  {"prod-net"},
 		"cidrs": {"not-a-cidr"},
 	}
-	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -173,7 +173,7 @@ func TestNetworkCreate_InlineErrorRequiredFields(t *testing.T) {
 		"name": {""},
 		// cidrs is empty array, which is required error
 	}
-	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)

--- a/internal/web/form_state.go
+++ b/internal/web/form_state.go
@@ -34,40 +34,40 @@ func trimEmpty(src []string) []string {
 // NebulaIPs is a slice to support multiple overlay addresses per host (issue #108).
 // NebulaIPErrors maps row index to per-row error messages for inline rendering.
 type hostFormState struct {
-	NetworkID        string
-	Name             string
-	NebulaIPs        []string
-	NebulaIPErrors   map[int]string
-	Role             string
-	Groups           string
-	PublicIP         string
-	ListenPort       string
-	AdvListenHost    string
-	AdvMTU           string
-	AdvTunDevice     string
-	AdvPunchy        string
-	AdvUnsafeRoutes  string
-	Kind             string
-	Variant          string
+	NetworkID       string
+	Name            string
+	NebulaIPs       []string
+	NebulaIPErrors  map[int]string
+	Role            string
+	Groups          string
+	PublicIP        string
+	ListenPort      string
+	AdvListenHost   string
+	AdvMTU          string
+	AdvTunDevice    string
+	AdvPunchy       string
+	AdvUnsafeRoutes string
+	Kind            string
+	Variant         string
 }
 
 func newHostFormState(r *http.Request) hostFormState {
 	return hostFormState{
-		NetworkID:        r.FormValue("network_id"),
-		Name:             r.FormValue("name"),
-		NebulaIPs:        trimEmpty(r.Form["nebula_ips"]),
-		NebulaIPErrors:   make(map[int]string),
-		Role:             r.FormValue("role"),
-		Groups:           r.FormValue("groups"),
-		PublicIP:         r.FormValue("public_ip"),
-		ListenPort:       r.FormValue("listen_port"),
-		AdvListenHost:    r.FormValue("adv_listen_host"),
-		AdvMTU:           r.FormValue("adv_mtu"),
-		AdvTunDevice:     r.FormValue("adv_tun_device"),
-		AdvPunchy:        r.FormValue("adv_punchy"),
-		AdvUnsafeRoutes:  r.FormValue("adv_unsafe_routes"),
-		Kind:             r.FormValue("kind"),
-		Variant:          r.FormValue("variant"),
+		NetworkID:       r.FormValue("network_id"),
+		Name:            r.FormValue("name"),
+		NebulaIPs:       trimEmpty(r.Form["nebula_ips"]),
+		NebulaIPErrors:  make(map[int]string),
+		Role:            r.FormValue("role"),
+		Groups:          r.FormValue("groups"),
+		PublicIP:        r.FormValue("public_ip"),
+		ListenPort:      r.FormValue("listen_port"),
+		AdvListenHost:   r.FormValue("adv_listen_host"),
+		AdvMTU:          r.FormValue("adv_mtu"),
+		AdvTunDevice:    r.FormValue("adv_tun_device"),
+		AdvPunchy:       r.FormValue("adv_punchy"),
+		AdvUnsafeRoutes: r.FormValue("adv_unsafe_routes"),
+		Kind:            r.FormValue("kind"),
+		Variant:         r.FormValue("variant"),
 	}
 }
 
@@ -78,10 +78,10 @@ func newHostFormState(r *http.Request) hostFormState {
 // CIDRs is a slice to support multiple CIDR blocks per network (issue #108).
 // CIDRErrors maps row index to per-row error messages for inline rendering.
 type networkFormState struct {
-	Name      string
-	CIDRs     []string
+	Name       string
+	CIDRs      []string
 	CIDRErrors map[int]string
-	CAID      string
+	CAID       string
 }
 
 func newNetworkFormState(r *http.Request) networkFormState {
@@ -279,11 +279,11 @@ func hostFormStateFromHost(h *models.Host) hostFormState {
 // payload is the cause. Mirrors renderHostNewError for consistency.
 func (w *Web) renderHostEditError(rw http.ResponseWriter, r *http.Request, host *models.Host, network *models.Network, form hostFormState, errMsg string) {
 	w.renderForRequestWithStatus(rw, r, http.StatusBadRequest, "host_edit.html", map[string]any{
-		"Active":   "hosts",
-		"Host":     host,
-		"Network":  network,
-		"Form":     form,
-		"Error":    errMsg,
+		"Active":  "hosts",
+		"Host":    host,
+		"Network": network,
+		"Form":    form,
+		"Error":   errMsg,
 	})
 }
 
@@ -318,8 +318,8 @@ func newOperatorFormState(r *http.Request) operatorFormState {
 // the active password policy.
 func (w *Web) renderOperatorNewError(rw http.ResponseWriter, r *http.Request, form operatorFormState, hint string) {
 	w.renderForRequestWithStatus(rw, r, http.StatusBadRequest, "operator_new.html", map[string]any{
-		"Active":        "operators",
-		"Form":          form,
-		"PasswordHint":  hint,
+		"Active":       "operators",
+		"Form":         form,
+		"PasswordHint": hint,
 	})
 }

--- a/internal/web/form_state_test.go
+++ b/internal/web/form_state_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -10,11 +11,11 @@ import (
 // from POST form cidrs[] fields into Form.CIDRs slice.
 func TestNewNetworkFormState_ParsesArrayCIDRs(t *testing.T) {
 	form := url.Values{
-		"name":   {"dual-stack"},
-		"cidrs":  {"10.42.0.0/24", "fd00:42::/64"},
-		"ca_id":  {"ca-1"},
+		"name":  {"dual-stack"},
+		"cidrs": {"10.42.0.0/24", "fd00:42::/64"},
+		"ca_id": {"ca-1"},
 	}
-	req := httptest.NewRequest("POST", "/ui/networks", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", nil)
 	req.PostForm = form
 
 	state := newNetworkFormState(req)
@@ -42,7 +43,7 @@ func TestNewNetworkFormState_TrimsEmpty(t *testing.T) {
 		"name":  {"net"},
 		"cidrs": {"10.0.0.0/24", "", "fd00::/64", ""},
 	}
-	req := httptest.NewRequest("POST", "/ui/networks", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", nil)
 	req.PostForm = form
 
 	state := newNetworkFormState(req)
@@ -67,7 +68,7 @@ func TestNewHostFormState_ParsesArrayNebulaIPs(t *testing.T) {
 		"nebula_ips": {"10.42.0.10", "fd00::10"},
 		"role":       {"host"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", nil)
 	req.PostForm = form
 
 	state := newHostFormState(req)
@@ -99,7 +100,7 @@ func TestNewHostFormState_TrimsEmptyNebulaIPs(t *testing.T) {
 		"name":       {"host-1"},
 		"nebula_ips": {"10.42.0.10", "", "fd00::10", ""},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", nil)
 	req.PostForm = form
 
 	state := newHostFormState(req)
@@ -124,7 +125,7 @@ func TestNewOperatorFormState_ParsesFields(t *testing.T) {
 		"display_name": {"Alice Smith"},
 		"role":         {"admin"},
 	}
-	req := httptest.NewRequest("POST", "/ui/operators", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators", nil)
 	req.PostForm = form
 
 	state := newOperatorFormState(req)
@@ -150,7 +151,7 @@ func TestNewOperatorFormState_ParsesFields(t *testing.T) {
 		"username":     {"bob"},
 		"display_name": {"Bob"},
 	}
-	req2 := httptest.NewRequest("POST", "/ui/operators", nil)
+	req2 := httptest.NewRequest(http.MethodPost, "/ui/operators", nil)
 	req2.PostForm = form2
 
 	state2 := newOperatorFormState(req2)
@@ -161,7 +162,7 @@ func TestNewOperatorFormState_ParsesFields(t *testing.T) {
 
 	// Case 3: Empty form yields empty struct with initialized Errors map
 	form3 := url.Values{}
-	req3 := httptest.NewRequest("POST", "/ui/operators", nil)
+	req3 := httptest.NewRequest(http.MethodPost, "/ui/operators", nil)
 	req3.PostForm = form3
 
 	state3 := newOperatorFormState(req3)
@@ -187,7 +188,7 @@ func TestNewOperatorFormState_TrimSpaces(t *testing.T) {
 		"display_name": {"\n Bob \t"},
 		"role":         {"admin"},
 	}
-	req := httptest.NewRequest("POST", "/ui/operators", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators", nil)
 	req.PostForm = form
 
 	state := newOperatorFormState(req)

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -13,11 +13,12 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/juev/nebula-mesh/internal/mobilebundle"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
 	"github.com/juev/nebula-mesh/internal/store"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // isEnrolmentPath reports whether a path is one of the routes a
@@ -71,8 +72,8 @@ func (w *Web) requireAuth(next http.Handler) http.Handler {
 
 func (w *Web) handleLoginPage(rw http.ResponseWriter, r *http.Request) {
 	w.renderForRequest(rw, r, "login.html", map[string]any{
-		"Error":                "",
-		"OIDCEnabled":          w.oidc.Enabled(),
+		"Error":                 "",
+		"OIDCEnabled":           w.oidc.Enabled(),
 		"AllowSelfRegistration": w.allowSelfRegistrationEffective(r.Context()),
 	})
 }
@@ -312,9 +313,9 @@ func (w *Web) handleTwoFARequired(rw http.ResponseWriter, r *http.Request) {
 }
 
 type totpSetup struct {
-	OTPURL       string
-	SecretGroup  string
-	SecretRaw    string
+	OTPURL      string
+	SecretGroup string
+	SecretRaw   string
 }
 
 func (w *Web) handleTwoFASetup(rw http.ResponseWriter, r *http.Request) {
@@ -1231,12 +1232,11 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 
 	caID := form.CAID
 	if caID == "" && op.Role != "admin" {
-		if len(cas) == 1 {
-			caID = cas[0].ID
-		} else {
+		if len(cas) != 1 {
 			w.renderNetworksError(rw, r, form, cas, "pick a CA to sign certificates for this network")
 			return
 		}
+		caID = cas[0].ID
 	}
 	if caID != "" && !containsCAID(cas, caID) {
 		w.renderNetworksError(rw, r, form, cas, "selected CA is not accessible to you")
@@ -1317,12 +1317,15 @@ func (w *Web) renderMobileBundle(rw http.ResponseWriter, r *http.Request, host *
 	qrSVG, qrErr := renderQRSVG(string(bundle))
 	downloadHref := "data:application/yaml;base64," + base64.StdEncoding.EncodeToString(bundle)
 	rw.Header().Set("Cache-Control", "no-store")
+	// QRSVG is server-rendered from the QR encoder library; DownloadHref is a
+	// server-built data: URL of base64-encoded server bundle. Neither carries
+	// user-controlled input.
 	w.renderForRequest(rw, r, "host_mobile_bundle.html", map[string]any{
 		"Host":         host,
 		"YAML":         string(bundle),
-		"QRSVG":        template.HTML(qrSVG),
+		"QRSVG":        template.HTML(qrSVG), //nolint:gosec // G203: server-generated SVG
 		"QRError":      qrErr,
-		"DownloadHref": template.URL(downloadHref),
+		"DownloadHref": template.URL(downloadHref), //nolint:gosec // G203: server-built data URL
 		"Active":       "hosts",
 	})
 }

--- a/internal/web/host_detail_test.go
+++ b/internal/web/host_detail_test.go
@@ -30,7 +30,7 @@ func TestHostDetail_HasEditButton(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
 		CreatedAt: time.Now(),
@@ -40,7 +40,7 @@ func TestHostDetail_HasEditButton(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-1", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -77,7 +77,7 @@ func TestHostDetail_RendersAdvanced(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
 		Advanced: &models.HostAdvanced{
@@ -92,7 +92,7 @@ func TestHostDetail_RendersAdvanced(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-1", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -154,7 +154,7 @@ func TestHostDetail_AdvancedAbsent_NoSection(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
 		Advanced:  nil,
@@ -165,7 +165,7 @@ func TestHostDetail_AdvancedAbsent_NoSection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-1", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -202,7 +202,7 @@ func TestHostDetail_PunchyRendering_True(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
 		Advanced: &models.HostAdvanced{
@@ -215,7 +215,7 @@ func TestHostDetail_PunchyRendering_True(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-1", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -257,7 +257,7 @@ func TestHostDetail_PunchyRendering_False(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
 		Advanced: &models.HostAdvanced{
@@ -270,7 +270,7 @@ func TestHostDetail_PunchyRendering_False(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-1", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -311,7 +311,7 @@ func TestHostDetail_UnsafeRoutesRendering(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
 		Advanced: &models.HostAdvanced{
@@ -327,7 +327,7 @@ func TestHostDetail_UnsafeRoutesRendering(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-1", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -371,7 +371,7 @@ func TestHandleHostDetail_MobileSection(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "iphone-test",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusPending,
 		Kind:      models.HostKindMobile,
@@ -383,7 +383,7 @@ func TestHandleHostDetail_MobileSection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-1", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -431,7 +431,7 @@ func TestHandleHostDetail_MobileSection_Android(t *testing.T) {
 		ID:        "h-2",
 		NetworkID: "n-1",
 		Name:      "android-test",
-		NebulaIPs:  []string{"192.168.100.20"},
+		NebulaIPs: []string{"192.168.100.20"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusPending,
 		Kind:      models.HostKindMobile,
@@ -443,7 +443,7 @@ func TestHandleHostDetail_MobileSection_Android(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-2", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-2", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -481,7 +481,7 @@ func TestHandleHostDetail_AgentNoMobileSection(t *testing.T) {
 		ID:        "h-3",
 		NetworkID: "n-1",
 		Name:      "agent-test",
-		NebulaIPs:  []string{"192.168.100.30"},
+		NebulaIPs: []string{"192.168.100.30"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
 		Kind:      models.HostKindAgent,
@@ -492,7 +492,7 @@ func TestHandleHostDetail_AgentNoMobileSection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-3", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-3", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -533,7 +533,7 @@ func TestHandleHostDetail_MobileEnrolled_ShowsRegenerate(t *testing.T) {
 		ID:        "h-4",
 		NetworkID: "n-1",
 		Name:      "iphone-enrolled",
-		NebulaIPs:  []string{"192.168.100.40"},
+		NebulaIPs: []string{"192.168.100.40"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
 		Kind:      models.HostKindMobile,
@@ -545,7 +545,7 @@ func TestHandleHostDetail_MobileEnrolled_ShowsRegenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-4", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-4", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -585,7 +585,7 @@ func TestHandleHostDetail_AgentToken_DisplaysWhenPassing(t *testing.T) {
 		ID:        "h-5",
 		NetworkID: "n-1",
 		Name:      "agent-with-token",
-		NebulaIPs:  []string{"192.168.100.50"},
+		NebulaIPs: []string{"192.168.100.50"},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusPending,
 		Kind:      models.HostKindAgent,
@@ -603,7 +603,7 @@ func TestHandleHostDetail_AgentToken_DisplaysWhenPassing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-5", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-5", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}

--- a/internal/web/host_edit_test.go
+++ b/internal/web/host_edit_test.go
@@ -17,7 +17,7 @@ func TestHostEdit_GET_NotFound(t *testing.T) {
 	w, _ := newTestWeb(t)
 	cookies := loginSession(t, w)
 
-	req := httptest.NewRequest("GET", "/ui/hosts/unknown-id/edit", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/unknown-id/edit", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -65,7 +65,7 @@ func TestHostEdit_GET_AsAdmin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/h-1/edit", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-1/edit", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -117,13 +117,13 @@ func TestHostUpdate_POST_HappyPath_Advanced(t *testing.T) {
 	}
 
 	host := &models.Host{
-		ID:         "h-1",
-		NetworkID:  "n-1",
-		Name:       "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
-		Groups:     []string{},
-		Role:       models.HostRoleHost,
-		Status:     models.HostStatusEnrolled,
+		ID:        "h-1",
+		NetworkID: "n-1",
+		Name:      "web-1",
+		NebulaIPs: []string{"192.168.100.10"},
+		Groups:    []string{},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
 		Advanced: &models.HostAdvanced{
 			MTU: 1300,
 		},
@@ -142,7 +142,7 @@ func TestHostUpdate_POST_HappyPath_Advanced(t *testing.T) {
 		"role":       {"host"},
 		"adv_mtu":    {"1280"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -208,7 +208,7 @@ func TestHostUpdate_POST_HappyPath_Rename(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Groups:    []string{},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
@@ -223,10 +223,10 @@ func TestHostUpdate_POST_HappyPath_Rename(t *testing.T) {
 	form := url.Values{
 		"network_id": {"n-1"},
 		"name":       {"web-2"},
-		"nebula_ips":  {"192.168.100.10"},
+		"nebula_ips": {"192.168.100.10"},
 		"role":       {"host"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -248,7 +248,7 @@ func TestHostUpdate_POST_HappyPath_Rename(t *testing.T) {
 	}
 
 	// Verify PendingRekey was set (cert change on name rename)
-	if updated.PendingRekey != true {
+	if !updated.PendingRekey {
 		t.Error("PendingRekey should be true after name change")
 	}
 }
@@ -272,7 +272,7 @@ func TestHostUpdate_POST_InvalidMTU(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Groups:    []string{},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
@@ -287,11 +287,11 @@ func TestHostUpdate_POST_InvalidMTU(t *testing.T) {
 	form := url.Values{
 		"network_id": {"n-1"},
 		"name":       {"web-1"},
-		"nebula_ips":  {"192.168.100.10"},
+		"nebula_ips": {"192.168.100.10"},
 		"role":       {"host"},
 		"adv_mtu":    {"99999"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -327,7 +327,7 @@ func TestHostUpdate_POST_RoleFlipToLighthouse_BumpsNetwork(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Groups:    []string{},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
@@ -345,14 +345,14 @@ func TestHostUpdate_POST_RoleFlipToLighthouse_BumpsNetwork(t *testing.T) {
 
 	// POST with role changed to lighthouse
 	form := url.Values{
-		"network_id": {"n-1"},
-		"name":       {"web-1"},
+		"network_id":  {"n-1"},
+		"name":        {"web-1"},
 		"nebula_ips":  {"192.168.100.10"},
-		"role":       {"lighthouse"},
-		"public_ip":  {"203.0.113.1"},
+		"role":        {"lighthouse"},
+		"public_ip":   {"203.0.113.1"},
 		"listen_port": {"4242"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -393,7 +393,7 @@ func TestHostUpdate_POST_NoChanges_NoAudit(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Groups:    []string{},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
@@ -408,10 +408,10 @@ func TestHostUpdate_POST_NoChanges_NoAudit(t *testing.T) {
 	form := url.Values{
 		"network_id": {"n-1"},
 		"name":       {"web-1"},
-		"nebula_ips":  {"192.168.100.10"},
+		"nebula_ips": {"192.168.100.10"},
 		"role":       {"host"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -458,7 +458,7 @@ func TestHostUpdate_POST_DuplicateIP(t *testing.T) {
 		ID:        "h-1",
 		NetworkID: "n-1",
 		Name:      "web-1",
-		NebulaIPs:  []string{"192.168.100.10"},
+		NebulaIPs: []string{"192.168.100.10"},
 		Groups:    []string{},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
@@ -473,7 +473,7 @@ func TestHostUpdate_POST_DuplicateIP(t *testing.T) {
 		ID:        "h-2",
 		NetworkID: "n-1",
 		Name:      "web-2",
-		NebulaIPs:  []string{"192.168.100.11"},
+		NebulaIPs: []string{"192.168.100.11"},
 		Groups:    []string{},
 		Role:      models.HostRoleHost,
 		Status:    models.HostStatusEnrolled,
@@ -488,10 +488,10 @@ func TestHostUpdate_POST_DuplicateIP(t *testing.T) {
 	form := url.Values{
 		"network_id": {"n-1"},
 		"name":       {"web-2"},
-		"nebula_ips":  {"192.168.100.10"},
+		"nebula_ips": {"192.168.100.10"},
 		"role":       {"host"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts/h-2/edit", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-2/edit", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)

--- a/internal/web/host_new_prefix_hint_test.go
+++ b/internal/web/host_new_prefix_hint_test.go
@@ -30,7 +30,7 @@ func TestHostNewForm_NetworkOptionsHaveDataCIDR(t *testing.T) {
 		}
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/new", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/new", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}

--- a/internal/web/host_new_segmented_test.go
+++ b/internal/web/host_new_segmented_test.go
@@ -32,7 +32,7 @@ func TestHostNewForm_SegmentedWidgetHooks(t *testing.T) {
 		}
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/new", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/new", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -81,10 +81,10 @@ func TestHostCreate_FriendlyNebulaIPInline(t *testing.T) {
 	form := url.Values{
 		"network_id": {"n-friendly"},
 		"name":       {"bad-ip"},
-		"nebula_ips":  {"10.42.0.22.333"},
+		"nebula_ips": {"10.42.0.22.333"},
 		"role":       {"host"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -117,12 +117,12 @@ func TestHostCreate_FriendlyPublicIPInline(t *testing.T) {
 	form := url.Values{
 		"network_id":  {"n-pub"},
 		"name":        {"lh"},
-		"nebula_ips":   {"10.0.0.5"},
+		"nebula_ips":  {"10.0.0.5"},
 		"role":        {"lighthouse"},
 		"public_ip":   {"203.0.113.999"},
 		"listen_port": {"4242"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -156,11 +156,11 @@ func TestHostCreate_FriendlyAdvancedListenHostInline(t *testing.T) {
 	form := url.Values{
 		"network_id":      {"n-adv"},
 		"name":            {"adv"},
-		"nebula_ips":       {"10.0.0.5"},
+		"nebula_ips":      {"10.0.0.5"},
 		"role":            {"host"},
 		"adv_listen_host": {"not-an-ip"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -187,17 +187,17 @@ func TestHandleHostNew_FormHasKindFields(t *testing.T) {
 
 	ctx := context.Background()
 	network := &models.Network{
-		ID:    "n-form-test",
-		Name:  "form-test",
-		CIDRs: []string{"10.0.0.0/24"},
-		CAID:  "ca-test",
+		ID:        "n-form-test",
+		Name:      "form-test",
+		CIDRs:     []string{"10.0.0.0/24"},
+		CAID:      "ca-test",
 		CreatedAt: time.Now(),
 	}
 	if err := s.CreateNetwork(ctx, network); err != nil {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/hosts/new", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/new", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -239,10 +239,10 @@ func TestHandleHostNew_PreservesKindOnError(t *testing.T) {
 
 	ctx := context.Background()
 	network := &models.Network{
-		ID:    "n-test",
-		Name:  "test-net",
-		CIDRs: []string{"10.0.0.0/24"},
-		CAID:  "ca-test",
+		ID:        "n-test",
+		Name:      "test-net",
+		CIDRs:     []string{"10.0.0.0/24"},
+		CAID:      "ca-test",
 		CreatedAt: time.Now(),
 	}
 	if err := s.CreateNetwork(ctx, network); err != nil {
@@ -252,13 +252,13 @@ func TestHandleHostNew_PreservesKindOnError(t *testing.T) {
 	form := url.Values{
 		"network_id": {"n-test"},
 		"name":       {"invalid-host"},
-		"nebula_ips":  {"10.0.0.5"},
+		"nebula_ips": {"10.0.0.5"},
 		"kind":       {"mobile"},
 		"variant":    {"ios"},
 		"role":       {"lighthouse"},
 	}
 
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)

--- a/internal/web/host_role_reachability_test.go
+++ b/internal/web/host_role_reachability_test.go
@@ -78,12 +78,12 @@ func TestCreateHostViaUI_RoleReachability(t *testing.T) {
 			form := url.Values{
 				"network_id":  {"net-rr"},
 				"name":        {"h-" + strings.ReplaceAll(tc.name, " ", "-")},
-				"nebula_ips":   {tc.nebulaIP},
+				"nebula_ips":  {tc.nebulaIP},
 				"role":        {tc.role},
 				"public_ip":   {tc.publicIP},
 				"listen_port": {tc.listenPort},
 			}
-			req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+			req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			for _, c := range cookies {
 				req.AddCookie(c)

--- a/internal/web/mobile_bundle_test.go
+++ b/internal/web/mobile_bundle_test.go
@@ -66,7 +66,7 @@ func TestHandleGenerateMobileBundle_Success(t *testing.T) {
 		ID:        "h-mobile",
 		Name:      "phone-test",
 		NetworkID: "n-bundle",
-		NebulaIPs:  []string{"10.0.0.5"},
+		NebulaIPs: []string{"10.0.0.5"},
 		Kind:      models.HostKindMobile,
 		Variant:   models.HostVariantIOS,
 		Role:      models.HostRoleHost,
@@ -77,7 +77,7 @@ func TestHandleGenerateMobileBundle_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("POST", "/ui/hosts/h-mobile/mobile-bundle/generate", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-mobile/mobile-bundle/generate", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -149,7 +149,7 @@ func TestHandleGenerateMobileBundle_AgentHostRejected(t *testing.T) {
 		ID:        "h-agent",
 		Name:      "agent-host",
 		NetworkID: "n-agent",
-		NebulaIPs:  []string{"10.0.0.5"},
+		NebulaIPs: []string{"10.0.0.5"},
 		Kind:      models.HostKindAgent,
 		Variant:   "",
 		Role:      models.HostRoleHost,
@@ -160,7 +160,7 @@ func TestHandleGenerateMobileBundle_AgentHostRejected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("POST", "/ui/hosts/h-agent/mobile-bundle/generate", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-agent/mobile-bundle/generate", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -183,7 +183,7 @@ func TestHandleGenerateMobileBundle_NotFound(t *testing.T) {
 	w, _ := newTestWeb(t)
 	cookies := loginSession(t, w)
 
-	req := httptest.NewRequest("POST", "/ui/hosts/h-nonexistent/mobile-bundle/generate", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-nonexistent/mobile-bundle/generate", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -216,7 +216,7 @@ func TestHandleGenerateMobileBundle_RequiresAuth(t *testing.T) {
 		ID:        "h-mobile-2",
 		Name:      "phone-noauth",
 		NetworkID: "n-auth",
-		NebulaIPs:  []string{"10.0.0.6"},
+		NebulaIPs: []string{"10.0.0.6"},
 		Kind:      models.HostKindMobile,
 		Variant:   models.HostVariantAndroid,
 		Role:      models.HostRoleHost,
@@ -227,7 +227,7 @@ func TestHandleGenerateMobileBundle_RequiresAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("POST", "/ui/hosts/h-mobile-2/mobile-bundle/generate", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-mobile-2/mobile-bundle/generate", nil)
 	// No session cookie.
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)

--- a/internal/web/networks_form_test.go
+++ b/internal/web/networks_form_test.go
@@ -15,7 +15,7 @@ func TestNetworksForm_HidesSelectorWhenSingleCA(t *testing.T) {
 	cookie := mintSession(t, s, "alice", "user")
 	ca := seedActiveCA(t, s, "ca-alice", "op-alice", "alice-ca")
 
-	req := httptest.NewRequest("GET", "/ui/networks", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/networks", nil)
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -51,7 +51,7 @@ func TestNetworksForm_ShowsSelectorWhenMultipleCAs(t *testing.T) {
 	ca1 := seedActiveCA(t, s, "ca-1", "op-alice", "ca-one")
 	ca2 := seedActiveCA(t, s, "ca-2", "op-alice", "ca-two")
 
-	req := httptest.NewRequest("GET", "/ui/networks", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/networks", nil)
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)

--- a/internal/web/oidc.go
+++ b/internal/web/oidc.go
@@ -14,10 +14,11 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/uuid"
+	"golang.org/x/oauth2"
+
 	"github.com/juev/nebula-mesh/internal/config"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"golang.org/x/oauth2"
 )
 
 const (

--- a/internal/web/oidc_test.go
+++ b/internal/web/oidc_test.go
@@ -34,7 +34,13 @@ func TestOIDC_MissingConfigErrors(t *testing.T) {
 
 func TestOIDC_StateLifecycle(t *testing.T) {
 	o := &OIDC{states: map[string]time.Time{}}
-	_ = o
+	o.rememberState("abc")
+	if !o.consumeState("abc") {
+		t.Fatal("expected freshly remembered state to be consumable once")
+	}
+	if o.consumeState("abc") {
+		t.Fatal("expected state to be consumed exactly once")
+	}
 }
 
 func TestOIDC_IsAllowed(t *testing.T) {
@@ -47,19 +53,19 @@ func TestOIDC_IsAllowed(t *testing.T) {
 	}{
 		{name: "no allowlist allows everyone", want: true},
 		{
-			name:   "email allowlist matches",
-			cfg:    config.OIDCConfig{AllowedEmails: []string{"alice@example.com"}},
-			email:  "alice@example.com", want: true,
+			name:  "email allowlist matches",
+			cfg:   config.OIDCConfig{AllowedEmails: []string{"alice@example.com"}},
+			email: "alice@example.com", want: true,
 		},
 		{
-			name:   "email allowlist case insensitive",
-			cfg:    config.OIDCConfig{AllowedEmails: []string{"alice@example.com"}},
-			email:  "Alice@Example.com", want: true,
+			name:  "email allowlist case insensitive",
+			cfg:   config.OIDCConfig{AllowedEmails: []string{"alice@example.com"}},
+			email: "Alice@Example.com", want: true,
 		},
 		{
-			name:   "email allowlist rejects",
-			cfg:    config.OIDCConfig{AllowedEmails: []string{"alice@example.com"}},
-			email:  "bob@example.com", want: false,
+			name:  "email allowlist rejects",
+			cfg:   config.OIDCConfig{AllowedEmails: []string{"alice@example.com"}},
+			email: "bob@example.com", want: false,
 		},
 		{
 			name:   "group allowlist matches",
@@ -83,15 +89,11 @@ func TestOIDC_IsAllowed(t *testing.T) {
 }
 
 func TestOIDC_HandleLoginRedirects(t *testing.T) {
-	// We don't have a real provider, so simulate manually.
-	o := &OIDC{
-		cfg:      config.OIDCConfig{Enabled: true},
-		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-		states:   map[string]time.Time{},
+	// Verify Enabled() reflects construction without invoking the real
+	// provider, which would require a network round-trip to discover.
+	if !(&OIDC{cfg: config.OIDCConfig{Enabled: true}}).Enabled() {
+		t.Fatal("expected Enabled() to be true for non-nil OIDC")
 	}
-	_ = o // skip; we only verify code paths compile.
-
-	_ = httptest.NewRecorder()
 }
 
 func TestOIDC_UpsertOperator(t *testing.T) {
@@ -122,7 +124,7 @@ func TestOIDC_HandleCallbackBadState(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		states: map[string]time.Time{},
 	}
-	req := httptest.NewRequest("GET", "/ui/oidc/callback?state=foo&code=bar", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/oidc/callback?state=foo&code=bar", nil)
 	rec := httptest.NewRecorder()
 	o.HandleCallback(rec, req)
 	if rec.Code != http.StatusBadRequest {

--- a/internal/web/operator_ca_gating_test.go
+++ b/internal/web/operator_ca_gating_test.go
@@ -48,7 +48,7 @@ func TestNetworkCreate_RejectsUserWithoutCA(t *testing.T) {
 	cookie := mintSession(t, s, "alice", "user")
 
 	form := url.Values{"name": {"alice-net"}, "cidrs": {"10.0.0.0/24"}}
-	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
@@ -84,7 +84,7 @@ func TestNetworkCreate_UserWithSingleCA(t *testing.T) {
 	ca := seedActiveCA(t, s, "ca-alice", "op-alice", "alice-ca")
 
 	form := url.Values{"name": {"alice-net"}, "cidrs": {"10.0.0.0/24"}}
-	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
@@ -115,7 +115,7 @@ func TestNetworkCreate_UserMustPickWhenMultipleCAs(t *testing.T) {
 	seedActiveCA(t, s, "ca-2", "op-alice", "ca-two")
 
 	form := url.Values{"name": {"alice-net"}, "cidrs": {"10.0.0.0/24"}}
-	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
@@ -139,7 +139,7 @@ func TestNetworkCreate_UserCannotPickForeignCA(t *testing.T) {
 	seedActiveCA(t, s, "ca-bob", "op-bob", "bob-ca")
 
 	form := url.Values{"name": {"alice-net"}, "cidrs": {"10.0.0.0/24"}, "ca_id": {"ca-bob"}}
-	req := httptest.NewRequest("POST", "/ui/networks", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
@@ -170,10 +170,10 @@ func TestHostCreate_UserCannotCreateInForeignNetwork(t *testing.T) {
 	form := url.Values{
 		"network_id": {bobNet.ID},
 		"name":       {"sneaky-host"},
-		"nebula_ips":  {"10.10.0.10"},
+		"nebula_ips": {"10.10.0.10"},
 		"role":       {"host"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
@@ -211,10 +211,10 @@ func TestHostCreate_UserOwnedNetworkInheritsCAID(t *testing.T) {
 	form := url.Values{
 		"network_id": {net.ID},
 		"name":       {"alice-host"},
-		"nebula_ips":  {"10.20.0.5"},
+		"nebula_ips": {"10.20.0.5"},
 		"role":       {"host"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
@@ -242,7 +242,7 @@ func TestHostNew_UserWithoutAccessibleNetworks(t *testing.T) {
 	w, s := newOperatorsWeb(t)
 	cookie := mintSession(t, s, "alice", "user")
 
-	req := httptest.NewRequest("GET", "/ui/hosts/new", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/new", nil)
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)

--- a/internal/web/operator_create_auto_provision_test.go
+++ b/internal/web/operator_create_auto_provision_test.go
@@ -30,7 +30,7 @@ func TestAdminCreatesUser_AutoProvisions(t *testing.T) {
 		"password_confirm": {"SecurePass123!@#"},
 		"role":             {"user"},
 	}.Encode()
-	req := httptest.NewRequest("POST", "/ui/operators", strings.NewReader(form))
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators", strings.NewReader(form))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(adminCookie)
 	rec := httptest.NewRecorder()
@@ -89,7 +89,7 @@ func TestAdminCreatesAdmin_AutoProvisions(t *testing.T) {
 		"password_confirm": {"SecurePass123!@#"},
 		"role":             {"admin"},
 	}.Encode()
-	req := httptest.NewRequest("POST", "/ui/operators", strings.NewReader(form))
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators", strings.NewReader(form))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(adminCookie)
 	rec := httptest.NewRecorder()
@@ -163,7 +163,7 @@ func TestAdminCreatesUser_SkipsAutoProvisionWhenNoMaster(t *testing.T) {
 		"password_confirm": {"SecurePass123!@#"},
 		"role":             {"user"},
 	}.Encode()
-	req := httptest.NewRequest("POST", "/ui/operators", strings.NewReader(form))
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators", strings.NewReader(form))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(adminCookie)
 	rec := httptest.NewRecorder()

--- a/internal/web/operators.go
+++ b/internal/web/operators.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // requireAdmin gates a route group to admins only — non-admin sessions

--- a/internal/web/operators_test.go
+++ b/internal/web/operators_test.go
@@ -312,11 +312,16 @@ func TestOperators_CreateInlineErrors_PerField(t *testing.T) {
 
 // TestOperators_APIKeyFlash covers GHSA-9pg3-25fq-p6cc end-to-end:
 // (1) the create-key POST's 303 Location header carries the operator-detail
-//     URL with NO new_key / key_name in the query (no Referer / log leak),
+//
+//	URL with NO new_key / key_name in the query (no Referer / log leak),
+//
 // (2) the following GET on operator detail (same session cookie) renders
-//     the freshly-minted key inline exactly once,
+//
+//	the freshly-minted key inline exactly once,
+//
 // (3) refreshing the detail page does NOT re-render the key (one-shot
-//     guarantee — refresh defense against shoulder-surfing).
+//
+//	guarantee — refresh defense against shoulder-surfing).
 func TestOperators_APIKeyFlash(t *testing.T) {
 	w, s := newOperatorsWeb(t)
 	cookie := mintSession(t, s, "root", "admin")

--- a/internal/web/profile_cas_test.go
+++ b/internal/web/profile_cas_test.go
@@ -14,7 +14,7 @@ func TestProfile_ShowsMyCAs(t *testing.T) {
 	ca1 := seedActiveCA(t, s, "ca-1", "op-alice", "ca-one")
 	ca2 := seedActiveCA(t, s, "ca-2", "op-alice", "ca-two")
 
-	req := httptest.NewRequest("GET", "/ui/profile", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/profile", nil)
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -59,7 +59,7 @@ func TestProfile_EmptyState(t *testing.T) {
 	w, s := newOperatorsWeb(t)
 	cookie := mintSession(t, s, "alice", "user")
 
-	req := httptest.NewRequest("GET", "/ui/profile", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/profile", nil)
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)

--- a/internal/web/profile_test.go
+++ b/internal/web/profile_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestProfilePage_RequiresLogin(t *testing.T) {
 	w, _ := newTestWeb(t)
-	req := httptest.NewRequest("GET", "/ui/profile", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/profile", nil)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 	if rec.Code != http.StatusSeeOther {
@@ -20,7 +20,7 @@ func TestProfilePage_RequiresLogin(t *testing.T) {
 func TestProfilePage_ShowsOperatorDetailsAndLogoutButton(t *testing.T) {
 	w, _ := newTestWeb(t)
 	cookies := loginSession(t, w)
-	req := httptest.NewRequest("GET", "/ui/profile", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/profile", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -41,7 +41,7 @@ func TestProfilePage_ShowsOperatorDetailsAndLogoutButton(t *testing.T) {
 func TestDashboard_HasProfileChipAndNoLogoutInSidebar(t *testing.T) {
 	w, _ := newTestWeb(t)
 	cookies := loginSession(t, w)
-	req := httptest.NewRequest("GET", "/ui/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}

--- a/internal/web/register_auto_provision_test.go
+++ b/internal/web/register_auto_provision_test.go
@@ -18,7 +18,7 @@ func TestSelfRegister_AutoProvisionsDefaultCA(t *testing.T) {
 		"password":         {strongPassword},
 		"password_confirm": {strongPassword},
 	}
-	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/register", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -68,7 +68,7 @@ func TestSelfRegister_SkipsAutoProvisionWhenNoMaster(t *testing.T) {
 		"password":         {strongPassword},
 		"password_confirm": {strongPassword},
 	}
-	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/register", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)

--- a/internal/web/register_test.go
+++ b/internal/web/register_test.go
@@ -20,7 +20,7 @@ const strongPassword = "Correcthorse-Battery!Staple1"
 func TestRegister_DisabledByDefault(t *testing.T) {
 	w, _ := newTestWeb(t)
 
-	req := httptest.NewRequest("GET", "/ui/register", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/register", nil)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -28,7 +28,7 @@ func TestRegister_DisabledByDefault(t *testing.T) {
 	}
 
 	form := url.Values{"username": {"alice"}, "password": {strongPassword}, "password_confirm": {strongPassword}}
-	req = httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req = httptest.NewRequest(http.MethodPost, "/ui/register", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec = httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -47,7 +47,7 @@ func TestRegister_Enabled_CreatesOperator(t *testing.T) {
 		"password":         {strongPassword},
 		"password_confirm": {strongPassword},
 	}
-	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/register", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -73,7 +73,7 @@ func TestRegister_RejectsDuplicateUsername(t *testing.T) {
 		"password":         {strongPassword},
 		"password_confirm": {strongPassword},
 	}
-	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/register", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -87,7 +87,7 @@ func TestRegister_RejectsShortPassword(t *testing.T) {
 	w.AllowSelfRegistration(true)
 
 	form := url.Values{"username": {"bob"}, "password": {"short"}, "password_confirm": {"short"}}
-	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/register", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -102,7 +102,7 @@ func TestRegister_RejectsMismatchedConfirmation(t *testing.T) {
 	w.AllowSelfRegistration(true)
 
 	form := url.Values{"username": {"carol"}, "password": {strongPassword}, "password_confirm": {strongPassword + "X"}}
-	req := httptest.NewRequest("POST", "/ui/register", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/register", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -113,7 +113,7 @@ func TestRegister_RejectsMismatchedConfirmation(t *testing.T) {
 
 func TestLoginPage_ShowsRegisterLinkOnlyWhenEnabled(t *testing.T) {
 	w, _ := newTestWeb(t)
-	req := httptest.NewRequest("GET", "/ui/login", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/login", nil)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 	if strings.Contains(rec.Body.String(), "Create an account") {
@@ -121,7 +121,7 @@ func TestLoginPage_ShowsRegisterLinkOnlyWhenEnabled(t *testing.T) {
 	}
 
 	w.AllowSelfRegistration(true)
-	req = httptest.NewRequest("GET", "/ui/login", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/login", nil)
 	rec = httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 	if !strings.Contains(rec.Body.String(), "Create an account") {

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -10,9 +10,10 @@ import (
 	"net/http"
 	"time"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -41,8 +42,8 @@ func (sm *SessionManager) SetCookieSecure(secure bool) {
 
 // LoginResult is the outcome of the first authentication step.
 type LoginResult struct {
-	Operator   *models.Operator
-	NeedsTOTP  bool
+	Operator  *models.Operator
+	NeedsTOTP bool
 }
 
 // Login looks up the operator by username, verifies the password (bcrypt),
@@ -65,7 +66,9 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 		return LoginResult{}, false, nil
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {
-		return LoginResult{}, false, nil
+		// Wrong password is a normal auth failure (bool=false), not a system
+		// error to surface to the caller.
+		return LoginResult{}, false, nil //nolint:nilerr
 	}
 
 	token, err := generateToken()
@@ -223,7 +226,7 @@ func (sm *SessionManager) IsAuthenticated(r *http.Request) bool {
 }
 
 // StartCleanup runs a background goroutine that periodically deletes expired
-// sessions from the store. It stops when ctx is cancelled.
+// sessions from the store. It stops when ctx is canceled.
 func (sm *SessionManager) StartCleanup(ctx context.Context, interval time.Duration) {
 	go func() {
 		ticker := time.NewTicker(interval)

--- a/internal/web/settings_handler.go
+++ b/internal/web/settings_handler.go
@@ -11,16 +11,16 @@ import (
 // field carries both the current value and a "source" tag so admins can
 // see whether a value comes from the database or the YAML defaults.
 type settingsView struct {
-	EnforceTOTP             bool
-	AllowSelfRegistration   bool
-	PasswordMinLength       int
-	PasswordRequireClasses  int
-	PasswordBlockCommon     bool
-	PasswordBlockUsername   bool
-	LogLevel                string
-	OIDCEnabled             bool
-	Saved                   bool
-	Error                   string
+	EnforceTOTP            bool
+	AllowSelfRegistration  bool
+	PasswordMinLength      int
+	PasswordRequireClasses int
+	PasswordBlockCommon    bool
+	PasswordBlockUsername  bool
+	LogLevel               string
+	OIDCEnabled            bool
+	Saved                  bool
+	Error                  string
 }
 
 func (w *Web) currentSettings(ctx context.Context) settingsView {
@@ -99,7 +99,7 @@ func (w *Web) handleSettingsSave(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// One audit-log line summarising the change set — easier to grep
+	// One audit-log line summarizing the change set — easier to grep
 	// than one per knob and still captures who pressed Save.
 	after := w.currentSettings(r.Context())
 	_ = w.store.AddAuditEntry(r.Context(), op.Username, "settings.update", "settings",

--- a/internal/web/sidebar_nav_test.go
+++ b/internal/web/sidebar_nav_test.go
@@ -14,7 +14,7 @@ func TestSidebarNav_NoCAsLink_UserRole(t *testing.T) {
 	w, s := newOperatorsWeb(t)
 	cookie := mintSession(t, s, "alice", "user")
 
-	req := httptest.NewRequest("GET", "/ui/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -52,7 +52,7 @@ func TestSidebarNav_NoCAsLink_AdminRole(t *testing.T) {
 	w, s := newOperatorsWeb(t)
 	cookie := mintSession(t, s, "bob", "admin")
 
-	req := httptest.NewRequest("GET", "/ui/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)

--- a/internal/web/totp.go
+++ b/internal/web/totp.go
@@ -20,7 +20,7 @@ const (
 // generateTOTPSecret creates a new TOTP secret keyed for the operator's
 // username. It returns the otpauth:// URL (for QR rendering) and the raw
 // base32-encoded secret to persist.
-func generateTOTPSecret(username string) (string, string, error) {
+func generateTOTPSecret(username string) (otpauthURL, secret string, err error) {
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      totpIssuer,
 		AccountName: username,

--- a/internal/web/totp_test.go
+++ b/internal/web/totp_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pquerna/otp/totp"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"github.com/pquerna/otp/totp"
 )
 
 func TestGenerateAndVerifyTOTP(t *testing.T) {
@@ -77,7 +78,7 @@ func TestLogin_TOTPFlow(t *testing.T) {
 
 	// Step 1: password
 	form := url.Values{"username": {testUsername}, "password": {testPassword}}
-	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -90,7 +91,7 @@ func TestLogin_TOTPFlow(t *testing.T) {
 	cookies := rec.Result().Cookies()
 
 	// Visiting /ui/ should still redirect to login because session is pending_totp
-	req = httptest.NewRequest("GET", "/ui/", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -102,7 +103,7 @@ func TestLogin_TOTPFlow(t *testing.T) {
 
 	// Step 2: TOTP code
 	form = url.Values{"code": {code}}
-	req = httptest.NewRequest("POST", "/ui/login/totp", strings.NewReader(form.Encode()))
+	req = httptest.NewRequest(http.MethodPost, "/ui/login/totp", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -117,7 +118,7 @@ func TestLogin_TOTPFlow(t *testing.T) {
 	}
 
 	// Now session should be fully authenticated
-	req = httptest.NewRequest("GET", "/ui/", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -133,14 +134,14 @@ func TestLogin_TOTPInvalidCode(t *testing.T) {
 	_, _ = enableTOTPForAdmin(t, w)
 
 	form := url.Values{"username": {testUsername}, "password": {testPassword}}
-	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 	cookies := rec.Result().Cookies()
 
 	form = url.Values{"code": {"000000"}}
-	req = httptest.NewRequest("POST", "/ui/login/totp", strings.NewReader(form.Encode()))
+	req = httptest.NewRequest(http.MethodPost, "/ui/login/totp", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -163,14 +164,14 @@ func TestLogin_TOTPRecoveryCode(t *testing.T) {
 	}
 
 	form := url.Values{"username": {testUsername}, "password": {testPassword}}
-	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 	cookies := rec.Result().Cookies()
 
 	form = url.Values{"recovery_code": {plainCode}}
-	req = httptest.NewRequest("POST", "/ui/login/totp", strings.NewReader(form.Encode()))
+	req = httptest.NewRequest(http.MethodPost, "/ui/login/totp", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -183,14 +184,14 @@ func TestLogin_TOTPRecoveryCode(t *testing.T) {
 
 	// Second attempt with same code should fail (single-use)
 	form = url.Values{"username": {testUsername}, "password": {testPassword}}
-	req = httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req = httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec = httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 	cookies = rec.Result().Cookies()
 
 	form = url.Values{"recovery_code": {plainCode}}
-	req = httptest.NewRequest("POST", "/ui/login/totp", strings.NewReader(form.Encode()))
+	req = httptest.NewRequest(http.MethodPost, "/ui/login/totp", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -207,7 +208,7 @@ func TestTwoFASetupAndEnable(t *testing.T) {
 	cookies := loginSession(t, w)
 
 	// Setup
-	req := httptest.NewRequest("POST", "/ui/2fa/setup", nil)
+	req := httptest.NewRequest(http.MethodPost, "/ui/2fa/setup", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -236,7 +237,7 @@ func TestTwoFASetupAndEnable(t *testing.T) {
 
 	// Enable
 	form := url.Values{"code": {code}}
-	req = httptest.NewRequest("POST", "/ui/2fa/enable", strings.NewReader(form.Encode()))
+	req = httptest.NewRequest(http.MethodPost, "/ui/2fa/enable", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -278,7 +279,7 @@ func TestTwoFADisable_RequiresPassword(t *testing.T) {
 
 	// Wrong password — should fail
 	form := url.Values{"password": {"wrong"}}
-	req := httptest.NewRequest("POST", "/ui/2fa/disable", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/2fa/disable", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -295,7 +296,7 @@ func TestTwoFADisable_RequiresPassword(t *testing.T) {
 
 	// Correct password — should succeed
 	form = url.Values{"password": {testPassword}}
-	req = httptest.NewRequest("POST", "/ui/2fa/disable", strings.NewReader(form.Encode()))
+	req = httptest.NewRequest(http.MethodPost, "/ui/2fa/disable", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -323,7 +324,7 @@ func TestTwoFAAuditEntries(t *testing.T) {
 
 	// Trigger failed disable
 	form := url.Values{"password": {"wrong"}}
-	req := httptest.NewRequest("POST", "/ui/2fa/disable", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/2fa/disable", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/juev/nebula-mesh/internal/auth"
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/pki"
@@ -314,7 +315,7 @@ func (w *Web) setupRoutes() {
 }
 
 // StartSessionCleanup starts periodic removal of expired sessions.
-// Stops when ctx is cancelled.
+// Stops when ctx is canceled.
 func (w *Web) StartSessionCleanup(ctx context.Context) {
 	w.session.StartCleanup(ctx, 1*time.Hour)
 }

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -58,7 +59,7 @@ func newTestWeb(t *testing.T) (*Web, *store.SQLiteStore) {
 func loginSession(t *testing.T, w *Web) []*http.Cookie {
 	t.Helper()
 	form := url.Values{"username": {testUsername}, "password": {testPassword}}
-	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -67,7 +68,7 @@ func loginSession(t *testing.T, w *Web) []*http.Cookie {
 
 func TestLoginPage(t *testing.T) {
 	w, _ := newTestWeb(t)
-	req := httptest.NewRequest("GET", "/ui/login", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/login", nil)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 
@@ -132,7 +133,7 @@ func TestSession_CookieSecureFlag(t *testing.T) {
 	// Re-issuing the logout cookie with mismatched attributes leaves
 	// browsers holding the original — assert the delete cookie matches
 	// the live cookie's fingerprint.
-	logoutReq := httptest.NewRequest("GET", "/ui/logout", nil)
+	logoutReq := httptest.NewRequest(http.MethodGet, "/ui/logout", nil)
 	logoutReq.AddCookie(live)
 	logoutRec := httptest.NewRecorder()
 	w.ServeHTTP(logoutRec, logoutReq)
@@ -167,7 +168,7 @@ func TestSession_CookieSecureDefault(t *testing.T) {
 func TestLogin_WrongPassword(t *testing.T) {
 	w, _ := newTestWeb(t)
 	form := url.Values{"username": {testUsername}, "password": {"wrong"}}
-	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -187,7 +188,7 @@ func TestLogin_DisabledOperator(t *testing.T) {
 		t.Fatal(err)
 	}
 	form := url.Values{"username": {testUsername}, "password": {testPassword}}
-	req := httptest.NewRequest("POST", "/ui/login", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
@@ -199,7 +200,7 @@ func TestLogin_DisabledOperator(t *testing.T) {
 
 func TestProtectedRouteRedirect(t *testing.T) {
 	w, _ := newTestWeb(t)
-	req := httptest.NewRequest("GET", "/ui/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 
@@ -220,14 +221,14 @@ func TestDashboard_Authenticated(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := s.CreateHost(ctx, &models.Host{
-		ID: "h1", NetworkID: "net1", Name: "web-1", NebulaIPs:  []string{"10.0.0.1"},
+		ID: "h1", NetworkID: "net1", Name: "web-1", NebulaIPs: []string{"10.0.0.1"},
 		Groups: []string{"web"}, Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
 		CreatedAt: time.Now(), UpdatedAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/ui/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -257,12 +258,12 @@ func TestHostsPage(t *testing.T) {
 	ctx := context.Background()
 	s.CreateNetwork(ctx, &models.Network{ID: "net1", Name: "test", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now()})
 	s.CreateHost(ctx, &models.Host{
-		ID: "h1", NetworkID: "net1", Name: "web-1", NebulaIPs:  []string{"10.0.0.1"},
+		ID: "h1", NetworkID: "net1", Name: "web-1", NebulaIPs: []string{"10.0.0.1"},
 		Groups: []string{"web"}, Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
 		CreatedAt: time.Now(), UpdatedAt: time.Now(),
 	})
 
-	req := httptest.NewRequest("GET", "/ui/hosts", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -294,7 +295,7 @@ func TestNetworksPage(t *testing.T) {
 	ctx := context.Background()
 	s.CreateNetwork(ctx, &models.Network{ID: "net1", Name: "prod", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now()})
 
-	req := httptest.NewRequest("GET", "/ui/networks", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/networks", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -319,10 +320,10 @@ func TestCreateHostViaUI(t *testing.T) {
 	form := url.Values{
 		"network_id": {"net1"},
 		"name":       {"new-host"},
-		"nebula_ips":  {"10.0.0.5"},
+		"nebula_ips": {"10.0.0.5"},
 		"role":       {"host"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -353,10 +354,10 @@ func TestCreateHostViaUI_InvalidPort(t *testing.T) {
 	form := url.Values{
 		"network_id":  {"net1"},
 		"name":        {"bad-port-host"},
-		"nebula_ips":   {"10.0.0.5"},
+		"nebula_ips":  {"10.0.0.5"},
 		"listen_port": {"70000"},
 	}
-	req := httptest.NewRequest("POST", "/ui/hosts", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for _, c := range cookies {
 		req.AddCookie(c)
@@ -373,7 +374,7 @@ func TestLogout(t *testing.T) {
 	w, _ := newTestWeb(t)
 	cookies := loginSession(t, w)
 
-	req := httptest.NewRequest("GET", "/ui/logout", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/logout", nil)
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
@@ -385,7 +386,7 @@ func TestLogout(t *testing.T) {
 	}
 
 	// After logout, dashboard should redirect to login
-	req = httptest.NewRequest("GET", "/ui/", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/", nil)
 	for _, c := range rec.Result().Cookies() {
 		req.AddCookie(c)
 	}
@@ -408,7 +409,7 @@ func TestIsAuthenticated_ExpiredSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
 
 	if sm.IsAuthenticated(req) {
@@ -427,7 +428,7 @@ func TestIsAuthenticated_ValidSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
 
 	if !sm.IsAuthenticated(req) {
@@ -438,7 +439,7 @@ func TestIsAuthenticated_ValidSession(t *testing.T) {
 func TestIsAuthenticated_NoCookie(t *testing.T) {
 	_, s := newTestWeb(t)
 	sm := NewSessionManager(s)
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	if sm.IsAuthenticated(req) {
 		t.Error("request without cookie should not be authenticated")
@@ -459,7 +460,7 @@ func TestIsAuthenticated_DisabledOperator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
 
 	if sm.IsAuthenticated(req) {
@@ -566,7 +567,7 @@ func TestBuildHostViews(t *testing.T) {
 
 func TestFavicon(t *testing.T) {
 	w, _ := newTestWeb(t)
-	req := httptest.NewRequest("GET", "/favicon.ico", nil)
+	req := httptest.NewRequest(http.MethodGet, "/favicon.ico", nil)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 
@@ -583,7 +584,7 @@ func TestFavicon(t *testing.T) {
 
 func TestStaticFiles(t *testing.T) {
 	w, _ := newTestWeb(t)
-	req := httptest.NewRequest("GET", "/static/htmx.min.js", nil)
+	req := httptest.NewRequest(http.MethodGet, "/static/htmx.min.js", nil)
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
 

--- a/tests/integration/e2e_dual_family_test.go
+++ b/tests/integration/e2e_dual_family_test.go
@@ -8,10 +8,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
 	"gopkg.in/yaml.v3"
+
+	"github.com/juev/nebula-mesh/internal/models"
 )
 
 // TestE2E_DualFamilyNetwork verifies that dual-stack (IPv4 + IPv6) networks work

--- a/tests/integration/e2e_edit_host_test.go
+++ b/tests/integration/e2e_edit_host_test.go
@@ -12,10 +12,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/juev/nebula-mesh/internal/models"
-	"github.com/juev/nebula-mesh/internal/store"
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
 )
 
 // EnrollmentResult holds the response from enrolling a host.

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -18,15 +18,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/juev/nebula-mesh/internal/api"
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+
 	agentpop "github.com/juev/nebula-mesh/internal/agent/pop"
+	"github.com/juev/nebula-mesh/internal/api"
 	"github.com/juev/nebula-mesh/internal/keystore"
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/pki"
 	corepop "github.com/juev/nebula-mesh/internal/pop"
 	"github.com/juev/nebula-mesh/internal/store"
-	"github.com/slackhq/nebula/cert"
-	"golang.org/x/crypto/curve25519"
 )
 
 // signingKeypair returns a fresh Ed25519 keypair and its PEM-encoded public
@@ -46,7 +47,7 @@ func signingKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey, string
 // to what internal/agent.Poller produces.
 func signedGetUpdates(t *testing.T, ts *httptest.Server, fingerprint string, signingPriv ed25519.PrivateKey) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest("GET", ts.URL+"/api/v1/agent/updates", nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/updates", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +457,7 @@ func TestAgentUpdates_CertSaveFailure(t *testing.T) {
 // below: it creates a host, runs the full enrollment handshake, and returns
 // the host record, its cert fingerprint, its rendered config, and the
 // Ed25519 signing private key needed to issue signed polls afterwards.
-func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP string, extra map[string]any) (*models.Host, string, string, ed25519.PrivateKey) {
+func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP string, extra map[string]any) (host *models.Host, fingerprint, renderedConfig string, signingKey ed25519.PrivateKey) {
 	t.Helper()
 	payload := map[string]any{
 		"network_id": networkID,


### PR DESCRIPTION
## Summary

- Replace the minimal `.golangci.yml` with an opinionated v2 config that enables `gosec`, `errorlint`, `noctx`, `bodyclose`, `rowserrcheck`, `sqlclosecheck`, `bidichk`, `usestdlibvars`, `prealloc`, `nakedret`, plus a stricter `govet` (`enable-all`) and broader `revive` / `gocritic`. Inspired by Tailscale's setup and adapted for this codebase.
- Document known `gosec` false positives that are excluded with a written rationale: **G124** (cookie attributes set via struct field, not literal — every cookie in this codebase sets HttpOnly/Secure/SameSite) and **G710** (same-origin relative redirects through `chi.URLParam`).
- Migrate every `database/sql` call site that already holds a `context.Context` to the `*Context` variant. `Migrate`, `migrationApplied`, `repairBlocklistCAID`, and ~30 store methods that previously took `_ context.Context` now actually use the context. `s.db.Begin()` → `s.db.BeginTx(ctx, nil)`, `tx.Exec/Query/QueryRow` → `*Context`.
- Thread `context.Context` through `agent.Enroll` / `agent.Reenroll`, `internal/cli` HTTP helpers (`http.NewRequestWithContext`), and the agent poller's poll loop.
- Annotate the handful of intentional `gosec` hits with `//nolint:gosec`: mobile-bundle YAML write (G705 — not an HTML response), QR SVG / data URL HTML rendering (G203 — server-generated content, no user input), server-config secret marshal (G117 — secrets are an expected part of the config), user-create plaintext password DTO (G117 — wire transport before server-side hashing). Also annotate the bcrypt nil-err return (`nilerr` false positive — wrong password is a normal auth failure, not a system error).
- Small refactors surfaced by the new linters: `http.NoBody` instead of `nil` for empty HTTP bodies (7 sites); rename builtin-shadowing parameter `max` in `internal/ratelimit/limiter.go`; drop `confusing-naming`/`var-naming` underscores in tests; name multi-result string returns (`Resolve`, `generateTOTPSecret`, `enrollHost`); restructure two `if/else` blocks to use early-return.
- Auto-fixes from `gofmt`, `goimports` (with `local-prefixes: github.com/juev/nebula-mesh`), `errorlint`, `misspell`, `usestdlibvars` applied across the tree.

End result: `make ci` clean, `go test -race -count=1 ./...` green, `.tools/golangci-lint run --timeout=5m ./...` reports **0 issues** (down from 651 on the initial run).

## Test plan

- [x] `make ci` passes (build + test + lint)
- [x] `go test -race -count=1 ./...` passes
- [x] `.tools/golangci-lint run --timeout=5m ./...` reports 0 issues
- [x] Manual review of every `//nolint` annotation to confirm the justification
- [x] Rebased onto latest `main` and resolved conflict in `internal/api/mobile_bundle_authz_test.go`
