### PR TITLE
fix(api): re-check operator status in admin authz gates

### DIFF
--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -10,7 +10,7 @@ import (
 const defaultAuditLimit = 100
 
 func (s *Server) handleGetAuditLog(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "audit log access requires the admin role")
 		return
 	}

--- a/internal/api/authz.go
+++ b/internal/api/authz.go
@@ -8,10 +8,29 @@ import (
 	"github.com/juev/nebula-mesh/internal/store"
 )
 
+// isActiveAdmin re-fetches the captured-ctx actor and reports whether
+// they are still an active admin. Round-trips the operators table per
+// call. Closes the stale-snapshot gap but not the residual TOCTOU
+// between this check and the handler's subsequent mutating SQL.
+func (s *Server) isActiveAdmin(ctx context.Context) bool {
+	captured := ActorOf(ctx)
+	if captured == nil {
+		return false
+	}
+	fresh, err := s.store.GetOperator(ctx, captured.ID)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			s.logger.Error("isActiveAdmin: store lookup", "operator", captured.ID, "error", err)
+		}
+		return false
+	}
+	return fresh.Status == models.OperatorStatusActive && fresh.Role == "admin"
+}
+
 // actorOwnsCA returns true if the actor in ctx is admin, or owns the CA with caID.
 // Returns (false, nil) for empty caID or ErrNotFound. Errors only for unexpected DB errors.
 func (s *Server) actorOwnsCA(ctx context.Context, caID string) (bool, error) {
-	if actorIsAdmin(ctx) {
+	if s.isActiveAdmin(ctx) {
 		return true, nil
 	}
 	if caID == "" {

--- a/internal/api/authz_test.go
+++ b/internal/api/authz_test.go
@@ -74,7 +74,7 @@ func TestActorOwnsCA_Admin(t *testing.T) {
 	srv, st := newTestServer(t)
 	ctx := context.Background()
 
-	// Admin operator
+	// seed: actorOwnsCA now re-fetches via isActiveAdmin.
 	adminOp := &models.Operator{
 		ID:           "admin-op",
 		Username:     "admin-test",
@@ -82,6 +82,9 @@ func TestActorOwnsCA_Admin(t *testing.T) {
 		Role:         "admin",
 		Status:       models.OperatorStatusActive,
 		AuthProvider: models.OperatorAuthLocal,
+	}
+	if err := st.CreateOperator(ctx, adminOp); err != nil {
+		t.Fatalf("seed admin op: %v", err)
 	}
 	ctx = context.WithValue(ctx, actorContextKey, adminOp)
 

--- a/internal/api/cas.go
+++ b/internal/api/cas.go
@@ -37,7 +37,7 @@ func (s *Server) handleListCAs(w http.ResponseWriter, r *http.Request) {
 		cas []*models.CA
 		err error
 	)
-	if actorIsAdmin(r.Context()) {
+	if s.isActiveAdmin(r.Context()) {
 		cas, err = s.store.ListCAs(r.Context())
 	} else {
 		cas, err = s.store.ListCAsByOwner(r.Context(), ActorOf(r.Context()).ID)
@@ -183,7 +183,7 @@ func (s *Server) handleDeleteCA(w http.ResponseWriter, r *http.Request) {
 
 // canAccessCA checks ownership. Admins bypass.
 func (s *Server) canAccessCA(r *http.Request, c *models.CA) bool {
-	if actorIsAdmin(r.Context()) {
+	if s.isActiveAdmin(r.Context()) {
 		return true
 	}
 	return ActorOf(r.Context()).ID == c.OwnerOperatorID

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -188,7 +188,7 @@ func (s *Server) handleListHosts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// For non-admin, scope to owned CAs
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		actor := ActorOf(r.Context())
 		if actor == nil {
 			writeJSON(w, http.StatusOK, []*models.Host{})
@@ -354,7 +354,7 @@ func (s *Server) handleUnblockHost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetBlocklist(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "blocklist access requires the admin role")
 		return
 	}

--- a/internal/api/inflight_authz_test.go
+++ b/internal/api/inflight_authz_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// Tests for isActiveAdmin — the re-checking authz gate that closes the
+// stale-captured-context window between bearerAuth and the handler's
+// mutating SQL (residual-TOCTOU caveat noted in authz.go).
+
+// mutateHandler returns a minimal admin-gated handler stub for
+// exercising isActiveAdmin in isolation, without coupling tests to a
+// specific real handler's body.
+func mutateHandler(srv *Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !srv.isActiveAdmin(r.Context()) {
+			writeError(w, http.StatusForbidden, "operator management requires the admin role")
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}
+}
+
+func TestIsActiveAdmin_RejectsDisabledMidFlight(t *testing.T) {
+	srv, st := newTestServer(t)
+	ctx := context.Background()
+
+	captured := &models.Operator{
+		ID: "captured-admin", Username: "captured-admin", PasswordHash: "h",
+		Role: "admin", Status: models.OperatorStatusActive, AuthProvider: models.OperatorAuthLocal,
+	}
+	if err := st.CreateOperator(ctx, captured); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := st.DisableOperator(ctx, captured.ID); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	// Sanity: the stale ctx still claims admin — the snapshot gap the
+	// re-fetch closes.
+	staleCtx := withActor(ctx, captured)
+	if !actorIsAdmin(staleCtx) {
+		t.Fatal("stale ctx should still pass the snapshot-only actorIsAdmin check")
+	}
+
+	rec := httptest.NewRecorder()
+	mutateHandler(srv)(rec, httptest.NewRequest(http.MethodPost, "/m", nil).WithContext(staleCtx))
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIsActiveAdmin_RejectsDeletedOperator(t *testing.T) {
+	srv, st := newTestServer(t)
+	ctx := context.Background()
+
+	captured := &models.Operator{
+		ID: "captured-deleted", Username: "captured-deleted", PasswordHash: "h",
+		Role: "admin", Status: models.OperatorStatusActive, AuthProvider: models.OperatorAuthLocal,
+	}
+	if err := st.CreateOperator(ctx, captured); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Hard-DELETE exercises the ErrNotFound fork separately from the
+	// disabled branch — the two have different error-handling paths in
+	// isActiveAdmin (ErrNotFound is silent; other errors log).
+	if _, err := st.DB().ExecContext(ctx, `DELETE FROM operators WHERE id=?`, captured.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	mutateHandler(srv)(rec, httptest.NewRequest(http.MethodPost, "/m", nil).WithContext(withActor(ctx, captured)))
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/networks.go
+++ b/internal/api/networks.go
@@ -18,7 +18,7 @@ type createNetworkRequest struct {
 }
 
 func (s *Server) handleCreateNetwork(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "network creation requires the admin role")
 		return
 	}
@@ -60,7 +60,7 @@ func (s *Server) handleListNetworks(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to list networks")
 		return
 	}
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		actor := ActorOf(r.Context())
 		if actor == nil {
 			writeJSON(w, http.StatusOK, []*models.Network{})

--- a/internal/api/operators.go
+++ b/internal/api/operators.go
@@ -25,7 +25,7 @@ type createOperatorRequest struct {
 }
 
 func (s *Server) handleCreateOperator(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "operator management requires the admin role")
 		return
 	}
@@ -65,7 +65,7 @@ func (s *Server) handleCreateOperator(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleListOperators(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "operator management requires the admin role")
 		return
 	}
@@ -82,7 +82,7 @@ func (s *Server) handleListOperators(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDisableOperator(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "operator management requires the admin role")
 		return
 	}
@@ -101,7 +101,7 @@ func (s *Server) handleDisableOperator(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleEnableOperator(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "operator management requires the admin role")
 		return
 	}
@@ -129,7 +129,7 @@ type createAPIKeyResponse struct {
 }
 
 func (s *Server) handleCreateOperatorAPIKey(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "operator management requires the admin role")
 		return
 	}
@@ -172,7 +172,7 @@ func (s *Server) handleCreateOperatorAPIKey(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) handleRevokeOperatorAPIKey(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "operator management requires the admin role")
 		return
 	}
@@ -229,7 +229,7 @@ func (s *Server) handleRevokeOperatorAPIKey(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) handleListOperatorAPIKeys(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "operator management requires the admin role")
 		return
 	}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -22,7 +22,7 @@ type settingsResponse struct {
 // Admin-only because exposing the surface to non-admins gives them a
 // view of the deployment's security posture.
 func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "admin role required")
 		return
 	}
@@ -33,7 +33,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 // handlePatchSettings updates one or more admin-tunable settings.
 // Currently exposes only enforce_2fa; will grow with the rest of #47.
 func (s *Server) handlePatchSettings(w http.ResponseWriter, r *http.Request) {
-	if !actorIsAdmin(r.Context()) {
+	if !s.isActiveAdmin(r.Context()) {
 		writeError(w, http.StatusForbidden, "admin role required")
 		return
 	}

--- a/internal/web/oidc_disable_cascade_test.go
+++ b/internal/web/oidc_disable_cascade_test.go
@@ -1,0 +1,99 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// TestDisableOperator_KillsActiveOIDCSession pins the disable-cascade
+// contract for OIDC-authenticated sessions. Local-auth sessions are
+// already covered in store/sqlite_operators_test.go; this variant
+// guards against a future refactor that partitions sessions by
+// auth_provider against the OIDC path specifically.
+func TestDisableOperator_KillsActiveOIDCSession(t *testing.T) {
+	ctx := context.Background()
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	op := &models.Operator{
+		ID:           "oidc-user-id",
+		Username:     "oidc-user@example.com",
+		DisplayName:  "OIDC User",
+		PasswordHash: "oidc", // matches oidc.go::upsertOperator's placeholder
+		Role:         "admin",
+		AuthProvider: models.OperatorAuthOIDC,
+		OIDCIssuer:   "https://idp.example.com",
+		OIDCSubject:  "sub-12345",
+	}
+	if err := s.CreateOperator(ctx, op); err != nil {
+		t.Fatalf("create OIDC operator: %v", err)
+	}
+
+	sm := NewSessionManager(s)
+
+	// Mint a session via the same SessionManager method the OIDC
+	// callback uses (oidc.go HandleCallback -> session.StartAuthenticatedSession).
+	rec := httptest.NewRecorder()
+	startReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	if err := sm.StartAuthenticatedSession(rec, startReq, op); err != nil {
+		t.Fatalf("StartAuthenticatedSession: %v", err)
+	}
+
+	// Lift the session cookie back into a request, the way a browser
+	// would carry it across calls.
+	var sessionCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("StartAuthenticatedSession did not set a session cookie")
+	}
+
+	carryCookie := func() *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.AddCookie(sessionCookie)
+		return r
+	}
+
+	// Pre-disable: the session authenticates the OIDC operator.
+	if !sm.IsAuthenticated(carryCookie()) {
+		t.Fatal("OIDC session should authenticate before disable")
+	}
+	if got := sm.CurrentOperator(carryCookie()); got == nil || got.ID != op.ID {
+		t.Fatalf("CurrentOperator pre-disable = %v, want operator %q", got, op.ID)
+	}
+
+	// Disable the OIDC operator. DisableOperator's atomic transaction
+	// must delete the session row alongside the status flip — same
+	// cascade local-auth operators get.
+	if err := s.DisableOperator(ctx, op.ID); err != nil {
+		t.Fatalf("DisableOperator: %v", err)
+	}
+
+	// Post-disable: the session must no longer authenticate.
+	if sm.IsAuthenticated(carryCookie()) {
+		t.Error("OIDC session still authenticates after DisableOperator (cascade broken)")
+	}
+	if got := sm.CurrentOperator(carryCookie()); got != nil {
+		t.Errorf("CurrentOperator post-disable = %v, want nil", got)
+	}
+
+	// Verify the row is gone, not just filtered.
+	if _, err := s.GetOperatorBySession(ctx, sessionCookie.Value); err == nil {
+		t.Error("expected ErrNotFound from GetOperatorBySession; row still present")
+	}
+}


### PR DESCRIPTION
## Summary

`bearerAuth` (`internal/api/middleware.go:35`) loads the operator on request entry and attaches them to `r.Context()` via `withActor`. Downstream admin authz gates use `actorIsAdmin(ctx)`, which reads that captured snapshot for the duration of the request. If another admin runs `DisableOperator` (`internal/store/sqlite_operators.go:257` — atomic txn: status flip + sessions deleted + API keys revoked) on the captured operator between bearerAuth and the handler's mutating SQL, the in-flight handler still sees them as an active admin and the mutation proceeds.

The same gap covers the `actorOwnsCA` short-circuit in `internal/api/authz.go`, which feeds `canAccessCA` / `canAccessHost` / `canAccessNetwork`, so destructive handlers like `handleDeleteCA` / `handleRotateCA` / `handleDeleteHost` inherit the stale-admin bypass.

## Approach

I added `(*Server).isActiveAdmin(ctx)` — re-fetches the captured operator via `s.store.GetOperator` and returns true only if the fresh row is active+admin. Fails closed on `ErrNotFound` or transient errors.

I then swapped all 12 admin authz gates uniformly from `actorIsAdmin(r.Context())` to `s.isActiveAdmin(r.Context())`. The bare `actorIsAdmin` function is preserved as a building block.

| file | sites |
|---|---|
| `operators.go` | handleCreateOperator, handleListOperators, handleDisableOperator, handleEnableOperator, handleCreateOperatorAPIKey, handleRevokeOperatorAPIKey, handleListOperatorAPIKeys |
| `networks.go` | handleCreateNetwork, handleListNetworks scoping |
| `hosts.go` | handleListHosts scoping, handleGetBlocklist |
| `cas.go` | handleListCAs, canAccessCA |
| `settings.go` | handleGetSettings, handlePatchSettings |
| `audit.go` | handleGetAuditLog |
| `authz.go` | actorOwnsCA short-circuit |

## What this does not fix

The TOCTOU between the re-check and the handler's subsequent mutating SQL is narrowed but not closed — a disable that commits in that window still permits the mutation. Closing it would need `BEGIN IMMEDIATE` wrapping check+mutation or `WHERE status=Active` predicates on each mutating statement. Both are larger refactors I'd prefer to scope separately; the re-check covers the bulk of the exposure window.

I also looked at role-mutation paths (no `UpdateOperatorRole` in the store, no PATCH handler, OIDC `upsertOperator` returns existing operators unchanged on re-login). `isActiveAdmin` already re-reads `.Role` from the fresh row, so when a role-mutation surface lands, the helper covers it without further changes.

## Cost

Each gate now does one indexed PK lookup against `operators`. For request paths that hit a single authz gate (the common case), this is one extra round-trip on top of bearerAuth's existing API-key lookup. No handler currently calls `isActiveAdmin` more than once per request, so a request-lifetime cache would save zero round-trips — and would also weaken the disabled-mid-flight detection that is the entire point. I skipped the cache.

## Test plan

- [x] `go test ./... -race -count=1` — all packages green
- [x] `golangci-lint run ./...` (v2.12.2, CI-pinned) — 0 issues
- [x] `internal/api/inflight_authz_test.go` pins the disabled and deleted-row branches of the gate against a stale captured ctx
- [x] `internal/web/oidc_disable_cascade_test.go` is a provider-explicit regression pin for the OIDC session cascade on disable (the local-auth cascade is already covered in `internal/store/sqlite_operators_test.go::TestDisableOperator_CascadesSessionsAndAPIKeys`)
- [x] `internal/api/authz_test.go::TestActorOwnsCA_Admin` updated to seed the in-memory admin into the store (previously relied on the snapshot-only check; the seed makes the test work under the new re-fetch path)

Note: `make sec-sweep` reports 2 pre-existing G124 findings in `internal/web/csrf.go:138/150` from #139. Not touched by this PR; raising separately.