### PR TITLE
fix(store): enforce network-scoped overlay-IP uniqueness (migration 018)

### DIFF
--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -160,6 +160,14 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		CreatedAt: now,
 	}
 	if err := s.store.CreateHostAndToken(r.Context(), host, token); err != nil {
+		// Reachable only via a TOCTOU race between concurrent host writes: the
+		// validateHostIPs fast-path above returns 400 for any collision visible
+		// at request time, so reaching the store's UNIQUE(network_id, address)
+		// guard means another writer claimed the IP in between.
+		if errors.Is(err, store.ErrIPTaken) {
+			writeError(w, http.StatusConflict, "one or more nebula_ips are already assigned to another host in this network")
+			return
+		}
 		s.logger.Error("create host and token", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to create host")
 		return
@@ -655,6 +663,14 @@ func (s *Server) handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 	// Update timestamp and persist
 	host.UpdatedAt = time.Now()
 	if err := s.store.UpdateHost(r.Context(), host); err != nil {
+		// Reachable only via a TOCTOU race between concurrent host writes: the
+		// validateHostIPs fast-path above returns 400 for any collision visible
+		// at request time, so reaching the store's UNIQUE(network_id, address)
+		// guard means another writer claimed the IP in between.
+		if errors.Is(err, store.ErrIPTaken) {
+			writeError(w, http.StatusConflict, "one or more nebula_ips are already assigned to another host in this network")
+			return
+		}
 		s.logger.Error("update host", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update host")
 		return

--- a/internal/store/migration_018_test.go
+++ b/internal/store/migration_018_test.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/juev/nebula-mesh/internal/store/migrations"
+
+	_ "modernc.org/sqlite"
+)
+
+// migrations017 is the ordered up-migration set preceding 018.
+var migrations017 = []string{
+	"001_initial.up.sql", "002_config_version.up.sql", "003_audit_log.up.sql",
+	"004_blocklist_fk.up.sql", "005_operators.up.sql", "006_operator_totp.up.sql",
+	"007_operator_oidc.up.sql", "008_host_advanced.up.sql", "009_per_operator_cas.up.sql",
+	"010_cert_alerts.up.sql", "011_server_settings.up.sql", "012_agent_auth.up.sql",
+	"013_host_mobile.up.sql", "014_multi_address.up.sql", "015_ca_predecessor.up.sql",
+	"016_enrollment_token_hash.up.sql", "017_pop_nonces.up.sql",
+}
+
+func applyMigrationFiles(t *testing.T, db *sql.DB, files []string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		name TEXT PRIMARY KEY, applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatalf("create schema_migrations: %v", err)
+	}
+	for _, f := range files {
+		b, err := migrations.FS.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, stmt := range splitSQLStatementsForTest(string(b)) {
+			if _, err := db.ExecContext(ctx, stmt); err != nil {
+				t.Fatalf("apply %s stmt %q: %v", f, stmt, err)
+			}
+		}
+		if _, err := db.ExecContext(ctx, "INSERT INTO schema_migrations (name) VALUES (?)", f); err != nil {
+			t.Fatalf("record %s: %v", f, err)
+		}
+	}
+}
+
+// execMigrationFile runs each statement of one migration file and returns the
+// first error (used to assert intentional fail-loud behavior).
+func execMigrationFile(db *sql.DB, file string) error {
+	b, err := migrations.FS.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	for _, stmt := range splitSQLStatementsForTest(string(b)) {
+		if _, err := db.ExecContext(context.Background(), stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mustExec(t *testing.T, db *sql.DB, q string, args ...any) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), q, args...); err != nil {
+		t.Fatalf("exec %q: %v", q, err)
+	}
+}
+
+// TestMigration018_BackfillsNetworkID_AndDownRoundTrip verifies the backfill of
+// pre-existing host_addresses rows (the SELECT that no store-method test
+// exercises, since those create rows after the column exists) and the down
+// migration's drop-index-before-drop-column round trip.
+func TestMigration018_BackfillsNetworkID_AndDownRoundTrip(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	applyMigrationFiles(t, db, migrations017)
+
+	// Seed a network + host + a pre-existing host_addresses row (pre-018 schema,
+	// no network_id column) so the 018 backfill SELECT is actually exercised.
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "host-1")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+
+	if columnExistsInDB(t, db, "host_addresses", "network_id") {
+		t.Fatal("network_id should not exist before 018")
+	}
+
+	if err := execMigrationFile(db, "018_host_address_network_uniqueness.up.sql"); err != nil {
+		t.Fatalf("apply 018: %v", err)
+	}
+
+	if !columnExistsInDB(t, db, "host_addresses", "network_id") {
+		t.Fatal("network_id should exist after 018")
+	}
+	var gotNet string
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT network_id FROM host_addresses WHERE host_id = ?`, "h1").Scan(&gotNet); err != nil {
+		t.Fatalf("read backfilled network_id: %v", err)
+	}
+	if gotNet != "net1" {
+		t.Errorf("backfilled network_id = %q, want net1", gotNet)
+	}
+
+	// Down round-trip: index dropped before column.
+	if err := execMigrationFile(db, "018_host_address_network_uniqueness.down.sql"); err != nil {
+		t.Fatalf("apply 018 down: %v", err)
+	}
+	if columnExistsInDB(t, db, "host_addresses", "network_id") {
+		t.Error("network_id should be gone after 018 down")
+	}
+}
+
+// TestMigration018_FailsLoudOnDuplicateOverlayIP pins the deliberate fail-safe:
+// if a database already holds two hosts sharing one overlay IP in a network (the
+// security defect this migration exists to prevent), CREATE UNIQUE INDEX must
+// abort the migration rather than silently tolerate it.
+func TestMigration018_FailsLoudOnDuplicateOverlayIP(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	applyMigrationFiles(t, db, migrations017)
+
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "host-1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h2", "net1", "host-2")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h2", 0, "10.0.0.5")
+
+	err = execMigrationFile(db, "018_host_address_network_uniqueness.up.sql")
+	if err == nil {
+		t.Fatal("018 must fail loud on a pre-existing duplicate overlay IP, but succeeded")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "unique") {
+		t.Errorf("018 failure = %v, want a UNIQUE constraint error", err)
+	}
+}

--- a/internal/store/migrations/018_host_address_network_uniqueness.down.sql
+++ b/internal/store/migrations/018_host_address_network_uniqueness.down.sql
@@ -1,0 +1,4 @@
+-- Reverse 018: drop the uniqueness index and the denormalized network_id
+-- column. The index must be dropped before the column it covers.
+DROP INDEX IF EXISTS ux_host_addresses_network_address;
+ALTER TABLE host_addresses DROP COLUMN network_id;

--- a/internal/store/migrations/018_host_address_network_uniqueness.up.sql
+++ b/internal/store/migrations/018_host_address_network_uniqueness.up.sql
@@ -1,0 +1,34 @@
+-- Restore network-scoped overlay-IP uniqueness.
+--
+-- Migration 001 enforced UNIQUE(network_id, nebula_ip) on the hosts table.
+-- Migration 014 (multi_address) moved overlay addresses into host_addresses
+-- and dropped that constraint without replacing it. That left validateHostIPs
+-- (a read-then-check in the API layer) as the only guard, a TOCTOU window two
+-- concurrent host creates can both pass, ending with two hosts bound to the
+-- same overlay IP.
+--
+-- In a Nebula mesh that is a security defect, not merely a data-integrity one.
+-- Two hosts sharing one overlay address means ambiguous routing and a CA that
+-- has issued certificates letting one host receive another host's traffic
+-- (interception or impersonation within the network).
+--
+-- host_addresses is keyed by host_id only, so a network-scoped UNIQUE index
+-- needs network_id on the row. It is denormalized from hosts here. A host's
+-- network_id is immutable after creation (no code path reassigns a host to a
+-- different network), so the copy cannot drift.
+--
+-- The CREATE UNIQUE INDEX below FAILS if a database already holds two hosts
+-- with the same overlay IP in one network. That is intentional and correct.
+-- Such a row is the security defect described above, and refusing to start
+-- until an operator resolves it (deciding which host keeps the address) is the
+-- right fail-safe. There is no safe automatic answer to which host wins, so the
+-- migration does not de-duplicate. The loader re-runs cleanly after the
+-- operator removes the offending row (ADD COLUMN is tolerated as a duplicate
+-- and the backfill UPDATE is idempotent).
+ALTER TABLE host_addresses ADD COLUMN network_id TEXT NOT NULL DEFAULT '';
+
+UPDATE host_addresses
+   SET network_id = (SELECT h.network_id FROM hosts h WHERE h.id = host_addresses.host_id);
+
+CREATE UNIQUE INDEX ux_host_addresses_network_address
+    ON host_addresses (network_id, address);

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -24,6 +24,7 @@ var (
 	ErrDuplicateEntry      = errors.New("duplicate entry")
 	ErrRekeyAlreadyPending = errors.New("rekey already pending")
 	ErrReplayedNonce       = errors.New("replayed nonce")
+	ErrIPTaken             = errors.New("nebula ip already assigned in network")
 )
 
 // SQLiteStore implements Store using SQLite.
@@ -117,6 +118,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		"015_ca_predecessor.up.sql",
 		"016_enrollment_token_hash.up.sql",
 		"017_pop_nonces.up.sql",
+		"018_host_address_network_uniqueness.up.sql",
 	}
 
 	// Tracking table. Created once; idempotent on subsequent starts.
@@ -463,19 +465,37 @@ func (s *SQLiteStore) ListNetworks(ctx context.Context) ([]*models.Network, erro
 
 // --- Hosts ---
 
-// setHostAddresses replaces all addresses for a host in a transaction.
-// Deletes existing rows and inserts new ones with position-based ordering.
-func (s *SQLiteStore) setHostAddresses(ctx context.Context, tx *sql.Tx, hostID string, addrs []string) error {
+// setHostAddresses replaces a host's overlay addresses. Each row carries the
+// host's network_id so the UNIQUE(network_id, address) index (migration 018)
+// enforces that an overlay IP belongs to at most one host per network. The
+// ON CONFLICT(network_id, address) DO NOTHING clause turns a cross-host
+// collision into a RowsAffected==0 signal (mapped to ErrIPTaken) instead of a
+// raw constraint error, while any *other* violation (PRIMARY KEY, NOT NULL)
+// still surfaces normally rather than being silently swallowed. This is the
+// authoritative guard against the create/update TOCTOU; validateHostIPs in the
+// API layer is a friendly fast-path that returns a 400 naming the conflicting
+// host before the write is attempted.
+func (s *SQLiteStore) setHostAddresses(ctx context.Context, tx *sql.Tx, hostID, networkID string, addrs []string) error {
 	if _, err := tx.ExecContext(ctx, "DELETE FROM host_addresses WHERE host_id = ?", hostID); err != nil {
 		return fmt.Errorf("delete host addresses: %w", err)
 	}
 
 	for position, addr := range addrs {
-		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`,
-			hostID, position, addr,
-		); err != nil {
+		res, err := tx.ExecContext(ctx,
+			`INSERT INTO host_addresses (host_id, position, address, network_id)
+			 VALUES (?, ?, ?, ?)
+			 ON CONFLICT(network_id, address) DO NOTHING`,
+			hostID, position, addr, networkID,
+		)
+		if err != nil {
 			return fmt.Errorf("insert host address at position %d: %w", position, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("host address rows affected at position %d: %w", position, err)
+		}
+		if n == 0 {
+			return fmt.Errorf("nebula_ip %s: %w", addr, ErrIPTaken)
 		}
 	}
 	return nil
@@ -546,7 +566,7 @@ func (s *SQLiteStore) CreateHost(ctx context.Context, h *models.Host) error {
 		return fmt.Errorf("insert host: %w", err)
 	}
 
-	if err := s.setHostAddresses(ctx, tx, h.ID, h.NebulaIPs); err != nil {
+	if err := s.setHostAddresses(ctx, tx, h.ID, h.NetworkID, h.NebulaIPs); err != nil {
 		return err
 	}
 
@@ -786,7 +806,7 @@ func (s *SQLiteStore) UpdateHost(ctx context.Context, h *models.Host) error {
 		return ErrNotFound
 	}
 
-	if err := s.setHostAddresses(ctx, tx, h.ID, h.NebulaIPs); err != nil {
+	if err := s.setHostAddresses(ctx, tx, h.ID, h.NetworkID, h.NebulaIPs); err != nil {
 		return err
 	}
 
@@ -1199,7 +1219,7 @@ func (s *SQLiteStore) CreateHostAndToken(ctx context.Context, h *models.Host, t 
 		return fmt.Errorf("insert host: %w", err)
 	}
 
-	if err := s.setHostAddresses(ctx, tx, h.ID, h.NebulaIPs); err != nil {
+	if err := s.setHostAddresses(ctx, tx, h.ID, h.NetworkID, h.NebulaIPs); err != nil {
 		return err
 	}
 

--- a/internal/store/sqlite_host_ip_collision_test.go
+++ b/internal/store/sqlite_host_ip_collision_test.go
@@ -1,0 +1,131 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// hostWithIP builds a pending host carrying a single overlay address.
+func hostWithIP(id, networkID, name, ip string) *models.Host {
+	now := time.Now()
+	return &models.Host{
+		ID: id, NetworkID: networkID, Name: name,
+		NebulaIPs: []string{ip}, Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusPending,
+		CreatedAt: now, UpdatedAt: now,
+	}
+}
+
+// TestCreateHost_DuplicateNebulaIP_Rejected locks the network-scoped overlay-IP
+// invariant that migration 001 guaranteed via UNIQUE(network_id, nebula_ip) and
+// migration 014 silently dropped: two distinct hosts in one network cannot hold
+// the same address. Before the migration-018 + ON CONFLICT guard this passed
+// silently (both inserts succeeded).
+func TestCreateHost_DuplicateNebulaIP_Rejected(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	if err := s.CreateHost(ctx, hostWithIP("h1", net.ID, "host-1", "192.168.100.10")); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	err := s.CreateHost(ctx, hostWithIP("h2", net.ID, "host-2", "192.168.100.10"))
+	if !errors.Is(err, ErrIPTaken) {
+		t.Fatalf("second create err = %v, want ErrIPTaken", err)
+	}
+
+	// The losing create must roll back whole — no orphan host row.
+	if _, err := s.GetHost(ctx, "h2"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("losing host h2 should not exist; GetHost err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestCreateHost_ConcurrentSameNebulaIP_ExactlyOneWins fires N concurrent creates
+// for distinct host names sharing one overlay IP and asserts exactly one wins
+// while the rest get ErrIPTaken — the TOCTOU window validateHostIPs alone could
+// not close. Mirrors TestPopNonces_ConcurrentSameNonceExactlyOneAccepted; run
+// with -race.
+func TestCreateHost_ConcurrentSameNebulaIP_ExactlyOneWins(t *testing.T) {
+	// File-backed so the connection pool grows past one — :memory: forces
+	// SetMaxOpenConns(1), serializing goroutines and masking the very race this
+	// guards (see TestConsumeToken_AtomicUnderConcurrency for the rationale).
+	dbPath := filepath.Join(t.TempDir(), "ip.db")
+	s, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	ctx := context.Background()
+	net := createTestNetwork(t, s)
+
+	const n = 8
+	var wg sync.WaitGroup
+	var wins, taken atomic.Int64
+	start := make(chan struct{})
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			h := hostWithIP(fmt.Sprintf("h%d", i), net.ID, fmt.Sprintf("host-%d", i), "192.168.100.20")
+			<-start
+			switch err := s.CreateHost(ctx, h); {
+			case err == nil:
+				wins.Add(1)
+			case errors.Is(err, ErrIPTaken):
+				taken.Add(1)
+			case strings.Contains(err.Error(), "database is locked"):
+				// SQLITE_BUSY under contention — a valid loss; the single-winner
+				// invariant is pinned by wins==1 below.
+				taken.Add(1)
+			default:
+				t.Errorf("goroutine %d: unexpected err %v", i, err)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if got := wins.Load(); got != 1 {
+		t.Errorf("winners = %d, want exactly 1", got)
+	}
+	if got := taken.Load(); got != n-1 {
+		t.Errorf("ErrIPTaken = %d, want %d", got, n-1)
+	}
+}
+
+// TestCreateHost_SameNebulaIP_DifferentNetworks_Allowed proves the guard is
+// network-scoped, not global: distinct networks are independent address spaces.
+func TestCreateHost_SameNebulaIP_DifferentNetworks_Allowed(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	netA := createTestNetwork(t, s)
+	netB := &models.Network{
+		ID: "net_test2", Name: "test-network-2",
+		CIDRs: []string{"192.168.100.0/24"}, CreatedAt: time.Now(),
+	}
+	if err := s.CreateNetwork(ctx, netB); err != nil {
+		t.Fatalf("create netB: %v", err)
+	}
+
+	if err := s.CreateHost(ctx, hostWithIP("ha", netA.ID, "host-a", "192.168.100.30")); err != nil {
+		t.Fatalf("create in netA: %v", err)
+	}
+	if err := s.CreateHost(ctx, hostWithIP("hb", netB.ID, "host-b", "192.168.100.30")); err != nil {
+		t.Fatalf("same IP in a different network must be allowed: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Migration 014 moved host addresses into a `host_addresses` table and dropped the `UNIQUE(network_id, nebula_ip)` constraint migration 001 had. The only remaining guard is `validateHostIPs`, an API-layer read-then-check — a TOCTOU window that two concurrent host creates can both pass, leaving two hosts bound to the same overlay IP. In a Nebula mesh that's a security defect, not just a data-integrity one: two hosts sharing an overlay address means ambiguous routing and a CA that has issued certs letting one host receive another's traffic.

## Fix

- **Migration 018** restores the invariant declaratively: denormalize `network_id` onto `host_addresses` (immutable post-create) + a `UNIQUE(network_id, address)` index.
- `setHostAddresses` inserts with `ON CONFLICT(network_id, address) DO NOTHING` and maps a zero-row result to `ErrIPTaken` — *targeted*, so `PRIMARY KEY` / `NOT NULL` violations still surface rather than being swallowed by a blunt `INSERT OR IGNORE`. The create/update handlers map `ErrIPTaken` → **409**.
- The migration is intentionally **fail-loud** on a pre-existing duplicate IP — it refuses to start until an operator resolves the defect (there's no safe automatic "which host wins") — and the statement-by-statement loader self-heals on re-run.

## Tests

Serial reject, concurrent exactly-one-wins (`-race`, file-backed so the connection pool actually grows), same-IP-different-networks allowed, plus a direct migration test covering backfill of pre-existing rows, the fail-loud-on-duplicate path, and the down round-trip.

---

Part of the #8c race-hardening work, split into two independent PRs; this is the host-IP-uniqueness half (the enrollment-token-atomicity half is a separate PR).
