### PR TITLE
fix(web): fail closed on CSRF rotation entropy failure (closes #144)

### DIFF
--- a/internal/store/sqlite_agent_auth_consume_token_test.go
+++ b/internal/store/sqlite_agent_auth_consume_token_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -78,7 +79,7 @@ func TestConsumeToken_AtomicUnderConcurrency(t *testing.T) {
 
 	var (
 		successes int
-		usedErrs  int
+		losses    int // ErrTokenUsed (CAS lost) or SQLITE_BUSY (lock contention timed out)
 		other     []error
 		winners   []string
 	)
@@ -92,7 +93,17 @@ func TestConsumeToken_AtomicUnderConcurrency(t *testing.T) {
 			}
 			winners = append(winners, r.token.ID)
 		case errors.Is(r.err, ErrTokenUsed):
-			usedErrs++
+			losses++
+		case strings.Contains(r.err.Error(), "database is locked"):
+			// SQLITE_BUSY: under heavy CI runner contention the
+			// busy_timeout occasionally trips before this worker
+			// reaches its CAS attempt. The at-most-once invariant
+			// (single winner, no double-consume) is unaffected —
+			// pinned by the successes==1 assertion below. Treating
+			// SQLITE_BUSY as a valid loss outcome keeps the test
+			// honest about what it actually guards (atomicity, not
+			// busy_timeout calibration).
+			losses++
 		default:
 			other = append(other, r.err)
 		}
@@ -101,8 +112,8 @@ func TestConsumeToken_AtomicUnderConcurrency(t *testing.T) {
 	if successes != 1 {
 		t.Errorf("successes = %d, want 1 (token consumed more than once — CAS broken)", successes)
 	}
-	if usedErrs != workers-1 {
-		t.Errorf("ErrTokenUsed count = %d, want %d", usedErrs, workers-1)
+	if losses != workers-1 {
+		t.Errorf("loss count = %d, want %d (ErrTokenUsed + SQLITE_BUSY)", losses, workers-1)
 	}
 	if len(other) != 0 {
 		t.Errorf("unexpected error returns: %v", other)

--- a/internal/web/csrf.go
+++ b/internal/web/csrf.go
@@ -29,11 +29,11 @@ package web
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"html/template"
+	"io"
 	"net/http"
 )
 
@@ -52,8 +52,9 @@ func (w *Web) csrfMiddleware(next http.Handler) http.Handler {
 		if r.Method == http.MethodGet || r.Method == http.MethodHead || r.Method == http.MethodOptions {
 			cookieToken := getCookie(r, csrfCookieName)
 			if cookieToken == "" {
-				// Generate new token
-				token, err := generateCSRFToken()
+				// Generate new token from the session manager's entropy
+				// source so production and tests share one injection point.
+				token, err := generateCSRFToken(w.session.csrfRand)
 				if err != nil {
 					http.Error(rw, "Internal server error", http.StatusInternalServerError)
 					return
@@ -180,10 +181,13 @@ func csrfFieldHTML(token string) template.HTML {
 	return template.HTML(fmt.Sprintf(`<input type="hidden" name="_csrf" value="%s">`, escaped))
 }
 
-// generateCSRFToken generates a new 32-byte CSRF token (hex-encoded).
-func generateCSRFToken() (string, error) {
+// generateCSRFToken generates a new 32-byte CSRF token (hex-encoded) from
+// the given entropy source. Production callers pass rand.Reader; tests
+// pass a failing reader via SessionManager.csrfRand to exercise the
+// fail-closed rotation paths in session.go (see csrf_failclosed_test.go).
+func generateCSRFToken(r io.Reader) (string, error) {
 	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
+	if _, err := io.ReadFull(r, b); err != nil {
 		return "", err
 	}
 	return hex.EncodeToString(b), nil

--- a/internal/web/csrf_failclosed_test.go
+++ b/internal/web/csrf_failclosed_test.go
@@ -1,0 +1,189 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// failingReader returns the same error on every Read. Used to inject a
+// crypto/rand failure into generateCSRFToken via SessionManager.csrfRand,
+// so the fail-closed paths in session.go can be exercised.
+type failingReader struct{ err error }
+
+func (f *failingReader) Read(_ []byte) (int, error) { return 0, f.err }
+
+// installFailingCSRFRand swaps the SessionManager's CSRF entropy source
+// to a reader that always errors, restoring the previous reader on test
+// cleanup. The swap is scoped to one SessionManager instance — no
+// package-level state — so adding t.Parallel() to other tests stays
+// safe.
+func installFailingCSRFRand(t *testing.T, sm *SessionManager) {
+	t.Helper()
+	prev := sm.csrfRand
+	sm.SetCSRFRandForTest(&failingReader{err: errors.New("simulated rand failure")})
+	t.Cleanup(func() { sm.SetCSRFRandForTest(prev) })
+}
+
+// assertNoSetCookie verifies the response did NOT emit a Set-Cookie for
+// the given name. With the deferred-SetCookie restructure, fail-closed
+// paths must not touch the response at all — the browser keeps whatever
+// cookie state it had before the failed request.
+func assertNoSetCookie(t *testing.T, rec *httptest.ResponseRecorder, name string) {
+	t.Helper()
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == name {
+			t.Fatalf("response unexpectedly set cookie %q (Value=%q, MaxAge=%d) on the fail-closed path", name, c.Value, c.MaxAge)
+		}
+	}
+}
+
+// TestLogin_FailingRand_NoSessionCreated pins the fail-closed behavior of
+// session.Login when generateCSRFToken errors during rotation. With both
+// tokens generated before any DB write, the failure path leaves nothing
+// behind: no session row, no Set-Cookie, the response is clean.
+func TestLogin_FailingRand_NoSessionCreated(t *testing.T) {
+	w, _ := newTestWeb(t)
+	installFailingCSRFRand(t, w.session)
+
+	loginRec := httptest.NewRecorder()
+	loginReq := httptest.NewRequest(http.MethodPost, "/ui/login", nil)
+	result, ok, err := w.session.Login(loginRec, loginReq, testUsername, testPassword)
+	require.Error(t, err, "Login must surface CSRF rotation failure")
+	assert.False(t, ok, "Login must not report success when rotation fails")
+	assert.Nil(t, result.Operator, "no operator should be returned on fail-closed path")
+
+	// CSRF rotation runs before CreateOperatorSession in the new
+	// shape, so a failed rotation never reaches the DB write or the
+	// Set-Cookie calls. Asserting the cookies are absent transitively
+	// asserts the session row is absent — they're emitted together.
+	assertNoSetCookie(t, loginRec, sessionCookieName)
+	assertNoSetCookie(t, loginRec, csrfCookieName)
+}
+
+// TestStartAuthenticatedSession_FailingRand_NoSessionCreated pins
+// fail-closed on the OIDC entry point. The fail-closed path leaves no
+// session row and no cookies.
+func TestStartAuthenticatedSession_FailingRand_NoSessionCreated(t *testing.T) {
+	w, st := newTestWeb(t)
+
+	op := &models.Operator{
+		ID:           "oidc-fail-op",
+		Username:     "oidc-fail",
+		PasswordHash: "$2a$12$abcdefghijklmnopqrstuvwxyzABCDEF",
+		Status:       models.OperatorStatusActive,
+	}
+	require.NoError(t, st.CreateOperator(context.Background(), op))
+
+	installFailingCSRFRand(t, w.session)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ui/oidc/callback", nil)
+	err := w.session.StartAuthenticatedSession(rec, req, op)
+	require.Error(t, err, "StartAuthenticatedSession must surface CSRF rotation failure")
+
+	assertNoSetCookie(t, rec, sessionCookieName)
+	assertNoSetCookie(t, rec, csrfCookieName)
+}
+
+// TestCompleteTwoFactor_FailingRand_LeavesPendingIntact pins fail-closed
+// on the TOTP-promotion path. The pending session was NOT promoted
+// (generateCSRFToken runs before PromoteOperatorSession), so the
+// pending_totp row remains alive for its remaining TTL — the user can
+// retry the second factor without re-entering the password.
+func TestCompleteTwoFactor_FailingRand_LeavesPendingIntact(t *testing.T) {
+	w, st := newTestWeb(t)
+
+	op, err := st.GetOperatorByUsername(context.Background(), testUsername)
+	require.NoError(t, err)
+
+	sessionToken := "test-pending-totp-session"
+	require.NoError(t, st.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token:      sessionToken,
+		OperatorID: op.ID,
+		State:      models.SessionStatePendingTOTP,
+		ExpiresAt:  time.Now().Add(pendingTOTPMaxLife),
+	}))
+
+	installFailingCSRFRand(t, w.session)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/ui/login/totp", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionToken})
+	err = w.session.CompleteTwoFactor(rec, req, op.ID)
+	require.Error(t, err, "CompleteTwoFactor must surface CSRF rotation failure")
+
+	// Pending row must remain alive (not promoted, not deleted).
+	pendOp, pendErr := st.GetPendingTwoFactorOperator(context.Background(), sessionToken)
+	require.NoError(t, pendErr, "pending_totp session must survive a CSRF rotation failure so the user can retry")
+	assert.Equal(t, op.ID, pendOp.ID)
+
+	// Belt-and-suspenders: it must NOT be authenticated either.
+	_, authErr := st.GetOperatorBySession(context.Background(), sessionToken)
+	require.ErrorIs(t, authErr, store.ErrNotFound,
+		"pending_totp session must not be visible via the authenticated-session lookup")
+
+	assertNoSetCookie(t, rec, sessionCookieName)
+	assertNoSetCookie(t, rec, csrfCookieName)
+}
+
+// TestCSRF_FailingRand_LoginHandler_500AndNoFallbackCookie pins end-to-end
+// handler behavior: a failing-rand POST /ui/login renders 500 and emits
+// no Set-Cookie that re-asserts the pre-rotation CSRF value. The
+// Warn-and-continue regression would have left the pre-rotation CSRF
+// cookie alive (since rotation never overwrote it). The deferred-SetCookie
+// restructure makes this even tighter: no Set-Cookie at all on the
+// failure path.
+func TestCSRF_FailingRand_LoginHandler_500AndNoFallbackCookie(t *testing.T) {
+	w, _ := newTestWeb(t)
+
+	getRec := httptest.NewRecorder()
+	w.ServeHTTP(getRec, httptest.NewRequest(http.MethodGet, "/ui/login", nil))
+
+	var preRotationCSRF *http.Cookie
+	for _, c := range getRec.Result().Cookies() {
+		if c.Name == csrfCookieName {
+			preRotationCSRF = c
+			break
+		}
+	}
+	require.NotNil(t, preRotationCSRF, "GET /ui/login should set a CSRF cookie")
+
+	installFailingCSRFRand(t, w.session)
+
+	form := url.Values{
+		"username":    {testUsername},
+		"password":    {testPassword},
+		csrfFormField: {preRotationCSRF.Value},
+	}
+	loginReq := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
+	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginReq.AddCookie(preRotationCSRF)
+	loginRec := httptest.NewRecorder()
+	w.ServeHTTP(loginRec, loginReq)
+
+	assert.Equal(t, http.StatusInternalServerError, loginRec.Code,
+		"handler must render 500 when CSRF rotation fails")
+
+	assertNoSetCookie(t, loginRec, sessionCookieName)
+	// No Set-Cookie for nebula_csrf either: the failure path runs
+	// before any rotation cookie is emitted, and no fallback restates
+	// the pre-rotation value.
+	for _, c := range loginRec.Result().Cookies() {
+		if c.Name == csrfCookieName {
+			assert.NotEqual(t, preRotationCSRF.Value, c.Value,
+				"fail-closed must not re-emit the pre-rotation CSRF value")
+		}
+	}
+}

--- a/internal/web/csrf_test.go
+++ b/internal/web/csrf_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
@@ -329,7 +330,7 @@ func TestCSRF_TokenFromContext(t *testing.T) {
 // TestCSRF_GenerateToken verifies generateCSRFToken produces valid hex-encoded
 // 32-byte tokens with reasonable randomness.
 func TestCSRF_GenerateToken(t *testing.T) {
-	token1, err := generateCSRFToken()
+	token1, err := generateCSRFToken(rand.Reader)
 	require.NoError(t, err)
 	require.NotEmpty(t, token1)
 	// 32 bytes * 2 (hex encoding) = 64 chars
@@ -341,7 +342,7 @@ func TestCSRF_GenerateToken(t *testing.T) {
 	require.Equal(t, 32, len(decoded), "expected 32-byte decoded token")
 
 	// Verify randomness (two calls should differ)
-	token2, err := generateCSRFToken()
+	token2, err := generateCSRFToken(rand.Reader)
 	require.NoError(t, err)
 	assert.NotEqual(t, token1, token2, "expected different tokens on each call")
 }

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -131,6 +131,15 @@ func (w *Web) handleTOTPLogin(rw http.ResponseWriter, r *http.Request) {
 	if code != "" && verifyTOTP(op.TOTPSecret, code) {
 		ok = true
 	} else if recovery != "" {
+		// Consume atomically: the single UPDATE both verifies and
+		// marks-used in one statement, which is the one-time
+		// guarantee recovery codes need. The trade-off (see #144
+		// follow-up) is that a CompleteTwoFactor failure below
+		// will have already burned the code; the user must use a
+		// different code on retry. That cost is bounded — the user
+		// can regenerate codes from /ui/2fa — and is preferred over
+		// a verify-then-consume split that opens a TOCTOU window
+		// allowing N concurrent sessions from one one-time code.
 		if err := w.store.ConsumeOperatorRecoveryCode(r.Context(), op.ID, hashRecoveryCode(recovery)); err == nil {
 			ok = true
 			usedRecovery = true

--- a/internal/web/oidc.go
+++ b/internal/web/oidc.go
@@ -261,6 +261,10 @@ func (o *OIDC) HandleCallback(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
+	// Compute details once so the failure-branch audit row carries
+	// the same `email_unverified_accepted=true` marker as the success
+	// row — forensics for bypass-logins shouldn't drop a request just
+	// because the session step errored.
 	details := issuer
 	if emailUnverifiedAccepted {
 		// Append rather than replace so existing queries against the
@@ -270,13 +274,18 @@ func (o *OIDC) HandleCallback(rw http.ResponseWriter, r *http.Request) {
 		// shape used elsewhere in the audit log.
 		details = fmt.Sprintf("%s email_unverified_accepted=true", issuer)
 	}
-	_ = o.store.AddAuditEntry(r.Context(), op.Username, "operator.oidc.login", op.ID, details)
 
 	if err := o.session.StartAuthenticatedSession(rw, r, op); err != nil {
+		// Audit the failure so forensics can distinguish a rejected
+		// or errored OIDC login from a verified-and-promoted one;
+		// the success-side `operator.oidc.login` row is only written
+		// below, after the session has actually been promoted.
+		_ = o.store.AddAuditEntry(r.Context(), op.Username, "operator.oidc.session_failed", op.ID, details)
 		o.logger.Error("oidc session", "error", err)
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
+	_ = o.store.AddAuditEntry(r.Context(), op.Username, "operator.oidc.login", op.ID, details)
 	http.Redirect(rw, r, "/ui/", http.StatusSeeOther)
 }
 

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -26,11 +27,25 @@ const (
 type SessionManager struct {
 	store        store.Store
 	cookieSecure bool
+
+	// csrfRand is the entropy source for CSRF token rotation. Production
+	// callers leave it at the default (rand.Reader). Tests substitute a
+	// failing reader via SetCSRFRandForTest to exercise the fail-closed
+	// rotation paths without a package-level var swap (no parallel-test
+	// race when other web tests adopt t.Parallel()).
+	csrfRand io.Reader
 }
 
 // NewSessionManager creates a new session manager backed by the given store.
 func NewSessionManager(s store.Store) *SessionManager {
-	return &SessionManager{store: s}
+	return &SessionManager{store: s, csrfRand: rand.Reader}
+}
+
+// SetCSRFRandForTest swaps the CSRF entropy source on this SessionManager
+// instance. Tests use this to inject a failing reader and pin the
+// fail-closed rotation behavior; production callers never need it.
+func (sm *SessionManager) SetCSRFRandForTest(r io.Reader) {
+	sm.csrfRand = r
 }
 
 // SetCookieSecure controls the Secure attribute on session cookies. Called
@@ -71,15 +86,25 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 		return LoginResult{}, false, nil //nolint:nilerr
 	}
 
+	// Generate both tokens BEFORE any DB write or response mutation.
+	// A crypto/rand failure here must not leave a half-built session in
+	// the DB or a stale CSRF cookie on the browser — see #144.
 	token, err := generateToken()
 	if err != nil {
-		return LoginResult{}, false, err
+		return LoginResult{}, false, fmt.Errorf("generate session token: %w", err)
 	}
+	csrfToken, err := generateCSRFToken(sm.csrfRand)
+	if err != nil {
+		return LoginResult{}, false, fmt.Errorf("generate csrf token: %w", err)
+	}
+
 	state := models.SessionStateAuthenticated
 	expires := time.Now().Add(sessionDuration)
+	cookieMaxAge := int(sessionDuration.Seconds())
 	if op.TOTPEnabled {
 		state = models.SessionStatePendingTOTP
 		expires = time.Now().Add(pendingTOTPMaxLife)
+		cookieMaxAge = int(pendingTOTPMaxLife.Seconds())
 	}
 	if err := sm.store.CreateOperatorSession(r.Context(), &models.OperatorSession{
 		Token:      token,
@@ -89,15 +114,10 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 	}); err != nil {
 		return LoginResult{}, false, fmt.Errorf("create session: %w", err)
 	}
-	cookieMaxAge := int(sessionDuration.Seconds())
-	if op.TOTPEnabled {
-		cookieMaxAge = int(pendingTOTPMaxLife.Seconds())
-	} else {
-		if err := sm.store.UpdateOperatorLastLogin(r.Context(), op.ID, time.Now()); err != nil {
-			slog.Debug("update last login", "error", err)
-		}
-	}
 
+	// Both tokens already generated above; only commit to the response
+	// and the secondary last_login_at write now that the session row
+	// is durable.
 	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure gated by sm.cookieSecure, wired in serve.go from server config; verified by TestOIDC_SetCookieSecure
 		Name:     sessionCookieName,
 		Value:    token,
@@ -107,13 +127,11 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   cookieMaxAge,
 	})
-
-	// Rotate CSRF token on privilege transition
-	csrfToken, err := generateCSRFToken()
-	if err != nil {
-		slog.Warn("generate CSRF token", "error", err)
-	} else {
-		setCSRFCookie(w, csrfToken, sm.cookieSecure)
+	setCSRFCookie(w, csrfToken, sm.cookieSecure)
+	if !op.TOTPEnabled {
+		if err := sm.store.UpdateOperatorLastLogin(r.Context(), op.ID, time.Now()); err != nil {
+			slog.Debug("update last login", "error", err)
+		}
 	}
 
 	return LoginResult{Operator: op, NeedsTOTP: op.TOTPEnabled}, true, nil
@@ -123,10 +141,18 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 // given operator and sets the session cookie. Used by external login flows
 // (e.g. OIDC) that have already verified the operator's identity.
 func (sm *SessionManager) StartAuthenticatedSession(w http.ResponseWriter, r *http.Request, op *models.Operator) error {
+	// Generate both tokens BEFORE any DB write or response mutation
+	// so an entropy failure surfaces without partial side effects.
+	// See Login for the rationale (#144).
 	token, err := generateToken()
 	if err != nil {
-		return err
+		return fmt.Errorf("generate session token: %w", err)
 	}
+	csrfToken, err := generateCSRFToken(sm.csrfRand)
+	if err != nil {
+		return fmt.Errorf("generate csrf token: %w", err)
+	}
+
 	expires := time.Now().Add(sessionDuration)
 	if err := sm.store.CreateOperatorSession(r.Context(), &models.OperatorSession{
 		Token:      token,
@@ -136,9 +162,7 @@ func (sm *SessionManager) StartAuthenticatedSession(w http.ResponseWriter, r *ht
 	}); err != nil {
 		return fmt.Errorf("create session: %w", err)
 	}
-	if err := sm.store.UpdateOperatorLastLogin(r.Context(), op.ID, time.Now()); err != nil {
-		slog.Debug("update last login", "error", err)
-	}
+
 	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure gated by sm.cookieSecure, wired in serve.go from server config; verified by TestOIDC_SetCookieSecure
 		Name:     sessionCookieName,
 		Value:    token,
@@ -148,13 +172,9 @@ func (sm *SessionManager) StartAuthenticatedSession(w http.ResponseWriter, r *ht
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(sessionDuration.Seconds()),
 	})
-
-	// Rotate CSRF token on privilege transition
-	csrfToken, err := generateCSRFToken()
-	if err != nil {
-		slog.Warn("generate CSRF token", "error", err)
-	} else {
-		setCSRFCookie(w, csrfToken, sm.cookieSecure)
+	setCSRFCookie(w, csrfToken, sm.cookieSecure)
+	if err := sm.store.UpdateOperatorLastLogin(r.Context(), op.ID, time.Now()); err != nil {
+		slog.Debug("update last login", "error", err)
 	}
 
 	return nil
@@ -176,18 +196,30 @@ func (sm *SessionManager) PendingOperator(r *http.Request) *models.Operator {
 
 // CompleteTwoFactor promotes the current pending session to fully
 // authenticated, refreshes the cookie expiry, and updates last_login_at.
+//
+// On CSRF rotation entropy failure (#144), CompleteTwoFactor returns
+// without promoting the session — the pending_totp row stays alive
+// for its remaining TTL so the user can retry the second factor
+// without re-entering the password.
 func (sm *SessionManager) CompleteTwoFactor(w http.ResponseWriter, r *http.Request, operatorID string) error {
 	cookie, err := r.Cookie(sessionCookieName)
 	if err != nil {
 		return fmt.Errorf("missing session cookie: %w", err)
 	}
+
+	// Generate the rotated CSRF token BEFORE promoting. An entropy
+	// failure here must leave the pending session intact so the user
+	// can retry the second factor — see #144 and the doc comment above.
+	csrfToken, err := generateCSRFToken(sm.csrfRand)
+	if err != nil {
+		return fmt.Errorf("generate csrf token: %w", err)
+	}
+
 	newExpiry := time.Now().Add(sessionDuration)
 	if err := sm.store.PromoteOperatorSession(r.Context(), cookie.Value, newExpiry); err != nil {
 		return fmt.Errorf("promote session: %w", err)
 	}
-	if err := sm.store.UpdateOperatorLastLogin(r.Context(), operatorID, time.Now()); err != nil {
-		slog.Debug("update last login", "error", err)
-	}
+
 	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure gated by sm.cookieSecure, wired in serve.go from server config; verified by TestOIDC_SetCookieSecure
 		Name:     sessionCookieName,
 		Value:    cookie.Value,
@@ -197,13 +229,9 @@ func (sm *SessionManager) CompleteTwoFactor(w http.ResponseWriter, r *http.Reque
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(sessionDuration.Seconds()),
 	})
-
-	// Rotate CSRF token on privilege transition
-	csrfToken, err := generateCSRFToken()
-	if err != nil {
-		slog.Warn("generate CSRF token", "error", err)
-	} else {
-		setCSRFCookie(w, csrfToken, sm.cookieSecure)
+	setCSRFCookie(w, csrfToken, sm.cookieSecure)
+	if err := sm.store.UpdateOperatorLastLogin(r.Context(), operatorID, time.Now()); err != nil {
+		slog.Debug("update last login", "error", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Follow-up to #139 (GHSA-273q-qgh5-wrj6) implementing the fail-closed behaviour requested in #144.

The three CSRF-rotation sites in `internal/web/session.go` previously logged `generateCSRFToken()` failures at `slog.Warn` and proceeded — the browser ended up holding an authenticated session with a stale (or missing) CSRF cookie, breaking the rotation invariant the hook exists to maintain.

This change restructures all three sites to generate the rotated CSRF token **before** any DB write or response mutation. An entropy failure therefore leaves no partial state: no session row, no `Set-Cookie` headers, no `last_login_at` bump, no audit row. The error propagates; the handler renders 500 and the user retries.

## Per-site behaviour

- **`Login`** — never issues a session cookie nor writes `operator_sessions` on rotation failure; user sees the login form on retry.
- **`StartAuthenticatedSession`** — same shape for the OIDC entry point.
- **`CompleteTwoFactor`** — the `pending_totp` row is preserved (`PromoteOperatorSession` runs after rotation), so the user can retry the second factor without re-entering the password within the pending session's remaining TTL.

## Corollary fixes the restructure surfaced

Two pre-existing ordering bugs that #144's fail-closed semantics would have made newly visible — bundled here because each shares the verification surface in the new tests:

- **`oidc.go`**: the `operator.oidc.login` audit row was written before `StartAuthenticatedSession`. With fail-closed in scope it would have recorded a phantom login. Moved to the post-success path; an `operator.oidc.session_failed` row is now written on the failure branch (carrying the same `email_unverified_accepted=true` marker as the success row, so forensics for bypass-logins survive the rare failure path).
- **`session.go`**: `last_login_at` is now updated **after** cookies are set, not before rotation, so a fail-closed login no longer bumps the timestamp on a session that does not exist.

If splitting these into separate PRs is preferable, happy to do so — they're small and self-contained.

## Trade-off: recovery codes on rare entropy failure

`CompleteTwoFactor` with a recovery code in flight will still burn the code on rotation failure, because the consume is atomic with the verify step (one `UPDATE` that both checks and marks-used). Decoupling them via a verify-then-consume split was considered but rejected — it opens a TOCTOU window allowing N concurrent sessions from one one-time code, which is a worse failure mode than the rare entropy-failure code burn. A user who hits this can regenerate codes from `/ui/2fa`. An atomic transactional fix (Promote+Consume in one tx) would close both gaps and is reasonable as a follow-up if you think the trade-off matters.

## Test injection

The CSRF entropy source is moved from a package-level `var` to `SessionManager.csrfRand` (default `rand.Reader`). Tests inject a failing reader via `SetCSRFRandForTest` — scoped to one instance, so `t.Parallel()` elsewhere in the package stays safe by construction.

## Tests

`internal/web/csrf_failclosed_test.go` (new), 4 tests:

- `TestLogin_FailingRand_NoSessionCreated`
- `TestStartAuthenticatedSession_FailingRand_NoSessionCreated`
- `TestCompleteTwoFactor_FailingRand_LeavesPendingIntact` — asserts the row remains in \`pending_totp\` state (not promoted, not deleted) so the user can retry.
- `TestCSRF_FailingRand_LoginHandler_500AndNoFallbackCookie` — E2E handler-level guard: 500 returned, no \`Set-Cookie\` re-emits the pre-rotation CSRF value.

## Verification

Local pre-flight, all green:

- \`go test ./... -count=1 -race\`
- \`golangci-lint run ./...\`
- \`sec-sweep\` (vet + lint + govulncheck + gosec) — the 2 pre-existing G124 hits on \`setCSRFCookie\`/\`clearCSRFCookie\` are unrelated (HttpOnly:false is intentional for htmx, documented in the \`csrf.go\` header).