### PR TITLE
chore(gosec): drop orphan #nosec G120 on the CSRF ParseForm

### DIFF
--- a/internal/web/csrf.go
+++ b/internal/web/csrf.go
@@ -80,10 +80,6 @@ func (w *Web) csrfMiddleware(next http.Handler) http.Handler {
 
 		// If not in header, try form field
 		if bodyToken == "" {
-			// #nosec G120 -- form parsing for CSRF token read; body size capped
-			// by http.Server.MaxHeaderBytes/ReadLimit at the server level
-			// (consistent with the rest of handlers.go which also calls
-			// ParseForm without explicit MaxBytesReader).
 			err := r.ParseForm()
 			if err != nil {
 				http.Error(rw, "Bad Request", http.StatusBadRequest)


### PR DESCRIPTION
The `#nosec G120` on the CSRF middleware's `ParseForm` had a factually wrong justification — it claimed the body was *"capped by http.Server.MaxHeaderBytes/ReadLimit,"* but those cap headers, not bodies, and there's no `ReadLimit` field.

Rather than rewrite it, I dropped the directive: it's an orphan. `golangci-lint`'s gosec (the CI gate, via `golangci-lint-action`) and standalone `gosec` both report **zero G120** at this site — with or without the `#nosec` — so it suppresses nothing. Matches the earlier orphan cleanup in `47fa414`.

For the record, this was never an unbounded exposure: urlencoded `ParseForm` is bounded by the stdlib `maxFormSize` cap (10 MB) when `r.Body` isn't a `MaxBytesReader` (verified — 11 MB → `http: POST too large`), and every `/ui` POST is rate-limited. A tighter explicit cap would be defense-in-depth, not a fix.

Comment-only, no behavior change. `golangci-lint run ./internal/web/` and `go vet` are green.