### PR TITLE
test(pki): cover CA key decryption, destruction, and signer boundaries

### DIFF
--- a/internal/pki/resolver_test.go
+++ b/internal/pki/resolver_test.go
@@ -1,0 +1,265 @@
+package pki_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"log/slog"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+
+	"github.com/juev/nebula-mesh/internal/keystore"
+	"github.com/juev/nebula-mesh/internal/models"
+	"github.com/juev/nebula-mesh/internal/pki"
+	"github.com/juev/nebula-mesh/internal/store"
+)
+
+// resolver.go had no test file, yet LoadByID is the key-decryption path: it
+// unwraps the DEK with the master key, opens the AEAD-sealed signing key, and
+// hands back a live CAManager. These tests pin that the round-trip recovers
+// the real key (not garbage that merely parsed), that a wiped manager can no
+// longer mint trusted certs ON THIS path (the GHSA-8h84 contract where it
+// matters most), that distinct CAs never share key material, and that every
+// decryption failure surfaces as an error rather than a usable-but-wrong CA.
+
+// mintCAInStore seeds an operator and mints+stores a CA owned by it, returning
+// the persisted CA row (with its encrypted key material).
+func mintCAInStore(t *testing.T, s store.Store, master *keystore.Master, opID string) *models.CA {
+	t.Helper()
+	op := seedOperator(t, s, opID, opID)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	c, _, err := pki.MintAndStoreCA(context.Background(), s, master, logger, pki.MintRequest{
+		Operator: op,
+		Name:     opID + "-ca",
+		Duration: 365 * 24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("MintAndStoreCA: %v", err)
+	}
+	return c
+}
+
+func mintResolverCA(t *testing.T, opID string) (store.Store, *models.CA, *keystore.Master) {
+	t.Helper()
+	s := newTestStore(t)
+	m := newTestMaster(t)
+	return s, mintCAInStore(t, s, m, opID), m
+}
+
+// hostPubKey returns a fresh X25519 public key for a host SignRequest.
+func hostPubKey(t *testing.T) []byte {
+	t.Helper()
+	priv := make([]byte, 32)
+	if _, err := rand.Read(priv); err != nil {
+		t.Fatal(err)
+	}
+	pub, err := curve25519.X25519(priv, curve25519.Basepoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub
+}
+
+func TestCAResolver_LoadByID_RoundTripRecoversSigningKey(t *testing.T) {
+	s, ca, master := mintResolverCA(t, "op-roundtrip")
+
+	mgr, err := pki.NewCAResolver(s, master).LoadByID(context.Background(), ca.ID)
+	if err != nil {
+		t.Fatalf("LoadByID: %v", err)
+	}
+
+	// The decrypted private key must correspond to the stored CA cert's
+	// public key. A wrong-but-valid key would still parse, so comparing the
+	// derived public key is what actually proves the DEK-unwrap + AEAD-open
+	// recovered the genuine signing key.
+	rawKey := mgr.RawKey()
+	if len(rawKey) != ed25519.PrivateKeySize {
+		t.Fatalf("RawKey length = %d, want %d", len(rawKey), ed25519.PrivateKeySize)
+	}
+	derivedPub, ok := rawKey.Public().(ed25519.PublicKey)
+	if !ok {
+		t.Fatal("RawKey.Public() is not ed25519.PublicKey")
+	}
+	if !bytes.Equal(derivedPub, mgr.CACert().PublicKey()) {
+		t.Error("decrypted private key does not match the stored CA cert public key")
+	}
+
+	fp, err := mgr.CACertFingerprint()
+	if err != nil {
+		t.Fatalf("CACertFingerprint: %v", err)
+	}
+	if fp != ca.Fingerprint {
+		t.Errorf("fingerprint = %q, want %q", fp, ca.Fingerprint)
+	}
+}
+
+// TestCAResolver_LoadByID_WipedManagerCannotMintVerifiableCert is the
+// behavioral GHSA-8h84 pin on the decryption path specifically: a manager
+// returned by LoadByID, once Wiped, must not be able to mint a cert that
+// verifies against its own CA. This complements the NewCA-path assertion in
+// signer_property_test.go — the two construction paths build CAManager
+// differently (NewCA vs LoadCAFromMaterial), so a regression that made
+// LoadCAFromMaterial copy the key into a non-aliased buffer would defeat the
+// byte-zero check below yet be caught here.
+func TestCAResolver_LoadByID_WipedManagerCannotMintVerifiableCert(t *testing.T) {
+	s, ca, master := mintResolverCA(t, "op-wipe-sign")
+
+	mgr, err := pki.NewCAResolver(s, master).LoadByID(context.Background(), ca.ID)
+	if err != nil {
+		t.Fatalf("LoadByID: %v", err)
+	}
+	certPEM, err := mgr.CACertPEM()
+	if err != nil {
+		t.Fatalf("CACertPEM: %v", err)
+	}
+	pool, err := cert.NewCAPoolFromPEM(certPEM)
+	if err != nil {
+		t.Fatalf("NewCAPoolFromPEM: %v", err)
+	}
+	req := pki.SignRequest{
+		Name:      "host",
+		PublicKey: hostPubKey(t),
+		Networks:  []netip.Prefix{netip.MustParsePrefix("10.0.0.1/24")},
+		Duration:  time.Hour,
+	}
+
+	// Positive control: the live decrypted key mints a verifiable cert.
+	good, err := mgr.Sign(req)
+	if err != nil {
+		t.Fatalf("Sign (pre-wipe): %v", err)
+	}
+	if _, err := pool.VerifyCertificate(time.Now(), good); err != nil {
+		t.Fatalf("pre-wipe cert failed to verify: %v", err)
+	}
+
+	mgr.Wipe()
+
+	bad, err := mgr.Sign(req)
+	if err != nil {
+		return // defensive: a future guard could refuse to sign with a wiped key
+	}
+	if _, err := pool.VerifyCertificate(time.Now(), bad); err == nil {
+		t.Error("cert signed after Wipe() verified — decrypted key survived Wipe on the resolver path")
+	}
+}
+
+// TestCAResolver_LoadByID_DistinctCAsDoNotShareKeys pins two properties of the
+// resolver's no-cache contract (documented on CAResolver): each CA decrypts to
+// its own key bound to its own cert, and Wiping one manager does not affect
+// another — i.e. LoadByID returns independent key material per call rather
+// than handing out aliases of a shared/cached buffer.
+func TestCAResolver_LoadByID_DistinctCAsDoNotShareKeys(t *testing.T) {
+	s := newTestStore(t)
+	master := newTestMaster(t)
+	caA := mintCAInStore(t, s, master, "op-dist-a")
+	caB := mintCAInStore(t, s, master, "op-dist-b")
+
+	resolver := pki.NewCAResolver(s, master)
+	mgrA, err := resolver.LoadByID(context.Background(), caA.ID)
+	if err != nil {
+		t.Fatalf("LoadByID A: %v", err)
+	}
+	mgrB, err := resolver.LoadByID(context.Background(), caB.ID)
+	if err != nil {
+		t.Fatalf("LoadByID B: %v", err)
+	}
+
+	// Each manager's key matches its own cert and not the other's.
+	pubA := mgrA.RawKey().Public().(ed25519.PublicKey)
+	pubB := mgrB.RawKey().Public().(ed25519.PublicKey)
+	if !bytes.Equal(pubA, mgrA.CACert().PublicKey()) || !bytes.Equal(pubB, mgrB.CACert().PublicKey()) {
+		t.Fatal("a manager's decrypted key does not match its own CA cert")
+	}
+	if bytes.Equal(pubA, pubB) {
+		t.Fatal("two distinct CAs resolved to the same key")
+	}
+
+	// Wiping A must not disturb B — proves the managers don't alias shared
+	// (e.g. cached) key material.
+	mgrA.Wipe()
+	allZero := true
+	for _, b := range mgrB.RawKey() {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		t.Error("Wiping CA A zeroed CA B's key — resolver is sharing key material across calls")
+	}
+}
+
+func TestCAResolver_LoadByID_WipeZeroesReturnedKey(t *testing.T) {
+	s, ca, master := mintResolverCA(t, "op-wipe")
+
+	mgr, err := pki.NewCAResolver(s, master).LoadByID(context.Background(), ca.ID)
+	if err != nil {
+		t.Fatalf("LoadByID: %v", err)
+	}
+
+	// RawKey aliases the manager's in-memory key, so Wipe must zero it in
+	// place — pinning the GHSA-8h84 "don't leave the key on the heap" contract
+	// for the resolver path specifically.
+	rawKey := mgr.RawKey()
+	mgr.Wipe()
+	for i, b := range rawKey {
+		if b != 0 {
+			t.Fatalf("byte %d not zeroed after Wipe: got %d", i, b)
+		}
+	}
+}
+
+func TestCAResolver_LoadByID_UnknownCA(t *testing.T) {
+	s := newTestStore(t)
+	master := newTestMaster(t)
+	if _, err := pki.NewCAResolver(s, master).LoadByID(context.Background(), "does-not-exist"); err == nil {
+		t.Error("LoadByID for unknown CA: want error, got nil")
+	}
+}
+
+func TestCAResolver_LoadByID_NilReceiverAndNilMaster(t *testing.T) {
+	var nilResolver *pki.CAResolver
+	if _, err := nilResolver.LoadByID(context.Background(), "x"); err == nil {
+		t.Error("nil resolver: want error, got nil")
+	}
+
+	s := newTestStore(t)
+	if _, err := pki.NewCAResolver(s, nil).LoadByID(context.Background(), "x"); err == nil {
+		t.Error("nil master: want error, got nil")
+	}
+}
+
+// fakeCAStore returns a fixed CA row for any id, so the decryption error paths
+// can be exercised with deliberately corrupted key material.
+type fakeCAStore struct{ ca *models.CA }
+
+func (f fakeCAStore) GetCA(context.Context, string) (*models.CA, error) { return f.ca, nil }
+
+func TestCAResolver_LoadByID_CorruptedKeyMaterialFails(t *testing.T) {
+	_, ca, master := mintResolverCA(t, "op-tamper")
+
+	for _, tc := range []struct {
+		name   string
+		tamper func(c *models.CA)
+	}{
+		{"corrupt DEK wrap", func(c *models.CA) { c.EncryptedKeyDEK[0] ^= 0xFF }},
+		{"corrupt key material", func(c *models.CA) { c.EncryptedKeyMaterial[0] ^= 0xFF }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := *ca
+			bad.EncryptedKeyDEK = append([]byte(nil), ca.EncryptedKeyDEK...)
+			bad.EncryptedKeyMaterial = append([]byte(nil), ca.EncryptedKeyMaterial...)
+			tc.tamper(&bad)
+
+			if _, err := pki.NewCAResolver(fakeCAStore{ca: &bad}, master).LoadByID(context.Background(), ca.ID); err == nil {
+				t.Errorf("%s: LoadByID returned a manager from corrupted material, want error", tc.name)
+			}
+		})
+	}
+}

--- a/internal/pki/signer_property_test.go
+++ b/internal/pki/signer_property_test.go
@@ -1,0 +1,117 @@
+package pki
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/slackhq/nebula/cert"
+)
+
+// hostSignRequest builds a minimal valid SignRequest for the property tests.
+func hostSignRequest(t *testing.T, dur time.Duration) SignRequest {
+	t.Helper()
+	pub, _ := generateHostKeypair(t)
+	return SignRequest{
+		Name:      "prop-host",
+		PublicKey: pub,
+		Networks:  []netip.Prefix{netip.MustParsePrefix("10.0.0.1/24")},
+		Duration:  dur,
+	}
+}
+
+// TestSign_AfterWipe_ProducesUnverifiableCert pins the behavioral half of the
+// GHSA-8h84 contract documented on CAManager.Wipe: "after Wipe(), any
+// subsequent Sign() will produce invalid signatures." The existing ca_test.go
+// only checks the key bytes are zeroed — the slice-zero property. This asserts
+// the consequence: a cert minted after Wipe cannot be verified against the CA,
+// so if caKey ever became a non-aliased copy (a clone, a crypto.Signer
+// adapter), Wipe leaving the live signer functional would be caught here.
+func TestSign_AfterWipe_ProducesUnverifiableCert(t *testing.T) {
+	ca := newTestCA(t)
+
+	certPEM, err := ca.CACertPEM()
+	if err != nil {
+		t.Fatalf("CACertPEM: %v", err)
+	}
+	pool, err := cert.NewCAPoolFromPEM(certPEM)
+	if err != nil {
+		t.Fatalf("NewCAPoolFromPEM: %v", err)
+	}
+
+	// Positive control: a cert signed with the live key verifies. This rules
+	// out a broken verify setup masking the post-wipe assertion below.
+	good, err := ca.Sign(hostSignRequest(t, time.Hour))
+	if err != nil {
+		t.Fatalf("Sign (pre-wipe): %v", err)
+	}
+	if _, err := pool.VerifyCertificate(time.Now(), good); err != nil {
+		t.Fatalf("pre-wipe cert failed to verify: %v", err)
+	}
+
+	ca.Wipe()
+
+	// In practice Sign does not error on a zeroed ed25519 key — it produces a
+	// signature that cannot verify against the CA's real public key, so the
+	// verify-failure branch is the one that fires. The error branch is
+	// defensive: a future guard refusing to sign with a wiped key would also
+	// satisfy the contract.
+	bad, err := ca.Sign(hostSignRequest(t, time.Hour))
+	if err != nil {
+		return
+	}
+	if _, err := pool.VerifyCertificate(time.Now(), bad); err == nil {
+		t.Error("cert signed after Wipe() verified against the CA pool — key was not effectively destroyed")
+	}
+}
+
+// TestSign_HostCertIsNeverCA pins that minted host certs are never CA certs.
+// signer.go hardcodes IsCA: false; this guards against a future "preserve
+// cert shape on renew" refactor (step-ca's Renew copies IsCA/MaxPathLen from
+// the old cert — exactly the pattern this must not adopt).
+func TestSign_HostCertIsNeverCA(t *testing.T) {
+	ca := newTestCA(t)
+	hostCert, err := ca.Sign(hostSignRequest(t, time.Hour))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if hostCert.IsCA() {
+		t.Error("minted host cert has IsCA=true; host certs must never be CAs")
+	}
+}
+
+// TestSign_ClampsNotAfterToCAExpiry pins the existing clamp: a host cert can
+// never outlive its CA. A request beyond the CA's expiry is clamped to the
+// CA's NotAfter; a request within validity is left untouched.
+func TestSign_ClampsNotAfterToCAExpiry(t *testing.T) {
+	ca, err := NewCA("short-ca", time.Hour)
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+	caNotAfter := ca.CACert().NotAfter()
+
+	t.Run("beyond CA expiry is clamped", func(t *testing.T) {
+		hostCert, err := ca.Sign(hostSignRequest(t, 30*24*time.Hour))
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		if !hostCert.NotAfter().Equal(caNotAfter) {
+			t.Errorf("notAfter = %v, want clamped to CA expiry %v", hostCert.NotAfter(), caNotAfter)
+		}
+	})
+
+	t.Run("within validity is not clamped", func(t *testing.T) {
+		hostCert, err := ca.Sign(hostSignRequest(t, time.Minute))
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		if !hostCert.NotAfter().Before(caNotAfter) {
+			t.Errorf("notAfter = %v, want strictly before CA expiry %v (no clamp expected)", hostCert.NotAfter(), caNotAfter)
+		}
+		// And it reflects the requested duration (~1m), not some other earlier
+		// value — a clamp to the wrong bound would still pass the check above.
+		if d := time.Until(hostCert.NotAfter()); d < 30*time.Second || d > 2*time.Minute {
+			t.Errorf("notAfter is %v from now, want ~1m (requested duration, unclamped)", d)
+		}
+	})
+}


### PR DESCRIPTION
## What

Test-only coverage for the CA key lifecycle — no production code changes.

`internal/pki/resolver.go` had no test file, yet `LoadByID` is the on-demand key-decryption path: it unwraps the DEK with the master key, opens the AEAD-sealed signing key, and returns a live `CAManager`. This adds:

- **round-trip**: the decrypted private key matches the stored CA cert's public key (proves the real key was recovered, not garbage that merely parsed)
- **destruction on the decryption path**: a `LoadByID` manager, once `Wipe()`d, can no longer mint a cert that verifies — the GHSA-8h84-fhqq-q58v contract pinned where it matters most
- **no key sharing across CAs**: distinct CAs decrypt to distinct keys, and wiping one manager does not disturb another (the resolver's documented no-cache contract)
- **failure surfaces as an error**: unknown CA, nil receiver/master, and tampered DEK / key-material (AEAD integrity) all error rather than returning a usable-but-wrong CA

Plus signer property pins:

- a cert minted after `Wipe()` fails verification (the `NewCA` construction path)
- minted host certs are never CA certs (`IsCA=false`)
- `notAfter` is clamped to the CA's expiry when a request exceeds it, and left untouched when it doesn't

## Notes

`go test ./... -race` and `golangci-lint run ./...` both green.
