### PR TITLE
test: regression coverage for GHSA-qm33 / -ghmh / -v2jf draft advisories

### DIFF
--- a/internal/api/audit_property_test.go
+++ b/internal/api/audit_property_test.go
@@ -1,0 +1,269 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// TestAuditRows_AllProductionPathsConform fires a representative sample
+// of write endpoints, then reads back every audit row the store emitted
+// and validates each one against assertValidAuditRow. The point is to
+// catch regressions where a handler:
+//
+//   - passes a literal action string not in the closed enum
+//     (e.g. the historical "settings.enforce_2fa" drift fixed alongside
+//     this test)
+//   - records an empty actor (recordAuditAction called outside the
+//     bearerAuth context)
+//   - records an empty resource for an action that requires one
+//   - lets a secret-shaped value into the details field
+//   - writes a JSON-looking details payload that doesn't parse
+//
+// Not exhaustive: the rotate-cert / reenroll / mobile-bundle /
+// ca.rotated paths are covered by other tests in this package (see
+// auditActionsExercisedElsewhere below) and not re-driven here. The
+// host.rekey.completed constant has no emitter at all and is tracked
+// in auditActionsPendingImplementation.
+func TestAuditRows_AllProductionPathsConform(t *testing.T) {
+	srv, st := newTestServer(t)
+	ctx := context.Background()
+
+	netID := createNetwork(t, srv)
+
+	// host.create — normal create.
+	hostID := mustCreateHost(t, srv, netID, "audit-h1", "192.168.100.50")
+
+	// host.update — PATCH the host's name, exercising the JSON-diff
+	// details payload.
+	mustDo(t, srv, http.MethodPatch, "/api/v1/hosts/"+hostID,
+		[]byte(`{"name":"audit-h1-renamed"}`), http.StatusOK)
+
+	// host.block / host.unblock.
+	mustDo(t, srv, http.MethodPost, "/api/v1/hosts/"+hostID+"/block", nil, http.StatusOK)
+	mustDo(t, srv, http.MethodPost, "/api/v1/hosts/"+hostID+"/unblock", nil, http.StatusOK)
+
+	// host.delete.
+	mustDo(t, srv, http.MethodDelete, "/api/v1/hosts/"+hostID, nil, http.StatusNoContent)
+
+	// ca.created — create a fresh non-default CA, then delete it.
+	caBody, _ := json.Marshal(createCARequest{Name: "audit-ca", Duration: "720h"})
+	caResp := mustDo(t, srv, http.MethodPost, "/api/v1/cas", caBody, http.StatusCreated)
+	var ca struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(caResp, &ca); err != nil {
+		t.Fatalf("decode ca: %v", err)
+	}
+
+	// ca.deleted — the new CA isn't the default, so delete is permitted.
+	mustDo(t, srv, http.MethodDelete, "/api/v1/cas/"+ca.ID, nil, http.StatusNoContent)
+
+	// operator.create.
+	opBody, _ := json.Marshal(createOperatorRequest{Username: "audit-op", Password: "pw"})
+	opResp := mustDo(t, srv, http.MethodPost, "/api/v1/operators", opBody, http.StatusCreated)
+	var op struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(opResp, &op); err != nil {
+		t.Fatalf("decode operator: %v", err)
+	}
+
+	// operator.disable / operator.enable.
+	mustDo(t, srv, http.MethodPost, "/api/v1/operators/"+op.ID+"/disable", nil, http.StatusNoContent)
+	mustDo(t, srv, http.MethodPost, "/api/v1/operators/"+op.ID+"/enable", nil, http.StatusNoContent)
+
+	// operator.api_key.create.
+	keyBody, _ := json.Marshal(createAPIKeyRequest{Name: "audit-key"})
+	keyResp := mustDo(t, srv, http.MethodPost, "/api/v1/operators/"+op.ID+"/api-keys", keyBody, http.StatusCreated)
+	var keyEntry struct {
+		Entry struct {
+			ID string `json:"id"`
+		} `json:"entry"`
+	}
+	if err := json.Unmarshal(keyResp, &keyEntry); err != nil {
+		t.Fatalf("decode api key: %v", err)
+	}
+
+	// operator.api_key.revoke.
+	mustDo(t, srv, http.MethodDelete,
+		fmt.Sprintf("/api/v1/operators/%s/api-keys/%s", op.ID, keyEntry.Entry.ID),
+		nil, http.StatusNoContent)
+
+	// settings.enforce_2fa — the action that was historically a literal
+	// string drift; PATCHing here verifies the const-based path emits a
+	// well-formed row.
+	mustDo(t, srv, http.MethodPatch, "/api/v1/settings",
+		[]byte(`{"enforce_2fa":true}`), http.StatusOK)
+
+	// host.auth.failed — a signed-poll with missing headers exercises
+	// the empty-resource exception (no host known yet).
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("signed-poll missing-headers: status = %d, want 400", rec.Code)
+	}
+
+	// Read back every audit row and validate each.
+	rows, err := st.ListAuditEntries(ctx, store.AuditFilter{Limit: 1000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("no audit rows recorded — test exercised nothing")
+	}
+
+	seen := map[string]int{}
+	for _, row := range rows {
+		assertValidAuditRow(t, row)
+		seen[row.Action]++
+	}
+
+	for _, want := range auditActionsExercisedByCoverageSweep {
+		if seen[want] == 0 {
+			t.Errorf("test did not produce any %q audit rows (coverage gap)", want)
+		}
+	}
+}
+
+// auditActionsExercisedByCoverageSweep is the single source of truth for
+// which audit actions the coverage sweep above is expected to drive.
+// TestAuditRows_AllProductionPathsConform verifies each one was
+// actually emitted; TestKnownAuditActions_HaveCallSiteCoverage derives
+// the orphan-detection set from this slice so the two tests cannot
+// drift apart.
+//
+// Add a new entry only after wiring the coverage sweep to drive a
+// handler that emits the action.
+var auditActionsExercisedByCoverageSweep = []string{
+	auditHostCreate,
+	auditHostUpdate,
+	auditHostBlock,
+	auditHostUnblock,
+	auditHostDelete,
+	auditCACreated,
+	auditCADeleted,
+	auditOperatorCreate,
+	auditOperatorDisable,
+	auditOperatorEnable,
+	auditOperatorAPIKeyCreate,
+	auditOperatorAPIKeyRevoke,
+	auditSettingsEnforce2FA,
+	auditHostAuthFailed,
+}
+
+// auditActionsExercisedElsewhere lists known audit actions that are
+// covered by other tests in this package rather than re-driven by the
+// coverage sweep above. Keep this list curated: any audit constant that
+// is neither in the coverage sweep nor here (nor in
+// auditActionsPendingImplementation) is an orphan, and
+// TestKnownAuditActions_HaveCallSiteCoverage will flag it.
+var auditActionsExercisedElsewhere = map[string]string{
+	auditHostRotateCertRequested:   "hosts_rotate_cert_test.go",
+	auditHostReenrollRequested:     "hosts_reenroll_test.go",
+	auditHostMobileBundleIssued:    "mobile_bundle_test.go",
+	auditHostMobileBundleForbidden: "mobile_bundle_test.go",
+	auditCARotated:                 "cas_test.go",
+}
+
+// auditActionsPendingImplementation lists audit constants that were
+// declared in advance of an emitter — typically because a feature was
+// landed in phases and the constant block was populated up-front so
+// later PRs could fill in the call sites. Each entry's string value is
+// a freeform tracker (PR / commit / issue) pointing at where the
+// constant was introduced and why.
+//
+// Loophole acknowledged: nothing prevents a contributor from adding a
+// constant + a plausible-looking entry here and shipping without
+// wiring an emitter. The map is a coordination aid, not a hard
+// forcing function. Human review is the real defense.
+//
+// Removing an entry without adding an emitter (or moving it to
+// auditActionsExercisedElsewhere) will trip
+// TestKnownAuditActions_HaveCallSiteCoverage on the next run.
+var auditActionsPendingImplementation = map[string]string{
+	auditHostRekeyCompleted: "introduced in PR #75/#78 (commit b04cfd6, " +
+		"\"feat(store): foundation for ADR 0004 agent auth\") alongside " +
+		"the other agent-auth audit labels, with the intent that a " +
+		"follow-up PR would wire the emit at the point where the agent " +
+		"completes its re-enrollment with the rekey-token-minted key. " +
+		"Not yet wired.",
+}
+
+// TestKnownAuditActions_HaveCallSiteCoverage asserts every action in
+// the api-package audit enum is either driven by TestAuditRows_
+// AllProductionPathsConform (derived from
+// auditActionsExercisedByCoverageSweep, the same slice that test uses
+// to verify emission), exercised by another test in this package
+// (auditActionsExercisedElsewhere), or documented as pending
+// implementation (auditActionsPendingImplementation).
+//
+// To resolve a failure: either wire up the missing emitter, point the
+// constant at the test file that exercises it (in the maps above), or
+// remove the constant from metrics.go + knownAuditActions.
+func TestKnownAuditActions_HaveCallSiteCoverage(t *testing.T) {
+	exercisedHere := make(map[string]struct{}, len(auditActionsExercisedByCoverageSweep))
+	for _, a := range auditActionsExercisedByCoverageSweep {
+		exercisedHere[a] = struct{}{}
+	}
+	for action := range knownAuditActions {
+		if _, ok := exercisedHere[action]; ok {
+			continue
+		}
+		if _, ok := auditActionsExercisedElsewhere[action]; ok {
+			continue
+		}
+		if _, ok := auditActionsPendingImplementation[action]; ok {
+			continue
+		}
+		t.Errorf("audit action %q has no documented call-site coverage: "+
+			"either drive it from TestAuditRows_AllProductionPathsConform, "+
+			"add it to auditActionsExercisedElsewhere with the covering "+
+			"test file, mark it auditActionsPendingImplementation with a "+
+			"spec pointer, or remove the constant from metrics.go", action)
+	}
+}
+
+// mustCreateHost POSTs a fresh host into the given network and returns
+// the host ID. Fatals on any non-201 response.
+func mustCreateHost(t *testing.T, srv *Server, networkID, name, ip string) string {
+	t.Helper()
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: networkID,
+		Name:      name,
+		NebulaIPs: []string{ip},
+	})
+	resp := mustDo(t, srv, http.MethodPost, "/api/v1/hosts", body, http.StatusCreated)
+	var out createHostResponse
+	if err := json.Unmarshal(resp, &out); err != nil {
+		t.Fatalf("decode createHostResponse: %v", err)
+	}
+	return out.Host.ID
+}
+
+// mustDo fires an admin-authenticated request and asserts the response
+// status. Returns the response body.
+func mustDo(t *testing.T, srv *Server, method, path string, body []byte, wantStatus int) []byte {
+	t.Helper()
+	var rdr *bytes.Buffer
+	if body != nil {
+		rdr = bytes.NewBuffer(body)
+	} else {
+		rdr = bytes.NewBuffer(nil)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != wantStatus {
+		t.Fatalf("%s %s: status = %d, want %d; body = %s",
+			method, path, w.Code, wantStatus, w.Body.String())
+	}
+	return w.Body.Bytes()
+}

--- a/internal/api/audit_validator_test.go
+++ b/internal/api/audit_validator_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// knownAuditActions mirrors the closed set of audit action constants
+// declared in metrics.go for the internal/api package. Any new audit
+// action name emitted by an api-package handler must:
+//
+//  1. Get a typed `audit*` constant in metrics.go.
+//  2. Be added to the newMetrics() pre-seed loop so the Prometheus
+//     counter shows up with a zero value before the first event.
+//  3. Be added to this set.
+//
+// Scope caveat: the internal/web/, internal/alerts/, and internal/cli/
+// packages also emit audit rows (via store.AddAuditEntry directly) with
+// their own action strings — those are NOT mirrored here, and this
+// validator does not assert anything about them. The audit-row contract
+// pinned by this file applies only to recordAuditAction call sites
+// under internal/api/.
+var knownAuditActions = map[string]struct{}{
+	auditHostCreate:                {},
+	auditHostDelete:                {},
+	auditHostUpdate:                {},
+	auditHostBlock:                 {},
+	auditHostUnblock:               {},
+	auditHostAuthFailed:            {},
+	auditHostRotateCertRequested:   {},
+	auditHostReenrollRequested:     {},
+	auditHostRekeyCompleted:        {},
+	auditHostMobileBundleIssued:    {},
+	auditHostMobileBundleForbidden: {},
+	auditCACreated:                 {},
+	auditCADeleted:                 {},
+	auditCARotated:                 {},
+	auditOperatorCreate:            {},
+	auditOperatorDisable:           {},
+	auditOperatorEnable:            {},
+	auditOperatorAPIKeyCreate:      {},
+	auditOperatorAPIKeyRevoke:      {},
+	auditSettingsEnforce2FA:        {},
+}
+
+// actionsAllowingEmptyResource lists the actions where Resource == ""
+// is semantically meaningful — currently just early-stage signed-poll
+// failures that fail before identifying a host (missing headers,
+// unknown fingerprint, blocklisted-but-deleted host row). For every
+// other action, an empty resource indicates a missing argument at the
+// recordAuditAction call site.
+var actionsAllowingEmptyResource = map[string]struct{}{
+	auditHostAuthFailed: {},
+}
+
+// piiPatterns are content shapes that must never appear in an audit
+// row's details field. The list is intentionally narrow — the spirit
+// is "catch obvious secret-pasting accidents", not exhaustive PII
+// detection.
+//
+// Deliberate blind spots:
+//
+//   - UUID-shaped strings — legitimate IDs (host.ID, operator.ID,
+//     api_key.ID) and raw enrollment tokens both look like UUIDs.
+//     If a future handler started writing raw enrollment tokens into
+//     `details`, this validator would not catch it.
+//
+//   - TOTP secrets (base32, ~16-32 chars, no separator) — minted in
+//     internal/web/totp.go. No current emitter logs them, but the
+//     shape is indistinguishable from base32 audit identifiers, so a
+//     regex would false-positive on legitimate content.
+//
+//   - 2FA recovery codes (10-char hex) — minted in internal/web/
+//     totp.go. Shape collides with short hex IDs in fixture data.
+//
+//   - Bare JWTs (without the "Bearer " prefix) — the bearer regex
+//     catches `Bearer eyJ...` but a raw JWT pasted naked passes. OIDC
+//     ID tokens flow through internal/web/oidc.go; check there if
+//     extending coverage.
+//
+//   - Operator API keys (32-byte hex) — indistinguishable from the
+//     SHA-256 hash digests that legitimately appear in audit rows
+//     (host fingerprints, token-hash IDs). Can't be regex-disambig-
+//     uated without false positives.
+//
+//   - The bearer regex requires at least 20 chars of base64-shaped
+//     trailing content, which dodges legitimate phrases like
+//     "bearer token expired" while still catching `Bearer eyJhbGc...`.
+//
+//   - The password regex requires a `:` or `=` separator and at least
+//     six trailing non-space chars so it doesn't trip on phrases like
+//     "password changed" or "password=". Tighten further if a handler
+//     legitimately needs to log a short value following "password=".
+var piiPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`),
+	regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._\-]{20,}`),
+	regexp.MustCompile(`(?i)\bpassword\s*[:=]\s*\S{6,}`),
+}
+
+// assertValidAuditRow checks a single audit row against the project's
+// audit-row contract: required fields populated, action in the closed
+// enum, details JSON-shaped values parse, no secret-shaped content
+// leaked into details. Failures are reported via t.Errorf so a single
+// test can surface every malformed row in one run.
+func assertValidAuditRow(t *testing.T, row *models.AuditEntry) {
+	t.Helper()
+	if row == nil {
+		t.Error("audit row: nil")
+		return
+	}
+	if row.Action == "" {
+		t.Error("audit row: empty action")
+		return
+	}
+	if _, ok := knownAuditActions[row.Action]; !ok {
+		t.Errorf("audit row: action %q not in knownAuditActions enum "+
+			"(drift — add an audit* const to internal/api/metrics.go, "+
+			"add it to the newMetrics pre-seed loop, and mirror it here)",
+			row.Action)
+	}
+	if row.Actor == "" {
+		t.Errorf("audit row %s: empty actor (recordAuditAction was called "+
+			"without an actor on the context — check bearerAuth ordering)",
+			row.Action)
+	}
+	if row.Resource == "" {
+		if _, ok := actionsAllowingEmptyResource[row.Action]; !ok {
+			t.Errorf("audit row %s: empty resource (only %s permits empty)",
+				row.Action, auditHostAuthFailed)
+		}
+	}
+	if row.Timestamp.IsZero() {
+		t.Errorf("audit row %s: zero timestamp", row.Action)
+	}
+	if row.Details != "" {
+		d := strings.TrimSpace(row.Details)
+		if strings.HasPrefix(d, "{") || strings.HasPrefix(d, "[") {
+			var v any
+			if err := json.Unmarshal([]byte(row.Details), &v); err != nil {
+				t.Errorf("audit row %s: details begins with {/[ but does not parse as JSON: %v",
+					row.Action, err)
+			}
+		}
+		for _, pat := range piiPatterns {
+			if pat.MatchString(row.Details) {
+				t.Errorf("audit row %s: details matches PII/secret pattern %s",
+					row.Action, pat)
+			}
+		}
+	}
+}
+
+// --- unit tests on the validator itself ----------------------------------
+
+func TestAuditValidator_AcceptsWellFormed(t *testing.T) {
+	cases := []models.AuditEntry{
+		{Actor: "alice", Action: auditHostCreate, Resource: "host-1", Details: "name=foo", Timestamp: nowForTest()},
+		{Actor: "alice", Action: auditHostUpdate, Resource: "host-1", Details: `{"name":["old","new"]}`, Timestamp: nowForTest()},
+		{Actor: "alice", Action: auditHostDelete, Resource: "host-1", Details: "", Timestamp: nowForTest()},
+		// auditHostAuthFailed: empty resource is allowed only for this action.
+		{Actor: "unknown", Action: auditHostAuthFailed, Resource: "", Details: authReasonUnknownFingerprint, Timestamp: nowForTest()},
+		{Actor: "alice", Action: auditSettingsEnforce2FA, Resource: "enforce_2fa", Details: "true", Timestamp: nowForTest()},
+	}
+	for _, row := range cases {
+		t.Run(row.Action, func(t *testing.T) {
+			sub := &testing.T{}
+			assertValidAuditRow(sub, &row)
+			if sub.Failed() {
+				t.Errorf("expected row to validate, but assertions failed: %+v", row)
+			}
+		})
+	}
+}
+
+func TestAuditValidator_RejectsBadShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		row  models.AuditEntry
+	}{
+		{"empty action", models.AuditEntry{Actor: "alice", Resource: "x", Timestamp: nowForTest()}},
+		{"unknown action", models.AuditEntry{Actor: "alice", Action: "host.totally_new_action", Resource: "x", Timestamp: nowForTest()}},
+		{"empty actor", models.AuditEntry{Action: auditHostCreate, Resource: "host-1", Timestamp: nowForTest()}},
+		{"empty resource on action that requires it", models.AuditEntry{Actor: "alice", Action: auditHostCreate, Resource: "", Timestamp: nowForTest()}},
+		{"zero timestamp", models.AuditEntry{Actor: "alice", Action: auditHostCreate, Resource: "host-1"}},
+		{"json-shaped details that does not parse", models.AuditEntry{Actor: "alice", Action: auditHostUpdate, Resource: "h", Details: `{name: nope}`, Timestamp: nowForTest()}},
+		{"private-key in details", models.AuditEntry{Actor: "alice", Action: auditHostCreate, Resource: "h", Details: "-----BEGIN PRIVATE KEY-----\nAAAA\n", Timestamp: nowForTest()}},
+		{"bearer token in details", models.AuditEntry{Actor: "alice", Action: auditHostCreate, Resource: "h", Details: "Bearer abcdefghijklmnopqrstuv1234", Timestamp: nowForTest()}},
+		{"password= in details", models.AuditEntry{Actor: "alice", Action: auditHostCreate, Resource: "h", Details: "password=hunter2", Timestamp: nowForTest()}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sub := &testing.T{}
+			assertValidAuditRow(sub, &c.row)
+			if !sub.Failed() {
+				t.Errorf("expected validator to reject row %+v, but it passed", c.row)
+			}
+		})
+	}
+}
+
+func nowForTest() time.Time { return time.Now() }

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -69,6 +69,7 @@ const (
 	auditOperatorEnable            = "operator.enable"
 	auditOperatorAPIKeyCreate      = "operator.api_key.create"
 	auditOperatorAPIKeyRevoke      = "operator.api_key.revoke"
+	auditSettingsEnforce2FA        = "settings.enforce_2fa"
 )
 
 // Audit reason codes used in the `details` field of host.auth.failed audit
@@ -192,6 +193,7 @@ func newMetrics(s store.Store) *metrics {
 		auditCACreated, auditCADeleted, auditCARotated,
 		auditOperatorCreate, auditOperatorDisable, auditOperatorEnable,
 		auditOperatorAPIKeyCreate, auditOperatorAPIKeyRevoke,
+		auditSettingsEnforce2FA,
 	} {
 		m.auditEntries.WithLabelValues(action).Add(0)
 	}

--- a/internal/api/pop/nonce_burst_test.go
+++ b/internal/api/pop/nonce_burst_test.go
@@ -1,0 +1,228 @@
+package pop
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestNonceCache_ConcurrentSameNonce_ExactlyOneTrue fires many goroutines
+// at the same (host, nonce) pair and asserts exactly one of them
+// observes a fresh-accept return. The point is to lock down the mutex
+// invariant that defeats the "two goroutines both miss the map,
+// both insert, both return true" race that would open a replay window
+// under concurrent load.
+//
+// Run with -race for full coverage of the data-race side.
+func TestNonceCache_ConcurrentSameNonce_ExactlyOneTrue(t *testing.T) {
+	const attempts = 200
+	c := NewNonceCache(NonceCacheConfig{Capacity: 1024, IdleTTL: time.Hour})
+
+	accepts := make(chan bool, attempts)
+	var wg sync.WaitGroup
+	wg.Add(attempts)
+	for i := 0; i < attempts; i++ {
+		go func() {
+			defer wg.Done()
+			accepts <- c.SeenOrAdd("h", "shared")
+		}()
+	}
+	wg.Wait()
+	close(accepts)
+
+	trueCount := 0
+	for got := range accepts {
+		if got {
+			trueCount++
+		}
+	}
+	if trueCount != 1 {
+		t.Errorf("fresh-accept count = %d, want 1 (replay window opened under concurrency)", trueCount)
+	}
+}
+
+// TestNonceCache_ConcurrentDistinctNonces_AllAccepted fires many
+// goroutines, each inserting a distinct nonce, and asserts every
+// insert returns true. Catches a defect where the LRU eviction path
+// under contention would incorrectly reject a fresh nonce.
+func TestNonceCache_ConcurrentDistinctNonces_AllAccepted(t *testing.T) {
+	const workers = 32
+	const noncesPerWorker = 64
+	c := NewNonceCache(NonceCacheConfig{
+		// Larger than workers*noncesPerWorker so no eviction during this test.
+		Capacity: workers * noncesPerWorker * 2,
+		IdleTTL:  time.Hour,
+	})
+
+	totalAccepts := make(chan int, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(workerID int) {
+			defer wg.Done()
+			ok := 0
+			for i := 0; i < noncesPerWorker; i++ {
+				if c.SeenOrAdd("h", fmt.Sprintf("w%d-n%d", workerID, i)) {
+					ok++
+				}
+			}
+			totalAccepts <- ok
+		}(w)
+	}
+	wg.Wait()
+	close(totalAccepts)
+
+	got := 0
+	for n := range totalAccepts {
+		got += n
+	}
+	if want := workers * noncesPerWorker; got != want {
+		t.Errorf("fresh-accept count = %d, want %d (LRU rejected a fresh nonce under contention)",
+			got, want)
+	}
+}
+
+// TestNonceCache_BurstEvictionDoesNotOpenReplayWindow exercises the
+// capacity-overflow path. Inserts n0..n3 (fills capacity=4), then
+// inserts an evictor that displaces the LRU tail (n0). Asserts:
+//
+//   - The evictor returns true (fresh accept).
+//   - n0 is acceptable as fresh again (it was evicted).
+//   - The other three (n1, n2, n3) and the evictor itself still
+//     reject replays — i.e. only the LRU tail moved out.
+//
+// Doesn't chain further re-inserts because that triggers cascade
+// evictions and obscures what's being asserted.
+func TestNonceCache_BurstEvictionDoesNotOpenReplayWindow(t *testing.T) {
+	c := NewNonceCache(NonceCacheConfig{
+		Capacity: 4,
+		IdleTTL:  time.Hour,
+		Now:      time.Now,
+	})
+
+	for i := 0; i < 4; i++ {
+		if !c.SeenOrAdd("h", fmt.Sprintf("n%d", i)) {
+			t.Fatalf("initial insert n%d returned false", i)
+		}
+	}
+	// Push past capacity. n0 was inserted first and never bumped, so
+	// it is the LRU victim.
+	if !c.SeenOrAdd("h", "evictor") {
+		t.Fatal("evictor insert returned false")
+	}
+
+	// The three nonces that should still be cached must reject replays.
+	for _, n := range []string{"n1", "n2", "n3", "evictor"} {
+		if c.SeenOrAdd("h", n) {
+			t.Errorf("still-cached %s wrongly accepted as fresh", n)
+		}
+	}
+}
+
+// TestNonceCache_EvictedNonceAcceptableAgain asserts that once a nonce
+// is evicted via LRU, it can be submitted again as fresh. Companion to
+// BurstEvictionDoesNotOpenReplayWindow — together they pin the LRU
+// contract from both sides (still-cached rejects, evicted accepts).
+func TestNonceCache_EvictedNonceAcceptableAgain(t *testing.T) {
+	c := NewNonceCache(NonceCacheConfig{
+		Capacity: 4,
+		IdleTTL:  time.Hour,
+		Now:      time.Now,
+	})
+	for i := 0; i < 4; i++ {
+		c.SeenOrAdd("h", fmt.Sprintf("n%d", i))
+	}
+	c.SeenOrAdd("h", "evictor") // n0 evicted.
+
+	if !c.SeenOrAdd("h", "n0") {
+		t.Error("n0 should be acceptable as fresh after LRU eviction")
+	}
+}
+
+// TestNonceCache_ReplayAttemptBumpsRecency is the defense the
+// implementation documents at nonce.go:73-78 ("bump recency to defeat
+// flood-then-replay tactics"). Without the bump, an attacker who
+// intercepted a legitimate nonce L could flood the cache with bogus
+// nonces to evict L via LRU and then replay L successfully. The bump
+// pins L at the head of the LRU on every replay attempt so the
+// attacker's flood evicts filler entries instead.
+//
+// Test shape:
+//
+//  1. Insert L (legitimate, lands at the LRU tail after X).
+//  2. Replay L — rejected AND bumped to head.
+//  3. Insert Y, exceeding capacity — the LRU tail is now X (filler),
+//     not L. Y's insertion evicts X.
+//  4. Replay L again — must still reject (L is still in the cache).
+func TestNonceCache_ReplayAttemptBumpsRecency(t *testing.T) {
+	now := time.Unix(0, 0)
+	c := NewNonceCache(NonceCacheConfig{
+		Capacity: 2,
+		IdleTTL:  10 * time.Minute,
+		Now:      func() time.Time { return now },
+	})
+
+	if !c.SeenOrAdd("h", "L") {
+		t.Fatal("L insert returned false")
+	}
+	if !c.SeenOrAdd("h", "X") {
+		t.Fatal("X insert returned false")
+	}
+
+	// Replay L: rejected AND bumped to head.
+	now = now.Add(time.Second)
+	if c.SeenOrAdd("h", "L") {
+		t.Fatal("L replay accepted (bug)")
+	}
+
+	// Push past capacity. With the bump, X (filler) is the LRU victim.
+	now = now.Add(time.Second)
+	if !c.SeenOrAdd("h", "Y") {
+		t.Fatal("Y insert returned false")
+	}
+
+	// L must still reject — it's the bump beneficiary.
+	if c.SeenOrAdd("h", "L") {
+		t.Error("L was bumped on replay attempt; should still reject after Y eviction")
+	}
+}
+
+// TestNonceCache_PerHostNamespacingPreventsCollision asserts the
+// (host_id, nonce) keying — the same nonce string used by two
+// different hosts is treated as two distinct entries, not as a replay.
+// Single-tenant deployments rely on this so an attacker who guesses a
+// well-known nonce value can't pre-pollute the cache for other hosts.
+func TestNonceCache_PerHostNamespacingPreventsCollision(t *testing.T) {
+	c := NewNonceCache(NonceCacheConfig{Capacity: 16, IdleTTL: time.Hour, Now: time.Now})
+	if !c.SeenOrAdd("hostA", "shared") {
+		t.Fatal("hostA initial insert returned false")
+	}
+	if !c.SeenOrAdd("hostB", "shared") {
+		t.Error("hostB's distinct entry for the same nonce string was wrongly rejected as a replay")
+	}
+	if c.SeenOrAdd("hostA", "shared") {
+		t.Error("hostA's own replay was wrongly accepted as fresh")
+	}
+}
+
+// TestNonceCache_LRUEvictionIsCrossHost documents that the LRU is a
+// single shared resource across all hosts — a flood under host B can
+// evict an idle entry belonging to host A. This is intentional: the
+// per-host key namespaces collisions, not eviction. Capacity sizing
+// in production (65536 default) is what bounds the practical attack
+// surface; per-host LRU partitioning is not the defense.
+func TestNonceCache_LRUEvictionIsCrossHost(t *testing.T) {
+	c := NewNonceCache(NonceCacheConfig{Capacity: 2, IdleTTL: time.Hour, Now: time.Now})
+	if !c.SeenOrAdd("hostA", "shared") {
+		t.Fatal("hostA initial insert returned false")
+	}
+	for i := 0; i < 4; i++ {
+		c.SeenOrAdd("hostB", fmt.Sprintf("filler-%d", i))
+	}
+	// hostA's entry is the LRU and was evicted by the flood. The
+	// freshest hostB entry survives.
+	if c.SeenOrAdd("hostB", "filler-3") {
+		t.Error("hostB's most-recent nonce wrongly evicted")
+	}
+}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -52,7 +52,7 @@ func (s *Server) handlePatchSettings(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to update setting")
 			return
 		}
-		s.recordAuditAction(r.Context(), "settings.enforce_2fa", "enforce_2fa", val)
+		s.recordAuditAction(r.Context(), auditSettingsEnforce2FA, settingEnforceTOTP, val)
 	}
 	v, _ := s.store.GetServerSetting(r.Context(), settingEnforceTOTP)
 	writeJSON(w, http.StatusOK, settingsResponse{EnforceTOTP: v == "true"})

--- a/internal/api/updates_signed_poll_audit_test.go
+++ b/internal/api/updates_signed_poll_audit_test.go
@@ -1,0 +1,295 @@
+package api
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corepop "github.com/juev/nebula-mesh/internal/pop"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// TestSignedPoll_AuditRowPerBranch drives each failure branch of
+// handleAgentUpdates (internal/api/updates.go) that records an
+// auditHostAuthFailed row, then reads back the audit row and validates
+// it against assertValidAuditRow (the audit-row contract test from
+// audit_validator_test.go). Pins the (reason code, resource shape)
+// contract for the signed-poll audit trail — operators key off these
+// strings when filtering the audit log, so a drift here is observable
+// to anyone running detection rules. All 11 audit-failed branches are
+// covered.
+func TestSignedPoll_AuditRowPerBranch(t *testing.T) {
+	cases := []struct {
+		name         string
+		setup        func(t *testing.T, srv *Server) (req *http.Request, wantStatus int)
+		wantReason   string
+		wantResource string // "" means: must be empty (early-stage branch)
+	}{
+		{
+			name: "missing_headers",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				return httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil),
+					http.StatusBadRequest
+			},
+			wantReason:   authReasonBadSignature,
+			wantResource: "",
+		},
+		{
+			name: "unknown_fingerprint",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				bogus := enrolledAgent{
+					fingerprint: "deadbeefdeadbeef",
+					signingPub:  agent.signingPub,
+					signingPriv: agent.signingPriv,
+				}
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, bogus)
+				return req, http.StatusUnauthorized
+			},
+			wantReason:   authReasonUnknownFingerprint,
+			wantResource: "",
+		},
+		{
+			name: "bad_signature_empty_signing_pem",
+			// Reaches updates.go:83 — decodeSigningPublicKeyPEM returns
+			// ErrBadSigningPEM on empty input. Reachable in production
+			// via legacy host rows that pre-date ADR 0004 enrollment
+			// (the surrounding comment in updates.go calls this out),
+			// not just synthetic corruption.
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				host, err := srv.store.GetHostByFingerprint(context.Background(), agent.fingerprint)
+				if err != nil {
+					t.Fatalf("get host by fingerprint: %v", err)
+				}
+				if err := srv.store.UpdateHostSigningPub(
+					context.Background(), host.ID, ""); err != nil {
+					t.Fatalf("clear signing pub: %v", err)
+				}
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent)
+				return req, http.StatusUnauthorized
+			},
+			wantReason:   authReasonBadSignature,
+			wantResource: "<non-empty-host-id>",
+		},
+		{
+			name: "bad_signature_wrong_key",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				_, otherPriv, _ := ed25519.GenerateKey(rand.Reader)
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent, withPrivateKey(otherPriv))
+				return req, http.StatusUnauthorized
+			},
+			wantReason: authReasonBadSignature,
+			// Resource is host.ID for branches reached AFTER fingerprint
+			// lookup. The exact ID is unknown until the fixture runs, so
+			// we just assert non-empty below.
+			wantResource: "<non-empty-host-id>",
+		},
+		{
+			name: "bad_signature_non_base64",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent)
+				// Overwrite the signature header with non-base64 garbage.
+				req.Header.Set(corepop.HeaderSignature, "!!!not-base64!!!")
+				return req, http.StatusUnauthorized
+			},
+			wantReason:   authReasonBadSignature,
+			wantResource: "<non-empty-host-id>",
+		},
+		{
+			name: "timestamp_unparseable",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent, withTimestamp("not-a-date"))
+				return req, http.StatusUnauthorized
+			},
+			wantReason:   authReasonTimestampSkew,
+			wantResource: "<non-empty-host-id>",
+		},
+		{
+			name: "timestamp_skewed",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				past := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent, withTimestamp(past))
+				return req, http.StatusUnauthorized
+			},
+			wantReason:   authReasonTimestampSkew,
+			wantResource: "<non-empty-host-id>",
+		},
+		{
+			name: "replayed_nonce",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				// First poll lands successfully and records the nonce.
+				first := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, first, agent, withNonce("fixed-nonce-1234"))
+				w := httptest.NewRecorder()
+				srv.ServeHTTP(w, first)
+				if w.Code != http.StatusOK {
+					t.Fatalf("seed poll: status = %d, body = %s", w.Code, w.Body.String())
+				}
+				// The replay attempt. NOTE: the seed poll also wrote a
+				// last-seen update; no audit row is emitted for the
+				// success path, so the only auditHostAuthFailed row is
+				// from the replay.
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent, withNonce("fixed-nonce-1234"))
+				return req, http.StatusUnauthorized
+			},
+			wantReason:   authReasonReplayedNonce,
+			wantResource: "<non-empty-host-id>",
+		},
+		{
+			name: "host_blocked",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				host, err := srv.store.GetHostByFingerprint(context.Background(), agent.fingerprint)
+				if err != nil {
+					t.Fatalf("get host by fingerprint: %v", err)
+				}
+				// Block via the store directly so the only audit row in
+				// the table is the one written by the signed-poll
+				// handler — the assertion below requires exactly one row.
+				if _, err := srv.store.BlockHostAndAddToBlocklist(
+					context.Background(), host.ID, "test"); err != nil {
+					t.Fatalf("block host: %v", err)
+				}
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent)
+				return req, http.StatusForbidden
+			},
+			wantReason:   authReasonRevoked,
+			wantResource: "<non-empty-host-id>",
+		},
+		{
+			name: "host_gone_after_delete_and_blocklist",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				host, err := srv.store.GetHostByFingerprint(context.Background(), agent.fingerprint)
+				if err != nil {
+					t.Fatalf("get host by fingerprint: %v", err)
+				}
+				// DeleteHostAndBlockCert removes the row and adds the
+				// fingerprint to the blocklist — the exact state that
+				// triggers the 410 gone branch (updates.go:58).
+				if err := srv.store.DeleteHostAndBlockCert(
+					context.Background(), host.ID, "test delete"); err != nil {
+					t.Fatalf("delete host: %v", err)
+				}
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent)
+				return req, http.StatusGone
+			},
+			wantReason:   authReasonGone,
+			wantResource: "", // host row gone by the time audit is recorded
+		},
+		{
+			name: "rotation_overlap_window_expired",
+			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
+				agent := enrolledFixture(t, srv)
+				host, err := srv.store.GetHostByFingerprint(context.Background(), agent.fingerprint)
+				if err != nil {
+					t.Fatalf("get host by fingerprint: %v", err)
+				}
+				// Park the agent's fingerprint as the *previous* one
+				// and rotate the host's current fingerprint to a
+				// synthetic value, backdating the rotation past the
+				// 2-minute overlap window (updates.go:38 returns
+				// 2*time.Minute). The next poll under the old
+				// fingerprint triggers the timeout branch
+				// (updates.go:154) → unknown_fingerprint audit.
+				rotatedAt := time.Now().Add(-1 * time.Hour)
+				if err := srv.store.SetPrevFingerprint(
+					context.Background(), host.ID, agent.fingerprint, rotatedAt); err != nil {
+					t.Fatalf("set prev fingerprint: %v", err)
+				}
+				if err := srv.store.UpdateHostCert(
+					context.Background(), host.ID, "synthetic-new-fp",
+					time.Now().Add(time.Hour)); err != nil {
+					t.Fatalf("update host cert: %v", err)
+				}
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+				signPoll(t, req, agent)
+				return req, http.StatusUnauthorized
+			},
+			wantReason:   authReasonUnknownFingerprint,
+			wantResource: "<non-empty-host-id>",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv, st := newTestServer(t)
+			ctx := context.Background()
+
+			req, wantStatus := c.setup(t, srv)
+
+			// Snapshot AFTER setup but BEFORE the poll. newTestServer
+			// seeds a CA (ca.created) and enrolledFixture posts hosts
+			// (host.create) — both legitimate setup audit rows. The
+			// contract under test is that the poll request itself
+			// emits exactly one audit row, no more, no less.
+			prereqRows, err := st.ListAuditEntries(ctx, store.AuditFilter{Limit: 100})
+			if err != nil {
+				t.Fatalf("list audit entries (prereq): %v", err)
+			}
+
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+			if w.Code != wantStatus {
+				t.Fatalf("status = %d, want %d, body = %s",
+					w.Code, wantStatus, w.Body.String())
+			}
+
+			rows, err := st.ListAuditEntries(ctx, store.AuditFilter{Limit: 100})
+			if err != nil {
+				t.Fatalf("list audit entries (post): %v", err)
+			}
+			if delta := len(rows) - len(prereqRows); delta != 1 {
+				for i, r := range rows {
+					t.Logf("row %d: action=%q actor=%q resource=%q details=%q",
+						i, r.Action, r.Actor, r.Resource, r.Details)
+				}
+				t.Fatalf("poll emitted %d audit rows, want 1", delta)
+			}
+			// rows is sorted timestamp DESC, so the row from this poll
+			// is at index 0.
+			row := rows[0]
+
+			assertValidAuditRow(t, row)
+			if row.Action != auditHostAuthFailed {
+				t.Errorf("action = %q, want %q", row.Action, auditHostAuthFailed)
+			}
+			if row.Details != c.wantReason {
+				t.Errorf("details = %q, want %q", row.Details, c.wantReason)
+			}
+			switch c.wantResource {
+			case "":
+				if row.Resource != "" {
+					t.Errorf("resource = %q, want empty for early-stage branch", row.Resource)
+				}
+			case "<non-empty-host-id>":
+				if row.Resource == "" {
+					t.Errorf("resource is empty; want non-empty host ID")
+				}
+			default:
+				if row.Resource != c.wantResource {
+					t.Errorf("resource = %q, want %q", row.Resource, c.wantResource)
+				}
+			}
+		})
+	}
+}

--- a/internal/models/token_test.go
+++ b/internal/models/token_test.go
@@ -1,0 +1,86 @@
+package models
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// TestHashEnrollmentToken_StableAndDoesNotLeak pins the contract that
+// closes GHSA-ghmh-jhmj-wcmf: the at-rest token hash must be a
+// deterministic SHA-256 hex digest of the raw input, distinct from the
+// input (no echo), and stable across calls. Inspired by netbird's
+// session_test.go::TestHashToken_StableAndDoesNotLeak.
+func TestHashEnrollmentToken_StableAndDoesNotLeak(t *testing.T) {
+	const raw = "550e8400-e29b-41d4-a716-446655440000" // UUID-shaped sample input
+	got := HashEnrollmentToken(raw)
+
+	// Deterministic — same input, same output.
+	if again := HashEnrollmentToken(raw); got != again {
+		t.Errorf("hash is non-deterministic: %q vs %q", got, again)
+	}
+
+	// Does not leak: the digest must not contain the raw input as a
+	// substring. SHA-256 hex output is 64 lowercase hex chars; a UUID
+	// has dashes and is 36 chars — they can't collide accidentally,
+	// but the assertion captures intent.
+	if strings.Contains(got, raw) {
+		t.Errorf("hash %q contains raw input %q", got, raw)
+	}
+
+	// SHA-256 hex shape: 64 lowercase hex chars.
+	if len(got) != 2*sha256.Size {
+		t.Errorf("hash length = %d, want %d (SHA-256 hex)", len(got), 2*sha256.Size)
+	}
+	for _, r := range got {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') {
+			continue
+		}
+		t.Errorf("hash contains non-lowercase-hex character %q", r)
+		break
+	}
+
+	// Computing the digest the long way must match.
+	sum := sha256.Sum256([]byte(raw))
+	if want := hex.EncodeToString(sum[:]); got != want {
+		t.Errorf("hash = %q, want %q (independent SHA-256)", got, want)
+	}
+}
+
+// TestHashEnrollmentToken_DistinguishesNeighbors asserts that small
+// input differences map to distinct outputs. Trivially true for any
+// cryptographic hash, but pins the dependency on a real hash function
+// (vs e.g. a stub that returns the raw input).
+func TestHashEnrollmentToken_DistinguishesNeighbors(t *testing.T) {
+	inputs := []string{
+		"",
+		"a",
+		"A",
+		"aa",
+		"550e8400-e29b-41d4-a716-446655440000",
+		"550e8400-e29b-41d4-a716-446655440001", // last hex flipped
+		"550e8400-e29b-41d4-a716-44665544000",  // truncated
+	}
+	seen := map[string]string{}
+	for _, in := range inputs {
+		h := HashEnrollmentToken(in)
+		if prev, ok := seen[h]; ok {
+			t.Errorf("collision: %q and %q both hash to %q", prev, in, h)
+		}
+		seen[h] = in
+	}
+}
+
+// TestHashEnrollmentToken_EmptyInput pins the behavior on empty input.
+// The function does not reject empty strings (callers are responsible
+// for validating token shape upstream) — it produces the SHA-256 of
+// the empty string, which is a well-known constant. Captured so a
+// future "reject empty" refactor is a deliberate decision.
+func TestHashEnrollmentToken_EmptyInput(t *testing.T) {
+	got := HashEnrollmentToken("")
+	const sha256OfEmpty = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got != sha256OfEmpty {
+		t.Errorf("hash of empty = %q, want %q", got, sha256OfEmpty)
+	}
+}


### PR DESCRIPTION
## Summary

Regression coverage for three draft advisories whose underlying fixes already
landed on main: GHSA-qm33 (audit-log admin gate), GHSA-ghmh (enrollment-token
at-rest hashing), GHSA-v2jf (signed-poll nonce LRU). No behavior changes in
production code apart from a small drift fix described below.

## What's in this PR

**Audit-row validator (commit 1).** A test-side helper + closed-action enum
mirror for `recordAuditAction` call sites under `internal/api/`. Asserts every
emitted row has non-empty actor / action / resource / timestamp, action is in
the closed enum, JSON-shaped details parse, and `details` doesn't contain a
small set of obvious secret patterns. `auditHostAuthFailed` is the one action
permitted to record an empty resource (early-stage signed-poll failures
before a host is identified).

**Coverage sweep (commit 1).** Fires a representative sample of write
endpoints, then validates every emitted audit row against the helper above.
Catches future drift where a handler adds a new action string outside the
closed enum. Orphan detection asserts every constant in the enum is either
driven by the sweep, exercised by another test in this package, or
documented as pending implementation (`auditHostRekeyCompleted` — declared in
the agent-auth foundation PR alongside the other ADR 0004 labels but never
wired up).

**Drift fix (commit 1).** `handlePatchSettings` was passing the literal
`"settings.enforce_2fa"` to `recordAuditAction`, bypassing the closed enum
and the `newMetrics()` pre-seed loop. Promoted to a typed constant; wire
bytes unchanged.

**Signed-poll coverage (commit 2).** Three test additions for the GHSA-v2jf
draft:
- `nonce_burst_test.go`: concurrent same-nonce collapse under `-race`,
  distinct-nonce burst, LRU eviction without replay window, replay-attempt
  recency bump (defends flood-then-replay), per-host namespacing prevents
  collision, LRU eviction is cross-host.
- `updates_signed_poll_audit_test.go`: per-branch audit-row assertion for
  all 11 reachable `auditHostAuthFailed` emit sites in `handleAgentUpdates`.
  Each sub-test fires its branch, snapshots the audit log before and after,
  asserts exactly one row was emitted with the expected reason code and
  resource shape.
- `token_test.go`: `HashEnrollmentToken` contract (deterministic, no echo,
  SHA-256 hex shape, neighbor distinction, empty-input pinned).

## Scope caveat

The audit-row validator is scoped to `internal/api/` handlers. The
`internal/web/`, `internal/alerts/`, and `internal/cli/` packages also emit
audit rows (via `store.AddAuditEntry` directly) with their own action
strings, which are out of scope here. Happy to do a follow-up that extends
or mirrors this coverage to those packages if you'd like.

## Test plan

- [x] \`go test ./... -race -count=1\` green across the repo
- [x] \`golangci-lint run ./...\` reports 0 issues
- [x] Per-branch test exercises all 11 audit-failed branches in
      \`handleAgentUpdates\`, including the legacy-PEM case reachable via host
      rows that pre-date ADR 0004