### PR TITLE
test(simtest): Tier-2 fleet-simulation harness + clock seam (ADR 0009)

### DIFF
--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -445,7 +445,7 @@ func (s *Server) handleRotateCert(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "no current cert to re-sign")
 		return
 	}
-	signed, err := s.signHostCert(r.Context(), host, certInfo)
+	signed, err := s.signHostCert(r.Context(), host, certInfo, s.now())
 	if err != nil {
 		s.logger.Error("sign cert for rotate-cert", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to sign new cert")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -34,6 +34,21 @@ type Server struct {
 	limiter            *ratelimit.Limiter
 	passwordPolicy     auth.Policy
 	enrollmentTokenTTL time.Duration
+	clock              func() time.Time // nil => time.Now; injectable for tests
+}
+
+// WithClock overrides the server's wall clock. The default (nil) uses
+// time.Now. Tests inject a controllable clock to exercise time-dependent paths
+// (cert renewal, the rotation overlap window, poll timestamp skew) without
+// real waits. Behavior is unchanged when unset.
+func (s *Server) WithClock(fn func() time.Time) { s.clock = fn }
+
+// now returns the current time from the injected clock, or time.Now.
+func (s *Server) now() time.Time {
+	if s.clock != nil {
+		return s.clock()
+	}
+	return time.Now()
 }
 
 // NewServer creates a new API server.

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -104,7 +104,7 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "timestamp_skew")
 		return
 	}
-	now := time.Now()
+	now := s.now()
 	if diff := now.Sub(ts); diff > pollClockSkew || diff < -pollClockSkew {
 		s.recordAuditAction(r.Context(), auditHostAuthFailed, host.ID, authReasonTimestampSkew)
 		writeError(w, http.StatusUnauthorized, "timestamp_skew")
@@ -185,8 +185,8 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 
 	// Check if certificate needs renewal
 	certInfo, err := s.store.GetCertificateInfo(r.Context(), host.ID)
-	if err == nil && pki.ShouldRenew(certInfo.NotBefore, certInfo.NotAfter) {
-		signed, renewErr := s.signHostCert(r.Context(), host, certInfo)
+	if err == nil && pki.ShouldRenewAt(certInfo.NotBefore, certInfo.NotAfter, now) {
+		signed, renewErr := s.signHostCert(r.Context(), host, certInfo, now)
 
 		if renewErr != nil {
 			s.metrics.recordRenewal(resultError)
@@ -282,7 +282,7 @@ type signResult struct {
 
 // signHostCert re-signs the host certificate with the same public key and fresh expiry.
 // CA lock is held only during crypto operations (Sign + CACertPEM).
-func (s *Server) signHostCert(ctx context.Context, host *models.Host, certInfo *models.CertificateInfo) (*signResult, error) {
+func (s *Server) signHostCert(ctx context.Context, host *models.Host, certInfo *models.CertificateInfo, now time.Time) (*signResult, error) {
 	// Prep work — no CA lock needed
 	currentCert, _, err := cert.UnmarshalCertificateFromPEM([]byte(certInfo.PEM))
 	if err != nil {
@@ -315,6 +315,7 @@ func (s *Server) signHostCert(ctx context.Context, host *models.Host, certInfo *
 			Networks:  prefixes,
 			Groups:    host.Groups,
 			Duration:  pki.DefaultAgentCertDuration,
+			Now:       now,
 		})
 		if signErr != nil {
 			return nil, nil, fmt.Errorf("sign renewed cert: %w", signErr)

--- a/internal/api/updates_renewal_test.go
+++ b/internal/api/updates_renewal_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/slackhq/nebula/cert"
+)
+
+// TestPoll_AutoRenewsInsideWindow drives the signed-poll handler with the
+// server clock advanced into the host cert's renewal window and asserts the
+// response carries a freshly-signed cert whose NotBefore tracks the injected
+// clock — a handler-level companion to the simtest CERT_RENEWAL invariant.
+func TestPoll_AutoRenewsInsideWindow(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	ci, err := st.GetCertificateInfo(context.Background(), agent.hostID)
+	if err != nil {
+		t.Fatalf("get cert info: %v", err)
+	}
+	// 1 day before expiry on a 30-day cert ⇒ ~3% TTL remaining, inside the 20% window.
+	clk := ci.NotAfter.Add(-24 * time.Hour).Truncate(time.Second)
+	srv.WithClock(func() time.Time { return clk })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent, withTimestamp(clk.UTC().Format(time.RFC3339)))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("poll status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp agentUpdatesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.CertificatePEM == nil {
+		t.Fatal("expected a renewed certificate in the poll response, got none")
+	}
+	renewed, _, err := cert.UnmarshalCertificateFromPEM([]byte(*resp.CertificatePEM))
+	if err != nil {
+		t.Fatalf("parse renewed cert: %v", err)
+	}
+	if renewed.NotBefore().Unix() != clk.Unix() {
+		t.Errorf("renewed NotBefore = %s, want injected clock %s", renewed.NotBefore(), clk)
+	}
+}
+
+// TestPoll_NoRenewOutsideWindow verifies a poll well before the renewal window
+// returns no new certificate.
+func TestPoll_NoRenewOutsideWindow(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	ci, err := st.GetCertificateInfo(context.Background(), agent.hostID)
+	if err != nil {
+		t.Fatalf("get cert info: %v", err)
+	}
+	// 1 day after issuance on a 30-day cert ⇒ ~96% TTL remaining, outside the window.
+	clk := ci.NotBefore.Add(24 * time.Hour).Truncate(time.Second)
+	srv.WithClock(func() time.Time { return clk })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent, withTimestamp(clk.UTC().Format(time.RFC3339)))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("poll status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp agentUpdatesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.CertificatePEM != nil {
+		t.Error("did not expect a renewed certificate outside the renewal window")
+	}
+}

--- a/internal/api/updates_signed_poll_test.go
+++ b/internal/api/updates_signed_poll_test.go
@@ -24,6 +24,7 @@ import (
 // enrolledAgent represents a fully enrolled host fixture in the
 // signed-poll test suite: cert fingerprint + Ed25519 signing keypair.
 type enrolledAgent struct {
+	hostID      string
 	fingerprint string
 	signingPub  ed25519.PublicKey
 	signingPriv ed25519.PrivateKey
@@ -93,7 +94,7 @@ func enrolledFixture(t *testing.T, srv *Server) enrolledAgent {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return enrolledAgent{fingerprint: fp, signingPub: edPub, signingPriv: edPriv}
+	return enrolledAgent{hostID: created.Host.ID, fingerprint: fp, signingPub: edPub, signingPriv: edPriv}
 }
 
 // signPoll mutates the request, attaching the four ADR 0004 headers.

--- a/internal/pki/renewal.go
+++ b/internal/pki/renewal.go
@@ -11,11 +11,18 @@ type HostCertInfo struct {
 	NotAfter  time.Time
 }
 
-// ShouldRenew returns true if the certificate should be renewed.
+// ShouldRenew returns true if the certificate should be renewed as of now.
 // Renewal is needed when remaining TTL is less than 20% of total duration.
 func ShouldRenew(notBefore, notAfter time.Time) bool {
+	return ShouldRenewAt(notBefore, notAfter, time.Now())
+}
+
+// ShouldRenewAt is ShouldRenew evaluated at an explicit instant, so callers
+// holding an injectable clock (and tests advancing simulated time) get a
+// deterministic decision instead of an implicit time.Now().
+func ShouldRenewAt(notBefore, notAfter, now time.Time) bool {
 	total := notAfter.Sub(notBefore)
-	remaining := time.Until(notAfter)
+	remaining := notAfter.Sub(now)
 
 	if remaining <= 0 {
 		return true

--- a/internal/pki/renewal_test.go
+++ b/internal/pki/renewal_test.go
@@ -5,55 +5,43 @@ import (
 	"time"
 )
 
-func TestShouldRenew(t *testing.T) {
+func TestShouldRenewAt(t *testing.T) {
+	// Fixed reference instant — no wall clock, so the table is deterministic
+	// (the old time.Now()-relative table could straddle a boundary).
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name      string
 		notBefore time.Time
 		notAfter  time.Time
 		want      bool
 	}{
-		{
-			name:      "90% TTL remaining — no renewal",
-			notBefore: time.Now().Add(-1 * 24 * time.Hour),
-			notAfter:  time.Now().Add(9 * 24 * time.Hour),
-			want:      false,
-		},
-		{
-			name:      "50% TTL remaining — no renewal",
-			notBefore: time.Now().Add(-5 * 24 * time.Hour),
-			notAfter:  time.Now().Add(5 * 24 * time.Hour),
-			want:      false,
-		},
-		{
-			name:      "15% TTL remaining — needs renewal",
-			notBefore: time.Now().Add(-17 * 24 * time.Hour),
-			notAfter:  time.Now().Add(3 * 24 * time.Hour),
-			want:      true,
-		},
-		{
-			name:      "expired — needs renewal",
-			notBefore: time.Now().Add(-10 * 24 * time.Hour),
-			notAfter:  time.Now().Add(-1 * time.Hour),
-			want:      true,
-		},
-		{
-			name:      "exactly 20% — needs renewal",
-			notBefore: time.Now().Add(-80 * time.Hour),
-			notAfter:  time.Now().Add(20 * time.Hour),
-			want:      true,
-		},
+		{"90% TTL remaining — no renewal", now.Add(-1 * 24 * time.Hour), now.Add(9 * 24 * time.Hour), false},
+		{"50% TTL remaining — no renewal", now.Add(-5 * 24 * time.Hour), now.Add(5 * 24 * time.Hour), false},
+		{"15% TTL remaining — needs renewal", now.Add(-17 * 24 * time.Hour), now.Add(3 * 24 * time.Hour), true},
+		{"expired — needs renewal", now.Add(-10 * 24 * time.Hour), now.Add(-1 * time.Hour), true},
+		{"exactly 20% — needs renewal", now.Add(-80 * time.Hour), now.Add(20 * time.Hour), true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ShouldRenew(tt.notBefore, tt.notAfter)
+			got := ShouldRenewAt(tt.notBefore, tt.notAfter, now)
 			if got != tt.want {
 				total := tt.notAfter.Sub(tt.notBefore)
-				remaining := time.Until(tt.notAfter)
+				remaining := tt.notAfter.Sub(now)
 				pct := float64(remaining) / float64(total) * 100
-				t.Errorf("ShouldRenew() = %v, want %v (remaining: %.1f%%)", got, tt.want, pct)
+				t.Errorf("ShouldRenewAt() = %v, want %v (remaining: %.1f%%)", got, tt.want, pct)
 			}
 		})
+	}
+}
+
+// TestShouldRenew_DelegatesToWallClock spot-checks the wall-clock wrapper.
+func TestShouldRenew_DelegatesToWallClock(t *testing.T) {
+	if !ShouldRenew(time.Now().Add(-10*24*time.Hour), time.Now().Add(-time.Hour)) {
+		t.Error("expired cert should need renewal via ShouldRenew")
+	}
+	if ShouldRenew(time.Now().Add(-time.Hour), time.Now().Add(9*24*time.Hour)) {
+		t.Error("fresh cert should not need renewal via ShouldRenew")
 	}
 }
 

--- a/internal/pki/signer.go
+++ b/internal/pki/signer.go
@@ -15,11 +15,18 @@ type SignRequest struct {
 	Networks  []netip.Prefix
 	Groups    []string
 	Duration  time.Duration
+	// Now sets the certificate's NotBefore (and the CA-expiry check instant).
+	// Zero means time.Now(). Callers holding an injectable clock pass it so
+	// re-signs under simulated time produce distinct, correctly-dated certs.
+	Now time.Time
 }
 
 // Sign creates and signs a host certificate using the CA.
 func (m *CAManager) Sign(req SignRequest) (cert.Certificate, error) {
-	now := time.Now()
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
 
 	// Validate CA is not expired
 	if m.caCert.Expired(now) {

--- a/internal/pki/signer_now_test.go
+++ b/internal/pki/signer_now_test.go
@@ -1,0 +1,41 @@
+package pki
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+)
+
+// TestSign_NowSetsValidity verifies that SignRequest.Now drives the cert
+// validity window exactly (no wall-clock slack), so the simulation harness can
+// mint certs at a controlled instant. The zero value falls back to time.Now(),
+// covered by the other signer tests.
+func TestSign_NowSetsValidity(t *testing.T) {
+	ca, err := NewCA("test-ca", 365*24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, _ := generateHostKeypair(t)
+
+	// An instant comfortably inside the freshly-minted CA's validity window.
+	now := time.Now().Add(48 * time.Hour).Truncate(time.Second)
+	dur := 30 * 24 * time.Hour
+
+	c, err := ca.Sign(SignRequest{
+		Name:      "host-now",
+		PublicKey: pub,
+		Networks:  []netip.Prefix{netip.MustParsePrefix("10.0.0.5/24")},
+		Duration:  dur,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	if c.NotBefore().Unix() != now.Unix() {
+		t.Errorf("NotBefore = %s, want injected Now %s", c.NotBefore(), now)
+	}
+	if want := now.Add(dur); c.NotAfter().Unix() != want.Unix() {
+		t.Errorf("NotAfter = %s, want %s", c.NotAfter(), want)
+	}
+}

--- a/internal/simtest/agent.go
+++ b/internal/simtest/agent.go
@@ -1,0 +1,179 @@
+package simtest
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"time"
+
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+
+	agentpop "github.com/forgekeep/nebula-mesh/internal/agent/pop"
+	corepop "github.com/forgekeep/nebula-mesh/internal/pop"
+)
+
+// Agent is a virtual host: an enrolled identity that speaks the real ADR 0004
+// poll protocol. It tracks only what an agent legitimately knows — its
+// fingerprint and signing key — never server-side state.
+type Agent struct {
+	HostID      string
+	Name        string
+	Fingerprint string
+
+	signingPriv ed25519.PrivateKey
+}
+
+// PollResponse is the subset of the agent-updates response the simulation
+// asserts against.
+type PollResponse struct {
+	Status         int
+	Reason         string   `json:"reason"` // set on 403/410 revocation bodies
+	HasUpdates     bool     `json:"has_updates"`
+	ConfigYAML     *string  `json:"config_yaml"`
+	CertificatePEM *string  `json:"certificate_pem"`
+	RekeyRequired  bool     `json:"rekey_required"`
+	Blocklist      []string `json:"blocklist"`
+}
+
+// CreateHost creates a host row and returns its ID and single-use enrollment
+// token. role may be "" (regular host), "lighthouse", or "relay".
+func (h *Harness) CreateHost(networkID, name, role, nebulaIP string) (hostID, token string) {
+	h.tb.Helper()
+	req := map[string]any{
+		"network_id": networkID,
+		"name":       name,
+		"nebula_ips": []string{nebulaIP},
+	}
+	if role != "" {
+		req["role"] = role
+		req["public_ip"] = "203.0.113.10"
+		req["listen_port"] = 4242
+	}
+	var out struct {
+		Host            struct{ ID string } `json:"host"`
+		EnrollmentToken string              `json:"enrollment_token"`
+	}
+	if code := h.API(http.MethodPost, "/api/v1/hosts", req, &out); code != http.StatusCreated {
+		h.tb.Fatalf("create host %q: HTTP %d", name, code)
+	}
+	return out.Host.ID, out.EnrollmentToken
+}
+
+// Enroll creates and enrolls a regular host, returning a ready-to-poll Agent.
+func (h *Harness) Enroll(networkID, name, nebulaIP string) *Agent {
+	h.tb.Helper()
+	hostID, token := h.CreateHost(networkID, name, "", nebulaIP)
+
+	// X25519 keypair for the Nebula cert; Ed25519 keypair for PoP signing.
+	priv := make([]byte, 32)
+	if _, err := rand.Read(priv); err != nil {
+		h.tb.Fatalf("rand: %v", err)
+	}
+	pub, err := curve25519.X25519(priv, curve25519.Basepoint)
+	if err != nil {
+		h.tb.Fatalf("x25519: %v", err)
+	}
+	pubPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pub)
+
+	signPub, signPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		h.tb.Fatalf("ed25519: %v", err)
+	}
+	signPubPEM := pem.EncodeToMemory(&pem.Block{Type: "NEBULA ED25519 PUBLIC KEY", Bytes: signPub})
+
+	var enrollOut struct {
+		CertificatePEM string `json:"certificate_pem"`
+	}
+	if code := h.API(http.MethodPost, "/api/v1/enroll", map[string]string{
+		"token":                  token,
+		"public_key_pem":         string(pubPEM),
+		"signing_public_key_pem": string(signPubPEM),
+	}, &enrollOut); code != http.StatusOK {
+		h.tb.Fatalf("enroll %q: HTTP %d", name, code)
+	}
+
+	hostCert, _, err := cert.UnmarshalCertificateFromPEM([]byte(enrollOut.CertificatePEM))
+	if err != nil {
+		h.tb.Fatalf("parse enrolled cert for %q: %v", name, err)
+	}
+	fp, err := hostCert.Fingerprint()
+	if err != nil {
+		h.tb.Fatalf("fingerprint for %q: %v", name, err)
+	}
+
+	h.Journal.Add(Event{Actor: name, Action: "enroll", Target: hostID})
+	return &Agent{HostID: hostID, Name: name, Fingerprint: fp, signingPriv: signPriv}
+}
+
+// Poll performs one signed GET /api/v1/agent/updates, the real ADR 0004 poll.
+func (a *Agent) Poll(h *Harness) PollResponse {
+	h.tb.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, h.Server.URL+"/api/v1/agent/updates", http.NoBody)
+	if err != nil {
+		h.tb.Fatalf("new poll request for %q: %v", a.Name, err)
+	}
+	ts := h.now().UTC().Format(time.RFC3339)
+	nb := make([]byte, 16)
+	if _, err := rand.Read(nb); err != nil {
+		h.tb.Fatalf("nonce: %v", err)
+	}
+	nonce := base64.StdEncoding.EncodeToString(nb)
+	canonical := corepop.CanonicalString(req.Method, req.URL.Path, req.URL.Host, ts, nonce)
+	sig, err := agentpop.Sign(a.signingPriv, canonical)
+	if err != nil {
+		h.tb.Fatalf("sign poll for %q: %v", a.Name, err)
+	}
+	req.Header.Set(corepop.HeaderFingerprint, a.Fingerprint)
+	req.Header.Set(corepop.HeaderTimestamp, ts)
+	req.Header.Set(corepop.HeaderNonce, nonce)
+	req.Header.Set(corepop.HeaderSignature, agentpop.EncodeSignature(sig))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.tb.Fatalf("do poll for %q: %v", a.Name, err)
+	}
+	defer resp.Body.Close()
+
+	out := PollResponse{Status: resp.StatusCode}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	h.Journal.Add(Event{
+		Actor:  a.Name,
+		Action: "poll",
+		Target: a.HostID,
+		Status: resp.StatusCode,
+		Note:   pollNote(out),
+	})
+	return out
+}
+
+// DrainToConverged polls until the server stops shipping config (steady
+// state), returning the number of polls. It fails the test if convergence is
+// not reached within maxPolls — a stuck host is itself a convergence failure.
+func (a *Agent) DrainToConverged(h *Harness, maxPolls int) int {
+	h.tb.Helper()
+	for i := 1; i <= maxPolls; i++ {
+		if r := a.Poll(h); r.ConfigYAML == nil {
+			return i
+		}
+	}
+	h.tb.Fatalf("%q did not converge within %d polls\n%s", a.Name, maxPolls, h.Journal.Report(a.HostID))
+	return maxPolls
+}
+
+func pollNote(r PollResponse) string {
+	switch {
+	case r.ConfigYAML != nil:
+		return "config shipped"
+	case r.CertificatePEM != nil:
+		return "cert renewed"
+	case r.RekeyRequired:
+		return "rekey required"
+	default:
+		return "no config"
+	}
+}

--- a/internal/simtest/cert_renewal_test.go
+++ b/internal/simtest/cert_renewal_test.go
@@ -1,6 +1,7 @@
 package simtest
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,8 +23,12 @@ func TestSim_CertAutoRenewal(t *testing.T) {
 	a := h.Enroll(netID, "renew-host", "10.80.0.10")
 	a.DrainToConverged(h, 5)
 
-	// Freeze the clock at the cert's birth; a fresh 30d cert must not renew.
-	h.SetClock(time.Now())
+	// Freeze the clock at the cert's actual birth; a fresh 30d cert must not renew.
+	ci, err := h.Store.GetCertificateInfo(context.Background(), a.HostID)
+	if err != nil {
+		t.Fatalf("get cert info: %v", err)
+	}
+	h.SetClock(ci.NotBefore)
 	if r := a.Poll(h); r.CertificatePEM != nil {
 		t.Fatalf("cert renewed while fresh (full TTL remaining) — unexpected")
 	}

--- a/internal/simtest/cert_renewal_test.go
+++ b/internal/simtest/cert_renewal_test.go
@@ -1,0 +1,46 @@
+package simtest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/pki"
+)
+
+// TestSim_CertAutoRenewal is the first time-dependent invariant, unlocked by
+// the clock seam (api.Server.WithClock + pki.ShouldRenewAt). A host cert lives
+// DefaultAgentCertDuration (30d) and is renewed when <20% remains. We freeze
+// the harness clock, confirm a fresh cert is NOT renewed, then advance into the
+// renewal window and confirm the next poll auto-renews.
+//
+// Advancing the harness clock moves the server's now and the agent's poll
+// timestamp together, so the PoP timestamp-skew check still passes — that
+// lockstep is exactly what the seam buys.
+func TestSim_CertAutoRenewal(t *testing.T) {
+	h := New(t)
+	netID := h.CreateNetwork("renew-net", "10.80.0.0/16")
+	a := h.Enroll(netID, "renew-host", "10.80.0.10")
+	a.DrainToConverged(h, 5)
+
+	// Freeze the clock at the cert's birth; a fresh 30d cert must not renew.
+	h.SetClock(time.Now())
+	if r := a.Poll(h); r.CertificatePEM != nil {
+		t.Fatalf("cert renewed while fresh (full TTL remaining) — unexpected")
+	}
+
+	// Jump to within the <20% renewal window (26/30 days elapsed -> ~13% left).
+	h.Advance(26 * 24 * time.Hour)
+	if r := a.Poll(h); r.CertificatePEM == nil {
+		t.Errorf("CERT_RENEWAL violated: no auto-renewal after advancing into the renewal window "+
+			"(threshold %.0f%%); poll returned status %d with no certificate", 100*0.20, r.Status)
+	}
+
+	// Sanity on the boundary helper itself.
+	nb := time.Unix(0, 0)
+	if pki.ShouldRenewAt(nb, nb.Add(30*24*time.Hour), nb.Add(20*24*time.Hour)) {
+		t.Error("ShouldRenewAt renewed at 33% remaining; threshold is 20%")
+	}
+	if !pki.ShouldRenewAt(nb, nb.Add(30*24*time.Hour), nb.Add(26*24*time.Hour)) {
+		t.Error("ShouldRenewAt did not renew at 13% remaining; threshold is 20%")
+	}
+}

--- a/internal/simtest/convergence_test.go
+++ b/internal/simtest/convergence_test.go
@@ -1,0 +1,71 @@
+package simtest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// TestSim_ConfigConvergence exercises the CONFIG_CONVERGENCE invariant from
+// ADR 0009: after a network-level config change bumps the network config
+// version, every live host must converge to the new version within bounded
+// polls — and exactly once (no host left stuck below the version, no host
+// re-shipped config forever).
+//
+// This is the propagation correctness that per-request unit tests cannot
+// reach: it depends on the interaction between BumpNetworkConfigVersion and
+// the host-vs-network version comparison in the agent-updates handler across a
+// whole fleet. The version bump is driven through the store directly — the
+// production trigger is a host role change (internal/api/hosts.go), but the
+// invariant under test is the delivery mechanism, not that one handler.
+func TestSim_ConfigConvergence(t *testing.T) {
+	const fleetSize = 25
+	ctx := context.Background()
+
+	h := New(t)
+	netID := h.CreateNetwork("sim-net", "10.10.0.0/16")
+
+	// Enroll a fleet of regular hosts and bring each to steady state.
+	agents := make([]*Agent, fleetSize)
+	for i := range agents {
+		agents[i] = h.Enroll(netID, fmt.Sprintf("host-%02d", i), fmt.Sprintf("10.10.1.%d", i+10))
+		agents[i].DrainToConverged(h, 5)
+	}
+
+	v0, err := h.Store.GetNetworkConfigVersion(ctx, netID)
+	if err != nil {
+		t.Fatalf("read network version: %v", err)
+	}
+
+	// A network-level config change occurs.
+	if err := h.Store.BumpNetworkConfigVersion(ctx, netID); err != nil {
+		t.Fatalf("bump network version: %v", err)
+	}
+	want := v0 + 1
+	h.Journal.Add(Event{Actor: "operator", Action: "bump-version", Target: netID,
+		Note: fmt.Sprintf("%d -> %d", v0, want)})
+
+	// Propagation: the next poll for every host must deliver the new config.
+	for _, a := range agents {
+		if r := a.Poll(h); r.ConfigYAML == nil {
+			t.Errorf("CONFIG_CONVERGENCE violated: %q did not receive config after version %d->%d\n%s",
+				a.Name, v0, want, h.Journal.Report(a.HostID))
+			continue
+		}
+		hv, err := h.Store.GetHostConfigVersion(ctx, a.HostID)
+		if err != nil {
+			t.Fatalf("read host version for %q: %v", a.Name, err)
+		}
+		if hv != want {
+			t.Errorf("CONFIG_CONVERGENCE violated: %q at version %d, want %d", a.Name, hv, want)
+		}
+	}
+
+	// Exactly-once: a subsequent poll must not re-ship config (no churn).
+	for _, a := range agents {
+		if r := a.Poll(h); r.ConfigYAML != nil {
+			t.Errorf("CONFIG_CONVERGENCE violated: %q re-shipped config while already at version %d (churn)\n%s",
+				a.Name, want, h.Journal.Report(a.HostID))
+		}
+	}
+}

--- a/internal/simtest/harness.go
+++ b/internal/simtest/harness.go
@@ -43,8 +43,7 @@ type TB interface {
 	Logf(format string, args ...any)
 }
 
-//nolint:gosec // static test credential, not a real secret
-const apiKey = "simtest-api-key" // #nosec G101
+const apiKey = "simtest-api-key" // #nosec G101 -- static test credential, not a real secret
 
 // Option configures a Harness.
 type Option func(*options)

--- a/internal/simtest/harness.go
+++ b/internal/simtest/harness.go
@@ -1,0 +1,329 @@
+// Package simtest is the in-process fleet-simulation scaffold described in
+// ADR 0009. It stands up the real management server behind an httptest
+// listener over an in-memory store, then drives it with virtual agents that
+// speak the real enrollment and proof-of-possession poll protocol — the only
+// thing virtualized is the Nebula node the server never observes. Tests use it
+// to assert fleet-scale invariants (config convergence, tenant isolation,
+// token single-use, ...) that per-request unit tests cannot reach.
+//
+// It is a test-support library: it is only ever imported from _test.go files,
+// so it is excluded from production binaries. It takes a minimal [TB] rather
+// than importing the testing package directly.
+package simtest
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/api"
+	"github.com/forgekeep/nebula-mesh/internal/keystore"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/pki"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// TB is the slice of *testing.T that simtest needs. Keeping it an interface
+// avoids importing the testing package from non-test source.
+type TB interface {
+	Helper()
+	Cleanup(func())
+	Fatalf(format string, args ...any)
+	Errorf(format string, args ...any)
+	Logf(format string, args ...any)
+}
+
+//nolint:gosec // static test credential, not a real secret
+const apiKey = "simtest-api-key" // #nosec G101
+
+// Option configures a Harness.
+type Option func(*options)
+
+type options struct{ fileStore bool }
+
+// WithFileStore backs the harness with a temp-file SQLite database instead of
+// ":memory:". The in-memory store pins MaxOpenConns(1), which serializes every
+// query and masks concurrency bugs; a file-backed store uses the production
+// pool (WAL, multiple connections), so concurrency invariants (token
+// single-use, IP-uniqueness races) exercise the real path. Required for any
+// test that relies on connection-level concurrency.
+func WithFileStore() Option { return func(o *options) { o.fileStore = true } }
+
+// Harness is a running management server plus the handles a test needs to
+// drive it: the store (for direct assertions and config-version reads), the
+// default CA, and a shared event Journal.
+type Harness struct {
+	tb      TB
+	Server  *httptest.Server
+	Store   *store.SQLiteStore
+	CA      *models.CA
+	Journal *Journal
+
+	master *keystore.Master
+	logger *slog.Logger
+	clk    *simClock
+}
+
+// simClock is a controllable clock shared by the server and the virtual
+// agents. Until SetClock is called it returns real time, so tests that don't
+// touch it behave exactly as before. Once set, Advance moves both the server's
+// now and the agents' poll timestamps in lockstep — so advancing past a cert's
+// renewal window does not also trip the PoP timestamp-skew check.
+type simClock struct {
+	mu  sync.Mutex
+	set bool
+	t   time.Time
+}
+
+func (c *simClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.set {
+		return c.t
+	}
+	return time.Now()
+}
+
+func (c *simClock) setTo(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.set, c.t = true, t
+}
+
+func (c *simClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.set {
+		c.set, c.t = true, time.Now()
+	}
+	c.t = c.t.Add(d)
+}
+
+// SetClock freezes the harness clock at t (server + agents). Call before
+// Advance to exercise time-dependent paths deterministically.
+func (h *Harness) SetClock(t time.Time) { h.clk.setTo(t) }
+
+// Advance moves the harness clock forward by d (freezing at now first if it
+// was still live).
+func (h *Harness) Advance(d time.Duration) { h.clk.advance(d) }
+
+// now returns the harness clock time (used by virtual agents for poll
+// timestamps so they stay consistent with the server's clock).
+func (h *Harness) now() time.Time { return h.clk.now() }
+
+// Tenant is a non-admin operator with its own API key and CA, for
+// multi-tenant isolation tests.
+type Tenant struct {
+	Key        string
+	OperatorID string
+	CAID       string
+}
+
+// New brings up a fresh in-memory server with one admin operator, an API key,
+// and a default CA — the same shape as the integration e2e harness, exposed as
+// a reusable library.
+func New(tb TB, opts ...Option) *Harness {
+	tb.Helper()
+	ctx := context.Background()
+
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	dbPath := ":memory:"
+	if o.fileStore {
+		dir, err := os.MkdirTemp("", "simtest-*")
+		if err != nil {
+			tb.Fatalf("temp dir: %v", err)
+		}
+		tb.Cleanup(func() { _ = os.RemoveAll(dir) })
+		dbPath = filepath.Join(dir, "nebula.db")
+	}
+
+	s, err := store.NewSQLiteStore(dbPath)
+	if err != nil {
+		tb.Fatalf("new store: %v", err)
+	}
+	if err := s.Migrate(ctx); err != nil {
+		tb.Fatalf("migrate: %v", err)
+	}
+	tb.Cleanup(func() { _ = s.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := api.NewServer(s, logger)
+	clk := &simClock{}
+	srv.WithClock(clk.now)
+
+	master, err := keystore.NewMaster(bytes.Repeat([]byte{0x77}, keystore.MasterKeySize))
+	if err != nil {
+		tb.Fatalf("new master: %v", err)
+	}
+	srv.WithMaster(master)
+	srv.WithCAResolver(pki.NewCAResolver(s, master))
+
+	op := &models.Operator{
+		ID:           "simtest-admin",
+		Username:     "admin",
+		PasswordHash: "hash",
+		Role:         "admin",
+		Status:       models.OperatorStatusActive,
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(ctx, op); err != nil {
+		tb.Fatalf("create operator: %v", err)
+	}
+	keySum := sha256.Sum256([]byte(apiKey))
+	if err := s.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID:         "simtest-admin-key",
+		OperatorID: op.ID,
+		Name:       "simtest-admin-key",
+		KeyHash:    hex.EncodeToString(keySum[:]),
+	}); err != nil {
+		tb.Fatalf("create api key: %v", err)
+	}
+
+	ca, _, err := pki.MintAndStoreCA(ctx, s, master, logger, pki.MintRequest{
+		Operator: op,
+		Name:     "simtest-ca",
+		Duration: 365 * 24 * time.Hour,
+	})
+	if err != nil {
+		tb.Fatalf("mint CA: %v", err)
+	}
+	srv.WithDefaultCAID(ca.ID)
+
+	ts := httptest.NewServer(srv)
+	tb.Cleanup(ts.Close)
+
+	return &Harness{tb: tb, Server: ts, Store: s, CA: ca, Journal: NewJournal(), master: master, logger: logger, clk: clk}
+}
+
+// NewTenant store-creates a non-admin operator with its own API key and CA,
+// returning a Tenant whose Key authenticates as that operator. Hosts created
+// under the tenant's CAID are owned by it; another tenant must not be able to
+// read or mutate them (authz gates on CA ownership — internal/api/authz.go).
+func (h *Harness) NewTenant(name string) *Tenant {
+	h.tb.Helper()
+	ctx := context.Background()
+	op := &models.Operator{
+		ID:           name,
+		Username:     name,
+		PasswordHash: "hash",
+		Role:         "user",
+		Status:       models.OperatorStatusActive,
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := h.Store.CreateOperator(ctx, op); err != nil {
+		h.tb.Fatalf("create operator %q: %v", name, err)
+	}
+	key := name + "-key"
+	sum := sha256.Sum256([]byte(key))
+	if err := h.Store.CreateOperatorAPIKey(ctx, &models.OperatorAPIKey{
+		ID:         name + "-key",
+		OperatorID: op.ID,
+		Name:       name + "-key",
+		KeyHash:    hex.EncodeToString(sum[:]),
+	}); err != nil {
+		h.tb.Fatalf("create api key for %q: %v", name, err)
+	}
+	ca, _, err := pki.MintAndStoreCA(ctx, h.Store, h.master, h.logger, pki.MintRequest{
+		Operator: op,
+		Name:     name + "-ca",
+		Duration: 365 * 24 * time.Hour,
+	})
+	if err != nil {
+		h.tb.Fatalf("mint CA for %q: %v", name, err)
+	}
+	return &Tenant{Key: key, OperatorID: op.ID, CAID: ca.ID}
+}
+
+// CreateHostUnderCA store-creates an enrolled-shaped host row owned by caID on
+// the given network, returning its ID. Bypasses the create API so isolation
+// tests can plant a host under one tenant's CA directly.
+func (h *Harness) CreateHostUnderCA(networkID, caID, name, ip string) string {
+	h.tb.Helper()
+	now := time.Now()
+	host := &models.Host{
+		ID:        name,
+		NetworkID: networkID,
+		Name:      name,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		Kind:      models.HostKindAgent,
+		CAID:      caID,
+		NebulaIPs: []string{ip},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := h.Store.CreateHost(context.Background(), host); err != nil {
+		h.tb.Fatalf("create host %q under CA %q: %v", name, caID, err)
+	}
+	return host.ID
+}
+
+// API issues an authenticated admin API request and returns the decoded JSON
+// body (into out, if non-nil) and status code. It fails the test on transport
+// errors so callers can focus on status assertions.
+func (h *Harness) API(method, path string, body, out any) int {
+	return h.APIAs(apiKey, method, path, body, out)
+}
+
+// APIAs is like API but authenticates with the given API key — used by
+// multi-tenant isolation tests to act as a specific Tenant.
+func (h *Harness) APIAs(key, method, path string, body, out any) int {
+	h.tb.Helper()
+	var r io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			h.tb.Fatalf("marshal %s %s body: %v", method, path, err)
+		}
+		r = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, h.Server.URL+path, r)
+	if err != nil {
+		h.tb.Fatalf("new request %s %s: %v", method, path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.tb.Fatalf("do %s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	if out != nil && resp.Body != nil {
+		// Best-effort decode; callers that don't care pass nil.
+		_ = json.NewDecoder(resp.Body).Decode(out)
+	} else {
+		_, _ = io.Copy(io.Discard, resp.Body)
+	}
+	return resp.StatusCode
+}
+
+// CreateNetwork creates a network and returns its ID.
+func (h *Harness) CreateNetwork(name string, cidrs ...string) string {
+	h.tb.Helper()
+	var net models.Network
+	code := h.API(http.MethodPost, "/api/v1/networks", map[string]any{
+		"name": name, "cidrs": cidrs,
+	}, &net)
+	if code != http.StatusCreated {
+		h.tb.Fatalf("create network %q: HTTP %d", name, code)
+	}
+	return net.ID
+}

--- a/internal/simtest/ipuniqueness_test.go
+++ b/internal/simtest/ipuniqueness_test.go
@@ -1,0 +1,103 @@
+package simtest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// TestSim_IPUniqueness_ConcurrentCreate exercises the IP_UNIQUENESS invariant
+// from ADR 0009 under concurrency. Overlay-IP uniqueness is enforced only in
+// application code: validateHostIPs (internal/api/validate_ip.go) reads the
+// host list, and the caller then issues a separate CreateHost write. The read
+// and write are not in one transaction, and migration 014 left no UNIQUE
+// constraint on host_addresses.address — so N concurrent creates of the same
+// IP can all pass validation before any of them inserts (TOCTOU), and the
+// overlay ends up with duplicate addresses.
+//
+// The assertion is the correct invariant: exactly one create may win. The race
+// is intermittently reproducible, so the test is skipped until the fix lands.
+func TestSim_IPUniqueness_ConcurrentCreate(t *testing.T) {
+	t.Skip("known TOCTOU race in overlay-IP uniqueness: intermittently reproducible under -race " +
+		"(scheduler-dependent; observed e.g. 2 of 16 concurrent creates winning, leaving two host rows " +
+		"with the same address). validateHostIPs reads then the caller writes with no enclosing transaction " +
+		"and no UNIQUE constraint on host_addresses.address; the production file-backed store allows " +
+		"concurrent connections, widening the window. Un-skip once a network-scoped uniqueness constraint lands.")
+
+	h := New(t, WithFileStore())
+	netID := h.CreateNetwork("race-net", "10.20.0.0/16")
+	const ip = "10.20.0.5"
+	const n = 16
+
+	start := make(chan struct{})
+	codes := make([]int, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			body, _ := json.Marshal(map[string]any{
+				"network_id": netID,
+				"name":       fmt.Sprintf("racer-%02d", i),
+				"nebula_ips": []string{ip},
+			})
+			req, err := http.NewRequestWithContext(context.Background(),
+				http.MethodPost, h.Server.URL+"/api/v1/hosts", bytes.NewReader(body))
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+			req.Header.Set("Content-Type", "application/json")
+			<-start // release barrier: maximize validate/write overlap
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			codes[i] = resp.StatusCode
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	created := 0
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("racer %d transport error: %v", i, errs[i])
+		}
+		if codes[i] == http.StatusCreated {
+			created++
+		}
+	}
+
+	// Ground-truth: how many host rows actually carry the IP.
+	hosts, err := h.Store.ListHosts(context.Background(), store.HostFilter{NetworkID: netID})
+	if err != nil {
+		t.Fatalf("list hosts: %v", err)
+	}
+	withIP := 0
+	for _, hh := range hosts {
+		for _, a := range hh.NebulaIPs {
+			if a == ip {
+				withIP++
+			}
+		}
+	}
+
+	if created != 1 || withIP != 1 {
+		t.Errorf("IP_UNIQUENESS violated (TOCTOU): %d/%d concurrent creates of %s returned 201 and %d host rows hold the address; want exactly 1. "+
+			"validateHostIPs reads then the caller writes with no enclosing transaction and no UNIQUE constraint on host_addresses.address.",
+			created, n, ip, withIP)
+	}
+}

--- a/internal/simtest/ipuniqueness_test.go
+++ b/internal/simtest/ipuniqueness_test.go
@@ -14,23 +14,16 @@ import (
 )
 
 // TestSim_IPUniqueness_ConcurrentCreate exercises the IP_UNIQUENESS invariant
-// from ADR 0009 under concurrency. Overlay-IP uniqueness is enforced only in
-// application code: validateHostIPs (internal/api/validate_ip.go) reads the
-// host list, and the caller then issues a separate CreateHost write. The read
-// and write are not in one transaction, and migration 014 left no UNIQUE
-// constraint on host_addresses.address — so N concurrent creates of the same
-// IP can all pass validation before any of them inserts (TOCTOU), and the
-// overlay ends up with duplicate addresses.
-//
-// The assertion is the correct invariant: exactly one create may win. The race
-// is intermittently reproducible, so the test is skipped until the fix lands.
+// from ADR 0009 under concurrency. The application-layer check has a TOCTOU:
+// validateHostIPs (internal/api/validate_ip.go) reads the host list, and the
+// caller then issues a separate CreateHost write with no enclosing transaction,
+// so N concurrent creates of the same IP can all pass validation. Migration 018
+// (#149) backstops this at the data layer with a network-scoped UNIQUE
+// constraint on host_addresses(network_id, address): the racing writes collapse
+// to a single winner and the losers map to ErrIPTaken. This test is the
+// regression guard over that fix — exactly one create wins and one row holds the
+// address (verified stable across repeated -race runs).
 func TestSim_IPUniqueness_ConcurrentCreate(t *testing.T) {
-	t.Skip("known TOCTOU race in overlay-IP uniqueness: intermittently reproducible under -race " +
-		"(scheduler-dependent; observed e.g. 2 of 16 concurrent creates winning, leaving two host rows " +
-		"with the same address). validateHostIPs reads then the caller writes with no enclosing transaction " +
-		"and no UNIQUE constraint on host_addresses.address; the production file-backed store allows " +
-		"concurrent connections, widening the window. Un-skip once a network-scoped uniqueness constraint lands.")
-
 	h := New(t, WithFileStore())
 	netID := h.CreateNetwork("race-net", "10.20.0.0/16")
 	const ip = "10.20.0.5"

--- a/internal/simtest/ipupdate_test.go
+++ b/internal/simtest/ipupdate_test.go
@@ -1,0 +1,92 @@
+package simtest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// TestSim_IPUniqueness_ConcurrentUpdate extends the IP_UNIQUENESS check to the
+// UPDATE path. handleUpdateHost validates via validateHostIPs then writes via a
+// separate UpdateHost (internal/api/hosts.go) — the same validate-then-write
+// pattern as the create path. N hosts with distinct IPs concurrently PATCH to
+// one target IP; the invariant is that exactly one ends up holding it.
+//
+// NOTE: in-process these requests usually serialize at validation (the losers
+// are rejected before the write window), so this rarely interleaves the
+// validate/write race. A pass here is therefore NOT proof the UPDATE path is
+// race-free — the TOCTOU exists in source, same as the create path. The test
+// is kept as a post-fix regression guard (it asserts the correct invariant).
+func TestSim_IPUniqueness_ConcurrentUpdate(t *testing.T) {
+	h := New(t, WithFileStore())
+	netID := h.CreateNetwork("upd-net", "10.40.0.0/16")
+
+	const n = 12
+	const target = "10.40.0.99"
+	ids := make([]string, n)
+	for i := range n {
+		ids[i], _ = h.CreateHost(netID, fmt.Sprintf("u-%02d", i), "", fmt.Sprintf("10.40.0.%d", i+10))
+	}
+
+	start := make(chan struct{})
+	codes := make([]int, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			body, _ := json.Marshal(map[string]any{"nebula_ips": []string{target}})
+			req, err := http.NewRequestWithContext(context.Background(),
+				http.MethodPatch, h.Server.URL+"/api/v1/hosts/"+ids[i], bytes.NewReader(body))
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+			req.Header.Set("Content-Type", "application/json")
+			<-start // release barrier: maximize validate/write overlap
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			codes[i] = resp.StatusCode
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("patcher %d transport error: %v", i, errs[i])
+		}
+	}
+
+	hosts, err := h.Store.ListHosts(context.Background(), store.HostFilter{NetworkID: netID})
+	if err != nil {
+		t.Fatalf("list hosts: %v", err)
+	}
+	withTarget := 0
+	for _, hh := range hosts {
+		for _, a := range hh.NebulaIPs {
+			if a == target {
+				withTarget++
+			}
+		}
+	}
+	if withTarget != 1 {
+		t.Errorf("IP_UNIQUENESS violated on UPDATE path (TOCTOU): %d hosts hold %s after concurrent PATCH; want exactly 1. "+
+			"handleUpdateHost validates via validateHostIPs then writes via a separate UpdateHost with no enclosing transaction.",
+			withTarget, target)
+	}
+}

--- a/internal/simtest/ipupdate_test.go
+++ b/internal/simtest/ipupdate_test.go
@@ -25,6 +25,8 @@ import (
 // race-free — the TOCTOU exists in source, same as the create path. The test
 // is kept as a post-fix regression guard (it asserts the correct invariant).
 func TestSim_IPUniqueness_ConcurrentUpdate(t *testing.T) {
+	t.Log("NOTE: in-process PATCHes usually serialize at validation, so a PASS here is a " +
+		"post-fix regression guard, not proof the UPDATE-path validate/write TOCTOU is closed.")
 	h := New(t, WithFileStore())
 	netID := h.CreateNetwork("upd-net", "10.40.0.0/16")
 

--- a/internal/simtest/journal.go
+++ b/internal/simtest/journal.go
@@ -1,0 +1,68 @@
+package simtest
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// Event is one entry in the simulation journal. The journal is what makes a
+// fleet-scale failure legible (ADR 0009): instead of "assertion failed", a
+// violated invariant prints the minimal trace of what happened to the
+// entities involved.
+type Event struct {
+	Step   int
+	Actor  string // virtual agent name, or operator action source
+	Action string // enroll | poll | bump-version | block | ...
+	Target string // host ID or network ID the action touched
+	Status int    // HTTP status, when applicable
+	Note   string // short human-readable detail
+}
+
+// Journal is a concurrency-safe append-only event log shared across a fleet.
+type Journal struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+// NewJournal returns an empty journal.
+func NewJournal() *Journal { return &Journal{} }
+
+// Add appends an event, stamping it with the next step number.
+func (j *Journal) Add(e Event) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	e.Step = len(j.events) + 1
+	j.events = append(j.events, e)
+}
+
+// Report renders the journal entries touching target (a host or network ID)
+// as a compact trace, for embedding in an invariant-violation failure message.
+// An empty target renders the whole journal.
+func (j *Journal) Report(target string) string {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- journal (target=%q) ---\n", target)
+	for _, e := range j.events {
+		if target != "" && e.Target != target {
+			continue
+		}
+		fmt.Fprintf(&b, "  step %-5d %-12s %-14s target=%s", e.Step, e.Action, e.Actor, e.Target)
+		if e.Status != 0 {
+			fmt.Fprintf(&b, " http=%d", e.Status)
+		}
+		if e.Note != "" {
+			fmt.Fprintf(&b, " (%s)", e.Note)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// Len returns the number of recorded events.
+func (j *Journal) Len() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return len(j.events)
+}

--- a/internal/simtest/journal.go
+++ b/internal/simtest/journal.go
@@ -59,10 +59,3 @@ func (j *Journal) Report(target string) string {
 	}
 	return b.String()
 }
-
-// Len returns the number of recorded events.
-func (j *Journal) Len() int {
-	j.mu.Lock()
-	defer j.mu.Unlock()
-	return len(j.events)
-}

--- a/internal/simtest/revocation_test.go
+++ b/internal/simtest/revocation_test.go
@@ -1,0 +1,56 @@
+package simtest
+
+import (
+	"net/http"
+	"slices"
+	"testing"
+)
+
+// TestSim_RevocationLiveness exercises the REVOCATION_LIVENESS invariant from
+// ADR 0009: a revoked host's poll loop is stopped promptly and the revocation
+// propagates to peers.
+//
+//   - Block -> the host's next signed poll gets a structured 403 reason=revoked
+//     (ADR 0004 §7.1), so the agent stops instead of draining config.
+//   - The blocked fingerprint appears in every peer's blocklist on the next poll.
+//   - Delete -> the row is gone but DeleteHostAndBlockCert keeps the cert
+//     blocklisted, so the poll gets a structured 410 reason=gone.
+func TestSim_RevocationLiveness(t *testing.T) {
+	h := New(t)
+	netID := h.CreateNetwork("revoke-net", "10.50.0.0/16")
+	victim := h.Enroll(netID, "victim", "10.50.0.10")
+	peer := h.Enroll(netID, "peer", "10.50.0.11")
+	victim.DrainToConverged(h, 5)
+	peer.DrainToConverged(h, 5)
+
+	if r := victim.Poll(h); r.Status != http.StatusOK {
+		t.Fatalf("victim baseline poll: status %d, want 200", r.Status)
+	}
+
+	if code := h.API(http.MethodPost, "/api/v1/hosts/"+victim.HostID+"/block", nil, nil); code != http.StatusOK {
+		t.Fatalf("block victim: HTTP %d", code)
+	}
+
+	// Blocked host: structured 403 revoked so the agent stops the loop.
+	if r := victim.Poll(h); r.Status != http.StatusForbidden || r.Reason != "revoked" {
+		t.Errorf("REVOCATION_LIVENESS: blocked victim poll = status %d reason %q; want 403 revoked\n%s",
+			r.Status, r.Reason, h.Journal.Report(victim.HostID))
+	}
+
+	// Propagation: the victim's fingerprint lands in the peer's blocklist.
+	if r := peer.Poll(h); !slices.Contains(r.Blocklist, victim.Fingerprint) {
+		t.Errorf("REVOCATION_LIVENESS: victim fingerprint %q not in peer blocklist after block; got %v",
+			victim.Fingerprint, r.Blocklist)
+	}
+
+	// Delete the row; the cert stays blocklisted (DeleteHostAndBlockCert).
+	if code := h.API(http.MethodDelete, "/api/v1/hosts/"+victim.HostID, nil, nil); code != http.StatusOK && code != http.StatusNoContent {
+		t.Fatalf("delete victim: HTTP %d", code)
+	}
+
+	// Gone host: structured 410 gone.
+	if r := victim.Poll(h); r.Status != http.StatusGone || r.Reason != "gone" {
+		t.Errorf("REVOCATION_LIVENESS: deleted victim poll = status %d reason %q; want 410 gone\n%s",
+			r.Status, r.Reason, h.Journal.Report(victim.HostID))
+	}
+}

--- a/internal/simtest/scale_test.go
+++ b/internal/simtest/scale_test.go
@@ -1,0 +1,72 @@
+package simtest
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+)
+
+// TestSim_ScaleBlocklistPropagation is the scale leg of ADR 0009. It enrolls a
+// fleet, blocks a subset, and checks two correctness properties plus surfaces a
+// documented scaling smell.
+//
+// Correctness:
+//   - all blocked fingerprints propagate to an unblocked host's next poll;
+//   - blocking does NOT trigger a config re-render (config_yaml stays nil) —
+//     handleBlockHost ships the blocklist without bumping the network config
+//     version, so a block is O(blocklist), not an O(N) re-render storm.
+//
+// Smell (logged, not asserted, since it is the current intended behavior):
+//   - once anything is blocked, has_updates is true and the full blocklist
+//     ships on every poll by every host regardless of churn (internal/api/
+//     updates.go). At fleet scale that is a standing O(blocklist x hosts /
+//     poll_interval) cost.
+func TestSim_ScaleBlocklistPropagation(t *testing.T) {
+	const (
+		fleet   = 60
+		blocked = 10
+	)
+	h := New(t) // payload/propagation test, not concurrency — :memory: is fine
+
+	netID := h.CreateNetwork("scale-net", "10.60.0.0/16")
+	agents := make([]*Agent, fleet)
+	t0 := time.Now()
+	for i := range agents {
+		agents[i] = h.Enroll(netID, fmt.Sprintf("h-%03d", i), fmt.Sprintf("10.60.%d.%d", i/250, i%250+1))
+		agents[i].DrainToConverged(h, 5)
+	}
+	t.Logf("enrolled+converged %d hosts in %s", fleet, time.Since(t0).Round(time.Millisecond))
+
+	// Baseline: a converged host's poll is quiet (nothing blocked yet).
+	if r := agents[0].Poll(h); r.HasUpdates || len(r.Blocklist) != 0 || r.ConfigYAML != nil {
+		t.Errorf("steady state not quiet before any block: has_updates=%v blocklist=%d config=%v",
+			r.HasUpdates, len(r.Blocklist), r.ConfigYAML != nil)
+	}
+
+	// Block the tail of the fleet.
+	var blockedFPs []string
+	for i := 0; i < blocked; i++ {
+		v := agents[fleet-1-i]
+		if code := h.API(http.MethodPost, "/api/v1/hosts/"+v.HostID+"/block", nil, nil); code != http.StatusOK {
+			t.Fatalf("block %s: HTTP %d", v.Name, code)
+		}
+		blockedFPs = append(blockedFPs, v.Fingerprint)
+	}
+
+	// An unblocked host's next poll must carry every blocked fingerprint, and
+	// must NOT re-render config (a block is not a network config change).
+	r := agents[0].Poll(h)
+	for _, fp := range blockedFPs {
+		if !slices.Contains(r.Blocklist, fp) {
+			t.Errorf("blocked fingerprint %q did not propagate to unblocked host's blocklist", fp)
+		}
+	}
+	if r.ConfigYAML != nil {
+		t.Errorf("blocking triggered a config re-render (config_yaml non-nil) — should be O(blocklist), not an O(N) re-render storm")
+	}
+
+	t.Logf("SCALE SMELL: after blocking %d/%d, an unblocked host's steady-state poll reports has_updates=%v and ships the full %d-entry blocklist; this repeats on every poll by every host regardless of churn",
+		blocked, fleet, r.HasUpdates, len(r.Blocklist))
+}

--- a/internal/simtest/tenant_isolation_test.go
+++ b/internal/simtest/tenant_isolation_test.go
@@ -1,0 +1,60 @@
+package simtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestSim_TenantIsolation exercises the TENANT_ISOLATION invariant from ADR
+// 0009 against the repo's most advisory-prone area. Two non-admin operators
+// each own a CA; a host owned by one (via its CA) must be invisible and
+// immutable to the other. Authz gates on CA ownership (internal/api/authz.go),
+// so this checks that gate holds across read, every mutation, and list.
+func TestSim_TenantIsolation(t *testing.T) {
+	h := New(t)
+	netID := h.CreateNetwork("iso-net", "10.70.0.0/16")
+	alice := h.NewTenant("alice")
+	bob := h.NewTenant("bob")
+	aHost := h.CreateHostUnderCA(netID, alice.CAID, "alice-host", "10.70.0.10")
+
+	// Sanity: the owner and an admin can read the host (so a deny below is
+	// isolation, not a broken fixture).
+	if code := h.APIAs(alice.Key, http.MethodGet, "/api/v1/hosts/"+aHost, nil, nil); code != http.StatusOK {
+		t.Fatalf("owner alice GET own host: HTTP %d, want 200", code)
+	}
+	if code := h.API(http.MethodGet, "/api/v1/hosts/"+aHost, nil, nil); code != http.StatusOK {
+		t.Fatalf("admin GET host: HTTP %d, want 200", code)
+	}
+
+	// Bob (a different tenant) must be denied read and every mutation.
+	probes := []struct {
+		op, method, path string
+		body             any
+	}{
+		{"read", http.MethodGet, "/api/v1/hosts/" + aHost, nil},
+		{"update", http.MethodPatch, "/api/v1/hosts/" + aHost, map[string]any{"name": "pwned"}},
+		{"block", http.MethodPost, "/api/v1/hosts/" + aHost + "/block", nil},
+		{"delete", http.MethodDelete, "/api/v1/hosts/" + aHost, nil},
+	}
+	for _, p := range probes {
+		if code := h.APIAs(bob.Key, p.method, p.path, p.body, nil); code != http.StatusForbidden {
+			t.Errorf("TENANT_ISOLATION: bob %s of alice's host = HTTP %d; want 403 forbidden", p.op, code)
+		}
+	}
+
+	// Bob's host list must not reveal alice's host.
+	var list json.RawMessage
+	if code := h.APIAs(bob.Key, http.MethodGet, "/api/v1/hosts", nil, &list); code != http.StatusOK {
+		t.Fatalf("bob list hosts: HTTP %d, want 200", code)
+	}
+	if bytes.Contains(list, []byte(aHost)) {
+		t.Errorf("TENANT_ISOLATION: alice's host %q leaked into bob's host list: %s", aHost, list)
+	}
+
+	// The host must survive bob's failed mutations intact.
+	if code := h.APIAs(alice.Key, http.MethodGet, "/api/v1/hosts/"+aHost, nil, nil); code != http.StatusOK {
+		t.Errorf("alice's host not intact after bob's probes: HTTP %d", code)
+	}
+}

--- a/internal/simtest/token_test.go
+++ b/internal/simtest/token_test.go
@@ -1,0 +1,104 @@
+package simtest
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+)
+
+// TestSim_TokenSingleUse asserts the TOKEN_SINGLE_USE invariant from ADR 0009:
+// a single enrollment token can be redeemed exactly once, even under
+// concurrent redemption. A double-redeem means two agents obtain valid certs
+// for one host identity.
+//
+// Runs against a file-backed store (WithFileStore): the :memory: store pins
+// MaxOpenConns(1) and would serialize the ConsumeToken transactions, masking
+// any race. ConsumeToken is a single SELECT-check-UPDATE transaction, so WAL
+// snapshot isolation should let exactly one redemption win — this test
+// confirms that holds rather than assuming it.
+func TestSim_TokenSingleUse(t *testing.T) {
+	h := New(t, WithFileStore())
+	netID := h.CreateNetwork("token-net", "10.30.0.0/16")
+	_, token := h.CreateHost(netID, "lonely-host", "", "10.30.0.7")
+
+	const n = 16
+	start := make(chan struct{})
+	codes := make([]int, n)
+	gotCert := make([]bool, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Each redeemer brings its own keypairs.
+			priv := make([]byte, 32)
+			if _, err := rand.Read(priv); err != nil {
+				errs[i] = err
+				return
+			}
+			pub, err := curve25519.X25519(priv, curve25519.Basepoint)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			pubPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pub)
+			signPub, _, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			signPubPEM := pem.EncodeToMemory(&pem.Block{Type: "NEBULA ED25519 PUBLIC KEY", Bytes: signPub})
+
+			body, _ := json.Marshal(map[string]string{
+				"token":                  token,
+				"public_key_pem":         string(pubPEM),
+				"signing_public_key_pem": string(signPubPEM),
+			})
+			req, err := http.NewRequestWithContext(context.Background(),
+				http.MethodPost, h.Server.URL+"/api/v1/enroll", bytes.NewReader(body))
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			req.Header.Set("Content-Type", "application/json")
+			<-start // release barrier: maximize ConsumeToken overlap
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			codes[i] = resp.StatusCode
+			var out struct {
+				CertificatePEM string `json:"certificate_pem"`
+			}
+			_ = json.NewDecoder(resp.Body).Decode(&out)
+			gotCert[i] = out.CertificatePEM != ""
+			_ = resp.Body.Close()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	redeemed := 0
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("redeemer %d transport error: %v", i, errs[i])
+		}
+		if codes[i] == http.StatusOK && gotCert[i] {
+			redeemed++
+		}
+	}
+	if redeemed != 1 {
+		t.Errorf("TOKEN_SINGLE_USE violated: %d/%d concurrent redemptions of one token returned 200+cert; want exactly 1", redeemed, n)
+	}
+}


### PR DESCRIPTION
Implements ADR 0009 Tier 2: an in-process fleet-simulation harness plus the injectable clock seam it needs. ADR 0009 already merged (#163); this lands the code conforming to the CI split it pins.

## Commits (reviewable in order)

1. **`feat(api,pki): injectable clock seam`** — *please review this one in focus; it touches the auth-adjacent poll path.* Adds `api.Server.WithClock(func() time.Time)` (default `time.Now`, behavior unchanged when unset), `pki.ShouldRenewAt(nb, na, now)` with `ShouldRenew` delegating, and an optional `pki.SignRequest.Now`. The signed-poll handler routes its renewal decision, rotation-overlap window, and timestamp-skew check through the seam, and threads `now` into `signHostCert`. Recorded/forensic timestamps (audit, revocation `At`/`BlockedAt`) intentionally stay on the wall clock.
2. **`test(simtest): fleet-simulation harness + invariants`** — N virtual agents drive the real `httptest` server under `-race`; named invariants are checked against the store + an event journal after each step: `CONFIG_CONVERGENCE`, `CERT_RENEWAL`, `REVOCATION_LIVENESS`, `TENANT_ISOLATION`, `TOKEN_SINGLE_USE`, `IP_UNIQUENESS`, plus scale characterization.
3. **`test(api,pki): deterministic seam unit tests`** — direct unit coverage for the seam (fixed-instant `ShouldRenewAt` table, exact-instant `SignRequest.Now`, handler-level renewal-window polls).
4. **`test(simtest): review-pass polish`** — small test-honesty fixes.
5. **`test(simtest): activate ConcurrentCreate IP_UNIQUENESS invariant`** — migration 018 (#149) is on main, so this previously-skipped invariant is now an active regression guard over that fix (verified stable across repeated `-race` runs).

## CI split (per the ADR)

The deterministic invariants run in the existing `go test -race ./...` gate (whole sim suite is well under a second). Nothing generative or long-running is on the PR path. The scheduled lane (generative fuzz with a time budget, long sim runs, Tier-3 interop) is a separate follow-up — this PR honors the boundary without wiring that workflow yet.

## Notes

- The `cawatch`/`alerts` scanners still read `time.Now()` directly — seaming them is the follow-up the ADR calls out.
- `last_seen_at` is routed through the seam by design (deterministic under simulation); it's never set in production, where it remains `time.Now()`.
- The harness lives under `internal/simtest/` and is imported by nothing outside its own tests.

Verified: `go test -race ./...` green; `make lint` (pinned) reports 0 issues.