### PR TITLE
fix(api): scope ListHosts to owned CAs in SQL so the row cap can't undercount

### DIFF
--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -180,14 +180,10 @@ func (s *Server) handleListHosts(w http.ResponseWriter, r *http.Request) {
 		Limit:     1000,
 	}
 
-	hosts, err := s.store.ListHosts(r.Context(), filter)
-	if err != nil {
-		s.logger.Error("list hosts", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to list hosts")
-		return
-	}
-
-	// For non-admin, scope to owned CAs
+	// Non-admins are scoped to hosts under CAs they own. Push that scope into
+	// the query rather than filtering the result in Go: a global LIMIT applied
+	// before the ownership filter could drop an operator's own hosts out of the
+	// window, silently undercounting once the deployment exceeds the limit.
 	if !s.isActiveAdmin(r.Context()) {
 		actor := ActorOf(r.Context())
 		if actor == nil {
@@ -200,18 +196,22 @@ func (s *Server) handleListHosts(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to check permissions")
 			return
 		}
-		ownedCAIDs := make(map[string]struct{}, len(cas))
-		for _, ca := range cas {
-			ownedCAIDs[ca.ID] = struct{}{}
+		if len(cas) == 0 {
+			writeJSON(w, http.StatusOK, []*models.Host{})
+			return
 		}
-		// Filter hosts to only those under owned CAs
-		filtered := hosts[:0]
-		for _, h := range hosts {
-			if _, ok := ownedCAIDs[h.CAID]; ok {
-				filtered = append(filtered, h)
-			}
+		caIDs := make([]string, len(cas))
+		for i, ca := range cas {
+			caIDs[i] = ca.ID
 		}
-		hosts = filtered
+		filter.CAIDs = caIDs
+	}
+
+	hosts, err := s.store.ListHosts(r.Context(), filter)
+	if err != nil {
+		s.logger.Error("list hosts", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list hosts")
+		return
 	}
 
 	writeJSON(w, http.StatusOK, hosts)

--- a/internal/api/list_hosts_scope_test.go
+++ b/internal/api/list_hosts_scope_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// TestListHosts_NonAdminNotUndercountedPastLimit reproduces work-yzu3: with
+// more hosts under CAs the caller does NOT own than the handler's 1000-row
+// query cap, the caller's own host (sorting after that window) must still be
+// returned. Previously the handler applied the owned-CA filter in Go AFTER the
+// SQL LIMIT, so the owner's host was dropped from the window before the filter
+// ran and the operator silently saw fewer hosts than they owned.
+func TestListHosts_NonAdminNotUndercountedPastLimit(t *testing.T) {
+	srv, st := newTestServer(t)
+	keyB, _, caB := createOperatorWithCA(t, srv)
+	ctx := context.Background()
+
+	// One network for the foreign hosts (the host network_id FK); the ca_id on
+	// the hosts is what scoping keys on.
+	require.NoError(t, st.CreateNetwork(ctx, &models.Network{
+		ID: "n-foreign", Name: "n-foreign", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now(),
+	}))
+	// 1001 foreign hosts whose names sort before the owned host, so a global
+	// "ORDER BY name LIMIT 1000" fills the entire window with them.
+	for i := 0; i < 1001; i++ {
+		require.NoError(t, st.CreateHost(ctx, &models.Host{
+			ID: fmt.Sprintf("hf-%04d", i), NetworkID: "n-foreign", CAID: "ca-foreign",
+			Name: fmt.Sprintf("aaa-%04d", i), Role: models.HostRoleHost, Status: models.HostStatusPending,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}))
+	}
+	// Operator B's single host, under a CA B owns, with a name that sorts last.
+	require.NoError(t, st.CreateNetwork(ctx, &models.Network{
+		ID: "n-mine", Name: "n-mine", CIDRs: []string{"10.1.0.0/24"}, CAID: caB.ID, CreatedAt: time.Now(),
+	}))
+	require.NoError(t, st.CreateHost(ctx, &models.Host{
+		ID: "h-mine", NetworkID: "n-mine", CAID: caB.ID, Name: "zzz-mine",
+		Role: models.HostRoleHost, Status: models.HostStatusPending, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts", nil)
+	req.Header.Set("Authorization", "Bearer "+keyB)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "zzz-mine", "owner's host dropped by LIMIT before ownership scoping (undercount)")
+	assert.NotContains(t, body, "aaa-", "foreign hosts must not leak to a non-owner")
+}

--- a/internal/store/list_hosts_scope_test.go
+++ b/internal/store/list_hosts_scope_test.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/juev/nebula-mesh/internal/models"
+)
+
+// TestListHosts_CAIDsScopeBeforeLimit pins that the CAIDs filter is applied in
+// SQL before the LIMIT. Without it, a global "ORDER BY name LIMIT N" can fill
+// the window with hosts under CAs the caller does not own, dropping the
+// caller's own hosts — the undercount handleListHosts previously had when it
+// filtered to owned CAs in Go after the limit.
+func TestListHosts_CAIDsScopeBeforeLimit(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	net := createTestNetwork(t, s) // satisfies the host network_id FK
+
+	mk := func(id, name, caID string) {
+		if err := s.CreateHost(ctx, &models.Host{
+			ID: id, NetworkID: net.ID, CAID: caID, Name: name,
+			Role: models.HostRoleHost, Status: models.HostStatusPending,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("CreateHost %s: %v", name, err)
+		}
+	}
+	// hosts.ca_id has no foreign key (migration 009), so these fabricated CA
+	// ids need no cas rows — the scope filter keys on the column value alone.
+	mk("h-foreign", "aaa-foreign", "ca-foreign") // sorts first by name
+	mk("h-mine", "zzz-mine", "ca-mine")          // sorts last by name
+
+	// Limit 1 with the foreign host sorting first: an unscoped query returns
+	// only "aaa-foreign". The CAIDs scope must select "zzz-mine" instead.
+	got, err := s.ListHosts(ctx, HostFilter{Limit: 1, CAIDs: []string{"ca-mine"}})
+	if err != nil {
+		t.Fatalf("ListHosts: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d hosts, want 1 (CAIDs scope must apply before LIMIT)", len(got))
+	}
+	if got[0].ID != "h-mine" {
+		t.Errorf("got host %q, want h-mine", got[0].ID)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -701,6 +701,17 @@ func (s *SQLiteStore) ListHosts(ctx context.Context, filter HostFilter) ([]*mode
 		query += ` AND groups_json LIKE ? ESCAPE '\'`
 		args = append(args, `%"`+escaped+`"%`)
 	}
+	if len(filter.CAIDs) > 0 {
+		// Bind the CA-id set as a single JSON-array parameter and expand it via
+		// json_each, so the query string stays constant (no dynamic SQL
+		// concatenation) while the ids remain fully parameterized.
+		idsJSON, err := json.Marshal(filter.CAIDs)
+		if err != nil {
+			return nil, fmt.Errorf("marshal ca id filter: %w", err)
+		}
+		query += ` AND ca_id IN (SELECT value FROM json_each(?))`
+		args = append(args, string(idsJSON))
+	}
 	query += ` ORDER BY name`
 	if filter.Limit > 0 {
 		query += ` LIMIT ?`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,7 +12,11 @@ type HostFilter struct {
 	NetworkID string
 	Group     string
 	Status    models.HostStatus
-	Limit     int // 0 = no limit
+	// CAIDs scopes results to hosts under these CA ids. When non-empty the
+	// scope is applied in SQL, so it composes correctly with Limit — the
+	// limit applies after scoping, not before. Empty means no CA scoping.
+	CAIDs []string
+	Limit int // 0 = no limit
 }
 
 // AuditFilter specifies filters for audit log queries.


### PR DESCRIPTION
## Problem (work-yzu3)

`handleListHosts` set `HostFilter.Limit = 1000`, called `ListHosts` (which applies `ORDER BY name LIMIT 1000` across **all** CAs), then filtered to the operator's owned CAs **in Go**. Once a deployment has more than 1000 hosts, a non-admin whose own hosts sort after the first 1000 silently sees fewer than they own — the ownership filter runs after the window has already dropped them.

## Fix

- `HostFilter` gains a `CAIDs []string` field. When set, `ListHosts` scopes with `AND ca_id IN (SELECT value FROM json_each(?))` **before** `ORDER BY name / LIMIT`. The CA ids are bound as a single JSON-array parameter, so the query string stays constant — fully parameterized, no dynamic SQL string-building.
- `handleListHosts` computes the non-admin's owned CA ids and passes them as `filter.CAIDs`, so the limit applies after scoping. It short-circuits to `[]` when the actor owns no CAs. The Go post-filter is removed.

Admins are unchanged (no `CAIDs` → unscoped, still capped at 1000 — the global pagination cap is a separate concern). All other `ListHosts` callers pass no `CAIDs`, so their queries are byte-identical.

## Tests

- store: `ListHosts` with `CAIDs` and `Limit: 1` returns the owned host even when a foreign host sorts first (scope-before-limit).
- api: with 1001 foreign hosts sorting ahead of the owner's one host, a non-admin still sees their host via `GET /api/v1/hosts` — the end-to-end work-yzu3 reproduction.

`go test ./... -race` and `golangci-lint run ./...` are green.
