### PR TITLE
chore(gosec): drop orphan #nosec G117 on yaml.Marshal(cfg)

### DIFF
--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -343,7 +343,7 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 // SaveServerConfig writes the config to path atomically (temp file + rename).
 // Existing comments and unknown fields in the file are not preserved.
 func SaveServerConfig(path string, cfg *ServerConfig) error {
-	data, err := yaml.Marshal(cfg) // #nosec G117
+	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("marshal config: %w", err)
 	}


### PR DESCRIPTION
## Summary

Per your 2026-05-21 email asking me to drop the G117 `cfg.APIKey` suppression entirely. The chronology you assumed (#127 deletes it as a side effect of removing the field) didn't pan out because #127 (74ca1b4) merged *before* #134 (1315ff4), so #134's annotation landed on the post-removal `yaml.Marshal(cfg)` at `internal/config/server.go:346` and survived. With the `APIKey` field gone from `ServerConfig`, gosec no longer flags the line — verified by re-running standalone gosec scoped to G117 against `SaveServerConfig` with the suppression removed (Issues: 0, Nosec count drops 27 → 26).

The `cli/user.go:33` G117 suppression on the `userCreateRequest` body stays per your note ("Keep the cli/user.go Password one if you want; that field stays.").

This is the only piece of the gosec follow-up I'm fast-tracking out of the parked queue — the rest (split #134 into A+B, G710 httptest table, G306 enroll.go paragraph engagement) is still parked behind your `.golangci.yml` config pass per your scheduling guidance.

## Test plan

- [x] `gosec -include=G117 ./...` — 0 issues
- [x] `go test ./... -race -count=1` — green
- [x] `golangci-lint run ./...` — 0 issues
