### PR TITLE
fix(api): consume enrollment token atomically with host enroll

### DIFF
--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -45,8 +45,11 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Consume token (validates one-time use and expiry)
-	tok, err := s.store.ConsumeToken(r.Context(), req.Token)
+	// Resolve + validate the token (one-time use, expiry) WITHOUT consuming it
+	// yet. The single-use consume happens atomically with the cert save in
+	// ConsumeTokenAndEnrollHost below, so a failure mid-enrollment does not burn
+	// the token (#8c enrollment-token rollback atomicity).
+	tok, err := s.store.GetEnrollmentToken(r.Context(), req.Token)
 	if errors.Is(err, store.ErrNotFound) {
 		s.metrics.recordEnrollment(resultDenied)
 		writeError(w, http.StatusUnauthorized, "invalid enrollment token")
@@ -164,10 +167,18 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Save certificate and enroll host atomically
-	if err := s.store.SaveCertificateAndEnrollHost(r.Context(), host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
+	// Atomically consume the single-use token and enroll the host with its
+	// freshly-signed cert. Consuming here (rather than up front) means a
+	// transient failure during signing leaves the token usable for retry; a
+	// concurrent enrollment that already consumed it loses the CAS and gets 409.
+	if err := s.store.ConsumeTokenAndEnrollHost(r.Context(), host.ID, req.Token, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
+		if errors.Is(err, store.ErrTokenUsed) {
+			s.metrics.recordEnrollment(resultDenied)
+			writeError(w, http.StatusConflict, "enrollment token already used")
+			return
+		}
 		s.metrics.recordEnrollment(resultError)
-		s.logger.Error("save certificate and enroll host", "error", err)
+		s.logger.Error("consume token and enroll host", "error", err)
 		writeError(w, http.StatusInternalServerError, "enrollment failed")
 		return
 	}

--- a/internal/api/enroll_token_reuse_test.go
+++ b/internal/api/enroll_token_reuse_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+)
+
+// TestEnroll_ReplayedToken_Returns409 exercises the enrollment-atomicity fix at
+// the HTTP layer: once a token has enrolled a host it cannot be replayed. The
+// first enroll succeeds (200); replaying the identical request returns 409
+// "enrollment token already used" — here via the GetEnrollmentToken peek, which
+// sees used=1. The concurrent variant (two requests both pass the peek, then the
+// ConsumeTokenAndEnrollHost CAS lets exactly one win) is pinned at the store
+// level by TestConsumeTokenAndEnrollHost_ConcurrentSameToken_ExactlyOneEnrolls.
+func TestEnroll_ReplayedToken_Returns409(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID: netID,
+		Name:      "replay-host",
+		NebulaIPs: []string{"192.168.100.40"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create host: %d / %s", w.Code, w.Body.String())
+	}
+	var created createHostResponse
+	_ = json.NewDecoder(w.Body).Decode(&created)
+
+	// A valid enroll request: X25519 cert key + Ed25519 signing key.
+	x25519Priv := make([]byte, 32)
+	if _, err := rand.Read(x25519Priv); err != nil {
+		t.Fatal(err)
+	}
+	x25519Pub, err := curve25519.X25519(x25519Priv, curve25519.Basepoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, x25519Pub)
+	edPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signingPubPEM := pem.EncodeToMemory(&pem.Block{Type: SigningPublicKeyPEMType, Bytes: edPub})
+
+	enrollBody, _ := json.Marshal(enrollRequest{
+		Token:         created.EnrollmentToken,
+		PublicKeyPEM:  string(pubKeyPEM),
+		SigningPubPEM: string(signingPubPEM),
+	})
+
+	// First enrollment succeeds.
+	first := httptest.NewRequest(http.MethodPost, "/api/v1/enroll", bytes.NewBuffer(enrollBody))
+	fw := httptest.NewRecorder()
+	srv.ServeHTTP(fw, first)
+	if fw.Code != http.StatusOK {
+		t.Fatalf("first enroll: %d / %s", fw.Code, fw.Body.String())
+	}
+
+	// Replaying the same token is rejected as already-used — not burned silently,
+	// not re-issued.
+	second := httptest.NewRequest(http.MethodPost, "/api/v1/enroll", bytes.NewBuffer(enrollBody))
+	sw := httptest.NewRecorder()
+	srv.ServeHTTP(sw, second)
+	if sw.Code != http.StatusConflict {
+		t.Fatalf("replayed enroll: %d / %s, want 409", sw.Code, sw.Body.String())
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -778,8 +778,8 @@ func TestEnroll_HostDeletedAfterTokenCreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Delete host bypassing FK cascade (simulates race condition:
-	// concurrent delete between ConsumeToken and GetHost)
+	// Delete host bypassing FK cascade (simulates the host being removed after
+	// its enrollment token was issued).
 	if _, err := st.DB().Exec("PRAGMA foreign_keys=OFF"); err != nil {
 		t.Fatal(err)
 	}
@@ -790,7 +790,8 @@ func TestEnroll_HostDeletedAfterTokenCreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Try enrollment — token is consumed OK, but GetHost returns ErrNotFound
+	// Try enrollment — the peek resolves the token but GetHost returns
+	// ErrNotFound, so enrollment fails before anything is consumed.
 	_, _, signingPEM := generateSigningKeypair(t)
 	enrollBody, _ := json.Marshal(enrollRequest{
 		Token:         resp.EnrollmentToken,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1261,6 +1261,33 @@ func (s *SQLiteStore) CreateTokenForHost(ctx context.Context, hostID, token stri
 	return nil
 }
 
+// GetEnrollmentToken resolves a raw enrollment token to its row by SHA-256 hex
+// WITHOUT consuming it, applying the same validity checks as ConsumeToken
+// (ErrNotFound / ErrTokenUsed / ErrTokenExpired). It lets the enrollment handler
+// resolve the target host and fail fast before the expensive CA signature; the
+// actual single-use consume then happens atomically with the certificate save
+// in ConsumeTokenAndEnrollHost. Tokens are hashed at rest (GHSA-ghmh-jhmj-wcmf).
+func (s *SQLiteStore) GetEnrollmentToken(ctx context.Context, token string) (*models.EnrollmentToken, error) {
+	t := &models.EnrollmentToken{}
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, host_id, token_hash, used, expires_at, created_at FROM enrollment_tokens WHERE token_hash = ?`,
+		models.HashEnrollmentToken(token),
+	).Scan(&t.ID, &t.HostID, &t.TokenHash, &t.Used, &t.ExpiresAt, &t.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get enrollment token: %w", err)
+	}
+	if t.Used {
+		return nil, ErrTokenUsed
+	}
+	if time.Now().After(t.ExpiresAt) {
+		return nil, ErrTokenExpired
+	}
+	return t, nil
+}
+
 // ConsumeToken accepts the raw token from the caller, hashes it, and
 // looks up by SHA-256 hex. Marks the row used on success. GHSA-ghmh-jhmj-wcmf.
 func (s *SQLiteStore) ConsumeToken(ctx context.Context, token string) (*models.EnrollmentToken, error) {
@@ -1331,9 +1358,10 @@ func (s *SQLiteStore) SaveCertificate(ctx context.Context, hostID string, certPE
 	return nil
 }
 
-// SaveCertificateAndEnrollHost atomically saves a certificate and marks the host as enrolled.
-// If the host has role=lighthouse, the network's config_version is bumped so peer
-// agents pick up the new lighthouse on their next poll.
+// SaveCertificateAndEnrollHost atomically saves a certificate and marks the host
+// as enrolled. Used by token-less enrollment paths (e.g. mobile-bundle
+// generation). The agent token flow uses ConsumeTokenAndEnrollHost, which folds
+// the single-use token consume into the same transaction.
 func (s *SQLiteStore) SaveCertificateAndEnrollHost(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -1345,9 +1373,26 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(ctx context.Context, hostID s
 		}
 	}()
 
+	if err := s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit enroll host: %w", err)
+	}
+	return nil
+}
+
+// enrollHostInTx saves a freshly-signed certificate and flips the host to
+// enrolled within an existing transaction. If the host has role=lighthouse, the
+// network's config_version is bumped so peer agents pick up the new lighthouse
+// on their next poll. Shared by SaveCertificateAndEnrollHost (token-less paths)
+// and ConsumeTokenAndEnrollHost (agent enrollment, which also consumes the
+// enrollment token in the same transaction).
+func (s *SQLiteStore) enrollHostInTx(ctx context.Context, tx *sql.Tx, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
 	var isLighthouse bool
 	var networkID string
-	err = tx.QueryRowContext(ctx,
+	err := tx.QueryRowContext(ctx,
 		`SELECT is_lighthouse, network_id FROM hosts WHERE id = ?`, hostID,
 	).Scan(&isLighthouse, &networkID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1385,9 +1430,51 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(ctx context.Context, hostID s
 			return fmt.Errorf("bump config version: %w", err)
 		}
 	}
+	return nil
+}
+
+// ConsumeTokenAndEnrollHost atomically consumes the single-use enrollment token
+// and enrolls the host with its freshly-signed certificate in one transaction,
+// so the token is marked used IFF the certificate is persisted and the host
+// enrolled. A transient failure anywhere in the caller before this call (CA
+// signing error, DB blip) therefore leaves the token usable for a clean retry,
+// while a concurrent second enrollment racing the same token loses the used=0
+// CAS and receives ErrTokenUsed -- preserving single-use. This closes the
+// burn-on-failure window left by consuming the token up front in its own
+// transaction. The caller is expected to have validated the token via
+// GetEnrollmentToken first, so a zero-row CAS here means the race was lost.
+func (s *SQLiteStore) ConsumeTokenAndEnrollHost(ctx context.Context, hostID, token string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Error("rollback", "error", err)
+		}
+	}()
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE enrollment_tokens SET used = 1, used_at = ? WHERE token_hash = ? AND used = 0`,
+		time.Now(), models.HashEnrollmentToken(token),
+	)
+	if err != nil {
+		return fmt.Errorf("consume token: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("consume token rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrTokenUsed
+	}
+
+	if err := s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter); err != nil {
+		return err
+	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit enroll host: %w", err)
+		return fmt.Errorf("commit consume and enroll: %w", err)
 	}
 	return nil
 }

--- a/internal/store/sqlite_enroll_token_test.go
+++ b/internal/store/sqlite_enroll_token_test.go
@@ -1,0 +1,187 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestGetEnrollmentToken_PeekDoesNotConsume verifies the read-only peek resolves
+// a token and validates it WITHOUT marking it used, and surfaces the same
+// sentinels as ConsumeToken.
+func TestGetEnrollmentToken_PeekDoesNotConsume(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "peek-host")
+
+	const raw = "peek-token"
+	if err := s.CreateTokenForHost(ctx, h.ID, raw, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	// Two peeks in a row both succeed — peek must not consume.
+	for i := 0; i < 2; i++ {
+		tok, err := s.GetEnrollmentToken(ctx, raw)
+		if err != nil {
+			t.Fatalf("peek %d: %v", i, err)
+		}
+		if tok.HostID != h.ID {
+			t.Errorf("peek host_id = %q, want %q", tok.HostID, h.ID)
+		}
+		if tok.Used {
+			t.Errorf("peek %d: token reported used", i)
+		}
+	}
+
+	// Unknown token → ErrNotFound.
+	if _, err := s.GetEnrollmentToken(ctx, "no-such-token"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("unknown token err = %v, want ErrNotFound", err)
+	}
+
+	// After an atomic consume+enroll, the peek reports the token used.
+	if err := s.ConsumeTokenAndEnrollHost(ctx, h.ID, raw, []byte("cert"), "fp-peek", time.Now(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("consume+enroll: %v", err)
+	}
+	if _, err := s.GetEnrollmentToken(ctx, raw); !errors.Is(err, ErrTokenUsed) {
+		t.Errorf("post-consume peek err = %v, want ErrTokenUsed", err)
+	}
+}
+
+// TestGetEnrollmentToken_Expired confirms the peek surfaces ErrTokenExpired (the
+// 410 path in handleEnroll), matching ConsumeToken's sentinel set.
+func TestGetEnrollmentToken_Expired(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "exp-host")
+
+	const raw = "exp-token"
+	if err := s.CreateTokenForHost(ctx, h.ID, raw, time.Now().Add(-time.Minute)); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	if _, err := s.GetEnrollmentToken(ctx, raw); !errors.Is(err, ErrTokenExpired) {
+		t.Errorf("expired token err = %v, want ErrTokenExpired", err)
+	}
+}
+
+// TestConsumeTokenAndEnrollHost_NoBurnOnEnrollFailure proves the atomicity that
+// closes the burn window: when the enroll step fails (here: a host that does not
+// exist), the token consume rolls back with it and the token stays usable —
+// instead of being permanently burned as it was when ConsumeToken committed up
+// front in a separate transaction.
+func TestConsumeTokenAndEnrollHost_NoBurnOnEnrollFailure(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "burn-host")
+
+	const raw = "burn-token"
+	if err := s.CreateTokenForHost(ctx, h.ID, raw, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	// Enroll against a non-existent host → enrollHostInTx fails → the whole tx
+	// rolls back, including the token consume.
+	err := s.ConsumeTokenAndEnrollHost(ctx, "no-such-host", raw, []byte("cert"), "fp-burn", time.Now(), time.Now().Add(time.Hour))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+
+	// Token must still be usable — no burn.
+	tok, err := s.GetEnrollmentToken(ctx, raw)
+	if err != nil {
+		t.Fatalf("token should still be usable after failed enroll: %v", err)
+	}
+	if tok.Used {
+		t.Error("token was consumed despite enroll failure (burn not prevented)")
+	}
+
+	// And a subsequent valid enrollment still succeeds.
+	if err := s.ConsumeTokenAndEnrollHost(ctx, h.ID, raw, []byte("cert"), "fp-burn-2", time.Now(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("retry enroll: %v", err)
+	}
+}
+
+// TestConsumeTokenAndEnrollHost_ConcurrentSameToken_ExactlyOneEnrolls fires N
+// goroutines at one token (as two agents racing a leaked token would) and
+// asserts exactly one enrolls while the rest get ErrTokenUsed — single-use holds
+// even with the consume folded into the enroll transaction. File-backed so the
+// connection pool actually grows (see TestConsumeToken_AtomicUnderConcurrency
+// for why :memory' would mask this). Run with -race.
+func TestConsumeTokenAndEnrollHost_ConcurrentSameToken_ExactlyOneEnrolls(t *testing.T) {
+	const workers = 10
+
+	dbPath := filepath.Join(t.TempDir(), "enroll.db")
+	s, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	ctx := context.Background()
+	h := newHostFixture(t, s, "race-host")
+	const raw = "race-token"
+	if err := s.CreateTokenForHost(ctx, h.ID, raw, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	var wins, losses atomic.Int64
+	var mu sync.Mutex
+	var other []error
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	done.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer done.Done()
+			start.Wait() // release-the-hounds to maximize contention.
+			err := s.ConsumeTokenAndEnrollHost(ctx, h.ID, raw, []byte("cert"), fmt.Sprintf("fp-%d", i), time.Now(), time.Now().Add(time.Hour))
+			switch {
+			case err == nil:
+				wins.Add(1)
+			case errors.Is(err, ErrTokenUsed):
+				losses.Add(1)
+			case strings.Contains(err.Error(), "database is locked"):
+				// SQLITE_BUSY under contention — a valid loss; the single-winner
+				// invariant is pinned by wins==1 below.
+				losses.Add(1)
+			default:
+				mu.Lock()
+				other = append(other, err)
+				mu.Unlock()
+			}
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+
+	if wins.Load() != 1 {
+		t.Errorf("successes = %d, want 1 (token enrolled more than once — CAS broken)", wins.Load())
+	}
+	if losses.Load() != workers-1 {
+		t.Errorf("losses = %d, want %d (ErrTokenUsed + SQLITE_BUSY)", losses.Load(), workers-1)
+	}
+	if len(other) != 0 {
+		t.Errorf("unexpected errors: %v", other)
+	}
+
+	// Token consumed exactly once, and the winner's cert was persisted.
+	if _, err := s.GetEnrollmentToken(ctx, raw); !errors.Is(err, ErrTokenUsed) {
+		t.Errorf("token peek err = %v, want ErrTokenUsed", err)
+	}
+	gotHost, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatalf("get host: %v", err)
+	}
+	if !strings.HasPrefix(gotHost.CertFingerprint, "fp-") {
+		t.Errorf("host cert_fingerprint = %q, want the winner's fp-N", gotHost.CertFingerprint)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -82,10 +82,12 @@ type Store interface {
 	CreateToken(ctx context.Context, t *models.EnrollmentToken) error
 	CreateTokenForHost(ctx context.Context, hostID, token string, expiresAt time.Time) error
 	ConsumeToken(ctx context.Context, token string) (*models.EnrollmentToken, error)
+	GetEnrollmentToken(ctx context.Context, token string) (*models.EnrollmentToken, error)
 
 	// Certificates
 	SaveCertificate(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	SaveCertificateAndEnrollHost(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
+	ConsumeTokenAndEnrollHost(ctx context.Context, hostID, token string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	SaveCertificateAndUpdateHostCert(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	GetCurrentCertificate(ctx context.Context, hostID string) ([]byte, error)
 	GetCertificateInfo(ctx context.Context, hostID string) (*models.CertificateInfo, error)


### PR DESCRIPTION
## Problem

`handleEnroll` consumed the single-use enrollment token up front in its own committed transaction, *before* the CA signature and certificate save. Any transient failure in those later steps (CA error, DB blip) permanently **burned** the token — the host could never re-enroll without an operator minting a fresh one.

## Fix

- New read-only `GetEnrollmentToken` peek resolves + validates the token (same `ErrNotFound` / `ErrTokenUsed` / `ErrTokenExpired` sentinels) *before* signing.
- New `ConsumeTokenAndEnrollHost` folds the CAS consume (`UPDATE … SET used=1 WHERE used=0`) + cert save + host enroll into **one transaction** — the token is marked used *iff* enrollment persists.
- `handleEnroll` is reordered to consume-last (peek → sign → atomic consume+enroll). A concurrent enrollment racing the same token loses the CAS → `ErrTokenUsed` → **409**.
- A shared `enrollHostInTx` keeps the token-less mobile-bundle path (`SaveCertificateAndEnrollHost`) unchanged.

Net: a transient failure now leaves the token reusable for a clean retry, and single-use is preserved (strengthened, even, under concurrency).

## Tests

Store-level peek-doesn't-consume, no-burn-on-enroll-failure, concurrent-same-token exactly-one-enrolls (`-race`, file-backed), expired peek; plus an API-level replayed-token → 409.

---

Part of the #8c race-hardening work, split into two independent PRs; this is the enrollment-token-atomicity half (the host-IP-uniqueness half is a separate PR). Note: the existing post-enroll `UpdateHostSigningPub` step remains outside the enroll transaction — pre-existing behavior, not widened by this change.
