### PR TITLE
fix(audit): validate URL params before audit + redirect in operator handlers

### DIFF
--- a/internal/api/operators.go
+++ b/internal/api/operators.go
@@ -210,6 +210,16 @@ func (s *Server) handleRevokeOperatorAPIKey(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := s.store.RevokeOperatorAPIKey(r.Context(), kid); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// Concurrent revoke (another admin, or a DisableOperator
+			// cascade) won the CAS between the GetOperatorAPIKey
+			// snapshot above and this UPDATE. Already revoked — mirror
+			// the RevokedAt != nil idempotent branch above (204, no
+			// audit row, since this actor's call did not cause the
+			// state change).
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		s.logger.Error("revoke api key", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to revoke api key")
 		return

--- a/internal/api/operators.go
+++ b/internal/api/operators.go
@@ -178,11 +178,38 @@ func (s *Server) handleRevokeOperatorAPIKey(w http.ResponseWriter, r *http.Reque
 	}
 	id := chi.URLParam(r, "id")
 	kid := chi.URLParam(r, "kid")
-	if err := s.store.RevokeOperatorAPIKey(r.Context(), kid); err != nil {
+	if _, err := s.store.GetOperator(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "operator not found")
+			return
+		}
+		s.logger.Error("get operator", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to look up operator")
+		return
+	}
+	// Verify the API key belongs to this operator before revoking, so the
+	// audit row reflects the key's real owner — not whichever {id} the
+	// caller supplied in the URL.
+	key, err := s.store.GetOperatorAPIKey(r.Context(), kid)
+	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "api key not found")
 			return
 		}
+		s.logger.Error("get api key", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to look up api key")
+		return
+	}
+	if key.OperatorID != id {
+		writeError(w, http.StatusNotFound, "api key not found")
+		return
+	}
+	if key.RevokedAt != nil {
+		// Already revoked. API stays idempotent — 204 with no new audit row.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if err := s.store.RevokeOperatorAPIKey(r.Context(), kid); err != nil {
 		s.logger.Error("revoke api key", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to revoke api key")
 		return

--- a/internal/api/operators_audit_validation_test.go
+++ b/internal/api/operators_audit_validation_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -13,6 +14,29 @@ import (
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
 )
+
+// concurrentRevokeStore wraps store.Store and injects exactly one CAS-race
+// on the first GetOperatorAPIKey of a non-revoked key by revoking the row
+// directly before the snapshot is returned. The handler's *models.OperatorAPIKey
+// pointer still reflects RevokedAt == nil (since it was unmarshalled before
+// the wrapper's intervening UPDATE), so the handler falls through past the
+// RevokedAt != nil early-return and into RevokeOperatorAPIKey, which now
+// returns store.ErrNotFound from the WHERE revoked_at IS NULL CAS clause.
+// Exercises the TOCTOU window between GetOperatorAPIKey and the atomic CAS.
+type concurrentRevokeStore struct {
+	store.Store
+	raceOnce sync.Once
+}
+
+func (r *concurrentRevokeStore) GetOperatorAPIKey(ctx context.Context, kid string) (*models.OperatorAPIKey, error) {
+	key, err := r.Store.GetOperatorAPIKey(ctx, kid)
+	if err == nil && key != nil && key.RevokedAt == nil {
+		r.raceOnce.Do(func() {
+			_ = r.RevokeOperatorAPIKey(ctx, kid)
+		})
+	}
+	return key, err
+}
 
 // seedOperatorWithKey seeds an operator + one API key and returns both ids
 // plus the raw token (caller usually only needs the ids). Distinct from
@@ -180,5 +204,54 @@ func TestAPI_HandleRevokeOperatorAPIKey_AlreadyRevoked_Idempotent(t *testing.T) 
 	}
 	if len(second) != 1 {
 		t.Errorf("after second revoke: %d audit entries, want 1 (no new row for idempotent re-revoke)", len(second))
+	}
+}
+
+// TestAPI_HandleRevokeOperatorAPIKey_ConcurrentRevokeRace_Idempotent
+// verifies the TOCTOU branch added on top of the GetOperatorAPIKey →
+// RevokeOperatorAPIKey sequence: if a concurrent revoke (another admin or
+// a DisableOperator cascade) wins the CAS between the lookup and the
+// UPDATE, the second actor's call must still return 204 with no new
+// audit row, mirroring the RevokedAt != nil early-return path. Before
+// the fix the race-loser surfaced as a 500 because store.ErrNotFound
+// from the CAS clause fell into the default error branch.
+func TestAPI_HandleRevokeOperatorAPIKey_ConcurrentRevokeRace_Idempotent(t *testing.T) {
+	srv, base := newTestServer(t)
+	adminKey := createUserWithAPIKey(t, srv, "admin")
+	opID, keyID, _ := seedOperatorWithKey(t, srv, "race", "user")
+
+	// Swap the server's store to one that races a concurrent revoke into
+	// the gap between GetOperatorAPIKey and RevokeOperatorAPIKey. Done
+	// after seeding so the seed path uses the real store directly.
+	srv.store = &concurrentRevokeStore{Store: srv.store}
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/operators/"+opID+"/api-keys/"+keyID, nil)
+	req.Header.Set("Authorization", "Bearer "+adminKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204 (idempotent on CAS-loss race)", rec.Code)
+	}
+
+	// Race-loser writes no audit row — only the race-winning revoke (which
+	// in this test was the wrapper's direct store call, intentionally
+	// bypassing audit) caused the state change.
+	entries, err := base.ListAuditEntries(context.Background(), store.AuditFilter{Action: auditOperatorAPIKeyRevoke, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("got %d revoke audit entries from race-loser, want 0", len(entries))
+	}
+
+	// Key is in fact revoked (by the race injection).
+	got, err := base.GetOperatorAPIKey(context.Background(), keyID)
+	if err != nil {
+		t.Fatalf("get key: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Error("key should be revoked after concurrent-revoke race injection")
 	}
 }

--- a/internal/api/operators_audit_validation_test.go
+++ b/internal/api/operators_audit_validation_test.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// seedOperatorWithKey seeds an operator + one API key and returns both ids
+// plus the raw token (caller usually only needs the ids). Distinct from
+// createUserWithAPIKey, which throws away the operator and key ids and
+// only returns the raw token — useful for admin-bearer-auth but not for
+// tests that need to address the seeded operator/key via URL paths.
+func seedOperatorWithKey(t *testing.T, srv *Server, username, role string) (operatorID, keyID, rawKey string) {
+	t.Helper()
+	ctx := context.Background()
+	op := &models.Operator{
+		ID:           "op-" + username,
+		Username:     "user-" + username,
+		PasswordHash: "x",
+		Role:         role,
+	}
+	if err := srv.store.CreateOperator(ctx, op); err != nil {
+		t.Fatalf("create operator %s: %v", username, err)
+	}
+	rawKey = uuid.New().String()
+	keySum := sha256.Sum256([]byte(rawKey))
+	key := &models.OperatorAPIKey{
+		ID:         "key-" + username,
+		OperatorID: op.ID,
+		KeyHash:    hex.EncodeToString(keySum[:]),
+	}
+	if err := srv.store.CreateOperatorAPIKey(ctx, key); err != nil {
+		t.Fatalf("create api key %s: %v", username, err)
+	}
+	return op.ID, key.ID, rawKey
+}
+
+// TestAPI_HandleRevokeOperatorAPIKey_NonExistentOperator_Returns404
+// verifies the JSON API mirrors the UI fix: a DELETE against a bogus {id}
+// returns 404 and writes no audit row.
+func TestAPI_HandleRevokeOperatorAPIKey_NonExistentOperator_Returns404(t *testing.T) {
+	srv, _ := newTestServer(t)
+	adminKey := createUserWithAPIKey(t, srv, "admin")
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/operators/op-does-not-exist/api-keys/anything", nil)
+	req.Header.Set("Authorization", "Bearer "+adminKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+
+	entries, err := srv.store.ListAuditEntries(context.Background(), store.AuditFilter{Action: auditOperatorAPIKeyRevoke, Limit: 100})
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	for _, e := range entries {
+		if e.Resource == "op-does-not-exist" {
+			t.Errorf("unexpected audit entry for non-existent operator: %+v", e)
+		}
+	}
+}
+
+// TestAPI_HandleRevokeOperatorAPIKey_KidBelongsToDifferentOperator_Returns404
+// verifies the API rejects a cross-operator kid and does NOT revoke the
+// real owner's key. Same audit-integrity invariant the UI fix locks.
+func TestAPI_HandleRevokeOperatorAPIKey_KidBelongsToDifferentOperator_Returns404(t *testing.T) {
+	srv, _ := newTestServer(t)
+	adminKey := createUserWithAPIKey(t, srv, "admin")
+
+	alphaID, _, _ := seedOperatorWithKey(t, srv, "alpha", "user")
+	_, betaKeyID, _ := seedOperatorWithKey(t, srv, "beta", "user")
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/operators/"+alphaID+"/api-keys/"+betaKeyID, nil)
+	req.Header.Set("Authorization", "Bearer "+adminKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+
+	// Beta's key must NOT be revoked.
+	got, err := srv.store.GetOperatorAPIKey(context.Background(), betaKeyID)
+	if err != nil {
+		t.Fatalf("get beta key: %v", err)
+	}
+	if got.RevokedAt != nil {
+		t.Errorf("beta's key was unexpectedly revoked (revoked_at=%v)", got.RevokedAt)
+	}
+
+	// No audit row under alpha.
+	entries, err := srv.store.ListAuditEntries(context.Background(), store.AuditFilter{Action: auditOperatorAPIKeyRevoke, Limit: 100})
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	for _, e := range entries {
+		if e.Resource == alphaID {
+			t.Errorf("unexpected audit entry under alpha for cross-operator kid: %+v", e)
+		}
+	}
+}
+
+// TestAPI_HandleRevokeOperatorAPIKey_AfterDisableCascade_Idempotent
+// verifies the API-side early-return-on-revoked branch via the
+// DisableOperator cascade path (key is auto-revoked, then admin tries an
+// explicit DELETE). Must return 204 with no new audit row.
+func TestAPI_HandleRevokeOperatorAPIKey_AfterDisableCascade_Idempotent(t *testing.T) {
+	srv, _ := newTestServer(t)
+	adminKey := createUserWithAPIKey(t, srv, "admin")
+	opID, keyID, _ := seedOperatorWithKey(t, srv, "epsilon", "user")
+
+	if err := srv.store.DisableOperator(context.Background(), opID); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/operators/"+opID+"/api-keys/"+keyID, nil)
+	req.Header.Set("Authorization", "Bearer "+adminKey)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204 (idempotent after cascade revoke)", rec.Code)
+	}
+	entries, err := srv.store.ListAuditEntries(context.Background(), store.AuditFilter{Action: auditOperatorAPIKeyRevoke, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("got %d revoke audit entries, want 0 (cascade doesn't audit each key; idempotent revoke doesn't either)", len(entries))
+	}
+}
+
+// TestAPI_HandleRevokeOperatorAPIKey_AlreadyRevoked_Idempotent verifies
+// the API returns 204 idempotently for a re-revoke of the same kid (after
+// either an explicit prior revoke or a DisableOperator cascade), and
+// writes no new audit row.
+func TestAPI_HandleRevokeOperatorAPIKey_AlreadyRevoked_Idempotent(t *testing.T) {
+	srv, _ := newTestServer(t)
+	adminKey := createUserWithAPIKey(t, srv, "admin")
+	opID, keyID, _ := seedOperatorWithKey(t, srv, "gamma", "user")
+
+	post := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodDelete,
+			"/api/v1/operators/"+opID+"/api-keys/"+keyID, nil)
+		req.Header.Set("Authorization", "Bearer "+adminKey)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := post(); rec.Code != http.StatusNoContent {
+		t.Fatalf("first revoke: status = %d, want 204", rec.Code)
+	}
+	first, err := srv.store.ListAuditEntries(context.Background(), store.AuditFilter{Action: auditOperatorAPIKeyRevoke, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("after first revoke: %d audit entries, want 1", len(first))
+	}
+
+	if rec := post(); rec.Code != http.StatusNoContent {
+		t.Errorf("second revoke: status = %d, want 204 (idempotent)", rec.Code)
+	}
+	second, err := srv.store.ListAuditEntries(context.Background(), store.AuditFilter{Action: auditOperatorAPIKeyRevoke, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 1 {
+		t.Errorf("after second revoke: %d audit entries, want 1 (no new row for idempotent re-revoke)", len(second))
+	}
+}

--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -480,6 +480,36 @@ func (s *SQLiteStore) GetOperatorByAPIKeyHash(ctx context.Context, keyHash strin
 	return op, &k, nil
 }
 
+// GetOperatorAPIKey returns the API key by its ID regardless of revoked
+// state. Callers that need ownership verification compare the returned
+// .OperatorID against the expected operator.
+func (s *SQLiteStore) GetOperatorAPIKey(ctx context.Context, keyID string) (*models.OperatorAPIKey, error) {
+	var (
+		k         models.OperatorAPIKey
+		lastUsed  sql.NullTime
+		revokedAt sql.NullTime
+	)
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, operator_id, name, key_hash, created_at, last_used_at, revoked_at FROM operator_api_keys WHERE id=?`,
+		keyID,
+	)
+	if err := row.Scan(&k.ID, &k.OperatorID, &k.Name, &k.KeyHash, &k.CreatedAt, &lastUsed, &revokedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get api key: %w", err)
+	}
+	if lastUsed.Valid {
+		t := lastUsed.Time
+		k.LastUsedAt = &t
+	}
+	if revokedAt.Valid {
+		t := revokedAt.Time
+		k.RevokedAt = &t
+	}
+	return &k, nil
+}
+
 func (s *SQLiteStore) ListOperatorAPIKeys(ctx context.Context, operatorID string) ([]*models.OperatorAPIKey, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, operator_id, name, key_hash, created_at, last_used_at, revoked_at FROM operator_api_keys WHERE operator_id=? ORDER BY created_at DESC`,

--- a/internal/store/sqlite_operators_test.go
+++ b/internal/store/sqlite_operators_test.go
@@ -155,6 +155,57 @@ func TestRevokeOperatorAPIKey(t *testing.T) {
 	}
 }
 
+// TestGetOperatorAPIKey covers the new ownership-verification lookup.
+// The method must return the row regardless of revoked state — callers
+// that need to verify kid-belongs-to-id compare key.OperatorID without
+// caring whether the key is still active.
+func TestGetOperatorAPIKey(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := newTestOperator(t, s, "grace")
+	if err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID: "k-grace", OperatorID: op.ID, Name: "primary", KeyHash: "grace-hash",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("active_key_returns", func(t *testing.T) {
+		got, err := s.GetOperatorAPIKey(ctx, "k-grace")
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if got.ID != "k-grace" || got.OperatorID != op.ID {
+			t.Errorf("got = %+v, want id=k-grace operator_id=%s", got, op.ID)
+		}
+		if got.RevokedAt != nil {
+			t.Errorf("revoked_at = %v, want nil for active key", got.RevokedAt)
+		}
+	})
+
+	t.Run("revoked_key_still_returns", func(t *testing.T) {
+		if err := s.RevokeOperatorAPIKey(ctx, "k-grace"); err != nil {
+			t.Fatal(err)
+		}
+		got, err := s.GetOperatorAPIKey(ctx, "k-grace")
+		if err != nil {
+			t.Fatalf("err = %v, want nil (revoked keys must still resolve for ownership check)", err)
+		}
+		if got.RevokedAt == nil {
+			t.Errorf("revoked_at = nil, want non-nil after revoke")
+		}
+		if got.OperatorID != op.ID {
+			t.Errorf("operator_id = %q, want %q (must survive revoke)", got.OperatorID, op.ID)
+		}
+	})
+
+	t.Run("missing_key_returns_ErrNotFound", func(t *testing.T) {
+		_, err := s.GetOperatorAPIKey(ctx, "k-does-not-exist")
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("err = %v, want ErrNotFound", err)
+		}
+	})
+}
+
 func TestSessionLifecycle(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -142,6 +142,7 @@ type Store interface {
 
 	// Operator API keys
 	CreateOperatorAPIKey(ctx context.Context, k *models.OperatorAPIKey) error
+	GetOperatorAPIKey(ctx context.Context, keyID string) (*models.OperatorAPIKey, error)
 	GetOperatorByAPIKeyHash(ctx context.Context, keyHash string) (*models.Operator, *models.OperatorAPIKey, error)
 	ListOperatorAPIKeys(ctx context.Context, operatorID string) ([]*models.OperatorAPIKey, error)
 	RevokeOperatorAPIKey(ctx context.Context, keyID string) error

--- a/internal/web/operator_existence_validation_test.go
+++ b/internal/web/operator_existence_validation_test.go
@@ -44,6 +44,24 @@ func TestHandleOperatorDisable_NonExistent_Returns404(t *testing.T) {
 	}
 }
 
+// TestHandleOperatorCreateAPIKey_NonExistent_Returns404 locks the
+// NotFound 404 path against future regression. The handler previously
+// swallowed all GetOperator errors as 404; the discrimination patch
+// makes that explicit (NotFound → 404, internal error → 500 + log).
+func TestHandleOperatorCreateAPIKey_NonExistent_Returns404(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators/op-does-not-exist/api-keys", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
 // TestHandleOperatorEnable_NonExistent_Returns404 mirrors the Disable
 // test for the Enable handler.
 func TestHandleOperatorEnable_NonExistent_Returns404(t *testing.T) {

--- a/internal/web/operator_existence_validation_test.go
+++ b/internal/web/operator_existence_validation_test.go
@@ -7,12 +7,36 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/juev/nebula-mesh/internal/models"
 	"github.com/juev/nebula-mesh/internal/store"
 )
+
+// concurrentRevokeStore wraps store.Store and injects exactly one CAS-race
+// on the first GetOperatorAPIKey of a non-revoked key by revoking the row
+// directly before the snapshot is returned. The handler's *models.OperatorAPIKey
+// pointer still reflects RevokedAt == nil (unmarshalled before the
+// wrapper's intervening UPDATE), so the handler falls past the
+// RevokedAt != nil early-return and into RevokeOperatorAPIKey, which now
+// returns store.ErrNotFound from the WHERE revoked_at IS NULL CAS clause.
+// Exercises the TOCTOU window between GetOperatorAPIKey and the atomic CAS.
+type concurrentRevokeStore struct {
+	store.Store
+	raceOnce sync.Once
+}
+
+func (r *concurrentRevokeStore) GetOperatorAPIKey(ctx context.Context, kid string) (*models.OperatorAPIKey, error) {
+	key, err := r.Store.GetOperatorAPIKey(ctx, kid)
+	if err == nil && key != nil && key.RevokedAt == nil {
+		r.raceOnce.Do(func() {
+			_ = r.RevokeOperatorAPIKey(ctx, kid)
+		})
+	}
+	return key, err
+}
 
 // TestHandleOperatorDisable_NonExistent_Returns404 verifies that
 // POST /ui/operators/{id}/disable with a non-existent {id} returns 404
@@ -372,5 +396,70 @@ func TestHandleOperator_HappyPath_AuditRowsCorrect(t *testing.T) {
 			t.Errorf("missing audit entry for action=%q resource=%q details=%q actor=root; got %d entries: %+v",
 				c.action, c.resource, c.details, len(entries), entries)
 		}
+	}
+}
+
+// TestHandleOperatorRevokeAPIKey_ConcurrentRevokeRace_Idempotent verifies
+// the TOCTOU branch on the UI surface: if a concurrent revoke (another
+// admin or a DisableOperator cascade) wins the CAS between the
+// GetOperatorAPIKey snapshot and the RevokeOperatorAPIKey UPDATE, the
+// second actor's POST must still return 303 with no new audit row,
+// mirroring the RevokedAt != nil early-return path. Before the fix the
+// race-loser surfaced as a 500 because store.ErrNotFound from the CAS
+// clause fell into the default error branch.
+func TestHandleOperatorRevokeAPIKey_ConcurrentRevokeRace_Idempotent(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+	ctx := context.Background()
+
+	if err := s.CreateOperator(ctx, &models.Operator{
+		ID:           "op-race",
+		Username:     "race",
+		PasswordHash: "x",
+		Status:       models.OperatorStatusActive,
+		Role:         "user",
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}); err != nil {
+		t.Fatalf("seed race: %v", err)
+	}
+	sum := sha256.Sum256([]byte("race-token"))
+	if err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID: "key-race", OperatorID: "op-race", Name: "r", KeyHash: hex.EncodeToString(sum[:]), CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create race key: %v", err)
+	}
+
+	// Swap the web's store to one that races a concurrent revoke into the
+	// gap between GetOperatorAPIKey and RevokeOperatorAPIKey. Done after
+	// seeding so the seed path uses the real store directly.
+	w.store = &concurrentRevokeStore{Store: w.store}
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators/op-race/api-keys/key-race/revoke", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d, want 303 (idempotent on CAS-loss race)", rec.Code)
+	}
+
+	// Race-loser writes no audit row.
+	entries, err := s.ListAuditEntries(ctx, store.AuditFilter{Action: "operator.api_key.revoke", Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("got %d revoke audit entries from race-loser, want 0", len(entries))
+	}
+
+	// Key is in fact revoked (by the race injection).
+	got, err := s.GetOperatorAPIKey(ctx, "key-race")
+	if err != nil {
+		t.Fatalf("get key: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Error("key should be revoked after concurrent-revoke race injection")
 	}
 }

--- a/internal/web/operator_existence_validation_test.go
+++ b/internal/web/operator_existence_validation_test.go
@@ -1,0 +1,358 @@
+package web
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// TestHandleOperatorDisable_NonExistent_Returns404 verifies that
+// POST /ui/operators/{id}/disable with a non-existent {id} returns 404
+// without writing an audit entry. Before this validation was added the
+// handler 303'd to the bogus operator detail URL and wrote an
+// `operator.disable` audit row with resource=<bogus id>, polluting the
+// forensic record.
+func TestHandleOperatorDisable_NonExistent_Returns404(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators/op-does-not-exist/disable", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+
+	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Action: "operator.disable", Limit: 100})
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	for _, e := range entries {
+		if e.Resource == "op-does-not-exist" {
+			t.Errorf("unexpected audit entry written for non-existent operator: %+v", e)
+		}
+	}
+}
+
+// TestHandleOperatorEnable_NonExistent_Returns404 mirrors the Disable
+// test for the Enable handler.
+func TestHandleOperatorEnable_NonExistent_Returns404(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators/op-does-not-exist/enable", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+
+	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Action: "operator.enable", Limit: 100})
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	for _, e := range entries {
+		if e.Resource == "op-does-not-exist" {
+			t.Errorf("unexpected audit entry written for non-existent operator: %+v", e)
+		}
+	}
+}
+
+// TestHandleOperatorRevokeAPIKey_NonExistentOperator_Returns404 verifies
+// that POST /ui/operators/{id}/api-keys/{kid}/revoke with a non-existent
+// {id} returns 404 and does not revoke any API key (nor write an audit
+// entry against the bogus id).
+func TestHandleOperatorRevokeAPIKey_NonExistentOperator_Returns404(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/ui/operators/op-does-not-exist/api-keys/kid-anything/revoke", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+
+	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Action: "operator.api_key.revoke", Limit: 100})
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	for _, e := range entries {
+		if e.Resource == "op-does-not-exist" {
+			t.Errorf("unexpected audit entry written for non-existent operator: %+v", e)
+		}
+	}
+}
+
+// TestHandleOperatorRevokeAPIKey_KidBelongsToDifferentOperator_Returns404
+// verifies that POST /ui/operators/{A}/api-keys/{kid-of-B}/revoke returns
+// 404, does NOT revoke the kid (the real owner's key stays active), and
+// does NOT write an audit row mislabelling the action under A.
+func TestHandleOperatorRevokeAPIKey_KidBelongsToDifferentOperator_Returns404(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	// Two non-admin operators, each owns a key. mintSession creates "root"
+	// (admin); seed "alpha" and "beta" directly so we control which kid
+	// belongs to which operator.
+	for _, username := range []string{"alpha", "beta"} {
+		if err := s.CreateOperator(context.Background(), &models.Operator{
+			ID:           "op-" + username,
+			Username:     username,
+			PasswordHash: "x",
+			Status:       models.OperatorStatusActive,
+			Role:         "user",
+			AuthProvider: models.OperatorAuthLocal,
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", username, err)
+		}
+	}
+
+	sum := sha256.Sum256([]byte("beta-raw-token"))
+	betaKey := &models.OperatorAPIKey{
+		ID:         "key-belongs-to-beta",
+		OperatorID: "op-beta",
+		Name:       "beta-ci",
+		KeyHash:    hex.EncodeToString(sum[:]),
+		CreatedAt:  time.Now(),
+	}
+	if err := s.CreateOperatorAPIKey(context.Background(), betaKey); err != nil {
+		t.Fatalf("create beta key: %v", err)
+	}
+
+	// Admin attempts to revoke beta's key via alpha's URL namespace.
+	req := httptest.NewRequest(http.MethodPost,
+		"/ui/operators/op-alpha/api-keys/key-belongs-to-beta/revoke", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+	// Body wording locks the side-channel: cross-operator-kid must look
+	// identical to "kid genuinely missing" so an attacker can't distinguish
+	// existence of someone else's key by probing.
+	if body := strings.TrimSpace(rec.Body.String()); body != "api key not found" {
+		t.Errorf("body = %q, want \"api key not found\" (distinct from \"operator not found\" would leak existence)", body)
+	}
+
+	// Verify beta's key was NOT revoked.
+	got, err := s.GetOperatorAPIKey(context.Background(), "key-belongs-to-beta")
+	if err != nil {
+		t.Fatalf("get beta key: %v", err)
+	}
+	if got.RevokedAt != nil {
+		t.Errorf("beta's key was unexpectedly revoked (revoked_at=%v)", got.RevokedAt)
+	}
+
+	// Verify no audit row was written under op-alpha (the URL operator).
+	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Action: "operator.api_key.revoke", Limit: 100})
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	for _, e := range entries {
+		if e.Resource == "op-alpha" {
+			t.Errorf("unexpected audit entry under op-alpha for cross-operator kid: %+v", e)
+		}
+	}
+}
+
+// TestHandleOperatorRevokeAPIKey_AlreadyRevoked_Idempotent verifies that
+// revoking the same kid twice (or revoking a kid that DisableOperator
+// already cascaded into the revoked state) returns 303 with no new audit
+// row. The handler's early-return on key.RevokedAt != nil avoids a doomed
+// store UPDATE; the audit log only records the original revoke event.
+func TestHandleOperatorRevokeAPIKey_AlreadyRevoked_Idempotent(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	// Seed a user operator with one key, then admin revokes once.
+	if err := s.CreateOperator(context.Background(), &models.Operator{
+		ID:           "op-gamma",
+		Username:     "gamma",
+		PasswordHash: "x",
+		Status:       models.OperatorStatusActive,
+		Role:         "user",
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}); err != nil {
+		t.Fatalf("seed gamma: %v", err)
+	}
+	sum := sha256.Sum256([]byte("gamma-token"))
+	if err := s.CreateOperatorAPIKey(context.Background(), &models.OperatorAPIKey{
+		ID: "key-gamma", OperatorID: "op-gamma", Name: "g", KeyHash: hex.EncodeToString(sum[:]), CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create gamma key: %v", err)
+	}
+
+	post := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/ui/operators/op-gamma/api-keys/key-gamma/revoke", nil)
+		req.AddCookie(cookie)
+		rec := httptest.NewRecorder()
+		w.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// First revoke: 303, writes one audit row.
+	if rec := post(); rec.Code != http.StatusSeeOther {
+		t.Fatalf("first revoke: status = %d, want 303", rec.Code)
+	}
+	first, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Action: "operator.api_key.revoke", Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("after first revoke: %d audit entries, want 1", len(first))
+	}
+
+	// Second revoke (same kid, same operator, already revoked): 303, NO new audit row.
+	if rec := post(); rec.Code != http.StatusSeeOther {
+		t.Errorf("second revoke: status = %d, want 303 (idempotent)", rec.Code)
+	}
+	second, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Action: "operator.api_key.revoke", Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 1 {
+		t.Errorf("after second revoke: %d audit entries, want 1 (no new row for idempotent re-revoke)", len(second))
+	}
+}
+
+// TestHandleOperatorRevokeAPIKey_AfterDisableCascade_Idempotent verifies
+// the early-return-on-revoked branch when the key was auto-revoked by a
+// prior DisableOperator (not by an explicit prior revoke). This is the
+// production-realistic flow: admin disables a compromised operator, then
+// belt-and-suspenders POSTs an explicit key revoke. Must return 303 with
+// no new audit row.
+func TestHandleOperatorRevokeAPIKey_AfterDisableCascade_Idempotent(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+	ctx := context.Background()
+
+	if err := s.CreateOperator(ctx, &models.Operator{
+		ID: "op-epsilon", Username: "epsilon", PasswordHash: "x",
+		Status: models.OperatorStatusActive, Role: "user", AuthProvider: models.OperatorAuthLocal,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed epsilon: %v", err)
+	}
+	sum := sha256.Sum256([]byte("epsilon-token"))
+	if err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID: "key-epsilon", OperatorID: "op-epsilon", KeyHash: hex.EncodeToString(sum[:]), CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cascade-revoke via DisableOperator.
+	if err := s.DisableOperator(ctx, "op-epsilon"); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators/op-epsilon/api-keys/key-epsilon/revoke", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d, want 303 (idempotent after cascade revoke)", rec.Code)
+	}
+	entries, err := s.ListAuditEntries(ctx, store.AuditFilter{Action: "operator.api_key.revoke", Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("got %d revoke audit entries, want 0 (cascade doesn't audit each key; idempotent revoke doesn't either)", len(entries))
+	}
+}
+
+// TestHandleOperator_HappyPath_AuditRowsCorrect locks the positive
+// assertion that the audit rows DO get written with the verified
+// resource/details when the handler succeeds. Without this, a regression
+// silently removing the AddAuditEntry call would pass every existing
+// negative-case test.
+func TestHandleOperator_HappyPath_AuditRowsCorrect(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+	ctx := context.Background()
+
+	// Seed a user operator with one key.
+	if err := s.CreateOperator(ctx, &models.Operator{
+		ID:           "op-delta",
+		Username:     "delta",
+		PasswordHash: "x",
+		Status:       models.OperatorStatusActive,
+		Role:         "user",
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}); err != nil {
+		t.Fatalf("seed delta: %v", err)
+	}
+	sum := sha256.Sum256([]byte("delta-token"))
+	if err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID: "key-delta", OperatorID: "op-delta", Name: "d", KeyHash: hex.EncodeToString(sum[:]), CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create delta key: %v", err)
+	}
+
+	exec := func(method, path string) {
+		req := httptest.NewRequest(method, path, nil)
+		req.AddCookie(cookie)
+		rec := httptest.NewRecorder()
+		w.ServeHTTP(rec, req)
+		if rec.Code != http.StatusSeeOther {
+			t.Fatalf("%s %s: status = %d, want 303; body=%s", method, path, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Revoke before Disable: DisableOperator cascades a revoke, which would
+	// make the explicit revoke take the idempotent early-return branch and
+	// skip the audit row this test is checking for.
+	exec(http.MethodPost, "/ui/operators/op-delta/api-keys/key-delta/revoke")
+	exec(http.MethodPost, "/ui/operators/op-delta/disable")
+	exec(http.MethodPost, "/ui/operators/op-delta/enable")
+
+	cases := []struct {
+		action, resource, details string
+	}{
+		{"operator.disable", "op-delta", ""},
+		{"operator.enable", "op-delta", ""},
+		{"operator.api_key.revoke", "op-delta", "key-delta"},
+	}
+	for _, c := range cases {
+		entries, err := s.ListAuditEntries(ctx, store.AuditFilter{Action: c.action, Limit: 100})
+		if err != nil {
+			t.Fatalf("list %s: %v", c.action, err)
+		}
+		found := false
+		for _, e := range entries {
+			if e.Resource == c.resource && e.Details == c.details && e.Actor == "root" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing audit entry for action=%q resource=%q details=%q actor=root; got %d entries: %+v",
+				c.action, c.resource, c.details, len(entries), entries)
+		}
+	}
+}

--- a/internal/web/operators.go
+++ b/internal/web/operators.go
@@ -166,6 +166,15 @@ func (w *Web) handleOperatorDetail(rw http.ResponseWriter, r *http.Request) {
 
 func (w *Web) handleOperatorDisable(rw http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+	if _, err := w.store.GetOperator(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(rw, "operator not found", http.StatusNotFound)
+			return
+		}
+		w.logger.Error("get operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
 	if err := w.store.DisableOperator(r.Context(), id); err != nil && !errors.Is(err, store.ErrNotFound) {
 		w.logger.Error("disable operator", "error", err)
 		http.Error(rw, "internal error", http.StatusInternalServerError)
@@ -178,6 +187,15 @@ func (w *Web) handleOperatorDisable(rw http.ResponseWriter, r *http.Request) {
 
 func (w *Web) handleOperatorEnable(rw http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+	if _, err := w.store.GetOperator(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(rw, "operator not found", http.StatusNotFound)
+			return
+		}
+		w.logger.Error("get operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
 	if err := w.store.EnableOperator(r.Context(), id); err != nil && !errors.Is(err, store.ErrNotFound) {
 		w.logger.Error("enable operator", "error", err)
 		http.Error(rw, "internal error", http.StatusInternalServerError)
@@ -263,19 +281,47 @@ func (w *Web) handleOperatorCreateAPIKey(rw http.ResponseWriter, r *http.Request
 func (w *Web) handleOperatorRevokeAPIKey(rw http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	kid := chi.URLParam(r, "kid")
-	err := w.store.RevokeOperatorAPIKey(r.Context(), kid)
-	switch {
-	case err == nil:
-		actor := actorUsername(r, w.session)
-		_ = w.store.AddAuditEntry(r.Context(), actor, "operator.api_key.revoke", id, kid)
-	case errors.Is(err, store.ErrNotFound):
+	if _, err := w.store.GetOperator(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(rw, "operator not found", http.StatusNotFound)
+			return
+		}
+		w.logger.Error("get operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	// Verify the API key belongs to this operator before revoking.
+	// Without this, an admin could revoke any operator's API key while
+	// the audit row records the URL-supplied operator id instead of the
+	// key's real owner, breaking forensic correlation.
+	key, err := w.store.GetOperatorAPIKey(r.Context(), kid)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(rw, "api key not found", http.StatusNotFound)
+			return
+		}
+		w.logger.Error("get api key", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if key.OperatorID != id {
+		http.Error(rw, "api key not found", http.StatusNotFound)
+		return
+	}
+	if key.RevokedAt != nil {
 		// Already revoked (DisableOperator auto-revokes every key in the
-		// same transaction). UI stays idempotent — just redirect back.
-	default:
+		// same transaction). UI stays idempotent — skip the no-op UPDATE
+		// and the audit row.
+		http.Redirect(rw, r, "/ui/operators/"+id, http.StatusSeeOther) // #nosec G710 -- same-origin redirect: hardcoded /ui/operators/ prefix ensures Location stays on the current host regardless of id contents
+		return
+	}
+	if err := w.store.RevokeOperatorAPIKey(r.Context(), kid); err != nil {
 		w.logger.Error("revoke api key", "error", err)
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
+	actor := actorUsername(r, w.session)
+	_ = w.store.AddAuditEntry(r.Context(), actor, "operator.api_key.revoke", id, kid)
 	http.Redirect(rw, r, "/ui/operators/"+id, http.StatusSeeOther) // #nosec G710 -- same-origin redirect: hardcoded /ui/operators/ prefix ensures Location stays on the current host regardless of id contents
 }
 

--- a/internal/web/operators.go
+++ b/internal/web/operators.go
@@ -242,7 +242,12 @@ func (w *Web) handleOperatorResetPassword(rw http.ResponseWriter, r *http.Reques
 func (w *Web) handleOperatorCreateAPIKey(rw http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if _, err := w.store.GetOperator(r.Context(), id); err != nil {
-		http.Error(rw, "operator not found", http.StatusNotFound)
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(rw, "operator not found", http.StatusNotFound)
+			return
+		}
+		w.logger.Error("get operator", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
 	name := strings.TrimSpace(r.FormValue("name"))

--- a/internal/web/operators.go
+++ b/internal/web/operators.go
@@ -321,6 +321,16 @@ func (w *Web) handleOperatorRevokeAPIKey(rw http.ResponseWriter, r *http.Request
 		return
 	}
 	if err := w.store.RevokeOperatorAPIKey(r.Context(), kid); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// Concurrent revoke (another admin in another session, or a
+			// DisableOperator cascade) won the CAS between the
+			// GetOperatorAPIKey snapshot above and this UPDATE. Already
+			// revoked — mirror the RevokedAt != nil idempotent branch
+			// above (303 redirect, no audit row, since this actor's call
+			// did not cause the state change).
+			http.Redirect(rw, r, "/ui/operators/"+id, http.StatusSeeOther) // #nosec G710 -- same-origin redirect: hardcoded /ui/operators/ prefix ensures Location stays on the current host regardless of id contents
+			return
+		}
 		w.logger.Error("revoke api key", "error", err)
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary

Admin handlers across `internal/web/operators.go` and `internal/api/operators.go` reflected URL params (operator `id`, api-key `kid`) into audit `Resource`/`Details` fields without confirming the params matched real entities. Forensic queries on `Resource` saw orphan rows. A related (observability-flavoured) inconsistency in the same UI handler family — `handleOperatorCreateAPIKey` swallowing all `GetOperator` errors as 404 without logging — is bundled in the second commit.

Concrete consequences pre-fix:
- `POST /ui/operators/{garbage-id}/disable` → 303 redirect + audit row with `resource=<garbage-id>`.
- `POST /ui/operators/{A}/api-keys/{kid-of-B}/revoke` → revokes B's real key, audit row says `resource=A details=kid-of-B`. Cross-operator-kid pollution.
- `DELETE /api/v1/operators/{A}/api-keys/{kid-of-B}` → same as above on the JSON API surface (`internal/api/operators.go:174-192` pre-fix).
- `POST /ui/operators/{id}/api-keys` with a DB outage on the operator lookup → 404 "operator not found" instead of 500 "internal error", with nothing logged. Operators chased a phantom missing-data bug instead of a real outage.

The pattern in `handleOperatorResetPassword` (`operators.go:191`) was already correct (GetOperator first, discriminate ErrNotFound from internal-error + log, 404 on NotFound). This PR brings the other four handlers in the file in line, adds a new `Store.GetOperatorAPIKey` to support kid-ownership verification, and covers the matching defect on the JSON API side.

## What changed

- **UI** (`internal/web/operators.go`): `handleOperatorDisable`, `handleOperatorEnable`, `handleOperatorRevokeAPIKey`, `handleOperatorCreateAPIKey` all now `GetOperator(id)` first, discriminate `ErrNotFound` from internal errors (404 vs 500 + log), and proceed only on success. `handleOperatorRevokeAPIKey` additionally calls `GetOperatorAPIKey(kid)` and verifies `key.OperatorID == id` before revoking; early-returns 303 if the kid is already revoked (skips the no-op UPDATE).
- **JSON API** (`internal/api/operators.go`): `handleRevokeOperatorAPIKey` mirrors the UI Revoke fix — `GetOperator(id)` + `GetOperatorAPIKey(kid)` + ownership check + early-return on already-revoked. (API-side `handleDisableOperator` and `handleEnableOperator` were already correct, only Revoke needed patching.)
- **Store interface** (`internal/store/store.go`, `internal/store/sqlite_operators.go`): new `GetOperatorAPIKey(ctx, keyID)` returning the key regardless of revoked state. Only `SQLiteStore` implements `Store`; no mocks to update.

## Behaviour changes visible to clients

| Request | Pre-fix | Post-fix |
|---------|---------|----------|
| `POST /ui/operators/{bogus}/disable` | 303 + bogus audit row | 404, no audit row |
| `POST /ui/operators/{bogus}/enable` | 303 + bogus audit row | 404, no audit row |
| `POST /ui/operators/{A}/api-keys/{kid-of-B}/revoke` | 303 + key revoked + audit row `resource=A` | 404 + key stays + no audit row |
| `POST /ui/operators/{id}/api-keys` under DB outage | 404 "operator not found", nothing logged | 500 "internal error" + slog.Error |
| `DELETE /api/v1/operators/{A}/api-keys/{kid-of-B}` | 204 + key revoked + audit row `resource=A` | 404 + key stays + no audit row |
| `DELETE /api/v1/operators/{id}/api-keys/{already-revoked-kid}` | 404 (ErrNotFound from `WHERE revoked_at IS NULL`) | 204 (idempotent no-op, REST-conventional) |

The last row is a real API client-visible behaviour change. Matches the canonical REST shape for idempotent DELETE.

## Tests

- `internal/web/operator_existence_validation_test.go` (new, 8 tests): Disable/Enable/Revoke/CreateAPIKey-non-existent → 404, cross-operator-kid → 404 (with body wording assertion to seal the existence side channel), already-revoked idempotent (explicit-second path AND disable-cascade path), happy-path audit rows correct (positive assertion locking the `AddAuditEntry` call sites).
- `internal/api/operators_audit_validation_test.go` (new, 4 tests): same scenario battery on the JSON API surface.
- `internal/store/sqlite_operators_test.go`: `TestGetOperatorAPIKey` with three sub-cases pinning the "returns regardless of revoked state" invariant the ownership check relies on.

## Test plan

- [x] `go test ./... -race -count=1` — full suite green (`internal/api` 41s, `internal/web` 50s, all others <10s).
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `gosec ./...` — 0 issues (pre-push hook also runs vet + govulncheck).
- [x] Manual: pre-existing happy-path UI flows (`TestOperators_AdminLifecycle` walks Disable + Revoke on a real operator/key) continues to pass — happy path semantics unchanged.

## Scope decisions

- **Bundled both UI and JSON API surfaces** since the audit-integrity invariant ("audit row reflects the key's real owner") only holds if both surfaces validate. Splitting would have re-opened the bug on whichever surface lagged.
- **Bundled the `handleOperatorCreateAPIKey` error-discrimination fix** (second commit) since it's the same file and the same 8-line pattern. Different theme (observability vs. audit-integrity) but combining saves a second review pass.
