### PR TITLE
fix(store): DeleteCA refuses while any ca_id-carrying table references the CA

### DIFF
--- a/internal/store/sqlite_cas.go
+++ b/internal/store/sqlite_cas.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/forgekeep/nebula-mesh/internal/models"
@@ -185,18 +186,37 @@ func (s *SQLiteStore) UpdateCAStatus(ctx context.Context, id string, status mode
 	return nil
 }
 
-// DeleteCA removes a CA row. The DB-level ON DELETE RESTRICT on
-// networks.ca_id (when enforced by application logic) is mirrored here:
-// the call returns an error if networks still reference the CA, so the
-// operator must retire / move networks first.
+// DeleteCA removes a CA row. ca_id is a plain column on networks, hosts,
+// certificates, and blocklist with no DB-level foreign key (it defaults to the
+// empty string for pre-multi-CA rows), so referential integrity is enforced
+// here: the call refuses while any of those tables still references the CA.
+// Without checking all four, deleting a CA orphans rows whose ca_id no longer
+// resolves, surfacing later as a silent failure in caForHost (ErrNotFound,
+// then 500). Each table is checked independently because they can reference a
+// CA in isolation, e.g. a blocklist row whose host was deleted via ON DELETE
+// SET NULL, or a host whose ca_id diverged from its network's.
 func (s *SQLiteStore) DeleteCA(ctx context.Context, id string) error {
-	row := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM networks WHERE ca_id = ?`, id)
-	var n int
-	if err := row.Scan(&n); err != nil {
-		return fmt.Errorf("check CA references: %w", err)
+	checks := []struct {
+		query string
+		label string
+	}{
+		{`SELECT COUNT(1) FROM networks WHERE ca_id = ?`, "network"},
+		{`SELECT COUNT(1) FROM hosts WHERE ca_id = ?`, "host"},
+		{`SELECT COUNT(1) FROM certificates WHERE ca_id = ?`, "certificate"},
+		{`SELECT COUNT(1) FROM blocklist WHERE ca_id = ?`, "blocklist entry"},
 	}
-	if n > 0 {
-		return fmt.Errorf("CA still has %d network(s); detach them first", n)
+	var blockers []string
+	for _, c := range checks {
+		var n int
+		if err := s.db.QueryRowContext(ctx, c.query, id).Scan(&n); err != nil {
+			return fmt.Errorf("check CA references: %w", err)
+		}
+		if n > 0 {
+			blockers = append(blockers, fmt.Sprintf("%d %s(s)", n, c.label))
+		}
+	}
+	if len(blockers) > 0 {
+		return fmt.Errorf("CA still has %s; detach them first", strings.Join(blockers, ", "))
 	}
 	result, err := s.db.ExecContext(ctx, `DELETE FROM cas WHERE id = ?`, id)
 	if err != nil {

--- a/internal/store/sqlite_cas_test.go
+++ b/internal/store/sqlite_cas_test.go
@@ -1,0 +1,207 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// seedCA creates an operator and an active CA owned by it. The encrypted-key
+// blobs are dummy — these tests exercise DeleteCA's reference checks, not key
+// material.
+func seedCA(t *testing.T, s *SQLiteStore, caID string) {
+	t.Helper()
+	ctx := context.Background()
+	op := &models.Operator{
+		ID:           "op-" + caID,
+		Username:     "user-" + caID,
+		DisplayName:  "user-" + caID,
+		PasswordHash: "x",
+		Role:         "user",
+		Status:       models.OperatorStatusActive,
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(ctx, op); err != nil {
+		t.Fatalf("CreateOperator: %v", err)
+	}
+	if err := s.CreateCA(ctx, &models.CA{
+		ID:                   caID,
+		Name:                 caID,
+		OwnerOperatorID:      op.ID,
+		Fingerprint:          "fp-" + caID,
+		CertPEM:              "pem",
+		Status:               models.CAStatusActive,
+		NotBefore:            time.Now(),
+		NotAfter:             time.Now().Add(time.Hour),
+		EncryptedKeyDEK:      []byte{1},
+		NonceDEK:             []byte{1},
+		EncryptedKeyMaterial: []byte{1},
+		NonceKey:             []byte{1},
+	}); err != nil {
+		t.Fatalf("CreateCA: %v", err)
+	}
+}
+
+func mustExecStore(t *testing.T, s *SQLiteStore, query string, args ...any) {
+	t.Helper()
+	if _, err := s.db.ExecContext(context.Background(), query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}
+
+func TestDeleteCA_SucceedsWhenUnreferenced(t *testing.T) {
+	s := newTestStore(t)
+	seedCA(t, s, "ca-free")
+
+	if err := s.DeleteCA(context.Background(), "ca-free"); err != nil {
+		t.Fatalf("DeleteCA on unreferenced CA: %v", err)
+	}
+	if _, err := s.GetCA(context.Background(), "ca-free"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetCA after delete: err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestDeleteCA_IgnoresEmptyCAIDRows pins that pre-multi-CA rows (ca_id = "",
+// the column default) never block a delete. A regression that matched the
+// empty string would over-block legitimate CA deletions.
+func TestDeleteCA_IgnoresEmptyCAIDRows(t *testing.T) {
+	s := newTestStore(t)
+	seedCA(t, s, "ca-empty")
+	// A legacy row carrying the default empty ca_id.
+	mustExecStore(t, s, `INSERT INTO blocklist (fingerprint, ca_id) VALUES (?, ?)`, "bl-legacy", "")
+
+	if err := s.DeleteCA(context.Background(), "ca-empty"); err != nil {
+		t.Fatalf("DeleteCA blocked by an empty-ca_id row: %v", err)
+	}
+}
+
+// TestDeleteCA_ReportsAllBlockers pins that when more than one table references
+// the CA, the refusal lists each of them (the strings.Join path).
+func TestDeleteCA_ReportsAllBlockers(t *testing.T) {
+	const caID = "ca-multi"
+	s := newTestStore(t)
+	seedCA(t, s, caID)
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "n1", Name: "n1", CIDRs: []string{"10.0.0.0/24"}, CAID: caID, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	mustExecStore(t, s, `INSERT INTO blocklist (fingerprint, ca_id) VALUES (?, ?)`, "bl-fp1", caID)
+
+	err := s.DeleteCA(context.Background(), caID)
+	if err == nil {
+		t.Fatal("DeleteCA succeeded while network and blocklist referenced the CA")
+	}
+	for _, want := range []string{"network", "blocklist entry"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to mention %q", err.Error(), want)
+		}
+	}
+	if _, gerr := s.GetCA(context.Background(), caID); gerr != nil {
+		t.Errorf("CA missing after refused delete: %v", gerr)
+	}
+}
+
+// TestDeleteCA_RefusesWhileReferenced pins that DeleteCA refuses to orphan a
+// reference in ANY of the four ca_id-carrying tables. Before the fix only
+// networks was checked, so deleting a CA still referenced by a host,
+// certificate, or blocklist row silently orphaned that row. Each case isolates
+// its table: the other tables either don't exist or point at a different CA.
+func TestDeleteCA_RefusesWhileReferenced(t *testing.T) {
+	const caID = "ca-ref"
+
+	for _, tc := range []struct {
+		name      string
+		wantLabel string
+		seedRef   func(t *testing.T, s *SQLiteStore)
+	}{
+		{
+			name:      "network",
+			wantLabel: "network",
+			seedRef: func(t *testing.T, s *SQLiteStore) {
+				if err := s.CreateNetwork(context.Background(), &models.Network{
+					ID: "n1", Name: "n1", CIDRs: []string{"10.0.0.0/24"}, CAID: caID, CreatedAt: time.Now(),
+				}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:      "host",
+			wantLabel: "host",
+			seedRef: func(t *testing.T, s *SQLiteStore) {
+				// Network points at a different CA so only the host references caID
+				// — mirrors a host whose ca_id diverged from its network's.
+				if err := s.CreateNetwork(context.Background(), &models.Network{
+					ID: "n1", Name: "n1", CIDRs: []string{"10.0.0.0/24"}, CAID: "other-ca", CreatedAt: time.Now(),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.CreateHost(context.Background(), &models.Host{
+					ID: "h1", NetworkID: "n1", CAID: caID, Name: "h1",
+					NebulaIPs: []string{"10.0.0.10"}, Groups: []string{},
+					Role: models.HostRoleHost, Status: models.HostStatusPending,
+					CreatedAt: time.Now(), UpdatedAt: time.Now(),
+				}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:      "certificate",
+			wantLabel: "certificate",
+			seedRef: func(t *testing.T, s *SQLiteStore) {
+				// Host/network point at a different CA; only the cert row references caID.
+				if err := s.CreateNetwork(context.Background(), &models.Network{
+					ID: "n1", Name: "n1", CIDRs: []string{"10.0.0.0/24"}, CAID: "other-ca", CreatedAt: time.Now(),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.CreateHost(context.Background(), &models.Host{
+					ID: "h1", NetworkID: "n1", CAID: "other-ca", Name: "h1",
+					NebulaIPs: []string{"10.0.0.10"}, Groups: []string{},
+					Role: models.HostRoleHost, Status: models.HostStatusPending,
+					CreatedAt: time.Now(), UpdatedAt: time.Now(),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				mustExecStore(t, s,
+					`INSERT INTO certificates (id, host_id, fingerprint, pem, not_before, not_after, ca_id) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+					"cert1", "h1", "fp-cert1", "pem", time.Now(), time.Now().Add(time.Hour), caID)
+			},
+		},
+		{
+			name:      "blocklist",
+			wantLabel: "blocklist entry",
+			seedRef: func(t *testing.T, s *SQLiteStore) {
+				// host_id NULL — the realistic orphan: the host was deleted (ON
+				// DELETE SET NULL) but the blocklist row keeps its ca_id.
+				mustExecStore(t, s, `INSERT INTO blocklist (fingerprint, ca_id) VALUES (?, ?)`, "bl-fp1", caID)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			seedCA(t, s, caID)
+			tc.seedRef(t, s)
+
+			err := s.DeleteCA(context.Background(), caID)
+			if err == nil {
+				t.Fatalf("DeleteCA succeeded while a %s referenced the CA — orphan created", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantLabel) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tc.wantLabel)
+			}
+			// The CA must still exist — a refused delete must not have removed it.
+			if _, gerr := s.GetCA(context.Background(), caID); gerr != nil {
+				t.Errorf("CA missing after refused delete: %v", gerr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`ca_id` is a plain `TEXT` column with no DB-level foreign key on `networks`, `hosts`, `certificates`, and `blocklist` — it defaults to the empty string for pre-multi-CA rows, so a real FK isn't possible and referential integrity is enforced in application code. But `DeleteCA` only checked `networks`.

Deleting a CA still referenced by a host, certificate, or blocklist row orphaned that row; its `ca_id` then failed to resolve in `caForHost`, surfacing as a 500 on the affected host's next enroll / poll / mobile-bundle. The realistic independent vectors are a blocklist row whose host was deleted (`ON DELETE SET NULL` keeps the row while `ca_id` lingers) and a host whose `ca_id` diverged from its network's via the default-CA fallback.

## Fix

Extend the reference check to all four `ca_id`-carrying tables. The CA is only deletable once nothing references it, and the refusal now names each blocking table. The single-network refusal message is byte-identical to before.

## Tests

`internal/store/sqlite_cas_test.go`: refuses for each of networks / hosts / certificates / blocklist independently (each case isolates its table), reports all blockers when several reference the CA, ignores legacy empty-`ca_id` rows, and succeeds when unreferenced. The host/certificate/blocklist cases fail without the fix.

`go test ./... -race` and `golangci-lint run ./...` are green.

## Follow-up (out of scope)

The reference checks and the `DELETE` are separate statements (as before this change), leaving a narrow admin-only TOCTOU window; closing it fully would wrap them in a single transaction.
