### PR TITLE
test: Tier-1 fuzz backlog — PoP canonical, IP validation, migrations, enroll, agent-poll (ADR 0009)

### DIFF
--- a/internal/api/validate_ip_fuzz_test.go
+++ b/internal/api/validate_ip_fuzz_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// fuzzIPStore is a minimal store.Store for FuzzValidateIP. validateHostIPs
+// touches only GetNetwork and ListHosts, so every other method is left to the
+// nil embedded interface — calling one would panic and surface an unexpected
+// new dependency instead of silently passing.
+type fuzzIPStore struct {
+	store.Store
+	net   *models.Network
+	hosts []*models.Host
+}
+
+func (f *fuzzIPStore) GetNetwork(context.Context, string) (*models.Network, error) {
+	if f.net == nil {
+		return nil, store.ErrNotFound
+	}
+	return f.net, nil
+}
+
+func (f *fuzzIPStore) ListHosts(context.Context, store.HostFilter) ([]*models.Host, error) {
+	return f.hosts, nil
+}
+
+// FuzzValidateIP drives validateHostIPs with random network CIDR sets and
+// requested addresses (ADR 0009 Tier 1). The safety property is
+// one-directional: whenever validation *accepts*, that acceptance must be
+// sound — every address parses, lands inside one configured CIDR, is not an
+// IPv4 network/broadcast address, is unique within the request, and collides
+// with no existing host. A false accept is an overlay-IP collision or an
+// out-of-range address reaching the data layer. The dual-family case (a
+// network carrying both a v4 and a v6 CIDR) falls out of fuzzing both CIDRs
+// independently. The target must also never panic.
+//
+//	go test ./internal/api/ -run '^$' -fuzz='^FuzzValidateIP$'
+func FuzzValidateIP(f *testing.F) {
+	f.Add("10.0.0.0/24", "fd00::/64", "10.0.0.5", "fd00::5", "10.0.0.9")
+	f.Add("10.0.0.0/30", "", "10.0.0.0", "10.0.0.3", "")          // network + broadcast (reserved)
+	f.Add("192.168.0.0/16", "", "192.168.1.1", "192.168.1.1", "") // duplicate within request
+	f.Add("", "", "", "", "")
+
+	f.Fuzz(func(t *testing.T, cidr1, cidr2, ip1, ip2, existingIP string) {
+		netCIDRs := fuzzNonEmpty(cidr1, cidr2)
+		reqIPs := fuzzNonEmpty(ip1, ip2)
+
+		st := &fuzzIPStore{net: &models.Network{ID: "net1", CIDRs: netCIDRs}}
+		if existingIP != "" {
+			st.hosts = []*models.Host{{ID: "other", Name: "other", NebulaIPs: []string{existingIP}}}
+		}
+
+		// A rejection — or a malformed-CIDR/network error — is always allowed;
+		// only an *acceptance* carries a soundness obligation.
+		if err := validateHostIPs(context.Background(), st, "net1", reqIPs, ""); err != nil {
+			return
+		}
+
+		// Accepted: re-derive the invariant independently. validateHostIPs only
+		// returns nil when every CIDR parsed, so this prefix list matches the
+		// one it used. Note: this re-check deliberately reuses forbiddenIPv4Reserved
+		// and the same Is4() family gate, so it asserts the accept path is
+		// self-consistent — a bug rooted in those shared helpers (e.g. how a
+		// 4-in-6 address is classified) would pass both sides by construction.
+		prefixes := make([]netip.Prefix, 0, len(netCIDRs))
+		for _, c := range netCIDRs {
+			if p, perr := netip.ParsePrefix(c); perr == nil {
+				prefixes = append(prefixes, p)
+			}
+		}
+		seen := make(map[string]bool, len(reqIPs))
+		for _, ip := range reqIPs {
+			addr, perr := netip.ParseAddr(ip)
+			if perr != nil {
+				t.Fatalf("accepted an unparseable IP %q (cidrs=%v)", ip, netCIDRs)
+			}
+			var containing netip.Prefix
+			inRange := false
+			for _, p := range prefixes {
+				if p.Contains(addr) {
+					containing, inRange = p, true
+					break
+				}
+			}
+			if !inRange {
+				t.Fatalf("accepted out-of-range IP %q (cidrs=%v)", ip, netCIDRs)
+			}
+			if addr.Is4() && forbiddenIPv4Reserved(containing, addr) {
+				t.Fatalf("accepted reserved IPv4 %q in %s", ip, containing)
+			}
+			if seen[ip] {
+				t.Fatalf("accepted duplicate IP %q within request", ip)
+			}
+			seen[ip] = true
+			if existingIP != "" && ip == existingIP {
+				t.Fatalf("accepted IP %q already held by another host", ip)
+			}
+		}
+	})
+}
+
+func fuzzNonEmpty(ss ...string) []string {
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/pop/canonical_fuzz_test.go
+++ b/internal/pop/canonical_fuzz_test.go
@@ -1,0 +1,94 @@
+package pop_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	agentpop "github.com/forgekeep/nebula-mesh/internal/agent/pop"
+	apipop "github.com/forgekeep/nebula-mesh/internal/api/pop"
+	"github.com/forgekeep/nebula-mesh/internal/pop"
+)
+
+// FuzzPoPCanonical exercises the proof-of-possession canonical string (ADR
+// 0004 §7.1) — the bytes every signed poll is authenticated over. Two
+// properties matter for auth soundness:
+//
+//  1. Injectivity. CanonicalString joins five fields with "\n" and escapes
+//     nothing, so the encoding is unambiguous *only* while no field contains
+//     the separator. For separator-free inputs, splitting the result on "\n"
+//     must recover the exact five fields — otherwise two distinct
+//     (method, path, host, timestamp, nonce) tuples could share one signed
+//     message, an auth-equivalence the verifier cannot see. The ADR flags the
+//     unescaped join as a latent fragility; this pins the safe envelope and
+//     catches any future change that narrows or breaks it.
+//
+//  2. Sign/verify agreement. A signature the agent produces over the canonical
+//     string must verify on the server; any tamper or wrong key must be
+//     rejected with ErrBadSignature — never a panic, never a false accept.
+//
+// Run the seed corpus with the unit tests; explore with
+//
+//	go test ./internal/pop/ -run '^$' -fuzz='^FuzzPoPCanonical$'
+func FuzzPoPCanonical(f *testing.F) {
+	// One keypair for the whole run: key generation is not under test, and
+	// ed25519 verification is deterministic in the message + key.
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		f.Fatal(err)
+	}
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	// Seeds: a real poll, the all-empty tuple, an embedded-separator field
+	// (exercises the non-injective branch), and an enroll-shaped POST.
+	f.Add("GET", "/api/v1/agent/updates", "mgmt.example:443", "2026-05-27T00:00:00Z", "bm9uY2U=")
+	f.Add("", "", "", "", "")
+	f.Add("GET", "/a\nb", "h", "t", "n")
+	f.Add("POST", "/api/v1/enroll", "h:8080", "2026-05-27T00:00:00Z", "")
+
+	f.Fuzz(func(t *testing.T, method, path, host, timestamp, nonce string) {
+		canonical := pop.CanonicalString(method, path, host, timestamp, nonce)
+
+		// (1) Injectivity holds exactly when no field carries the separator.
+		fields := []string{method, path, host, timestamp, nonce}
+		separatorFree := true
+		for _, fld := range fields {
+			if strings.Contains(fld, "\n") {
+				separatorFree = false
+				break
+			}
+		}
+		if separatorFree {
+			got := strings.Split(canonical, "\n")
+			if len(got) != len(fields) {
+				t.Fatalf("separator-free input split into %d fields, want %d\ncanonical=%q", len(got), len(fields), canonical)
+			}
+			for i := range fields {
+				if got[i] != fields[i] {
+					t.Fatalf("field %d not recovered: got %q want %q\ncanonical=%q", i, got[i], fields[i], canonical)
+				}
+			}
+		}
+
+		// (2) Sign/verify round-trip, plus rejection of wrong key and tamper.
+		sig, err := agentpop.Sign(priv, canonical)
+		if err != nil {
+			t.Fatalf("Sign errored on canonical string: %v", err)
+		}
+		if err := apipop.Verify(pub, canonical, sig); err != nil {
+			t.Fatalf("Verify rejected a freshly signed canonical string: %v\ncanonical=%q", err, canonical)
+		}
+		if err := apipop.Verify(otherPub, canonical, sig); err == nil {
+			t.Fatalf("Verify accepted a signature under the wrong key\ncanonical=%q", canonical)
+		}
+		// Appending any byte changes the signed message, so the same signature
+		// must no longer verify.
+		if err := apipop.Verify(pub, canonical+"x", sig); err == nil {
+			t.Fatalf("Verify accepted a tampered canonical string\ncanonical=%q", canonical)
+		}
+	})
+}

--- a/internal/store/migrations_fuzz_test.go
+++ b/internal/store/migrations_fuzz_test.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/store/migrations"
+)
+
+// applyMigrationsBefore runs every up-migration that sorts before stopAt and
+// records it in schema_migrations, leaving the DB at the schema version right
+// before stopAt. It lets a fuzz target seed rows in the pre-migration shape and
+// then exercise the remaining migrations' transforms on that data.
+func applyMigrationsBefore(tb testing.TB, s *SQLiteStore, stopAt string) {
+	tb.Helper()
+	ctx := context.Background()
+	if _, err := s.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		name        TEXT PRIMARY KEY,
+		applied_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		tb.Fatalf("create schema_migrations: %v", err)
+	}
+	// Sorted *.up.sql reproduces Migrate's hardcoded migrationFiles order, which
+	// holds as long as migrations keep their zero-padded numeric prefix (NNN_).
+	files, err := fs.Glob(migrations.FS, "*.up.sql")
+	if err != nil {
+		tb.Fatalf("glob migrations: %v", err)
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		if f == stopAt {
+			return
+		}
+		b, err := migrations.FS.ReadFile(f)
+		if err != nil {
+			tb.Fatalf("read %s: %v", f, err)
+		}
+		if _, err := s.db.ExecContext(ctx, string(b)); err != nil {
+			tb.Fatalf("apply %s: %v", f, err)
+		}
+		if _, err := s.db.ExecContext(ctx, `INSERT INTO schema_migrations (name) VALUES (?)`, f); err != nil {
+			tb.Fatalf("record %s: %v", f, err)
+		}
+	}
+}
+
+// FuzzMigrations checks the migration chain for totality on schema-plausible
+// legacy data (ADR 0009 Tier 1). It seeds a network and N hosts in the pre-014
+// single-address shape with fuzzed overlay-IP strings, then runs the remaining
+// migrations — exercising 014's nebula_ip -> host_addresses backfill and 018's
+// network-scoped uniqueness index on whatever bytes the fuzzer supplies.
+// Properties:
+//
+//   - totality: Migrate completes without panicking or erroring on data the
+//     pre-014 schema accepted, and never half-applies;
+//
+//   - idempotency: a second Migrate is a clean no-op;
+//
+//   - backfill conservation: every legacy nebula_ip becomes exactly one
+//     host_addresses row — none dropped, none duplicated.
+//
+// Run the seed corpus with the unit tests; explore with
+//
+//	go test ./internal/store/ -run '^$' -fuzz='^FuzzMigrations$'
+func FuzzMigrations(f *testing.F) {
+	f.Add("10.0.0.0/24", []byte("10.0.0.5\n10.0.0.6\nfd00::1"))
+	f.Add("", []byte(""))
+	f.Add("not-a-cidr", []byte("not-an-ip\n\n  \nx"))
+
+	f.Fuzz(func(t *testing.T, cidr string, data []byte) {
+		s, err := NewSQLiteStore(":memory:")
+		if err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer s.Close()
+		ctx := context.Background()
+
+		applyMigrationsBefore(t, s, "014_multi_address.up.sql")
+
+		if _, err := s.db.ExecContext(ctx,
+			`INSERT INTO networks (id, name, cidr) VALUES ('net1', 'n1', ?)`, cidr); err != nil {
+			t.Fatalf("seed network: %v", err)
+		}
+
+		// Distinct, non-empty overlay IPs: the pre-014 UNIQUE(network_id,
+		// nebula_ip) and UNIQUE(network_id, name) constraints require both, so
+		// dedup here rather than letting an insert fail the seed.
+		seen := make(map[string]bool)
+		seeded := 0
+		for _, ip := range strings.Split(string(data), "\n") {
+			if ip == "" || seen[ip] {
+				continue
+			}
+			seen[ip] = true
+			if _, err := s.db.ExecContext(ctx,
+				`INSERT INTO hosts (id, network_id, name, nebula_ip) VALUES (?, 'net1', ?, ?)`,
+				fmt.Sprintf("h%d", seeded), fmt.Sprintf("name%d", seeded), ip); err != nil {
+				t.Fatalf("seed host %q: %v", ip, err)
+			}
+			seeded++
+		}
+
+		if err := s.Migrate(ctx); err != nil {
+			t.Fatalf("Migrate failed on schema-plausible legacy data (cidr=%q, hosts=%d): %v", cidr, seeded, err)
+		}
+		if err := s.Migrate(ctx); err != nil {
+			t.Fatalf("second Migrate was not idempotent: %v", err)
+		}
+
+		var addrCount int
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM host_addresses`).Scan(&addrCount); err != nil {
+			t.Fatalf("count host_addresses: %v", err)
+		}
+		if addrCount != seeded {
+			t.Fatalf("backfill not conserved: host_addresses=%d, seeded legacy IPs=%d", addrCount, seeded)
+		}
+	})
+}

--- a/tests/integration/agent_updates_fuzz_test.go
+++ b/tests/integration/agent_updates_fuzz_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	corepop "github.com/forgekeep/nebula-mesh/internal/pop"
+)
+
+// FuzzAgentUpdatesHeaders fuzzes the four proof-of-possession headers on GET
+// /api/v1/agent/updates with a *real enrolled host's* fingerprint provisioned by
+// the harness (ADR 0009 Tier 1, ADR 0004 §7.1). Pinning a valid fingerprint
+// carries the corpus past the host lookup into the verification core: signature
+// base64-decode, canonical-string assembly, ed25519 verify, RFC3339 timestamp
+// validation, and the nonce-replay cache. No fuzzed signature can match the
+// host's bound key, so the handler must never 5xx (chi's Recoverer surfaces a
+// panic, bar http.ErrAbortHandler, as a 500) and never 2xx (no forged poll
+// authenticates).
+//
+//	go test ./tests/integration/ -run '^$' -fuzz='^FuzzAgentUpdatesHeaders$'
+func FuzzAgentUpdatesHeaders(f *testing.F) {
+	ts, _, _ := setupE2E(f)
+	_, fingerprint := enrollHostForFuzz(f, ts)
+
+	// Seeds pin the real fingerprint so the corpus reaches signature verification;
+	// none carries a valid signature, so none authenticates.
+	f.Add(fingerprint, "2026-05-27T00:00:00Z", "bm9uY2U=", "c2ln")
+	f.Add(fingerprint, "not-a-time", "n", "!!!notbase64")
+	f.Add("deadbeefdeadbeef", "2026-05-27T00:00:00Z", "bm9uY2U=", "AAAA")
+	f.Add("", "", "", "")
+
+	f.Fuzz(func(t *testing.T, fpHdr, timestamp, nonce, signature string) {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/updates", nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		req.Header.Set(corepop.HeaderFingerprint, fpHdr)
+		req.Header.Set(corepop.HeaderTimestamp, timestamp)
+		req.Header.Set(corepop.HeaderNonce, nonce)
+		req.Header.Set(corepop.HeaderSignature, signature)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return // client refused an invalid header value, or transport error
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode/100 == 5 {
+			t.Fatalf("agent/updates returned %d on fuzzed PoP headers (server fault)", resp.StatusCode)
+		}
+		if resp.StatusCode/100 == 2 {
+			t.Fatalf("agent/updates returned %d — a fuzzed signature authenticated", resp.StatusCode)
+		}
+	})
+}

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -32,11 +32,11 @@ import (
 
 // signingKeypair returns a fresh Ed25519 keypair and its PEM-encoded public
 // key — the same shape an agent would send to /api/v1/enroll under ADR 0004.
-func signingKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey, string) {
-	t.Helper()
+func signingKeypair(tb testing.TB) (ed25519.PublicKey, ed25519.PrivateKey, string) {
+	tb.Helper()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "NEBULA ED25519 PUBLIC KEY", Bytes: pub})
 	return pub, priv, string(pemBytes)
@@ -75,17 +75,20 @@ func signedGetUpdates(t *testing.T, ts *httptest.Server, fingerprint string, sig
 
 const testAPIKey = "e2e-test-api-key"
 
-func setupE2E(t *testing.T) (*httptest.Server, *store.SQLiteStore, *models.CA) {
-	t.Helper()
+// setupE2E takes a testing.TB (not *testing.T) so both ordinary tests and the
+// signed-poll / enroll fuzz targets can stand the server up once. It uses only
+// TB-available methods (Helper/Fatal/Cleanup) — no t.Run/Parallel.
+func setupE2E(tb testing.TB) (*httptest.Server, *store.SQLiteStore, *models.CA) {
+	tb.Helper()
 
 	s, err := store.NewSQLiteStore(":memory:")
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	if err := s.Migrate(context.Background()); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
-	t.Cleanup(func() { s.Close() })
+	tb.Cleanup(func() { s.Close() })
 
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -94,7 +97,7 @@ func setupE2E(t *testing.T) (*httptest.Server, *store.SQLiteStore, *models.CA) {
 	// Setup CA for test: create master + resolver + default CA
 	master, err := keystore.NewMaster(bytes.Repeat([]byte{0x77}, keystore.MasterKeySize))
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	srv.WithMaster(master)
 	srv.WithCAResolver(pki.NewCAResolver(s, master))
@@ -111,7 +114,7 @@ func setupE2E(t *testing.T) (*httptest.Server, *store.SQLiteStore, *models.CA) {
 		UpdatedAt:    time.Now(),
 	}
 	if err := s.CreateOperator(ctx, op); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	// Seed testAPIKey as an operator API key so e2e requests authenticate via
@@ -123,7 +126,7 @@ func setupE2E(t *testing.T) (*httptest.Server, *store.SQLiteStore, *models.CA) {
 		Name:       "e2e-admin-key",
 		KeyHash:    hex.EncodeToString(keySum[:]),
 	}); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	ca, _, err := pki.MintAndStoreCA(ctx, s, master, logger, pki.MintRequest{
@@ -132,19 +135,19 @@ func setupE2E(t *testing.T) (*httptest.Server, *store.SQLiteStore, *models.CA) {
 		Duration: 365 * 24 * time.Hour,
 	})
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	srv.WithDefaultCAID(ca.ID)
 
 	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
+	tb.Cleanup(ts.Close)
 
 	// Return stored CA (not the manager)
 	return ts, s, ca
 }
 
-func apiCall(t *testing.T, ts *httptest.Server, method, path string, body any) *http.Response {
-	t.Helper()
+func apiCall(tb testing.TB, ts *httptest.Server, method, path string, body any) *http.Response {
+	tb.Helper()
 	var bodyReader io.Reader
 	if body != nil {
 		data, _ := json.Marshal(body)
@@ -155,9 +158,40 @@ func apiCall(t *testing.T, ts *httptest.Server, method, path string, body any) *
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	return resp
+}
+
+// provisionNetwork creates a network and returns its ID, used by the
+// signed-poll fuzz target's host provisioning.
+func provisionNetwork(tb testing.TB, ts *httptest.Server) string {
+	tb.Helper()
+	resp := apiCall(tb, ts, "POST", "/api/v1/networks", map[string]any{
+		"name":  "fuzz-net",
+		"cidrs": []string{"192.168.100.0/24"},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		tb.Fatalf("create network: HTTP %d: %s", resp.StatusCode, b)
+	}
+	var network models.Network
+	if err := json.NewDecoder(resp.Body).Decode(&network); err != nil {
+		tb.Fatalf("decode network: %v", err)
+	}
+	resp.Body.Close()
+	return network.ID
+}
+
+// enrollHostForFuzz provisions a network, fully enrolls a host, and returns its
+// Ed25519 signing key and cert fingerprint — the identity an agent poll
+// authenticates as. A thin testing.TB adapter over enrollHost so a fuzz harness
+// can reach the PoP verify path.
+func enrollHostForFuzz(tb testing.TB, ts *httptest.Server) (ed25519.PrivateKey, string) {
+	tb.Helper()
+	netID := provisionNetwork(tb, ts)
+	_, fp, _, signingPriv := enrollHost(tb, ts, netID, "fuzz-host", "192.168.100.10", nil)
+	return signingPriv, fp
 }
 
 func TestE2E_FullCycle(t *testing.T) {
@@ -457,8 +491,8 @@ func TestAgentUpdates_CertSaveFailure(t *testing.T) {
 // below: it creates a host, runs the full enrollment handshake, and returns
 // the host record, its cert fingerprint, its rendered config, and the
 // Ed25519 signing private key needed to issue signed polls afterwards.
-func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP string, extra map[string]any) (host *models.Host, fingerprint, renderedConfig string, signingKey ed25519.PrivateKey) {
-	t.Helper()
+func enrollHost(tb testing.TB, ts *httptest.Server, networkID, name, nebulaIP string, extra map[string]any) (host *models.Host, fingerprint, renderedConfig string, signingKey ed25519.PrivateKey) {
+	tb.Helper()
 	payload := map[string]any{
 		"network_id": networkID,
 		"name":       name,
@@ -467,30 +501,30 @@ func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP str
 	for k, v := range extra {
 		payload[k] = v
 	}
-	resp := apiCall(t, ts, "POST", "/api/v1/hosts", payload)
+	resp := apiCall(tb, ts, "POST", "/api/v1/hosts", payload)
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create host %s: HTTP %d: %s", name, resp.StatusCode, string(body))
+		tb.Fatalf("create host %s: HTTP %d: %s", name, resp.StatusCode, string(body))
 	}
 	var created struct {
 		Host            *models.Host `json:"host"`
 		EnrollmentToken string       `json:"enrollment_token"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
-		t.Fatalf("decode created %s: %v", name, err)
+		tb.Fatalf("decode created %s: %v", name, err)
 	}
 	resp.Body.Close()
 
 	privKey := make([]byte, 32)
 	if _, err := rand.Read(privKey); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	pubKey, err := curve25519.X25519(privKey, curve25519.Basepoint)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pubKey)
-	_, signingPriv, signingPubPEM := signingKeypair(t)
+	_, signingPriv, signingPubPEM := signingKeypair(tb)
 
 	enrollData, _ := json.Marshal(map[string]string{
 		"token":                  created.EnrollmentToken,
@@ -499,12 +533,12 @@ func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP str
 	})
 	enrollResp, err := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(enrollData))
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	defer enrollResp.Body.Close()
 	if enrollResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(enrollResp.Body)
-		t.Fatalf("enroll %s: HTTP %d: %s", name, enrollResp.StatusCode, string(body))
+		tb.Fatalf("enroll %s: HTTP %d: %s", name, enrollResp.StatusCode, string(body))
 	}
 
 	var enrolled struct {
@@ -512,15 +546,15 @@ func enrollHost(t *testing.T, ts *httptest.Server, networkID, name, nebulaIP str
 		ConfigYAML     string `json:"config_yaml"`
 	}
 	if err := json.NewDecoder(enrollResp.Body).Decode(&enrolled); err != nil {
-		t.Fatalf("decode enroll %s: %v", name, err)
+		tb.Fatalf("decode enroll %s: %v", name, err)
 	}
 	hostCert, _, err := cert.UnmarshalCertificateFromPEM([]byte(enrolled.CertificatePEM))
 	if err != nil {
-		t.Fatalf("parse cert %s: %v", name, err)
+		tb.Fatalf("parse cert %s: %v", name, err)
 	}
 	fp, err := hostCert.Fingerprint()
 	if err != nil {
-		t.Fatalf("fingerprint %s: %v", name, err)
+		tb.Fatalf("fingerprint %s: %v", name, err)
 	}
 
 	return created.Host, fp, enrolled.ConfigYAML, signingPriv

--- a/tests/integration/enroll_fuzz_test.go
+++ b/tests/integration/enroll_fuzz_test.go
@@ -35,17 +35,9 @@ func FuzzEnrollPayload(f *testing.F) {
 
 	// A well-formed seed (valid signing PEM, non-empty token+pubkey) so the
 	// corpus clears the early guards and reaches enrollment-token lookup, which
-	// 401s — no token is minted.
-	if _, signingPub, err := ed25519.GenerateKey(rand.Reader); err == nil {
-		signingPEM := pem.EncodeToMemory(&pem.Block{Type: "NEBULA ED25519 PUBLIC KEY", Bytes: signingPub})
-		if seed, mErr := json.Marshal(map[string]string{
-			"token":                  "bogus-but-well-formed",
-			"public_key_pem":         "non-empty",
-			"signing_public_key_pem": string(signingPEM),
-		}); mErr == nil {
-			f.Add(seed)
-		}
-	}
+	// 401s — no token is minted. TestEnrollWellFormedSeedReaches401 pins that
+	// depth, since the never-5xx/never-2xx assertion below cannot.
+	f.Add(wellFormedEnrollSeed(f))
 
 	f.Fuzz(func(t *testing.T, body []byte) {
 		resp, err := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(body))
@@ -62,4 +54,57 @@ func FuzzEnrollPayload(f *testing.F) {
 			t.Fatalf("enroll returned %d — a certificate completed without a valid token; body=%q", resp.StatusCode, body)
 		}
 	})
+}
+
+// wellFormedEnrollSeed builds an enroll payload that clears all three early 400
+// guards in handleEnroll — JSON decode, the non-empty token+public_key_pem
+// check, and the Ed25519 signing-PEM decoder (which requires exactly
+// ed25519.PublicKeySize bytes) — with a deliberately bogus token, so the request
+// then 401s at enrollment-token lookup. It is shared by the FuzzEnrollPayload
+// seed corpus and TestEnrollWellFormedSeedReaches401 so the two cannot drift.
+//
+// The signing key must be the public half. ed25519.GenerateKey returns
+// (PublicKey, PrivateKey, error) — public first; binding the private half (64
+// bytes) instead fails the 32-byte signing-PEM guard and the request stops at a
+// 400, which still satisfies the fuzz never-5xx/never-2xx assertion. That silent
+// degradation is exactly what TestEnrollWellFormedSeedReaches401 guards against.
+func wellFormedEnrollSeed(tb testing.TB) []byte {
+	tb.Helper()
+	signingPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		tb.Fatalf("generate signing key: %v", err)
+	}
+	signingPEM := pem.EncodeToMemory(&pem.Block{Type: "NEBULA ED25519 PUBLIC KEY", Bytes: signingPub})
+	seed, err := json.Marshal(map[string]string{
+		"token":                  "bogus-but-well-formed",
+		"public_key_pem":         "non-empty",
+		"signing_public_key_pem": string(signingPEM),
+	})
+	if err != nil {
+		tb.Fatalf("marshal enroll seed: %v", err)
+	}
+	return seed
+}
+
+// TestEnrollWellFormedSeedReaches401 pins the depth the FuzzEnrollPayload
+// well-formed seed depends on: the payload must clear the early 400 guards and
+// reach enrollment-token lookup, which 401s on the bogus token. The fuzz
+// assertion alone cannot see this — 400 and 401 both satisfy never-5xx/never-2xx
+// — so a seed that silently stops at a 400 guard would still pass the fuzz. This
+// test fails loudly instead.
+func TestEnrollWellFormedSeedReaches401(t *testing.T) {
+	ts, _, _ := setupE2E(t)
+
+	resp, err := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(wellFormedEnrollSeed(t)))
+	if err != nil {
+		t.Fatalf("POST enroll: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("well-formed enroll seed: got %d, want 401 — the seed must clear the early 400 guards "+
+			"(JSON, non-empty, 32-byte signing PEM) and reach enrollment-token lookup; a 400 means it "+
+			"silently degraded to a generic malformed input", resp.StatusCode)
+	}
 }

--- a/tests/integration/enroll_fuzz_test.go
+++ b/tests/integration/enroll_fuzz_test.go
@@ -1,0 +1,65 @@
+package integration
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// FuzzEnrollPayload feeds arbitrary bytes to the public POST /api/v1/enroll
+// handler (ADR 0009 Tier 1). The harness mints no token, so no input can
+// complete an enrollment. This is an honest robustness guard, not a deep target:
+// the body-handling is thin glue (JSON decode, non-empty guards, the Ed25519
+// signing-PEM decoder), while the cert-signing and config-render work sits
+// behind the single-use-token gate and operates on stored host state — not
+// reachable from the body. Every garbage body must draw a client error: never a
+// 5xx (chi's Recoverer surfaces a panic, bar http.ErrAbortHandler, as a 500) and
+// never a 2xx (no certificate without a valid token). The PoP verify core is
+// fuzzed by FuzzAgentUpdatesHeaders; host-creation validation is tracked as a
+// follow-up fuzz target.
+//
+//	go test ./tests/integration/ -run '^$' -fuzz='^FuzzEnrollPayload$'
+func FuzzEnrollPayload(f *testing.F) {
+	ts, _, _ := setupE2E(f)
+
+	f.Add([]byte(`{"token":"t","public_key_pem":"-----BEGIN NEBULA X25519 PUBLIC KEY-----\nAA==\n-----END NEBULA X25519 PUBLIC KEY-----","signing_public_key_pem":"x"}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"token":"","public_key_pem":""}`))
+	f.Add([]byte(`not json`))
+	f.Add([]byte(``))
+
+	// A well-formed seed (valid signing PEM, non-empty token+pubkey) so the
+	// corpus clears the early guards and reaches enrollment-token lookup, which
+	// 401s — no token is minted.
+	if _, signingPub, err := ed25519.GenerateKey(rand.Reader); err == nil {
+		signingPEM := pem.EncodeToMemory(&pem.Block{Type: "NEBULA ED25519 PUBLIC KEY", Bytes: signingPub})
+		if seed, mErr := json.Marshal(map[string]string{
+			"token":                  "bogus-but-well-formed",
+			"public_key_pem":         "non-empty",
+			"signing_public_key_pem": string(signingPEM),
+		}); mErr == nil {
+			f.Add(seed)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, body []byte) {
+		resp, err := http.Post(ts.URL+"/api/v1/enroll", "application/json", bytes.NewReader(body))
+		if err != nil {
+			return // transport/client-side rejection — not a server fault
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode/100 == 5 {
+			t.Fatalf("enroll returned %d on fuzzed body (server fault); body=%q", resp.StatusCode, body)
+		}
+		if resp.StatusCode/100 == 2 {
+			t.Fatalf("enroll returned %d — a certificate completed without a valid token; body=%q", resp.StatusCode, body)
+		}
+	})
+}


### PR DESCRIPTION
## What

Five native-Go fuzz targets (ADR 0009 Tier 1), seeded from the existing table tests. **Test-only — no production code changes.**

| Target | Package | Property |
|--------|---------|----------|
| `FuzzPoPCanonical` | `internal/pop` | canonical-string injectivity (separator-free inputs) + agent-`Sign`/server-`Verify` agreement, incl. wrong-key and tamper rejection (ADR 0004 §7.1) |
| `FuzzValidateIP` | `internal/api` | `validateHostIPs` accept ⟹ sound: each IP parses, is in a configured CIDR, is not an IPv4 network/broadcast address, unique, and free of any existing-host collision |
| `FuzzMigrations` | `internal/store` | migration-chain totality (no panic / no half-apply) + idempotency + 014 `nebula_ip`→`host_addresses` backfill conservation, on schema-plausible legacy data |
| `FuzzEnrollPayload` | `tests/integration` | `POST /api/v1/enroll` answers every arbitrary body with a client error — never 5xx, never 2xx |
| `FuzzAgentUpdatesHeaders` | `tests/integration` | signed-poll PoP verify core (signature decode, canonical assembly, ed25519 verify, RFC3339 timestamp, nonce-replay cache) — never 5xx, never 2xx |

Each target's seed corpus runs as an ordinary test in the existing `-race` lane; the generative pass runs on the scheduled slow lane added in #171.

## Notes

- The two integration targets stand the real `httptest` server up once. To allow that, I widened the shared test helpers (`setupE2E`, `apiCall`, `signingKeypair`, `enrollHost`) from `*testing.T` to `testing.TB` — backward-compatible, since `*testing.T` satisfies it — and added a small `provisionNetwork` plus an `enrollHostForFuzz` adapter over the existing `enrollHost`.
- Building these surfaced two minor robustness gaps that I'll send as focused follow-up PRs, each paired with the fuzz target that proves it: (1) creating a host with a duplicate name returns 500 instead of 409, and (2) `validateHostIPs` doesn't apply the IPv4 network/broadcast reservation to the IPv4-mapped IPv6 (`::ffff:…`) form of an address.
- Validated locally: `go test -race ./...` green, `golangci-lint` clean, each target explored with a short `-fuzztime` (no crashers).