### PR TITLE
chore(lint): drop stale govet printf.funcs entry

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,12 +70,6 @@ linters:
       disable:
         - fieldalignment # too noisy; only useful for hot-path structs
         - shadow         # too many false positives in idiomatic Go
-      settings:
-        printf:
-          funcs:
-            - (github.com/forgekeep/nebula-mesh/internal/alerts.Logger).Infof
-            - (github.com/forgekeep/nebula-mesh/internal/alerts.Logger).Warnf
-            - (github.com/forgekeep/nebula-mesh/internal/alerts.Logger).Errorf
 
     staticcheck:
       checks:


### PR DESCRIPTION
## What

Remove the `govet` → `printf.funcs` block from `.golangci.yml`:

```yaml
settings:
  printf:
    funcs:
      - (…/internal/alerts.Logger).Infof
      - (…/internal/alerts.Logger).Warnf
      - (…/internal/alerts.Logger).Errorf
```

## Why

It's **dead config**. It registers `alerts.Logger.{Infof,Warnf,Errorf}` as printf-style wrappers so `go vet`'s printf analyzer would format-check their calls — but that type/those methods don't exist. The `internal/alerts` package uses `*slog.Logger` (structured `Info`/`Warn`/`Error`, no `f`-suffixed methods), and there are **zero** `.Infof`/`.Warnf` call sites repo-wide. It's a leftover from a removed custom-logger API (surfaced while completing the forgekeep migration in #167 — the path was being kept current on a no-op).

## Verification

`golangci-lint config verify` passes and `make lint` → `0 issues`.