### PR TITLE
ci: cap the scheduled fuzz job with timeout-minutes (follow-up to #171)

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -39,6 +39,10 @@ jobs:
   fuzz:
     name: generative fuzz (${{ matrix.target }})
     runs-on: ubuntu-latest
+    # Safety ceiling: workflow_dispatch accepts an arbitrary fuzztime, so cap the
+    # job well below GitHub's 6h default — a typo'd or oversized fuzztime can't
+    # pin a runner. Comfortably above the nightly 10m/target plus setup.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Follow-up to your optional, non-blocking suggestion on #171: cap the scheduled fuzz job with `timeout-minutes: 30`. `workflow_dispatch` accepts an arbitrary `fuzztime`, so the only ceiling today is GitHub's 6h job default — a typo'd or oversized dispatch could pin a runner. 30m sits comfortably above the nightly 10m/target + setup while bounding a runaway. `actionlint` clean.