### PR TITLE
ci: add scheduled slow lane for generative fuzzing (ADR 0009)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,9 @@
+# Fast lane — gates every PR (ADR 0009 §"CI integration (PR-gate vs scheduled)").
+# Runs the bounded, deterministic subset: build, `go test -race`, lint, the
+# Tier-1 fuzz seed corpora (executed as ordinary `go test`), and — once they
+# land — the deterministic Tier-2 invariants. Unbounded generative fuzz and the
+# long sim / Tier-3 interop runs live in the scheduled slow lane
+# (.github/workflows/scheduled.yml), never here.
 name: CI
 
 on:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,72 @@
+# Scheduled / manual "slow lane" — never on the PR path.
+#
+# ADR 0009 §"CI integration (PR-gate vs scheduled)" pins this boundary as
+# normative: the fast lane (ci.yml) gates every PR on build + `go test -race` +
+# lint + the Tier-1 fuzz seed corpora + the deterministic Tier-2 invariants;
+# the slow, unbounded work runs here on a nightly schedule and on manual
+# dispatch. A slow or flaky gate is one people learn to ignore — so it stays
+# off the PR path.
+#
+# Today this lane runs Tier-1 *generative* fuzzing only (the rest of ADR 0009
+# isn't built yet). It grows by adding matrix entries / jobs as tiers land:
+#   - more Tier-1 fuzz targets (FuzzPoPCanonical, FuzzValidateIP, FuzzMigrations,
+#     FuzzEnrollPayload, FuzzAgentUpdatesHeaders);
+#   - long / high-fan-out Tier-2 simulation runs (once internal/simtest lands);
+#   - Tier-3 Nebula interop (`go test -tags e2e_testing ./...`) + the VM capstone.
+name: Scheduled
+
+on:
+  schedule:
+    # 07:37 UTC nightly — deliberately off the hour to dodge GitHub Actions'
+    # top-of-hour scheduler congestion and the dispatch delay it causes.
+    - cron: '37 7 * * *'
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: 'Per-target generative fuzz budget (go test -fuzztime)'
+        required: false
+        default: '10m'
+
+permissions:
+  contents: read
+
+concurrency:
+  # One slow-lane run at a time per ref; a newer run supersedes an in-flight one.
+  group: scheduled-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: generative fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg: ./internal/configgen
+            target: FuzzGenerate
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: generative fuzz
+        run: |
+          go test -run='^$' -fuzz='^${{ matrix.target }}$' \
+            -fuzztime='${{ github.event.inputs.fuzztime || '10m' }}' \
+            '${{ matrix.pkg }}'
+
+      # A crasher the generative pass finds is an asset: upload its minimized
+      # input so it can be committed under testdata/fuzz/ as a fast-lane
+      # regression (ADR 0009 — "filed and its input committed as a fast-lane
+      # regression").
+      - name: upload crashers
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashers-${{ matrix.target }}
+          path: '**/testdata/fuzz/**'
+          if-no-files-found: ignore


### PR DESCRIPTION
## What

Adds `.github/workflows/scheduled.yml` — the "slow lane" defined in ADR 0009 §"CI integration (PR-gate vs scheduled)". It runs nightly (`cron: '37 7 * * *'`, off-the-hour to dodge GitHub's scheduler congestion) and on manual `workflow_dispatch` (with a `fuzztime` input, default `10m`), and currently runs Tier-1 generative fuzzing over a target matrix.

Also annotates `ci.yml` with a header comment marking it the fast lane / PR gate, so the ADR's normative boundary is legible where it's enforced. No behavioral change to the fast lane.

## Why

ADR 0009 pins a normative fast/slow split: the fast lane gates every PR on the bounded, deterministic subset (build + `go test -race` + lint + Tier-1 fuzz seed corpora + the deterministic Tier-2 invariants), while unbounded generative fuzzing and the long sim / Tier-3 interop runs stay off the PR path — "a slow or flaky gate is one people learn to ignore." Until now only the fast lane existed.

## Scope (minimal by design)

Only `FuzzGenerate` (the one fuzz target on `main`, from #155) runs today. The workflow grows by adding matrix entries / jobs as the rest of ADR 0009 lands:

- more Tier-1 targets (`FuzzPoPCanonical`, `FuzzValidateIP`, `FuzzMigrations`, `FuzzEnrollPayload`, `FuzzAgentUpdatesHeaders`);
- long / high-fan-out Tier-2 simulation runs (once `internal/simtest` lands);
- Tier-3 Nebula interop (`go test -tags e2e_testing ./...`) + the optional VM capstone.

On a crash, the generative pass uploads the minimized input as an artifact, so it can be committed under `testdata/fuzz/` as a fast-lane regression — the file-and-commit loop ADR 0009 describes.

## Notes

- Build/vet/lint are intentionally not duplicated here; they gate on the fast lane.
- `schedule` / `workflow_dispatch` only take effect once this is on `main`, so this workflow doesn't run as a PR check. I'll smoke-test it with a short `-fuzztime` via manual dispatch right after merge.
- `permissions: contents: read`; a `concurrency` group prevents overlapping runs.

Validated with `actionlint` (clean) and by running the exact fuzz invocation locally on Go 1.26.