### PR TITLE
fix(store): actionable migration-018 startup error on overlay-IP conflicts

### DIFF
--- a/internal/store/migration_018_test.go
+++ b/internal/store/migration_018_test.go
@@ -1,8 +1,12 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
+	"log/slog"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -139,5 +143,360 @@ func TestMigration018_FailsLoudOnDuplicateOverlayIP(t *testing.T) {
 	}
 	if !strings.Contains(strings.ToLower(err.Error()), "unique") {
 		t.Errorf("018 failure = %v, want a UNIQUE constraint error", err)
+	}
+}
+
+// openSeeded017 returns a single-connection in-memory DB with migrations 001–017
+// applied. Foreign keys are off (sql.Open default), so tests can seed orphan
+// host_addresses rows directly; MaxOpenConns(1) keeps the per-connection
+// ":memory:" database stable across the guard's multiple queries.
+func openSeeded017(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	applyMigrationFiles(t, db, migrations017)
+	// Migration 014 ends with PRAGMA foreign_keys=ON; turn it back off so tests
+	// can seed orphan host_addresses rows (the realistic FK-on path is covered by
+	// the Migrate-level tests, which reopen via NewSQLiteStore).
+	mustExec(t, db, `PRAGMA foreign_keys = OFF`)
+	return db
+}
+
+// seedTempDBThrough017 creates a temp-file SQLite database, applies migrations
+// 001–017 with foreign keys off (so orphan rows can be seeded), runs seed, then
+// closes it. Returns the path for NewSQLiteStore to reopen.
+func seedTempDBThrough017(t *testing.T, seed func(*sql.DB)) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "store.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	applyMigrationFiles(t, db, migrations017)
+	// Disable FK so seed can insert orphan rows; NewSQLiteStore reopens with
+	// foreign_keys=ON, exercising the realistic path.
+	mustExec(t, db, `PRAGMA foreign_keys = OFF`)
+	seed(db)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seed db: %v", err)
+	}
+	return path
+}
+
+func countHostAddresses(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM host_addresses`).Scan(&n); err != nil {
+		t.Fatalf("count host_addresses: %v", err)
+	}
+	return n
+}
+
+func countHostAddressesFor(t *testing.T, db *sql.DB, hostID string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM host_addresses WHERE host_id = ?`, hostID).Scan(&n); err != nil {
+		t.Fatalf("count host_addresses for %s: %v", hostID, err)
+	}
+	return n
+}
+
+func hostAddressList(t *testing.T, db *sql.DB, hostID string) []string {
+	t.Helper()
+	rows, err := db.Query(`SELECT address FROM host_addresses WHERE host_id = ? ORDER BY position`, hostID)
+	if err != nil {
+		t.Fatalf("list host_addresses for %s: %v", hostID, err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var a string
+		if err := rows.Scan(&a); err != nil {
+			t.Fatalf("scan address: %v", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate addresses: %v", err)
+	}
+	return out
+}
+
+// TestCheckOverlayIPConflicts_CrossHostFailsLoud pins the irreducible case: two
+// distinct hosts sharing one overlay IP. The guard fails loud with a message
+// naming both hosts and the IP, frames it as a security defect, is precise that
+// removing the row does not revoke the certificate, and mutates nothing.
+func TestCheckOverlayIPConflicts_CrossHostFailsLoud(t *testing.T) {
+	db := openSeeded017(t)
+	defer db.Close()
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "web-1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h2", "net1", "web-2")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h2", 0, "10.0.0.5")
+
+	err := checkOverlayIPConflicts(context.Background(), db)
+	if err == nil {
+		t.Fatal("cross-host duplicate must fail loud, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"10.0.0.5", "web-1", "web-2", "security", "does NOT revoke", "before upgrading"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q\n--- message ---\n%s", want, msg)
+		}
+	}
+	if n := countHostAddresses(t, db); n != 2 {
+		t.Errorf("cross-host fail path mutated host_addresses: got %d rows, want 2", n)
+	}
+}
+
+// TestCheckOverlayIPConflicts_SameHostDupAutoCollapses verifies one host bound to
+// the same IP twice is collapsed to a single row (no winner to choose, same
+// certificate), so the guard returns nil and 018 then applies.
+func TestCheckOverlayIPConflicts_SameHostDupAutoCollapses(t *testing.T) {
+	db := openSeeded017(t)
+	defer db.Close()
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "web-1")
+	// h1 holds 10.0.0.5 twice (a redundant binding to collapse) and 10.0.0.8 once
+	// (a legitimately distinct second address that must be preserved — guards
+	// against a regression that keyed the DELETE on host_id alone).
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 1, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 2, "10.0.0.8")
+
+	if err := checkOverlayIPConflicts(context.Background(), db); err != nil {
+		t.Fatalf("same-host duplicate should auto-collapse, got error: %v", err)
+	}
+	addrs := hostAddressList(t, db, "h1")
+	got := map[string]int{}
+	for _, a := range addrs {
+		got[a]++
+	}
+	if len(addrs) != 2 || got["10.0.0.5"] != 1 || got["10.0.0.8"] != 1 {
+		t.Errorf("collapse should leave exactly one 10.0.0.5 and preserve 10.0.0.8, got %v", addrs)
+	}
+	if err := execMigrationFile(db, "018_host_address_network_uniqueness.up.sql"); err != nil {
+		t.Fatalf("018 should apply cleanly after collapse: %v", err)
+	}
+}
+
+// TestCheckOverlayIPConflicts_CrossHostFailDoesNotCleanup pins the invariant that
+// the cross-host fail path mutates nothing — even when orphan and same-host
+// duplicate rows (which would otherwise be auto-repaired) are also present. A
+// regression that ran cleanup before the fail-loud check would delete rows from
+// a database meant to be left untouched, and would pass every other test.
+func TestCheckOverlayIPConflicts_CrossHostFailDoesNotCleanup(t *testing.T) {
+	db := openSeeded017(t)
+	defer db.Close()
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "web-1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h2", "net1", "web-2")
+	// Cross-host conflict (must fail loud).
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h2", 0, "10.0.0.5")
+	// Cleanable rows that must NOT be touched on the fail path.
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 1, "10.0.0.7")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 2, "10.0.0.7")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "ghost", 0, "10.0.0.9")
+
+	before := countHostAddresses(t, db)
+	if err := checkOverlayIPConflicts(context.Background(), db); err == nil {
+		t.Fatal("cross-host conflict must fail loud")
+	}
+	if after := countHostAddresses(t, db); after != before {
+		t.Errorf("fail path mutated host_addresses: before=%d after=%d (cleanup must not run when failing loud)", before, after)
+	}
+}
+
+// TestCrossHostOverlayConflicts_GroupingAndDedup exercises the grouping logic:
+// multiple distinct conflicts produce one group each in deterministic order, and
+// a host appearing twice within a group (via a same-host duplicate) is listed
+// once.
+func TestCrossHostOverlayConflicts_GroupingAndDedup(t *testing.T) {
+	db := openSeeded017(t)
+	defer db.Close()
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	for _, h := range []struct{ id, name string }{{"h1", "web-1"}, {"h2", "web-2"}, {"h3", "web-3"}} {
+		mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, h.id, "net1", h.name)
+	}
+	// Group A (10.0.0.5): h1 (listed twice) + h2 → h1 must dedup to one entry.
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 1, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h2", 0, "10.0.0.5")
+	// Group B (10.0.0.6): h2 + h3.
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h2", 1, "10.0.0.6")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h3", 0, "10.0.0.6")
+
+	conflicts, err := crossHostOverlayConflicts(context.Background(), db)
+	if err != nil {
+		t.Fatalf("crossHostOverlayConflicts: %v", err)
+	}
+	if len(conflicts) != 2 {
+		t.Fatalf("want 2 conflict groups, got %d: %+v", len(conflicts), conflicts)
+	}
+	if conflicts[0].address != "10.0.0.5" || conflicts[1].address != "10.0.0.6" {
+		t.Errorf("groups out of order: %q then %q", conflicts[0].address, conflicts[1].address)
+	}
+	if len(conflicts[0].hosts) != 2 {
+		t.Errorf("group 10.0.0.5 should list 2 distinct hosts (h1 deduped), got %v", conflicts[0].hosts)
+	}
+}
+
+// TestFormatCrossHostConflicts_Caps exercises the truncation guards on both the
+// group list and the per-group host list (a slice-bound or off-by-one here would
+// otherwise only surface on a pathological database during a failed upgrade).
+func TestFormatCrossHostConflicts_Caps(t *testing.T) {
+	var groups []overlayConflict
+	for i := 0; i < maxConflictsListed+3; i++ {
+		groups = append(groups, overlayConflict{
+			network: "net1", address: fmt.Sprintf("10.0.0.%d", i), hosts: []string{"a (h-a)", "b (h-b)"},
+		})
+	}
+	if msg := formatCrossHostConflicts(groups); !strings.Contains(msg, "… and 3 more") {
+		t.Errorf("group cap not applied:\n%s", msg)
+	}
+
+	var hosts []string
+	for i := 0; i < maxConflictsListed+5; i++ {
+		hosts = append(hosts, fmt.Sprintf("host-%d (h%d)", i, i))
+	}
+	if msg := formatCrossHostConflicts([]overlayConflict{{network: "net1", address: "10.0.0.1", hosts: hosts}}); !strings.Contains(msg, "… and 5 more") {
+		t.Errorf("per-group host cap not applied:\n%s", msg)
+	}
+}
+
+// TestCheckOverlayIPConflicts_CleanupLogsAudit verifies the auto-repair emits the
+// slog.Warn audit lines — the only operator-visible record that startup silently
+// mutated host_addresses.
+func TestCheckOverlayIPConflicts_CleanupLogsAudit(t *testing.T) {
+	db := openSeeded017(t)
+	defer db.Close()
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "web-1")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 1, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "ghost", 0, "10.0.0.9")
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	if err := checkOverlayIPConflicts(context.Background(), db); err != nil {
+		t.Fatalf("auto-repair should succeed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "removed orphaned host_addresses") {
+		t.Errorf("missing orphan cleanup audit log:\n%s", out)
+	}
+	if !strings.Contains(out, "collapsed duplicate same-host") {
+		t.Errorf("missing same-host cleanup audit log:\n%s", out)
+	}
+}
+
+// TestCheckOverlayIPConflicts_OrphanAutoRemoves verifies a host_addresses row
+// whose host no longer exists (reachable only with foreign keys off) is removed
+// as dangling junk; the guard returns nil.
+func TestCheckOverlayIPConflicts_OrphanAutoRemoves(t *testing.T) {
+	db := openSeeded017(t)
+	defer db.Close()
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "web-1")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "ghost", 0, "10.0.0.9")
+
+	if err := checkOverlayIPConflicts(context.Background(), db); err != nil {
+		t.Fatalf("orphan row should auto-remove, got error: %v", err)
+	}
+	if n := countHostAddressesFor(t, db, "ghost"); n != 0 {
+		t.Errorf("orphan row not removed: %d remain", n)
+	}
+	if total := countHostAddresses(t, db); total != 1 {
+		t.Errorf("expected 1 surviving row, got %d", total)
+	}
+}
+
+// TestCheckOverlayIPConflicts_NoneIsNoop verifies distinct IPs with no orphans
+// return nil and leave the table untouched.
+func TestCheckOverlayIPConflicts_NoneIsNoop(t *testing.T) {
+	db := openSeeded017(t)
+	defer db.Close()
+	mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "web-1")
+	mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h2", "net1", "web-2")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+	mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h2", 0, "10.0.0.6")
+
+	if err := checkOverlayIPConflicts(context.Background(), db); err != nil {
+		t.Fatalf("no conflicts should return nil, got: %v", err)
+	}
+	if n := countHostAddresses(t, db); n != 2 {
+		t.Errorf("no-op case mutated rows: got %d, want 2", n)
+	}
+}
+
+// TestMigrate_CrossHostConflictFailsLoudUntouched drives a real Migrate over a DB
+// with a cross-host duplicate: it must fail before 018 runs, so network_id is
+// never added and the conflicting rows are left intact for the operator.
+func TestMigrate_CrossHostConflictFailsLoudUntouched(t *testing.T) {
+	path := seedTempDBThrough017(t, func(db *sql.DB) {
+		mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+		mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "web-1")
+		mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h2", "net1", "web-2")
+		mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+		mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h2", 0, "10.0.0.5")
+	})
+
+	st, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	if err := st.Migrate(context.Background()); err == nil {
+		t.Fatal("Migrate must fail loud on a cross-host overlay-IP conflict")
+	}
+	if columnExistsInDB(t, st.db, "host_addresses", "network_id") {
+		t.Error("018 must not run on the fail path (network_id was added)")
+	}
+	if n := countHostAddresses(t, st.db); n != 2 {
+		t.Errorf("fail path mutated host_addresses: got %d rows, want 2", n)
+	}
+}
+
+// TestMigrate_AutoResolvesOrphanAndSameHost drives a real Migrate over a DB with
+// an orphan row and a same-host duplicate (no cross-host conflict): the guard
+// repairs both and 018 applies cleanly.
+func TestMigrate_AutoResolvesOrphanAndSameHost(t *testing.T) {
+	path := seedTempDBThrough017(t, func(db *sql.DB) {
+		mustExec(t, db, `INSERT INTO networks (id, name) VALUES (?, ?)`, "net1", "n1")
+		mustExec(t, db, `INSERT INTO hosts (id, network_id, name) VALUES (?, ?, ?)`, "h1", "net1", "web-1")
+		mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 0, "10.0.0.5")
+		mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "h1", 1, "10.0.0.5")
+		mustExec(t, db, `INSERT INTO host_addresses (host_id, position, address) VALUES (?, ?, ?)`, "ghost", 0, "10.0.0.9")
+	})
+
+	st, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	if err := st.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate should auto-resolve and succeed, got: %v", err)
+	}
+	if !columnExistsInDB(t, st.db, "host_addresses", "network_id") {
+		t.Error("018 should have applied (network_id missing)")
+	}
+	if n := countHostAddressesFor(t, st.db, "ghost"); n != 0 {
+		t.Errorf("orphan not removed: %d rows for ghost", n)
+	}
+	if n := countHostAddressesFor(t, st.db, "h1"); n != 1 {
+		t.Errorf("same-host dup not collapsed: %d rows for h1, want 1", n)
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -137,6 +137,17 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		if applied {
 			continue
 		}
+		// Migration 018 enforces UNIQUE(network_id, address). Before applying it,
+		// resolve the data conditions that would otherwise make it fail with a raw
+		// SQLite error: a cross-host duplicate (a security defect with no safe
+		// automatic winner) fails loud with an actionable message and no schema
+		// change, while orphan and same-host-duplicate rows are repaired
+		// automatically (and logged). See checkOverlayIPConflicts.
+		if f == "018_host_address_network_uniqueness.up.sql" {
+			if err := checkOverlayIPConflicts(ctx, s.db); err != nil {
+				return err
+			}
+		}
 		sqlBytes, err := migrations.FS.ReadFile(f)
 		if err != nil {
 			return fmt.Errorf("read migration %s: %w", f, err)
@@ -201,6 +212,240 @@ func (s *SQLiteStore) repairBlocklistCAID(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// maxConflictsListed caps how many cross-host conflict groups (and hosts per
+// group) the fail-loud message enumerates, and how many auto-repaired rows the
+// cleanup logs sample, so a pathological database can't produce a multi-megabyte
+// startup error or log line.
+const maxConflictsListed = 20
+
+// overlayConflict is one (network, address) claimed by two or more distinct
+// hosts — a security defect with no safe automatic winner.
+type overlayConflict struct {
+	network, address string
+	hosts            []string // "name (id)", distinct, first-seen order
+}
+
+// checkOverlayIPConflicts runs before migration 018 applies its
+// UNIQUE(network_id, address) index over host_addresses. 018 has two reachable
+// failure modes on a valid schema: the backfill UPDATE hits a NOT NULL violation
+// on an orphan host_addresses row (whose host no longer exists), and CREATE
+// UNIQUE INDEX fails on a duplicate (network_id, address). The duplicate case
+// splits in two:
+//
+//   - Cross-host (two or more distinct hosts share one overlay IP): a security
+//     defect — a CA has issued certificates that let one host receive another's
+//     traffic. There is no data-derivable answer to which host should keep the
+//     address, so this fails loud with an actionable message and the database is
+//     left untouched for an operator to resolve.
+//   - Same-host (one host bound to the same address at two positions) and orphan
+//     rows: redundant/dangling data with no policy decision and no certificate
+//     implication, so they are repaired automatically (and logged) rather than
+//     blocking startup.
+//
+// It runs before 018 adds network_id, so the cross-host query derives the
+// network by joining host_addresses to hosts. Returns a fail-loud error only for
+// the cross-host case; returns nil (after any auto-repair) otherwise.
+func checkOverlayIPConflicts(ctx context.Context, db *sql.DB) error {
+	conflicts, err := crossHostOverlayConflicts(ctx, db)
+	if err != nil {
+		return err
+	}
+	if len(conflicts) > 0 {
+		// Irreducible: bail to the operator without mutating anything, so the
+		// "no schema changes were made" guarantee holds and any orphan/same-host
+		// rows are left for the post-resolution restart to repair.
+		return errors.New(formatCrossHostConflicts(conflicts))
+	}
+	// No cross-host conflict remains, so the rest is safe to repair in place.
+	if err := cleanOrphanHostAddresses(ctx, db); err != nil {
+		return err
+	}
+	return cleanSameHostAddressDuplicates(ctx, db)
+}
+
+// crossHostOverlayConflicts returns every host_addresses row whose
+// (network_id, address) group is claimed by two or more distinct hosts, grouped
+// by (network, address) with distinct hosts listed in scan order.
+func crossHostOverlayConflicts(ctx context.Context, db *sql.DB) ([]overlayConflict, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT h.network_id, ha.address, h.id, h.name
+		FROM host_addresses ha
+		JOIN hosts h ON h.id = ha.host_id
+		WHERE (
+			SELECT COUNT(DISTINCT h2.id)
+			FROM host_addresses ha2
+			JOIN hosts h2 ON h2.id = ha2.host_id
+			WHERE h2.network_id = h.network_id AND ha2.address = ha.address
+		) >= 2
+		ORDER BY h.network_id, ha.address, h.id`)
+	if err != nil {
+		return nil, fmt.Errorf("check cross-host overlay-ip conflicts: %w", err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			slog.Error("close cross-host overlay-ip rows", "error", cerr)
+		}
+	}()
+
+	var order []string
+	groups := map[string]*overlayConflict{}
+	seenHost := map[string]bool{} // key = network\x00address\x00hostID
+	for rows.Next() {
+		var network, address, hostID, hostName string
+		if err := rows.Scan(&network, &address, &hostID, &hostName); err != nil {
+			return nil, fmt.Errorf("scan cross-host overlay-ip conflict: %w", err)
+		}
+		key := network + "\x00" + address
+		g := groups[key]
+		if g == nil {
+			g = &overlayConflict{network: network, address: address}
+			groups[key] = g
+			order = append(order, key)
+		}
+		hk := key + "\x00" + hostID
+		if !seenHost[hk] {
+			seenHost[hk] = true
+			g.hosts = append(g.hosts, fmt.Sprintf("%s (%s)", hostName, hostID))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cross-host overlay-ip conflicts: %w", err)
+	}
+
+	out := make([]overlayConflict, 0, len(order))
+	for _, key := range order {
+		out = append(out, *groups[key])
+	}
+	return out, nil
+}
+
+// formatCrossHostConflicts builds the operator-facing fail-loud message. The
+// cert-revocation guidance is deliberately precise: removing a host_addresses
+// row (or reassigning the address) does NOT revoke the displaced host's
+// certificate — only deleting the host through the management API/UI blocklists
+// it (DeleteHostAndBlockCert). And because the server is down during this
+// failure, that path is unavailable until the duplicate is cleared and the
+// server boots, hence the two-phase wording.
+func formatCrossHostConflicts(conflicts []overlayConflict) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "migration 018 (network-scoped overlay-IP uniqueness) cannot be applied: "+
+		"%d overlay IP(s) are each claimed by more than one host. The server will not start "+
+		"until these are resolved:\n", len(conflicts))
+	for i, c := range conflicts {
+		if i >= maxConflictsListed {
+			fmt.Fprintf(&b, "  … and %d more\n", len(conflicts)-maxConflictsListed)
+			break
+		}
+		fmt.Fprintf(&b, "  network %s — IP %s — hosts: %s\n", c.network, c.address, joinCapped(c.hosts))
+	}
+	b.WriteString("\nTwo hosts sharing one overlay IP is a security defect: a CA has issued " +
+		"certificates that let one host receive the other's traffic, and there is no safe " +
+		"automatic choice of which host keeps the address.\n\n" +
+		"Resolve: remove one host's binding to the conflicting address from host_addresses so the " +
+		"migration can apply and the server can start. Removing the row does NOT revoke the " +
+		"displaced host's certificate — it stays valid until revoked. Once the server is running, " +
+		"delete the displaced host through the management interface (which blocklists its " +
+		"certificate). Resolving this before upgrading, while the server is still running, avoids " +
+		"the startup failure entirely. No schema changes were made.")
+	return b.String()
+}
+
+// cleanOrphanHostAddresses deletes host_addresses rows whose host_id no longer
+// matches any hosts row. These are dangling bindings (only reachable with
+// foreign keys disabled — e.g. a restored or hand-edited database); 018's
+// backfill UPDATE would otherwise fail on them. Logged when any are removed.
+func cleanOrphanHostAddresses(ctx context.Context, db *sql.DB) error {
+	sample, err := sampleHostAddresses(ctx, db, `
+		SELECT host_id, address FROM host_addresses
+		WHERE NOT EXISTS (SELECT 1 FROM hosts h WHERE h.id = host_addresses.host_id)
+		ORDER BY host_id, address LIMIT ?`)
+	if err != nil {
+		return err
+	}
+	res, err := db.ExecContext(ctx, `
+		DELETE FROM host_addresses
+		WHERE NOT EXISTS (SELECT 1 FROM hosts h WHERE h.id = host_addresses.host_id)`)
+	if err != nil {
+		return fmt.Errorf("remove orphan host_addresses: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		slog.Warn("migration 018: removed orphaned host_addresses rows (referenced host no longer exists)",
+			"count", n, "sample", sample)
+	}
+	return nil
+}
+
+// cleanSameHostAddressDuplicates collapses rows where one host holds the same
+// address at more than one position, keeping the lowest-rowid row. This is a
+// redundant binding for a single host — same certificate, no winner to choose —
+// so it is safe to repair automatically. Logged when any are removed.
+func cleanSameHostAddressDuplicates(ctx context.Context, db *sql.DB) error {
+	sample, err := sampleHostAddresses(ctx, db, `
+		SELECT host_id, address FROM host_addresses ha
+		WHERE EXISTS (
+			SELECT 1 FROM host_addresses ha2
+			WHERE ha2.host_id = ha.host_id AND ha2.address = ha.address
+			  AND ha2.rowid < ha.rowid)
+		ORDER BY host_id, address LIMIT ?`)
+	if err != nil {
+		return err
+	}
+	res, err := db.ExecContext(ctx, `
+		DELETE FROM host_addresses
+		WHERE rowid IN (
+			SELECT ha.rowid FROM host_addresses ha
+			WHERE EXISTS (
+				SELECT 1 FROM host_addresses ha2
+				WHERE ha2.host_id = ha.host_id AND ha2.address = ha.address
+				  AND ha2.rowid < ha.rowid))`)
+	if err != nil {
+		return fmt.Errorf("collapse same-host duplicate host_addresses: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		slog.Warn("migration 018: collapsed duplicate same-host overlay-IP bindings",
+			"count", n, "sample", sample)
+	}
+	return nil
+}
+
+// sampleHostAddresses runs query — a complete, in-package literal that selects
+// host_id, address and ends with LIMIT ? — and returns up to maxConflictsListed
+// "host_id=…/address=…" labels for log context before a cleanup DELETE.
+func sampleHostAddresses(ctx context.Context, db *sql.DB, query string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, query, maxConflictsListed)
+	if err != nil {
+		return nil, fmt.Errorf("sample host_addresses: %w", err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			slog.Error("close host_addresses sample rows", "error", cerr)
+		}
+	}()
+	var out []string
+	for rows.Next() {
+		var hostID, address string
+		if err := rows.Scan(&hostID, &address); err != nil {
+			return nil, fmt.Errorf("scan host_addresses sample: %w", err)
+		}
+		out = append(out, fmt.Sprintf("host_id=%s/address=%s", hostID, address))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate host_addresses sample: %w", err)
+	}
+	return out, nil
+}
+
+// joinCapped joins host labels with ", ", truncating to maxConflictsListed with
+// an "… and N more" suffix so a single IP claimed by many hosts can't bloat the
+// message.
+func joinCapped(hosts []string) string {
+	if len(hosts) <= maxConflictsListed {
+		return strings.Join(hosts, ", ")
+	}
+	return strings.Join(hosts[:maxConflictsListed], ", ") +
+		fmt.Sprintf(", … and %d more", len(hosts)-maxConflictsListed)
 }
 
 // splitSQLStatements splits a SQL script on top-level `;` boundaries. It


### PR DESCRIPTION
## Summary

Follow-up to #149. Migration 018 (`UNIQUE(network_id, address)` over
`host_addresses`) is intentionally fail-loud on a pre-existing duplicate overlay
IP, but an operator hitting it today sees only the raw runner breadcrumb
(`apply migration 018_... stmt "CREATE UNIQUE INDEX ...": <sqlite error>`),
which names neither the offending network/IP/hosts nor the remediation. The
operator whose server won't boot is reading the startup log, so I made the
failure self-explanatory there.

I added a pre-apply guard in `Migrate` (mirroring the existing
`CountEmptyCAIDRows` startup check) that runs before 018 and handles its two
reachable failure modes by class:

- **Cross-host duplicate** (two or more distinct hosts share one overlay IP) — a
  security defect (a CA has issued certificates that let one host receive the
  other's traffic) with no data-derivable answer to which host should win. Fails
  loud with a message naming each conflict, and leaves the database untouched.
- **Orphan `host_addresses` rows** (referenced host no longer exists) and
  **same-host position duplicates** (one host bound to the same address twice) —
  redundant/dangling data with no policy decision and no certificate
  implication. Repaired automatically and logged via `slog.Warn`.

## Why this shape

018 has exactly two reachable failure modes on a valid schema: the backfill
`UPDATE` hits a `NOT NULL` violation on an orphan row, and `CREATE UNIQUE INDEX`
fails on a duplicate. A guard that checks both has complete coverage, so I kept
it a pure pre-check rather than wrapping the statement-exec loop — which means a
conflicted database that fails loud is left byte-identical ("no schema changes
were made"), and the only case requiring a human is the one where resolution
genuinely depends on operator knowledge of which host owns the IP.

The remediation wording is deliberately precise about certificates: removing a
`host_addresses` row (or reassigning the address) does not revoke the displaced
host's certificate — only deleting the host through the management API/UI does
(`DeleteHostAndBlockCert`). Since the management server is down during this
failure, the message directs the operator to clear the conflict at the database
level to boot, then revoke the certificate once the server is running, and notes
that resolving it before upgrading avoids the failure entirely.

## Tests

`internal/store/migration_018_test.go`: cross-host fail-loud (including that the
fail path mutates nothing even when cleanable rows are present), same-host
auto-collapse (preserving a host's legitimately distinct second address), orphan
auto-removal, grouping/dedup, message truncation caps, cleanup audit logging,
and two end-to-end `Migrate` tests over a real store. The existing direct-SQL
`TestMigration018_FailsLoudOnDuplicateOverlayIP` is unchanged.

`go test ./... -race` and `golangci-lint run ./...` are green.
