### PR TITLE
fix(ci): complete forgekeep migration in release/config refs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/juev/nebula-mesh/security/advisories/new
+    url: https://github.com/forgekeep/nebula-mesh/security/advisories/new
     about: Please report security issues privately, not as a public issue.
   - name: Question / discussion
-    url: https://github.com/juev/nebula-mesh/discussions
+    url: https://github.com/forgekeep/nebula-mesh/discussions
     about: For usage questions and open-ended discussion.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,9 +73,9 @@ linters:
       settings:
         printf:
           funcs:
-            - (github.com/juev/nebula-mesh/internal/alerts.Logger).Infof
-            - (github.com/juev/nebula-mesh/internal/alerts.Logger).Warnf
-            - (github.com/juev/nebula-mesh/internal/alerts.Logger).Errorf
+            - (github.com/forgekeep/nebula-mesh/internal/alerts.Logger).Infof
+            - (github.com/forgekeep/nebula-mesh/internal/alerts.Logger).Warnf
+            - (github.com/forgekeep/nebula-mesh/internal/alerts.Logger).Errorf
 
     staticcheck:
       checks:
@@ -228,7 +228,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - github.com/juev/nebula-mesh
+        - github.com/forgekeep/nebula-mesh
   exclusions:
     generated: lax
     paths:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,9 +80,9 @@ nfpms:
   - id: nebula-mgmt
     package_name: nebula-mgmt
     ids: [nebula-mgmt]
-    vendor: "juev"
-    homepage: "https://github.com/juev/nebula-mesh"
-    maintainer: "juev <https://github.com/juev>"
+    vendor: "forgekeep"
+    homepage: "https://github.com/forgekeep/nebula-mesh"
+    maintainer: "forgekeep <https://github.com/forgekeep>"
     description: |
       Self-hosted control plane for Slack Nebula. Issues certificates,
       manages hosts, distributes config to nebula-agent instances, and
@@ -127,16 +127,16 @@ nfpms:
       summary: Self-hosted control plane for Slack Nebula
     deb:
       fields:
-        Bugs: "https://github.com/juev/nebula-mesh/issues"
+        Bugs: "https://github.com/forgekeep/nebula-mesh/issues"
       lintian_overrides:
         - "statically-linked-binary"
 
   - id: nebula-agent
     package_name: nebula-agent
     ids: [nebula-agent]
-    vendor: "juev"
-    homepage: "https://github.com/juev/nebula-mesh"
-    maintainer: "juev <https://github.com/juev>"
+    vendor: "forgekeep"
+    homepage: "https://github.com/forgekeep/nebula-mesh"
+    maintainer: "forgekeep <https://github.com/forgekeep>"
     description: |
       Polling agent for the nebula-mesh management server.
       Enrolls a host, keeps host.crt/host.key/ca.crt/config.yml in sync,
@@ -171,7 +171,7 @@ nfpms:
       summary: Polling agent for nebula-mesh
     deb:
       fields:
-        Bugs: "https://github.com/juev/nebula-mesh/issues"
+        Bugs: "https://github.com/forgekeep/nebula-mesh/issues"
       lintian_overrides:
         - "statically-linked-binary"
 
@@ -182,13 +182,13 @@ dockers:
     ids: [nebula-mgmt]
     dockerfile: deploy/docker/Dockerfile.server
     image_templates:
-      - "ghcr.io/juev/nebula-mgmt:{{ .Version }}-amd64"
+      - "ghcr.io/forgekeep/nebula-mgmt:{{ .Version }}-amd64"
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.title=nebula-mgmt"
       - "--label=org.opencontainers.image.description=Self-hosted control plane for Slack Nebula"
-      - "--label=org.opencontainers.image.source=https://github.com/juev/nebula-mesh"
+      - "--label=org.opencontainers.image.source=https://github.com/forgekeep/nebula-mesh"
       - "--label=org.opencontainers.image.licenses=MIT"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
@@ -200,13 +200,13 @@ dockers:
     ids: [nebula-mgmt]
     dockerfile: deploy/docker/Dockerfile.server
     image_templates:
-      - "ghcr.io/juev/nebula-mgmt:{{ .Version }}-arm64"
+      - "ghcr.io/forgekeep/nebula-mgmt:{{ .Version }}-arm64"
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.title=nebula-mgmt"
       - "--label=org.opencontainers.image.description=Self-hosted control plane for Slack Nebula"
-      - "--label=org.opencontainers.image.source=https://github.com/juev/nebula-mesh"
+      - "--label=org.opencontainers.image.source=https://github.com/forgekeep/nebula-mesh"
       - "--label=org.opencontainers.image.licenses=MIT"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
@@ -218,13 +218,13 @@ dockers:
     ids: [nebula-agent]
     dockerfile: deploy/docker/Dockerfile.agent
     image_templates:
-      - "ghcr.io/juev/nebula-agent:{{ .Version }}-amd64"
+      - "ghcr.io/forgekeep/nebula-agent:{{ .Version }}-amd64"
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.title=nebula-agent"
       - "--label=org.opencontainers.image.description=Polling agent for nebula-mesh"
-      - "--label=org.opencontainers.image.source=https://github.com/juev/nebula-mesh"
+      - "--label=org.opencontainers.image.source=https://github.com/forgekeep/nebula-mesh"
       - "--label=org.opencontainers.image.licenses=MIT"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
@@ -236,35 +236,35 @@ dockers:
     ids: [nebula-agent]
     dockerfile: deploy/docker/Dockerfile.agent
     image_templates:
-      - "ghcr.io/juev/nebula-agent:{{ .Version }}-arm64"
+      - "ghcr.io/forgekeep/nebula-agent:{{ .Version }}-arm64"
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.title=nebula-agent"
       - "--label=org.opencontainers.image.description=Polling agent for nebula-mesh"
-      - "--label=org.opencontainers.image.source=https://github.com/juev/nebula-mesh"
+      - "--label=org.opencontainers.image.source=https://github.com/forgekeep/nebula-mesh"
       - "--label=org.opencontainers.image.licenses=MIT"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.created={{.Date}}"
 
 docker_manifests:
-  - name_template: "ghcr.io/juev/nebula-mgmt:{{ .Version }}"
+  - name_template: "ghcr.io/forgekeep/nebula-mgmt:{{ .Version }}"
     image_templates:
-      - "ghcr.io/juev/nebula-mgmt:{{ .Version }}-amd64"
-      - "ghcr.io/juev/nebula-mgmt:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/juev/nebula-mgmt:latest"
+      - "ghcr.io/forgekeep/nebula-mgmt:{{ .Version }}-amd64"
+      - "ghcr.io/forgekeep/nebula-mgmt:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/forgekeep/nebula-mgmt:latest"
     image_templates:
-      - "ghcr.io/juev/nebula-mgmt:{{ .Version }}-amd64"
-      - "ghcr.io/juev/nebula-mgmt:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/juev/nebula-agent:{{ .Version }}"
+      - "ghcr.io/forgekeep/nebula-mgmt:{{ .Version }}-amd64"
+      - "ghcr.io/forgekeep/nebula-mgmt:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/forgekeep/nebula-agent:{{ .Version }}"
     image_templates:
-      - "ghcr.io/juev/nebula-agent:{{ .Version }}-amd64"
-      - "ghcr.io/juev/nebula-agent:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/juev/nebula-agent:latest"
+      - "ghcr.io/forgekeep/nebula-agent:{{ .Version }}-amd64"
+      - "ghcr.io/forgekeep/nebula-agent:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/forgekeep/nebula-agent:latest"
     image_templates:
-      - "ghcr.io/juev/nebula-agent:{{ .Version }}-amd64"
-      - "ghcr.io/juev/nebula-agent:{{ .Version }}-arm64"
+      - "ghcr.io/forgekeep/nebula-agent:{{ .Version }}-amd64"
+      - "ghcr.io/forgekeep/nebula-agent:{{ .Version }}-arm64"
 
 checksum:
   name_template: "checksums.txt"
@@ -299,7 +299,7 @@ changelog:
 
 release:
   github:
-    owner: juev
+    owner: forgekeep
     name: nebula-mesh
   draft: false
   prerelease: auto
@@ -307,11 +307,11 @@ release:
   header: |
     ## nebula-mesh {{ .Tag }}
 
-    **Install** — see [README](https://github.com/juev/nebula-mesh#install) for the full snippets.
+    **Install** — see [README](https://github.com/forgekeep/nebula-mesh#install) for the full snippets.
 
-    - Server: `nebula-mgmt_{{ .Version }}_<os>_<arch>.tar.gz` or `docker pull ghcr.io/juev/nebula-mgmt:{{ .Version }}`
-    - Agent: `nebula-agent_{{ .Version }}_<os>_<arch>.tar.gz` or `docker pull ghcr.io/juev/nebula-agent:{{ .Version }}`
+    - Server: `nebula-mgmt_{{ .Version }}_<os>_<arch>.tar.gz` or `docker pull ghcr.io/forgekeep/nebula-mgmt:{{ .Version }}`
+    - Agent: `nebula-agent_{{ .Version }}_<os>_<arch>.tar.gz` or `docker pull ghcr.io/forgekeep/nebula-agent:{{ .Version }}`
   footer: |
     ---
 
-    **Full changelog**: https://github.com/juev/nebula-mesh/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full changelog**: https://github.com/forgekeep/nebula-mesh/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/README.md
+++ b/README.md
@@ -179,16 +179,16 @@ docker run -d --name nebula-mgmt \
   -v nebula-mgmt-data:/var/lib/nebula-mgmt \
   -v nebula-mgmt-etc:/etc/nebula-mgmt \
   -e NEBULA_MGMT_MASTER_KEY \
-  ghcr.io/juev/nebula-mgmt:latest
+  ghcr.io/forgekeep/nebula-mgmt:latest
 
 # Agent (typically sidecar to nebula, sharing the same PID namespace):
 docker run -d --name nebula-agent \
   -v /etc/nebula-agent:/etc/nebula-agent \
   -v /etc/nebula:/etc/nebula \
-  ghcr.io/juev/nebula-agent:latest
+  ghcr.io/forgekeep/nebula-agent:latest
 ```
 
-Images: `ghcr.io/juev/nebula-mgmt`, `ghcr.io/juev/nebula-agent`. Tags: `:latest` and `:X.Y.Z` (semver, no `v` prefix). See [Packages](https://github.com/juev?tab=packages&repo_name=nebula-mesh).
+Images: `ghcr.io/forgekeep/nebula-mgmt`, `ghcr.io/forgekeep/nebula-agent`. Tags: `:latest` and `:X.Y.Z` (semver, no `v` prefix). See [Packages](https://github.com/orgs/forgekeep/packages?repo_name=nebula-mesh).
 
 ### From source
 

--- a/deploy/systemd/nebula-agent.service
+++ b/deploy/systemd/nebula-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Nebula Management Agent
-Documentation=https://github.com/juev/nebula-mgmt
+Documentation=https://github.com/forgekeep/nebula-mesh
 After=network-online.target nebula.service
 Wants=network-online.target
 PartOf=nebula.service

--- a/deploy/systemd/nebula-mgmt.service
+++ b/deploy/systemd/nebula-mgmt.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Nebula Management Server
-Documentation=https://github.com/juev/nebula-mgmt
+Documentation=https://github.com/forgekeep/nebula-mesh
 After=network-online.target
 Wants=network-online.target
 


### PR DESCRIPTION
## Problem

The forgekeep org move (#159) renamed the Go module path but left `juev` references in release/CI config. This **broke the v0.3.6 release**: GoReleaser failed to push `ghcr.io/juev/nebula-agent` — `denied: permission_denied`, because the forgekeep repo's `GITHUB_TOKEN` cannot push to the `juev` ghcr namespace. No release was published (docker step runs before the GitHub-release step), and the `v0.3.6` tag has been removed pending this fix.

## Fix

Complete the migration in all release/config-facing refs:

- **`.goreleaser.yml`** — `ghcr.io/juev` → `ghcr.io/forgekeep` (image_templates + manifests), release `owner: juev` → `forgekeep`, plus homepage / source labels / changelog / `vendor` / `maintainer`.
- **`.golangci.yml`** — `github.com/juev/nebula-mesh` → `forgekeep` (stale module path **silently disabled** the depguard allow-rule, the printf-func checks, and the goimports local-prefix).
- **`README.md`** — docker pull image refs + Packages link (now `/orgs/forgekeep/packages`).
- **`.github/ISSUE_TEMPLATE/config.yml`** — security-advisory + discussions URLs.
- **`deploy/systemd/*.service`** — `Documentation=` URL (also fixes wrong repo name `nebula-mgmt` → `nebula-mesh`).

`goreleaser check` passes. `CODE_OF_CONDUCT.md`'s `git log` author reference is intentionally left as `juev` (it points at the maintainer's commit identity, not a repo URL).

## Note

`vendor`/`maintainer` in the `.deb`/`.rpm` packages now read `forgekeep` (was `juev`), baked into published artifacts — consistent with org ownership.

## Next

Once merged, re-tag `v0.3.6` on `main` to re-run the release.