### PR TITLE
test(api): pin multi-tenant read-side scoping (property harness + boundary battery)

### DIFF
--- a/internal/api/scoping_boundary_test.go
+++ b/internal/api/scoping_boundary_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestListHosts_ForeignNetworkFilterDoesNotBypassScoping pins that a
+// non-admin cannot exfiltrate another operator's hosts by passing the
+// foreign network's id as the ?network_id= filter. The filter runs in the
+// store query, but the owned-CA scoping in handleListHosts runs afterwards
+// (hosts.go:190), so the result must stay empty for B even when the filter
+// matches A's hosts.
+func TestListHosts_ForeignNetworkFilterDoesNotBypassScoping(t *testing.T) {
+	srv, st := newTestServer(t)
+	keyA, _, caA := createOperatorWithCA(t, srv)
+	keyB, _, _ := createOperatorWithCA(t, srv)
+	netA, _ := seedNetworkAndHost(t, st, caA.ID, "a", "10.10.0.0/24", "10.10.0.10")
+
+	// B aims the filter at A's network.
+	codeB, bodyB := authedGET(srv, "/api/v1/hosts?network_id="+netA, keyB)
+	assert.Equal(t, http.StatusOK, codeB)
+	assert.NotContains(t, bodyB, caA.ID, "filter must not let B read A's hosts")
+	assert.NotContains(t, bodyB, "host-a")
+
+	// Sanity: the filter itself works for the owner — A sees the host when
+	// it scopes to A's own network. This proves the empty result for B is
+	// the scoping, not a broken filter.
+	codeA, bodyA := authedGET(srv, "/api/v1/hosts?network_id="+netA, keyA)
+	assert.Equal(t, http.StatusOK, codeA)
+	assert.Contains(t, bodyA, caA.ID)
+	assert.Contains(t, bodyA, "host-a")
+}
+
+// TestListOperators_NonAdminForbiddenBody pins that a non-admin is refused
+// with the role-required error and, crucially, that the 403 body does not
+// enumerate operators. The CA-id leak marker used by the property harness
+// does not apply here (operators carry no ca_id), so the operator username is
+// the marker: it must never appear in the refusal body.
+func TestListOperators_NonAdminForbiddenBody(t *testing.T) {
+	srv, _ := newTestServer(t)
+	keyA, opA, _ := createOperatorWithCA(t, srv)
+
+	code, body := authedGET(srv, "/api/v1/operators", keyA)
+	assert.Equal(t, http.StatusForbidden, code)
+	assert.Contains(t, body, "operator management requires the admin role")
+	assert.NotContains(t, body, opA.Username, "403 body must not enumerate operators")
+}
+
+// TestGetHost_NonOwnerDoesNotLeakBody pins the security-critical invariant on
+// the single-host read: a non-owner never receives the host body, whether the
+// host exists-but-is-foreign or does not exist at all.
+//
+// Note the existence side-channel that remains: a foreign-but-existing host
+// returns 403 while a missing id returns 404, so the status code distinguishes
+// existence. That split is systemic across the by-id host handlers (get,
+// delete, block, unblock, rotate-cert, reenroll, update — all GetHost→404 then
+// canAccessHost→403). Collapsing it to a uniform 404 is a behavior change for
+// a separate PR, so this test deliberately asserts the non-leak invariant
+// rather than pinning the 403/404 split — a future uniform-404 hardening must
+// not have to fight this test.
+func TestGetHost_NonOwnerDoesNotLeakBody(t *testing.T) {
+	srv, st := newTestServer(t)
+	_, _, caA := createOperatorWithCA(t, srv)
+	keyB, _, _ := createOperatorWithCA(t, srv)
+	_, hostA := seedNetworkAndHost(t, st, caA.ID, "a", "10.10.0.0/24", "10.10.0.10")
+
+	foreignCode, foreignBody := authedGET(srv, "/api/v1/hosts/"+hostA, keyB)
+	missingCode, missingBody := authedGET(srv, "/api/v1/hosts/does-not-exist", keyB)
+	t.Logf("by-id existence side-channel: foreign-existing=%d missing=%d", foreignCode, missingCode)
+
+	for _, c := range []struct {
+		name string
+		code int
+		body string
+	}{
+		{"foreign-existing", foreignCode, foreignBody},
+		{"missing", missingCode, missingBody},
+	} {
+		assert.NotEqual(t, http.StatusOK, c.code, "%s: non-owner must never get 200", c.name)
+		assert.NotContains(t, c.body, caA.ID, "%s: host body must not leak", c.name)
+		assert.NotContains(t, c.body, "host-a", "%s: host body must not leak", c.name)
+	}
+}
+
+// TestGetByID_NonOwnerDoesNotLeak extends the single-host non-leak guarantee
+// to the other singleResource by-id reads — network, firewall, and CA. The
+// property harness only drives the collection routes, so without this the
+// GHSA-598g cross-operator boundary for these endpoints would rest entirely
+// on the pre-existing *_authz_test.go batteries. Pinning it here keeps the
+// whole read-side boundary in one place: a regression that inverted an
+// ownership comparison in canAccessNetwork / the CA gate is caught by this PR.
+func TestGetByID_NonOwnerDoesNotLeak(t *testing.T) {
+	srv, st := newTestServer(t)
+	_, _, caA := createOperatorWithCA(t, srv)
+	keyB, _, _ := createOperatorWithCA(t, srv)
+	netA, _ := seedNetworkAndHost(t, st, caA.ID, "a", "10.10.0.0/24", "10.10.0.10")
+
+	for _, c := range []struct{ name, path string }{
+		{"network-by-id", "/api/v1/networks/" + netA},
+		{"network-firewall", "/api/v1/networks/" + netA + "/firewall"},
+		{"ca-by-id", "/api/v1/cas/" + caA.ID},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			code, body := authedGET(srv, c.path, keyB)
+			assert.NotEqual(t, http.StatusOK, code, "non-owner must never get 200")
+			assert.NotContains(t, body, caA.ID, "non-owner must not receive owner's resource")
+		})
+	}
+}

--- a/internal/api/scoping_property_test.go
+++ b/internal/api/scoping_property_test.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// listScoping classifies a registered GET route by its multi-tenant
+// read-side behavior. The registry below pairs with two tests:
+//
+//   - TestProtectedGETRoutesAreClassified walks the live chi router and
+//     fails the build if any GET route is missing from the registry. A new
+//     list endpoint added without a deliberate scoping decision therefore
+//     breaks CI at PR time — which is the point. The cross-operator data
+//     leak that GHSA-598g-h2vc-h5vg fixed slipped in precisely because new
+//     read paths were not forced to declare their scoping.
+//
+//   - TestListEndpointsScopeToOwner drives the actual assertions from the
+//     same registry, so the exhaustiveness check and the behavioral check
+//     never drift apart.
+type listScoping int
+
+const (
+	// scopedToOwner: a non-admin sees only rows under CAs they own; an
+	// admin sees every row. Enforced today by the ListCAsByOwner filter in
+	// each handler (hosts.go, networks.go, cas.go).
+	scopedToOwner listScoping = iota
+	// adminOnly: a non-admin is refused with 403 and no tenant data in the
+	// body; an admin gets 200.
+	adminOnly
+	// singleResource: GET /.../{id}, guarded per-row by canAccess* and
+	// covered by the *_authz_test.go batteries and scoping_boundary_test.go.
+	// Not exercised by the collection-scoping loop.
+	singleResource
+	// publicRoute: unauthenticated or non-operator surface (health probes,
+	// metrics, agent poll). Not an operator-facing tenant read.
+	publicRoute
+)
+
+// protectedGETScoping is the single source of truth for the read-side
+// multi-tenant behavior of every GET route the API registers. Keep it in
+// sync with setupRoutes — TestProtectedGETRoutesAreClassified enforces that.
+var protectedGETScoping = map[string]listScoping{
+	// Public / non-operator surfaces.
+	"/health":               publicRoute,
+	"/healthz":              publicRoute,
+	"/readyz":               publicRoute,
+	"/metrics":              publicRoute,
+	"/debug/vars":           publicRoute,
+	"/api/v1/agent/updates": publicRoute, // agent poll, signed-poll auth — not operator bearer
+
+	// Collection reads — must scope non-admins to owned CAs.
+	"/api/v1/networks": scopedToOwner,
+	"/api/v1/hosts":    scopedToOwner,
+	"/api/v1/cas":      scopedToOwner,
+
+	// Admin-only reads — non-admin gets 403, no tenant data in the body.
+	"/api/v1/operators":               adminOnly,
+	"/api/v1/operators/{id}/api-keys": adminOnly,
+	"/api/v1/audit-log":               adminOnly,
+	"/api/v1/blocklist":               adminOnly,
+	"/api/v1/settings":                adminOnly,
+
+	// Single-resource reads — guarded per-row by canAccess*.
+	"/api/v1/networks/{id}":          singleResource,
+	"/api/v1/networks/{id}/firewall": singleResource,
+	"/api/v1/hosts/{id}":             singleResource,
+	"/api/v1/cas/{id}":               singleResource,
+}
+
+// TestProtectedGETRoutesAreClassified fails the moment setupRoutes registers
+// a GET route that protectedGETScoping does not classify. It is the tripwire
+// that forces every future read endpoint to declare its tenant scoping.
+func TestProtectedGETRoutesAreClassified(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	var unclassified []string
+	err := chi.Walk(srv.router, func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		if method != http.MethodGet {
+			return nil
+		}
+		if _, ok := protectedGETScoping[route]; !ok {
+			unclassified = append(unclassified, route)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	if len(unclassified) > 0 {
+		sort.Strings(unclassified)
+		t.Fatalf("unclassified GET route(s) found by chi.Walk — add each to protectedGETScoping\n"+
+			"with its multi-tenant scoping (scopedToOwner / adminOnly / singleResource / publicRoute);\n"+
+			"if it returns a collection, it must be scopedToOwner or adminOnly so the leak test below\n"+
+			"covers it:\n  %s", strings.Join(unclassified, "\n  "))
+	}
+}
+
+// TestListEndpointsScopeToOwner pins the read-side invariant for every
+// collection and admin-only route: operator A never sees operator B's data
+// and vice-versa, while an admin sees both. The CA id is used as the leak
+// marker because it surfaces in every scoped collection — as ca_id on hosts
+// and networks, and as id on the CA itself.
+func TestListEndpointsScopeToOwner(t *testing.T) {
+	srv, st := newTestServer(t)
+
+	keyA, _, caA := createOperatorWithCA(t, srv)
+	keyB, _, caB := createOperatorWithCA(t, srv)
+	// Distinct CIDRs/IPs so the seed is robust to any nebula_ip uniqueness
+	// scheme; ownership is what the test cares about, not addressing.
+	seedNetworkAndHost(t, st, caA.ID, "a", "10.10.0.0/24", "10.10.0.10")
+	seedNetworkAndHost(t, st, caB.ID, "b", "10.20.0.0/24", "10.20.0.10")
+
+	for route, scoping := range protectedGETScoping {
+		switch scoping {
+		case scopedToOwner:
+			t.Run("scoped "+route, func(t *testing.T) {
+				codeA, bodyA := authedGET(srv, route, keyA)
+				assert.Equal(t, http.StatusOK, codeA)
+				assert.Contains(t, bodyA, caA.ID, "owner A must see its own resources")
+				assert.NotContains(t, bodyA, caB.ID, "owner A must not see operator B's resources")
+				assert.NotContains(t, bodyA, srv.defaultCAID, "owner A must not see the admin-owned default CA")
+
+				codeB, bodyB := authedGET(srv, route, keyB)
+				assert.Equal(t, http.StatusOK, codeB)
+				assert.Contains(t, bodyB, caB.ID, "owner B must see its own resources")
+				assert.NotContains(t, bodyB, caA.ID, "owner B must not see operator A's resources")
+				assert.NotContains(t, bodyB, srv.defaultCAID, "owner B must not see the admin-owned default CA")
+
+				codeAdmin, bodyAdmin := authedGET(srv, route, testAPIKey)
+				assert.Equal(t, http.StatusOK, codeAdmin)
+				assert.Contains(t, bodyAdmin, caA.ID, "admin must see operator A's resources")
+				assert.Contains(t, bodyAdmin, caB.ID, "admin must see operator B's resources")
+			})
+		case adminOnly:
+			t.Run("admin-only "+route, func(t *testing.T) {
+				code, body := authedGET(srv, route, keyA)
+				assert.Equal(t, http.StatusForbidden, code, "non-admin must be refused")
+				assert.NotContains(t, body, caA.ID, "403 body must not leak tenant data")
+				assert.NotContains(t, body, caB.ID, "403 body must not leak tenant data")
+
+				adminCode, _ := authedGET(srv, route, testAPIKey)
+				assert.Equal(t, http.StatusOK, adminCode, "admin must be allowed")
+			})
+		}
+	}
+}
+
+// authedGET issues GET against the route as the bearer of key and returns the
+// status and body. Route patterns with {id} are bound to the seeded admin
+// operator, which exists in every newTestServer.
+func authedGET(srv *Server, route, key string) (int, string) {
+	req := httptest.NewRequest(http.MethodGet, concretePath(route), nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w.Code, w.Body.String()
+}
+
+// concretePath binds the {id} param in a chi route pattern so the registry
+// can be requested directly. Admin-only handlers gate on role before reading
+// the id, so the bound value only matters for the admin success case
+// (test-admin always exists). Only GET routes reach here, and none carry a
+// {kid} sub-key param, so {id} is the only substitution needed.
+func concretePath(route string) string {
+	return strings.ReplaceAll(route, "{id}", "test-admin")
+}
+
+// seedNetworkAndHost inserts a network and a host bound to caID directly via
+// the store, bypassing the create handlers (which would re-derive ownership
+// from the caller). This lets the scoping tests set up cross-operator
+// fixtures that the API would otherwise refuse to create. Returns the network
+// and host ids.
+func seedNetworkAndHost(t *testing.T, st *store.SQLiteStore, caID, label, cidr, ip string) (netID, hostID string) {
+	t.Helper()
+	ctx := context.Background()
+	netID = uuid.New().String()
+	hostID = uuid.New().String()
+	require.NoError(t, st.CreateNetwork(ctx, &models.Network{
+		ID:        netID,
+		Name:      "net-" + label,
+		CIDRs:     []string{cidr},
+		CAID:      caID,
+		CreatedAt: time.Now(),
+	}))
+	require.NoError(t, st.CreateHost(ctx, &models.Host{
+		ID:        hostID,
+		NetworkID: netID,
+		CAID:      caID,
+		Name:      "host-" + label,
+		NebulaIPs: []string{ip},
+		Groups:    []string{},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}))
+	return netID, hostID
+}


### PR DESCRIPTION
## What

A property-test harness that pins the read-side multi-tenant scoping surface, plus the boundary battery. Test-only — no production code changes.

The keystone is a registry classifying every registered `GET` route, paired with a `chi.Walk` test that fails the moment a new GET route appears unclassified. The cross-operator data leak fixed in GHSA-598g-h2vc-h5vg slipped in because new read paths were not forced to declare their scoping; this turns that omission into a build failure rather than an advisory.

The same registry drives the assertions:

- **collection reads** (`/hosts`, `/networks`, `/cas`) — a non-admin sees only resources under CAs they own; an admin sees all; neither operator sees the other's data or the admin-owned default CA.
- **admin-only reads** (`/operators`, `/operators/{id}/api-keys`, `/audit-log`, `/blocklist`, `/settings`) — non-admins get 403 with no tenant data in the body.

Boundary battery:

- `?network_id=<foreign>` cannot be used to read another operator's hosts (the store filter runs before the owned-CA scoping).
- `/operators` 403 does not enumerate operators.
- a non-owner never receives a single-resource body — host, network, firewall, or CA.

## Notes

`go test ./... -race` and `golangci-lint run ./...` both green.

While writing the by-id tests I noticed a low-severity existence side-channel: a foreign-but-existing host returns 403 while a missing id returns 404, so the status distinguishes existence. It is systemic across the by-id host handlers. The test asserts the non-leak invariant rather than pinning the 403/404 split, so a future uniform-404 hardening will not have to fight it — happy to follow up separately if you would like that change.
