### PR TITLE
test(store): atomic CAS coverage for ConsumeToken (GHSA-v2jf, enrollment side)

### DIFF
--- a/internal/store/sqlite_agent_auth_consume_token_test.go
+++ b/internal/store/sqlite_agent_auth_consume_token_test.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// TestConsumeToken_AtomicUnderConcurrency fires N goroutines at the
+// same enrollment token and asserts exactly one observes success while
+// the other N-1 receive ErrTokenUsed. The property guarded here is the
+// at-most-once semantics of enrollment-token consumption — if two
+// agents racing the same leaked token both saw success, both could
+// enroll fresh keypairs against the same host row, breaking the
+// single-host-per-token invariant the agent-auth design assumes.
+//
+// Run with -race for full coverage of the data-race side.
+//
+// Note: this test deliberately uses a file-backed store rather than the
+// shared newTestStore helper. The helper opens ":memory:" which forces
+// SetMaxOpenConns(1) (see sqlite.go: dbPath == ":memory:" branch); all
+// goroutines would then serialize through a single connection and any
+// "broken" implementation that splits SELECT/UPDATE across un-tx'd
+// calls would still pass. A file-backed DSN lets the connection pool
+// grow, so the race the production code's transaction + busy_timeout
+// defends against is actually exercised.
+//
+// Existing happy-path / used / expired / not-found cases are covered
+// by TestConsumeToken_{Success,AlreadyUsed,Expired,NotFound} in
+// sqlite_test.go. This file covers only the concurrency property
+// those tests cannot exercise.
+func TestConsumeToken_AtomicUnderConcurrency(t *testing.T) {
+	const workers = 10
+
+	dbPath := filepath.Join(t.TempDir(), "cas.db")
+	s, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	ctx := context.Background()
+	h := newHostFixture(t, s, "h1")
+
+	const raw = "single-shared-token"
+	if err := s.CreateTokenForHost(ctx, h.ID, raw, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	type outcome struct {
+		token *models.EnrollmentToken
+		err   error
+	}
+	results := make(chan outcome, workers)
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	done.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer done.Done()
+			start.Wait() // release-the-hounds to maximize contention.
+			tok, err := s.ConsumeToken(ctx, raw)
+			results <- outcome{token: tok, err: err}
+		}()
+	}
+	start.Done()
+	done.Wait()
+	close(results)
+
+	var (
+		successes int
+		usedErrs  int
+		other     []error
+		winners   []string
+	)
+	for r := range results {
+		switch {
+		case r.err == nil:
+			successes++
+			if r.token == nil {
+				t.Error("nil err but nil token — implementation bug")
+				continue
+			}
+			winners = append(winners, r.token.ID)
+		case errors.Is(r.err, ErrTokenUsed):
+			usedErrs++
+		default:
+			other = append(other, r.err)
+		}
+	}
+
+	if successes != 1 {
+		t.Errorf("successes = %d, want 1 (token consumed more than once — CAS broken)", successes)
+	}
+	if usedErrs != workers-1 {
+		t.Errorf("ErrTokenUsed count = %d, want %d", usedErrs, workers-1)
+	}
+	if len(other) != 0 {
+		t.Errorf("unexpected error returns: %v", other)
+	}
+	if len(winners) > 1 {
+		t.Errorf("multiple winner token IDs: %v", winners)
+	}
+}


### PR DESCRIPTION
## Summary

Regression coverage for the GHSA-v2jf draft on the enrollment side. One
new test, no production changes.

\`ConsumeToken\` is atomic today via SQLite's WAL + \`busy_timeout\`
serialization, not via an explicit \`WHERE used = 0\` CAS in the UPDATE.
The test pins that property so a future refactor (transaction dropped,
journal mode changed, driver swapped) can't silently break the
at-most-once invariant.

## Note on the test fixture

Uses a file-backed DSN deliberately — \`newTestStore\`'s \`:memory:\` mode
caps \`SetMaxOpenConns(1)\`, serializing all goroutines through one
connection and making the test unable to catch a broken CAS.

## Not in scope

The bd item also mentioned a TTL boundary off-by-one test (\`now ==
expires_at\`). The current implementation uses \`time.Now().After(t.ExpiresAt)\`
with no clock injection, so the exact-boundary case isn't deterministic-
ally reachable from a test. Happy to follow up with a clock-injection
refactor if you'd want that.

## Test plan

- [x] \`go test ./... -race -count=1\` green
- [x] \`go test -run TestConsumeToken_AtomicUnderConcurrency -count=20 -race\`
      stable across 20 iterations
- [x] \`golangci-lint run ./...\` 0 issues