### PR TITLE
fix(configgen): round-trippable YAML for non-literal-safe inline PEM (GHSA-7hp6)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	dario.cat/mergo v1.0.2 // indirect
 	filippo.io/bigmod v0.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -34,7 +35,9 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.70.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 filippo.io/bigmod v0.1.0 h1:UNzDk7y9ADKST+axd9skUpBQeW7fG2KrTZyOE4uGQy8=
 filippo.io/bigmod v0.1.0/go.mod h1:OjOXDNlClLblvXdwgFFOQFJEocLhhtai8vGLy0JCZlI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -68,6 +70,8 @@ go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=

--- a/internal/configgen/fuzz_test.go
+++ b/internal/configgen/fuzz_test.go
@@ -1,0 +1,105 @@
+package configgen
+
+import (
+	"testing"
+
+	nebcfg "github.com/slackhq/nebula/config"
+	"gopkg.in/yaml.v3"
+)
+
+// FuzzGenerate asserts the invariant the typed-struct generator was built to
+// guarantee (GHSA-7hp6, issue #126): no operator-controlled field can break
+// out of the YAML structure, and the result is something a real Nebula agent
+// can actually load. For every input:
+//
+//  1. Generate must succeed (it only marshals a typed struct, so the only
+//     possible error is an encoder fault, which would be a regression).
+//  2. The output must re-parse through Nebula's *own* config loader — the
+//     same code path an agent runs on SIGHUP. "Valid YAML" is necessary but
+//     not sufficient; this checks the parser the agent will actually use.
+//  3. The scalar fields an agent reads (am_lighthouse, punchy.punch,
+//     listen.port) must round-trip with their Go type intact. A quoted bool
+//     or stringified int still parses as YAML but silently changes behavior
+//     on reload, so the assertions go through the same accessors the agent
+//     uses (GetBool / GetInt), not a raw map compare.
+//
+// config.C's LoadString/Get/GetString/GetBool/GetInt never touch its
+// (here nil) logger, so a zero-value C is safe and this target adds no new
+// module dependency.
+//
+// Run the seed corpus with the rest of the unit tests; explore with
+//
+//	go test ./internal/configgen/ -run '^$' -fuzz='^FuzzGenerate$'
+func FuzzGenerate(f *testing.F) {
+	// Seeds mirror the table-driven cases in generator_test.go: a regular
+	// host, a lighthouse, and a mobile (inline-PEM) host.
+	f.Add("web-1", "192.168.100.10", "192.168.100.1", "203.0.113.10:4242",
+		"", "", "any", "icmp", "any", 0, 0, false, false, true, false, "")
+	f.Add("lh-1", "10.0.0.1", "", "", "0.0.0.0", "nebula1", "22", "tcp", "admin",
+		4242, 1300, true, false, false, false, "")
+	f.Add("mobile", "10.0.0.5", "10.0.0.1", "198.51.100.7:4242",
+		"", "", "443", "udp", "ops", 0, 0, false, true, true, true,
+		"-----BEGIN NEBULA CERTIFICATE-----\nAQ==\n-----END NEBULA CERTIFICATE-----")
+
+	f.Fuzz(func(t *testing.T,
+		hostName, ip, lhIP, lhAddr, listenHost, tunDev, fwPort, fwProto, fwGroup string,
+		listenPort, mtu int, isLH, isRelay, punch, inlinePEM bool, pemBlock string,
+	) {
+		punchy := punch // address-of a copy; PunchyOverride wants *bool
+		in := GeneratorInput{
+			HostName:         hostName,
+			NebulaIPs:        []string{ip},
+			IsLighthouse:     isLH,
+			IsRelay:          isRelay,
+			ListenPort:       listenPort,
+			ListenHost:       listenHost,
+			MTU:              mtu,
+			TunDevice:        tunDev,
+			PunchyOverride:   &punchy,
+			Lighthouses:      []LighthouseInfo{{NebulaIPs: []string{lhIP}, PublicAddr: lhAddr}},
+			FirewallInbound:  []FirewallRule{{Port: fwPort, Proto: fwProto, Group: fwGroup}},
+			FirewallOutbound: []FirewallRule{{Port: fwPort, Proto: fwProto, Group: fwGroup}},
+		}
+		// Generate only emits the inline-PEM section when CACertPEM is set
+		// (see buildConfig); otherwise it falls back to the path form.
+		if inlinePEM && pemBlock != "" {
+			in.CACertPEM, in.CertPEM, in.KeyPEM = pemBlock, pemBlock, pemBlock
+		} else {
+			in.CACertPath = "/etc/nebula/ca.crt"
+			in.CertPath = "/etc/nebula/host.crt"
+			in.KeyPath = "/etc/nebula/host.key"
+		}
+
+		out, err := Generate(in)
+		if err != nil {
+			t.Fatalf("Generate errored on structured input: %v", err)
+		}
+
+		// (1) Well-formed YAML — cheap, and gives the clearest failure first.
+		var sink map[string]any
+		if err := yaml.Unmarshal(out, &sink); err != nil {
+			t.Fatalf("generator emitted invalid YAML: %v\n--- config ---\n%s", err, out)
+		}
+
+		// (2) Loads in Nebula's own parser (the real SIGHUP-reload path).
+		var c nebcfg.C
+		if err := c.LoadString(string(out)); err != nil {
+			t.Fatalf("Nebula config.LoadString rejected generated config: %v\n--- config ---\n%s", err, out)
+		}
+
+		// (3) Type-preserving round-trip of the scalars the agent reads.
+		if got := c.GetBool("lighthouse.am_lighthouse", !isLH); got != isLH {
+			t.Fatalf("am_lighthouse round-trip: got %v want %v\n--- config ---\n%s", got, isLH, out)
+		}
+		if got := c.GetBool("punchy.punch", !punchy); got != punchy {
+			t.Fatalf("punchy.punch round-trip: got %v want %v\n--- config ---\n%s", got, punchy, out)
+		}
+		wantPort := listenPort
+		if wantPort == 0 && isLH {
+			wantPort = 4242 // generator's lighthouse default
+		}
+		if got := c.GetInt("listen.port", wantPort-1); got != wantPort {
+			t.Fatalf("listen.port round-trip: got %d want %d\n--- config ---\n%s", got, wantPort, out)
+		}
+	})
+}

--- a/internal/configgen/generator_test.go
+++ b/internal/configgen/generator_test.go
@@ -559,3 +559,62 @@ func TestGenerate_InlinePEM_RoundTrip(t *testing.T) {
 		t.Error("key does not contain X25519 private key PEM header")
 	}
 }
+
+// TestGenerate_InlinePEM_NonLiteralSafeRoundTrips is a regression test for the
+// FuzzGenerate finding: inline PEM content that is not literal-block-safe (a
+// tab, a leading/trailing space, a CR) was emitted as a forced literal-block
+// scalar the YAML parser — and the Nebula config loader — could not read back
+// ("found a tab character where an indentation space is expected"). The
+// generator must emit a representation that round-trips for any content.
+func TestGenerate_InlinePEM_NonLiteralSafeRoundTrips(t *testing.T) {
+	cases := map[string]string{
+		"lone tab":            "\t",
+		"leading tab line":    "-----BEGIN-----\n\tdata\n-----END-----",
+		"leading space line":  "-----BEGIN-----\n data\n-----END-----",
+		"trailing space line": "-----BEGIN-----\ndata \n-----END-----",
+		"carriage return":     "-----BEGIN-----\r\ndata\r\n-----END-----",
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			data, err := Generate(GeneratorInput{
+				HostName:  "mobile-x",
+				NebulaIPs: []string{"10.0.0.2"},
+				CACertPEM: content,
+				CertPEM:   content,
+				KeyPEM:    content,
+			})
+			if err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			var parsed struct {
+				PKI struct {
+					CA   string `yaml:"ca"`
+					Cert string `yaml:"cert"`
+					Key  string `yaml:"key"`
+				} `yaml:"pki"`
+			}
+			if err := yaml.Unmarshal(data, &parsed); err != nil {
+				t.Fatalf("generated config does not round-trip: %v\n--- config ---\n%s", err, data)
+			}
+			if parsed.PKI.CA != content {
+				t.Errorf("ca did not round-trip: got %q want %q", parsed.PKI.CA, content)
+			}
+		})
+	}
+}
+
+func TestLiteralBlockSafe(t *testing.T) {
+	realPEM := "-----BEGIN NEBULA CERTIFICATE-----\nCACA...CA...CACA\n-----END NEBULA CERTIFICATE-----"
+	safe := []string{realPEM, realPEM + "\n", "single-line", "a\nb\nc"}
+	unsafe := []string{"", "\t", " leading", "trailing ", "a\n\nb", "ctrl\x01here", "ünïcode"}
+	for _, s := range safe {
+		if !literalBlockSafe(s) {
+			t.Errorf("expected literal-safe: %q", s)
+		}
+	}
+	for _, s := range unsafe {
+		if literalBlockSafe(s) {
+			t.Errorf("expected NOT literal-safe: %q", s)
+		}
+	}
+}

--- a/internal/configgen/marshal.go
+++ b/internal/configgen/marshal.go
@@ -3,6 +3,7 @@ package configgen
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -35,16 +36,52 @@ type pkiSection struct {
 	Key  any `yaml:"key"`
 }
 
-// literalString marshals as a YAML literal-block scalar (|). Used for the
-// inline PEM blocks so the multi-line content is preserved verbatim.
+// literalString marshals the inline PEM blocks as a YAML literal-block scalar
+// (|) when that round-trips, so the multi-line content stays readable.
 type literalString string
 
 func (l literalString) MarshalYAML() (any, error) {
-	return &yaml.Node{
-		Kind:  yaml.ScalarNode,
-		Style: yaml.LiteralStyle,
-		Value: string(l),
-	}, nil
+	n := &yaml.Node{Kind: yaml.ScalarNode, Value: string(l)}
+	// Only request literal-block style for content we know parses back
+	// identically. yaml.v3 honors an explicit LiteralStyle even for content
+	// the YAML parser then rejects — e.g. a line beginning with a tab or
+	// space, emitted verbatim under a block indent the parser reads as broken
+	// indentation ("found a tab character where an indentation space is
+	// expected"). For anything not literal-safe we leave Style unset so the
+	// encoder picks a representation that does round-trip (double-quoted),
+	// which the Nebula config loader parses identically. Well-formed PEM
+	// blocks are literal-safe and keep their readable multi-line form.
+	if literalBlockSafe(string(l)) {
+		n.Style = yaml.LiteralStyle
+	}
+	return n, nil
+}
+
+// literalBlockSafe reports whether s can be emitted as a YAML literal-block
+// scalar and parsed back identically. It is deliberately conservative: a false
+// negative only costs prettiness (the value is double-quoted instead), while a
+// false positive emits YAML the agent cannot reload. A line is literal-safe
+// when it is non-empty, has no leading or trailing space, and contains only
+// printable ASCII (0x20–0x7E) — which excludes tabs, CR, and other control
+// bytes. A single trailing newline (the block-chomping marker) is allowed.
+func literalBlockSafe(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(s, "\n"), "\n") {
+		if line == "" {
+			return false
+		}
+		if line[0] == ' ' || line[len(line)-1] == ' ' {
+			return false
+		}
+		for i := 0; i < len(line); i++ {
+			if c := line[i]; c < 0x20 || c > 0x7e {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 type lighthouseSection struct {


### PR DESCRIPTION
## What
`configgen.Generate` could emit a YAML literal-block scalar that neither
`gopkg.in/yaml.v3` nor Nebula's own config loader can parse back, for
inline-PEM content that isn't literal-block-safe (a leading tab/space or
control bytes). `literalString.MarshalYAML` hard-coded `yaml.LiteralStyle`,
which bypasses the encoder's own safety fallback.

This is a residual round-trip gap in the GHSA-7hp6 hardening: that change moved
generation to a typed struct so structural-break characters can't escape, but
forcing literal style on arbitrary content can still produce YAML that won't
reload. Reachability is low (the inline-PEM path is fed server-minted PEMs, not
raw operator input), so it's a latent correctness gap, not a live exploit — but
it contradicts the round-trip guarantee the generator is meant to provide.

## Fix
Gate literal-block style behind a conservative `literalBlockSafe` predicate;
fall back to double-quoted (which always round-trips) otherwise. Well-formed PEM
blocks stay literal-safe and keep their readable multi-line form, so normal
output is unchanged.

## How it was found
`FuzzGenerate` feeds randomized `GeneratorInput` through `Generate`, re-loads
the output through Nebula's real `config.C` parser (the path an agent runs on
reload), and round-trips the scalar fields an agent reads (`am_lighthouse`,
`punchy.punch`, `listen.port`). It surfaced the tab/whitespace case in ~25s.

## Test plan
- `go test ./internal/configgen/ -race` (existing + new regression + predicate tests)
- `go test ./internal/configgen/ -run '^$' -fuzz=FuzzGenerate` — 60s+, clean (407k execs)
- `golangci-lint run ./internal/configgen/`

The fuzz test imports `slackhq/nebula/config`, which adds a few `// indirect`
entries to go.mod (logrus, mergo, yaml v2/v3 — already in the module graph via
Nebula).

## Note
First piece of a broader testing investment (correctness/concurrency/scale/fuzz).
I'll send a short proposal separately and would value your take before the
heavier parts.
