### PR TITLE
fix(web): scope accessibleHosts to owned CAs in SQL to fix list undercount past 1000

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -563,37 +563,30 @@ func computeStats(hosts []*models.Host, networkCount int) dashboardStats {
 }
 
 // accessibleHosts returns the hosts an operator may see: admins see every
-// host; non-admins see only hosts under CAs they own. Mirrors
-// accessibleNetworks (a blank ca_id is a legacy pre-multi-CA row, hidden from
-// non-admins per issue #93). The owned-CA filter runs in Go after the store
-// query; once HostFilter.CAIDs lands (the API handleListHosts fix, work-yzu3)
-// this should scope in SQL so the row cap can't undercount.
+// host; non-admins see only hosts under CAs they own. The owned-CA scope is
+// pushed into the query via HostFilter.CAIDs so it applies before ORDER BY /
+// LIMIT — a global LIMIT applied before the ownership filter could drop an
+// operator's own hosts out of the window, silently undercounting once the
+// deployment exceeds the cap (#157, mirrors the API handleListHosts fix in
+// #154). A blank ca_id is a legacy pre-multi-CA row: it matches no owned CA
+// id, so the SQL scope hides it from non-admins per issue #93.
 func (w *Web) accessibleHosts(ctx context.Context, op *models.Operator) ([]*models.Host, error) {
-	hosts, err := w.store.ListHosts(ctx, store.HostFilter{Limit: 1000})
-	if err != nil {
-		return nil, err
-	}
-	if op.Role == "admin" {
-		return hosts, nil
-	}
-	cas, err := w.store.ListCAsByOwner(ctx, op.ID)
-	if err != nil {
-		return nil, err
-	}
-	owned := make(map[string]struct{}, len(cas))
-	for _, c := range cas {
-		owned[c.ID] = struct{}{}
-	}
-	out := make([]*models.Host, 0, len(hosts))
-	for _, h := range hosts {
-		if h.CAID == "" {
-			continue
+	filter := store.HostFilter{Limit: 1000}
+	if op.Role != "admin" {
+		cas, err := w.store.ListCAsByOwner(ctx, op.ID)
+		if err != nil {
+			return nil, err
 		}
-		if _, ok := owned[h.CAID]; ok {
-			out = append(out, h)
+		if len(cas) == 0 {
+			return []*models.Host{}, nil
 		}
+		caIDs := make([]string, len(cas))
+		for i, c := range cas {
+			caIDs[i] = c.ID
+		}
+		filter.CAIDs = caIDs
 	}
-	return out, nil
+	return w.store.ListHosts(ctx, filter)
 }
 
 func (w *Web) handleDashboard(rw http.ResponseWriter, r *http.Request) {

--- a/internal/web/list_hosts_scope_test.go
+++ b/internal/web/list_hosts_scope_test.go
@@ -1,0 +1,62 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// TestWebHosts_NonAdminNotUndercountedPastLimit reproduces #157 on the web side:
+// with more hosts under CAs the operator does NOT own than accessibleHosts'
+// 1000-row query cap, the operator's own host (sorting after that window) must
+// still appear in /ui/hosts. Previously accessibleHosts applied the owned-CA
+// filter in Go AFTER the SQL LIMIT, so the owner's host was dropped from the
+// window before the filter ran and the operator silently saw fewer hosts than
+// they owned. Mirrors the API-side TestListHosts_NonAdminNotUndercountedPastLimit.
+func TestWebHosts_NonAdminNotUndercountedPastLimit(t *testing.T) {
+	w, s := newSettingsWeb(t)
+	ctx := t.Context()
+
+	bob := authedSession(t, s, "bob", "user")
+	// bob owns ca-b / net-b / host-b (name "host-b" sorts after "aaa-*").
+	seedTenant(t, s, "op-bob", "b")
+
+	// 1001 foreign hosts under a CA bob does NOT own, with names that sort
+	// before "host-b", so a global "ORDER BY name LIMIT 1000" fills the whole
+	// window with them and drops host-b.
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-foreign", Name: "n-foreign", CIDRs: []string{"10.9.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 1001; i++ {
+		if err := s.CreateHost(ctx, &models.Host{
+			ID: fmt.Sprintf("hf-%04d", i), NetworkID: "n-foreign", CAID: "ca-foreign",
+			Name: fmt.Sprintf("aaa-%04d", i), Role: models.HostRoleHost, Status: models.HostStatusPending,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts", nil)
+	req.AddCookie(bob)
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("hosts list: status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "host-b") {
+		t.Error("bob's own host dropped by LIMIT before ownership scoping (undercount)")
+	}
+	if strings.Contains(body, "aaa-") {
+		t.Error("foreign hosts must not leak to a non-owner")
+	}
+}


### PR DESCRIPTION
## Problem

`accessibleHosts` (`internal/web/handlers.go`) called `ListHosts(ctx, HostFilter{Limit: 1000})` and then filtered to the operator's owned CAs **in Go**. This is the same scope-after-limit pattern #154 fixed on the JSON API side.

Once a deployment has more than 1000 hosts, the global `ORDER BY name LIMIT 1000` can fill the window with hosts under CAs the operator does **not** own, dropping the operator's own hosts before the Go ownership filter runs. A non-admin then silently sees fewer hosts than they own (undercount). Not a cross-tenant leak — a correctness/visibility bug. The doc comment on `accessibleHosts` already flagged this follow-up.

Closes #157.

## Fix

Port the #154 fix into `accessibleHosts`:

- Non-admins: compute owned CA ids and pass them as `HostFilter.CAIDs`, so the owned-CA scope is applied in SQL (`AND ca_id IN (SELECT value FROM json_each(?))`) **before** `ORDER BY name / LIMIT`. Short-circuit to `[]` when the actor owns no CAs — an empty `CAIDs` means "unscoped" in `ListHosts`, so the guard prevents a CA-less non-admin from seeing every host.
- The Go post-filter (`owned` map + loop) is removed.
- Admins are unchanged (no `CAIDs` → unscoped, still capped at 1000 — the global pagination cap is a separate concern).

Legacy blank-`ca_id` hosts match no owned CA id, so the SQL scope keeps them hidden from non-admins (issue #93 behavior preserved). The store layer (`HostFilter.CAIDs`, SQL scoping in `ListHosts`) already landed in #154 — this PR is handler-only.

All three callers (`handleDashboard`, `handlePartialStats`, `handleHosts`) benefit through the single shared helper.

## Tests

- `TestWebHosts_NonAdminNotUndercountedPastLimit`: with 1001 foreign hosts sorting ahead of the owner's one host, a non-admin still sees their host via `GET /ui/hosts` — the web-side reproduction (mirrors the API-side test).
- Existing tenant-scope suite stays green (`TestWebHosts_ListScopedToOwner`, `TestWebHosts_AdminSeesAllTenants`, `TestWebHost_EmptyCAIDHiddenFromNonAdmin`).

`go test ./... -race` is green; `golangci-lint run ./internal/web/...` reports only the pre-existing G120 baseline (diff is lint-neutral).

Related: #154.
