### PR TITLE
docs(release): bump install examples to VERSION=0.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On a fresh Debian / Ubuntu VM (`amd64`):
 
 ```sh
 # 1. Install the server.
-VERSION=0.3.5
+VERSION=0.3.6
 curl -fsSLO "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSION}/nebula-mgmt_${VERSION}_linux_amd64.deb"
 sudo apt install -y "./nebula-mgmt_${VERSION}_linux_amd64.deb"
 
@@ -120,12 +120,12 @@ nebula-mesh ships **two** static binaries. Install whichever you need on each ma
 | `nebula-mgmt` | one server (the control plane) |
 | `nebula-agent` | every Nebula host, next to `nebula` |
 
-Pick an install method below. The examples assume `VERSION=0.3.5` — replace with the latest from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest). Each release ships a `checksums.txt` (SHA-256).
+Pick an install method below. The examples assume `VERSION=0.3.6` — replace with the latest from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest). Each release ships a `checksums.txt` (SHA-256).
 
 ### Debian / Ubuntu (`.deb`)
 
 ```sh
-VERSION=0.3.5
+VERSION=0.3.6
 ARCH=$(dpkg --print-architecture)   # amd64 | arm64 | armhf (agent only)
 
 # Server (control plane):
@@ -140,7 +140,7 @@ sudo apt install -y "./nebula-agent_${VERSION}_linux_${ARCH}.deb"
 ### RHEL / Fedora / Rocky / Alma (`.rpm`)
 
 ```sh
-VERSION=0.3.5
+VERSION=0.3.6
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
 sudo rpm -i "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSION}/nebula-mgmt_${VERSION}_linux_${ARCH}.rpm"
@@ -154,7 +154,7 @@ sudo rpm -i "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSI
 Download a tarball from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest) and extract:
 
 ```sh
-VERSION=0.3.5
+VERSION=0.3.6
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,8 +29,8 @@ Quickstart:
 
 ```hcl
 module "nebula_mgmt" {
-  source              = "github.com/forgekeep/nebula-mesh//deploy/terraform/nebula-mgmt?ref=v0.3.5"
-  release_version     = "v0.3.5"
+  source              = "github.com/forgekeep/nebula-mesh//deploy/terraform/nebula-mgmt?ref=v0.3.6"
+  release_version     = "v0.3.6"
   fqdn                = "mgmt.internal.example.com"
   instance_id         = aws_instance.nebula_mgmt.id
   instance_public_ip  = aws_instance.nebula_mgmt.public_ip


### PR DESCRIPTION
Bump install/deploy examples to `VERSION=0.3.6` ahead of cutting the `v0.3.6` tag.

Release covers since v0.3.5:
- fix(store): DeleteCA refuses while any ca_id-carrying table references the CA (#153)
- fix(web): scope accessible hosts to owned CAs in SQL (#162)
- fix(web): unify host-ownership anchor on host.CAID across edit/update/mobile-bundle (#161)
- test(web): assert owner-allowed path in host update and mobile-bundle scope tests (#164)
- feat(web): apple-touch and PWA icons (#160)
- docs(adr): 0009 scale, concurrency, and fuzz testing (#163)

Docs-only; no code change.