### PR TITLE
docs(adr): 0009 review follow-ups (clock-seam status, migration 018, ADR index)

### DIFF
--- a/docs/adr/0009-scale-and-fuzz-testing.md
+++ b/docs/adr/0009-scale-and-fuzz-testing.md
@@ -104,14 +104,15 @@ tests; the simulation earns its place on the interleavings a single-feature
 test won't reach — revocation racing renewal under load, that class of thing —
 and each fix gains a Tier 2 invariant as it lands.
 
-**Clock seam (implemented).** Cert renewal, the rotation overlap window, and
+**Clock seam (proposed).** Cert renewal, the rotation overlap window, and
 TTLs read time. Deterministic testing of those needs an injectable clock:
-`Server.WithClock(func() time.Time)` (default `time.Now`),
-`pki.ShouldRenewAt(notBefore, notAfter, now)`, and an optional
-`SignRequest.Now`. Behavior is unchanged when the clock is unset; advancing it
-lets the sim cross a cert's renewal window in milliseconds. (The `cawatch` /
-`alerts` background scanners still read `time.Now()` directly; seaming them is a
-follow-up for their time-dependent invariants.)
+a `Server.WithClock(func() time.Time)` seam (default `time.Now`), a
+`pki.ShouldRenewAt(notBefore, notAfter, now)` helper, and an optional
+`SignRequest.Now`. Behavior will be unchanged when the clock is unset; advancing
+it will let the sim cross a cert's renewal window in milliseconds. This seam
+lands in its own PR (see Phasing). (The `cawatch` / `alerts` background scanners
+read `time.Now()` directly; seaming them is a follow-up for their
+time-dependent invariants.)
 
 ### Tier 3 — Nebula interop
 
@@ -173,8 +174,8 @@ the store and the event journal after each scenario step:
 
 - **`IP_UNIQUENESS`** — no two enrolled hosts on a network share any overlay
   address. (Migration 014 normalized addresses into the `host_addresses` table;
-  a network-scoped uniqueness constraint backs this at the data layer, and the
-  invariant guards it under concurrency.)
+  migration 018 added the network-scoped uniqueness constraint that backs this
+  at the data layer, and the invariant guards it under concurrency.)
 - **`CERT_VALIDATES`** — every issued cert verifies against its issuing CA, and
   against the trust bundle during a rotation overlap.
 - **`TENANT_ISOLATION`** — one operator's artifacts never reference another's

--- a/docs/adr/0009-scale-and-fuzz-testing.md
+++ b/docs/adr/0009-scale-and-fuzz-testing.md
@@ -104,13 +104,13 @@ tests; the simulation earns its place on the interleavings a single-feature
 test won't reach — revocation racing renewal under load, that class of thing —
 and each fix gains a Tier 2 invariant as it lands.
 
-**Clock seam (proposed).** Cert renewal, the rotation overlap window, and
+**Clock seam (implemented).** Cert renewal, the rotation overlap window, and
 TTLs read time. Deterministic testing of those needs an injectable clock:
 a `Server.WithClock(func() time.Time)` seam (default `time.Now`), a
 `pki.ShouldRenewAt(notBefore, notAfter, now)` helper, and an optional
-`SignRequest.Now`. Behavior will be unchanged when the clock is unset; advancing
-it will let the sim cross a cert's renewal window in milliseconds. This seam
-lands in its own PR (see Phasing). (The `cawatch` / `alerts` background scanners
+`SignRequest.Now`. Behavior is unchanged when the clock is unset; advancing
+it lets the sim cross a cert's renewal window in milliseconds. The seam landed
+in #170. (The `cawatch` / `alerts` background scanners
 read `time.Now()` directly; seaming them is a follow-up for their
 time-dependent invariants.)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,3 +7,7 @@
 | [0003](0003-ca-encryption-model.md) | CA key encryption model (operator-derived KEK vs status quo) | Accepted |
 | [0004](0004-agent-authorization.md) | Agent authorization model (token TTL, PoP, rotation, revocation) | Accepted |
 | [0005](0005-pre-auth-keys.md) | Pre-auth keys (reusable, ephemeral, tag-bound enrollment tokens) | Accepted, implementation deferred |
+| [0006](0006-multi-address-overlay.md) | Multiple overlay addresses per network and per host | Accepted |
+| [0007](0007-remove-legacy-ca-stack.md) | Remove legacy on-disk CA stack | Accepted |
+| [0008](0008-ca-rotation.md) | Hybrid CA rotation | Accepted |
+| [0009](0009-scale-and-fuzz-testing.md) | Scale, concurrency, and fuzz testing | Proposed |


### PR DESCRIPTION
Post-merge follow-up to #163, addressing the three points from your review there.

1. **Clock seam marked `(proposed)`, not `(implemented)`.** `Server.WithClock`, `pki.ShouldRenewAt`, and `SignRequest.Now` aren't in the tree yet — the seam lands in its own PR (per the Phasing section). I switched the label and put the paragraph in the future tense so it's consistent with `Status: Proposed` and the phasing note.
2. **`IP_UNIQUENESS` now credits migration 018.** Migration 014 normalized addresses into `host_addresses`; the network-scoped uniqueness constraint itself came in `018_host_address_network_uniqueness`. Fixed the attribution.
3. **ADR index backfilled.** `docs/adr/README.md` stopped at 0005 — I added 0006–0009.

Docs only; no code paths touched.