### PR TITLE
fix(lint): clean up linter issues introduced by #135

### DIFF
--- a/internal/config/oidc_validate_test.go
+++ b/internal/config/oidc_validate_test.go
@@ -101,29 +101,29 @@ func TestOIDCConfig_Validate_ErrorMessageNamesFields(t *testing.T) {
 // be caught by CI instead of silently downgrading the gate.
 func TestOIDCConfig_RequireEmailVerified_YAMLRoundTrip(t *testing.T) {
 	cases := []struct {
-		name              string
-		yamlSnippet       string
-		wantParseError    bool
-		wantPointerNil    bool
-		wantRequired      bool // value of EmailVerifiedRequired() after parse (only checked if no parse error)
+		name           string
+		yamlSnippet    string
+		wantParseError bool
+		wantPointerNil bool
+		wantRequired   bool // value of EmailVerifiedRequired() after parse (only checked if no parse error)
 	}{
 		{
-			name:              "unset_defaults_to_required",
-			yamlSnippet:       `enabled: true`,
-			wantPointerNil:    true,
-			wantRequired:      true,
+			name:           "unset_defaults_to_required",
+			yamlSnippet:    `enabled: true`,
+			wantPointerNil: true,
+			wantRequired:   true,
 		},
 		{
-			name:              "bare_true_keeps_required",
-			yamlSnippet:       "enabled: true\nrequire_email_verified: true\n",
-			wantPointerNil:    false,
-			wantRequired:      true,
+			name:           "bare_true_keeps_required",
+			yamlSnippet:    "enabled: true\nrequire_email_verified: true\n",
+			wantPointerNil: false,
+			wantRequired:   true,
 		},
 		{
-			name:              "bare_false_opts_out",
-			yamlSnippet:       "enabled: true\nrequire_email_verified: false\n",
-			wantPointerNil:    false,
-			wantRequired:      false,
+			name:           "bare_false_opts_out",
+			yamlSnippet:    "enabled: true\nrequire_email_verified: false\n",
+			wantPointerNil: false,
+			wantRequired:   false,
 		},
 		{
 			// yaml.v3 default mode: !!str cannot unmarshal into

--- a/internal/web/oidc.go
+++ b/internal/web/oidc.go
@@ -350,7 +350,7 @@ func (o *OIDC) rememberState(state string) {
 
 // sweepLocked drops every state entry whose expiry is at or before now. The
 // caller MUST hold stateMu. Called lazily from rememberState so the per-call
-// cost is amortised across logins and the map cannot grow without bound
+// cost is amortized across logins and the map cannot grow without bound
 // when an unauthenticated client bursts /ui/oidc/login. Avoiding a
 // background goroutine keeps the OIDC type cheap to construct and matches
 // the project's preference for lazy in-memory cleanup where the hot path

--- a/internal/web/oidc_email_verified_test.go
+++ b/internal/web/oidc_email_verified_test.go
@@ -31,13 +31,13 @@ import (
 func TestOIDC_HandleCallback_EmailVerified(t *testing.T) {
 	skipCheck := false
 	cases := []struct {
-		name             string
-		emailVerified    any  // value to put under the email_verified key
-		omitClaim        bool // true = drop the email_verified key entirely
-		requireOverride  *bool
-		wantStatus       int
-		wantBodyContain  string
-		wantAuditAction  string
+		name            string
+		emailVerified   any  // value to put under the email_verified key
+		omitClaim       bool // true = drop the email_verified key entirely
+		requireOverride *bool
+		wantStatus      int
+		wantBodyContain string
+		wantAuditAction string
 	}{
 		{
 			name:            "verified true succeeds",

--- a/internal/web/oidc_state_error_test.go
+++ b/internal/web/oidc_state_error_test.go
@@ -51,7 +51,7 @@ func TestOIDC_HandleCallback_ErrorParamConsumesState(t *testing.T) {
 	})
 	// driveCallback re-seats the state — bypass that for the replay test
 	// so we observe the post-error state.
-	req := httptest.NewRequest("GET", "/ui/oidc/callback?state="+stateValue+"&code=code-replay", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/oidc/callback?state="+stateValue+"&code=code-replay", nil)
 	req.AddCookie(&http.Cookie{Name: oidcStateCookieName, Value: stateValue})
 	replayRec := httptest.NewRecorder()
 	o.HandleCallback(replayRec, req)

--- a/internal/web/oidc_testhelper_test.go
+++ b/internal/web/oidc_testhelper_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+
 	"github.com/juev/nebula-mesh/internal/config"
 	"github.com/juev/nebula-mesh/internal/store"
 )
@@ -301,13 +302,13 @@ func newOIDCFromMock(t *testing.T, idp *mockIDP, s store.Store, extraCfg config.
 // variant or set the cookie / query explicitly in the test.
 func driveCallback(t *testing.T, o *OIDC, stateValue, code string) *httptest.ResponseRecorder {
 	t.Helper()
-	// Pre-seat the state so consumeState recognises it.
+	// Pre-seat the state so consumeState recognizes it.
 	o.rememberState(stateValue)
 	q := "/ui/oidc/callback?state=" + stateValue
 	if code != "" {
 		q += "&code=" + code
 	}
-	req := httptest.NewRequest("GET", q, nil)
+	req := httptest.NewRequest(http.MethodGet, q, nil)
 	req.AddCookie(&http.Cookie{Name: oidcStateCookieName, Value: stateValue})
 	rec := httptest.NewRecorder()
 	o.HandleCallback(rec, req)
@@ -322,7 +323,7 @@ func driveCallbackWithError(t *testing.T, o *OIDC, stateValue, errParam string) 
 	t.Helper()
 	o.rememberState(stateValue)
 	q := "/ui/oidc/callback?error=" + errParam + "&state=" + stateValue
-	req := httptest.NewRequest("GET", q, nil)
+	req := httptest.NewRequest(http.MethodGet, q, nil)
 	req.AddCookie(&http.Cookie{Name: oidcStateCookieName, Value: stateValue})
 	rec := httptest.NewRecorder()
 	o.HandleCallback(rec, req)
@@ -334,7 +335,7 @@ func driveCallbackWithError(t *testing.T, o *OIDC, stateValue, errParam string) 
 // IdP, store, or session manager. State-sweep tests want to drive those
 // methods directly; the full newOIDCFromMock path stands up an httptest
 // server, generates an RSA key, and runs OIDC discovery, all of which are
-// irrelevant to the in-memory map's behaviour.
+// irrelevant to the in-memory map's behavior.
 //
 // Returns a struct with: empty states map, a discard-sink slog logger, an
 // empty OIDCConfig, and zero values for the rest. Future required


### PR DESCRIPTION
## Summary

Re-run of `golangci-lint v2.12` against latest `main` flags **9 issues** introduced by the OIDC hardening PR (#135). The PR's CI lint check apparently missed them — likely a stale cached result evaluated before the final rebase landed on top of #136's stricter config.

| Linter | Issue | Sites |
|---|---|---|
| `gofmt` | struct-table alignment | `internal/config/oidc_validate_test.go`, `internal/web/oidc_email_verified_test.go` |
| `goimports` | import group ordering | `internal/web/oidc_testhelper_test.go` |
| `misspell` (US locale) | `amortised` → `amortized`, `recognises` → `recognizes`, `behaviour` → `behavior` | `oidc.go`, `oidc_testhelper_test.go` |
| `usestdlibvars` | `"GET"` → `http.MethodGet` | `oidc_state_error_test.go`, `oidc_testhelper_test.go` (3 sites) |

Pure mechanical fixes via `golangci-lint run --fix`; no behaviour change.

## Test plan

- [x] `.tools/golangci-lint run --timeout=5m ./...` → `0 issues.`
- [x] `go test -race -count=1 ./internal/config/ ./internal/web/` → pass
- [x] Manual review of diff — all changes are formatter/spell/stdlib-vars hits, no semantic edits
