### PR TITLE
fix(web): unify host-ownership anchor on host.CAID across edit/update/mobile-bundle

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -959,41 +959,9 @@ func (w *Web) handleHostDetail(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (w *Web) handleHostEdit(rw http.ResponseWriter, r *http.Request) {
-	op := w.session.CurrentOperator(r)
-	if op == nil {
-		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+	host, ok := w.loadAccessibleHost(rw, r)
+	if !ok {
 		return
-	}
-
-	id := chi.URLParam(r, "id")
-	host, err := w.store.GetHost(r.Context(), id)
-	if errors.Is(err, store.ErrNotFound) {
-		http.NotFound(rw, r)
-		return
-	}
-	if err != nil {
-		w.logger.Error("get host for edit", "error", err)
-		http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	// Ownership check: non-admin operators must own the CA signing the network
-	if op.Role != "admin" {
-		network, err := w.store.GetNetwork(r.Context(), host.NetworkID)
-		if err != nil {
-			w.logger.Error("get network for ownership check", "error", err)
-			http.Error(rw, "Failed to load network", http.StatusInternalServerError)
-			return
-		}
-		if network.CAID == "" {
-			http.Error(rw, "Unauthorized", http.StatusForbidden)
-			return
-		}
-		ca, err := w.store.GetCA(r.Context(), network.CAID)
-		if err != nil || ca.OwnerOperatorID != op.ID {
-			http.Error(rw, "Unauthorized", http.StatusForbidden)
-			return
-		}
 	}
 
 	// Load network for CIDR display and validation
@@ -1018,41 +986,17 @@ func (w *Web) handleHostUpdate(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "bad request", http.StatusBadRequest)
 		return
 	}
+	// op is fetched up front because the audit entry below needs op.Username;
+	// loadAccessibleHost performs the host.CAID ownership gate.
 	op := w.session.CurrentOperator(r)
 	if op == nil {
 		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
 		return
 	}
 
-	id := chi.URLParam(r, "id")
-	host, err := w.store.GetHost(r.Context(), id)
-	if errors.Is(err, store.ErrNotFound) {
-		http.NotFound(rw, r)
+	host, ok := w.loadAccessibleHost(rw, r)
+	if !ok {
 		return
-	}
-	if err != nil {
-		w.logger.Error("get host for update", "error", err)
-		http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	// Ownership check
-	if op.Role != "admin" {
-		network, err := w.store.GetNetwork(r.Context(), host.NetworkID)
-		if err != nil {
-			w.logger.Error("get network for ownership check", "error", err)
-			http.Error(rw, "Failed to load network", http.StatusInternalServerError)
-			return
-		}
-		if network.CAID == "" {
-			http.Error(rw, "Unauthorized", http.StatusForbidden)
-			return
-		}
-		ca, err := w.store.GetCA(r.Context(), network.CAID)
-		if err != nil || ca.OwnerOperatorID != op.ID {
-			http.Error(rw, "Unauthorized", http.StatusForbidden)
-			return
-		}
 	}
 
 	form := newHostFormState(r)
@@ -1363,42 +1307,16 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (w *Web) handleGenerateMobileBundle(rw http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	host, err := w.store.GetHost(r.Context(), id)
-	if errors.Is(err, store.ErrNotFound) {
-		http.NotFound(rw, r)
-		return
-	}
-	if err != nil {
-		w.logger.Error("get host for mobile bundle", "error", err)
-		http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
+	host, ok := w.loadAccessibleHost(rw, r)
+	if !ok {
 		return
 	}
 
-	// Verify host is mobile
+	// Verify host is mobile. Checked after the ownership gate so a non-owner
+	// cannot probe another tenant's host kind.
 	if host.Kind != models.HostKindMobile {
 		http.Error(rw, "Host is not a mobile host", http.StatusBadRequest)
 		return
-	}
-
-	// Operator ownership check: non-admin operators must own the CA
-	op := w.session.CurrentOperator(r)
-	if op != nil && op.Role != "admin" {
-		network, err := w.store.GetNetwork(r.Context(), host.NetworkID)
-		if err != nil {
-			w.logger.Error("get network for ownership check", "error", err)
-			http.Error(rw, "Failed to load network", http.StatusInternalServerError)
-			return
-		}
-		if network.CAID == "" {
-			http.Error(rw, "Unauthorized", http.StatusForbidden)
-			return
-		}
-		ca, err := w.store.GetCA(r.Context(), network.CAID)
-		if err != nil || ca.OwnerOperatorID != op.ID {
-			http.Error(rw, "Unauthorized", http.StatusForbidden)
-			return
-		}
 	}
 
 	w.renderMobileBundle(rw, r, host)

--- a/internal/web/tenant_scope_test.go
+++ b/internal/web/tenant_scope_test.go
@@ -139,6 +139,69 @@ func TestWebHostDelete_NonOwnerForbidden(t *testing.T) {
 	}
 }
 
+func TestWebHostEdit_NonOwnerForbidden(t *testing.T) {
+	w, s := newSettingsWeb(t)
+	bob, foreignHost, ownHost := twoTenants(t, w, s)
+
+	// bob can open the edit form for his own host.
+	if code := webGET(t, w, "/ui/hosts/"+ownHost+"/edit", bob); code != http.StatusOK {
+		t.Errorf("own host edit: status = %d, want 200", code)
+	}
+	// bob cannot open the edit form for alice's host.
+	if code := webGET(t, w, "/ui/hosts/"+foreignHost+"/edit", bob); code != http.StatusForbidden {
+		t.Errorf("foreign host edit: status = %d, want 403", code)
+	}
+}
+
+func TestWebHostUpdate_NonOwnerForbidden(t *testing.T) {
+	w, s := newSettingsWeb(t)
+	bob, foreignHost, ownHost := twoTenants(t, w, s)
+
+	// CSRF token from a page bob can load (his own host edit form).
+	token, cookies := getCSRFTokenFromCookies(t, w, "/ui/hosts/"+ownHost+"/edit", []*http.Cookie{bob})
+
+	// Body carries a renamed host; ownership must reject it before any mutation.
+	body := "_csrf=" + token + "&name=hacked&nebula_ip=10.0.0.9&role=host"
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/"+foreignHost+"/edit", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("update foreign host: status = %d, want 403", rec.Code)
+	}
+	// The foreign host must be untouched.
+	got, err := s.GetHost(context.Background(), foreignHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "host-a" {
+		t.Errorf("foreign host was updated despite the 403: name = %q, want %q", got.Name, "host-a")
+	}
+}
+
+func TestWebGenerateMobileBundle_NonOwnerForbidden(t *testing.T) {
+	w, s := newSettingsWeb(t)
+	bob, foreignHost, ownHost := twoTenants(t, w, s)
+
+	token, cookies := getCSRFTokenFromCookies(t, w, "/ui/hosts/"+ownHost+"/edit", []*http.Cookie{bob})
+
+	// Ownership is checked before the mobile-kind gate, so a non-owner is
+	// rejected with 403 even though the foreign host is not a mobile host.
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/"+foreignHost+"/mobile-bundle/generate", strings.NewReader("_csrf="+token))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("generate mobile bundle for foreign host: status = %d, want 403", rec.Code)
+	}
+}
+
 func TestWebNetworks_ListScopedToOwner(t *testing.T) {
 	w, s := newSettingsWeb(t)
 	bob, _, _ := twoTenants(t, w, s) // creates net-a (alice) and net-b (bob)


### PR DESCRIPTION
## Summary

Unifies the web layer's host-ownership anchor on `host.CAID`, matching the JSON API.

`handleHostEdit`, `handleHostUpdate`, and `handleGenerateMobileBundle` previously gated ownership on **`network.CAID`** (the CA of the host's *network*). The other host handlers (`handleHostDetail` / `handleHostBlock` / `handleHostDelete`, fixed under GHSA-c6v2-3ffm-vcmc) and the entire JSON API (`canAccessHost` → `actorOwnsCA(h.CAID)`) gate on **`host.CAID`** (the CA of the *host itself*).

These three handlers are now routed through the existing `loadAccessibleHost` helper, making `host.CAID` the single authoritative ownership anchor across the web layer.

There is no live cross-tenant gap today — both create paths set `host.CAID = networkCAID(network)`, so the two anchors agree. This removes the fragile divergence: any future path where `host.CAID` differs from its network's CA would otherwise make these handlers authorize differently from detail/block/delete and from the API.

## Changes

- `internal/web/handlers.go`:
  - `handleHostEdit` — replace the manual `CurrentOperator`/`GetHost`/`network.CAID` ownership block with `loadAccessibleHost`; keep the `GetNetwork` load for CIDR display.
  - `handleHostUpdate` — keep `ParseForm` first and `op` (still needed for the `op.Username` audit entry); replace the ownership block with `loadAccessibleHost`.
  - `handleGenerateMobileBundle` — `loadAccessibleHost` first, then the mobile-kind gate.
- `internal/web/tenant_scope_test.go` — three regression tests (non-owner 403 on edit/update/mobile-bundle, plus owner-positive and store-state assertions).

Net: ~92 lines of duplicated ownership logic removed, 3 tests added.

## Side effects (both hardening)

- **`handleGenerateMobileBundle` now checks ownership before the mobile-kind gate** — a non-owner gets `403` instead of `400`, so they can no longer probe another tenant's host kind.
- **Closes a latent nil-operator skip** — the old `if op != nil && op.Role != "admin"` guard let an unauthenticated request bypass the ownership check entirely; `loadAccessibleHost` redirects nil operators to login.

## Testing

- `go build ./...` — OK
- `go test -race ./internal/web/` — green (new tests + existing admin happy-path tests unaffected; admin branch of `loadAccessibleHost` keeps them passing)
- `go vet ./internal/web/` — clean
- `golangci-lint run ./internal/web/` — identical 23 G120 baseline as `main` (lint-neutral; this change adds no `ParseForm`/`FormValue`)

Closes #156
