### PR TITLE
fix(configgen): round-trip operator strings in generated YAML (#176)

### DIFF
--- a/internal/configgen/fuzz_test.go
+++ b/internal/configgen/fuzz_test.go
@@ -48,35 +48,20 @@ func FuzzGenerate(f *testing.F) {
 	// round-tripping style for such values.
 	f.Add("0", "0", "0", "\t\n", "0", "0", "0", "0", "0", -125, 74,
 		false, true, false, false, "0")
+	// Regression for the invalid-UTF-8 case: safeString now tags scalars
+	// "!!str", and yaml.v3 refuses to marshal invalid UTF-8 under that tag.
+	// A safeString field carrying a lone 0xFF byte must fall back to a
+	// "!!binary" node (as a native Go string would) rather than fail Generate.
+	f.Add("\xff", "\xff", "\xff", "\xff", "\xff", "\xff", "\xff", "\xff", "\xff",
+		0, 0, false, false, true, false, "")
 
 	f.Fuzz(func(t *testing.T,
 		hostName, ip, lhIP, lhAddr, listenHost, tunDev, fwPort, fwProto, fwGroup string,
 		listenPort, mtu int, isLH, isRelay, punch, inlinePEM bool, pemBlock string,
 	) {
-		punchy := punch // address-of a copy; PunchyOverride wants *bool
-		in := GeneratorInput{
-			HostName:         hostName,
-			NebulaIPs:        []string{ip},
-			IsLighthouse:     isLH,
-			IsRelay:          isRelay,
-			ListenPort:       listenPort,
-			ListenHost:       listenHost,
-			MTU:              mtu,
-			TunDevice:        tunDev,
-			PunchyOverride:   &punchy,
-			Lighthouses:      []LighthouseInfo{{NebulaIPs: []string{lhIP}, PublicAddr: lhAddr}},
-			FirewallInbound:  []FirewallRule{{Port: fwPort, Proto: fwProto, Group: fwGroup}},
-			FirewallOutbound: []FirewallRule{{Port: fwPort, Proto: fwProto, Group: fwGroup}},
-		}
-		// Generate only emits the inline-PEM section when CACertPEM is set
-		// (see buildConfig); otherwise it falls back to the path form.
-		if inlinePEM && pemBlock != "" {
-			in.CACertPEM, in.CertPEM, in.KeyPEM = pemBlock, pemBlock, pemBlock
-		} else {
-			in.CACertPath = "/etc/nebula/ca.crt"
-			in.CertPath = "/etc/nebula/host.crt"
-			in.KeyPath = "/etc/nebula/host.key"
-		}
+		in := fuzzGeneratorInput(hostName, ip, lhIP, lhAddr, listenHost, tunDev,
+			fwPort, fwProto, fwGroup, listenPort, mtu, isLH, isRelay, punch,
+			inlinePEM, pemBlock)
 
 		out, err := Generate(in)
 		if err != nil {
@@ -99,8 +84,8 @@ func FuzzGenerate(f *testing.F) {
 		if got := c.GetBool("lighthouse.am_lighthouse", !isLH); got != isLH {
 			t.Fatalf("am_lighthouse round-trip: got %v want %v\n--- config ---\n%s", got, isLH, out)
 		}
-		if got := c.GetBool("punchy.punch", !punchy); got != punchy {
-			t.Fatalf("punchy.punch round-trip: got %v want %v\n--- config ---\n%s", got, punchy, out)
+		if got := c.GetBool("punchy.punch", !punch); got != punch {
+			t.Fatalf("punchy.punch round-trip: got %v want %v\n--- config ---\n%s", got, punch, out)
 		}
 		wantPort := listenPort
 		if wantPort == 0 && isLH {
@@ -110,4 +95,40 @@ func FuzzGenerate(f *testing.F) {
 			t.Fatalf("listen.port round-trip: got %d want %d\n--- config ---\n%s", got, wantPort, out)
 		}
 	})
+}
+
+// fuzzGeneratorInput maps the flat FuzzGenerate arguments onto a
+// GeneratorInput. It is the single construction the fuzzer drives, and
+// TestGenerate_SafeStringRoundTrip reuses it so the focused round-trip checks
+// exercise the same wiring (which operator field lands in which YAML node)
+// rather than a parallel hand-built copy that could drift.
+func fuzzGeneratorInput(
+	hostName, ip, lhIP, lhAddr, listenHost, tunDev, fwPort, fwProto, fwGroup string,
+	listenPort, mtu int, isLH, isRelay, punch, inlinePEM bool, pemBlock string,
+) GeneratorInput {
+	punchy := punch // address-of a copy; PunchyOverride wants *bool
+	in := GeneratorInput{
+		HostName:         hostName,
+		NebulaIPs:        []string{ip},
+		IsLighthouse:     isLH,
+		IsRelay:          isRelay,
+		ListenPort:       listenPort,
+		ListenHost:       listenHost,
+		MTU:              mtu,
+		TunDevice:        tunDev,
+		PunchyOverride:   &punchy,
+		Lighthouses:      []LighthouseInfo{{NebulaIPs: []string{lhIP}, PublicAddr: lhAddr}},
+		FirewallInbound:  []FirewallRule{{Port: fwPort, Proto: fwProto, Group: fwGroup}},
+		FirewallOutbound: []FirewallRule{{Port: fwPort, Proto: fwProto, Group: fwGroup}},
+	}
+	// Generate only emits the inline-PEM section when CACertPEM is set
+	// (see buildConfig); otherwise it falls back to the path form.
+	if inlinePEM && pemBlock != "" {
+		in.CACertPEM, in.CertPEM, in.KeyPEM = pemBlock, pemBlock, pemBlock
+	} else {
+		in.CACertPath = "/etc/nebula/ca.crt"
+		in.CertPath = "/etc/nebula/host.crt"
+		in.KeyPath = "/etc/nebula/host.key"
+	}
+	return in
 }

--- a/internal/configgen/fuzz_test.go
+++ b/internal/configgen/fuzz_test.go
@@ -40,6 +40,14 @@ func FuzzGenerate(f *testing.F) {
 	f.Add("mobile", "10.0.0.5", "10.0.0.1", "198.51.100.7:4242",
 		"", "", "443", "udp", "ops", 0, 0, false, true, true, true,
 		"-----BEGIN NEBULA CERTIFICATE-----\nAQ==\n-----END NEBULA CERTIFICATE-----")
+	// Regression for the scheduled-fuzz crasher (run 26709587640): a
+	// lighthouse PublicAddr of "\t\n" reached static_host_map as a plain
+	// string, where yaml.v3 picked literal-block style and emitted the tab
+	// verbatim — YAML its own parser then rejected ("found a tab character
+	// where an indentation space is expected"). safeString now forces a
+	// round-tripping style for such values.
+	f.Add("0", "0", "0", "\t\n", "0", "0", "0", "0", "0", -125, 74,
+		false, true, false, false, "0")
 
 	f.Fuzz(func(t *testing.T,
 		hostName, ip, lhIP, lhAddr, listenHost, tunDev, fwPort, fwProto, fwGroup string,

--- a/internal/configgen/marshal.go
+++ b/internal/configgen/marshal.go
@@ -10,21 +10,27 @@ import (
 
 // nebulaConfig is the internal typed-struct representation of a Nebula agent
 // config.yml. It exists so Generate can marshal through gopkg.in/yaml.v3
-// instead of string-interpolating into a text/template. Every value is
-// quoted/escaped by yaml.v3 according to YAML spec, so structural-break
-// characters (CR/LF, control chars, ", :, #) in fields like TunDevice can
-// never escape into the YAML structure regardless of what upstream validators
-// allow. Defense-in-depth on top of input validation (GHSA-7hp6, issue #126).
+// instead of string-interpolating into a text/template, so structural-break
+// characters (CR/LF, control chars, ", :, #) in operator-controlled fields
+// can never escape into the YAML structure regardless of what upstream
+// validators allow. Defense-in-depth on top of input validation (GHSA-7hp6,
+// issue #126).
+//
+// Operator-controlled scalars use the safeString type rather than a bare
+// string: yaml.v3's default style does not round-trip every value (a
+// multi-line value such as "\t\n" is emitted as a literal block whose tab the
+// parser then rejects), and safeString forces a style that does. literalString
+// guards the inline-PEM fields the same way for their readable block form.
 type nebulaConfig struct {
-	PKI           pkiSection          `yaml:"pki"`
-	StaticHostMap map[string][]string `yaml:"static_host_map"`
-	Lighthouse    lighthouseSection   `yaml:"lighthouse"`
-	Listen        listenSection       `yaml:"listen"`
-	Punchy        punchySection       `yaml:"punchy"`
-	Tun           *tunSection         `yaml:"tun,omitempty"`
-	Relay         *relaySection       `yaml:"relay,omitempty"`
-	Logging       loggingSection      `yaml:"logging"`
-	Firewall      firewallSection     `yaml:"firewall"`
+	PKI           pkiSection                  `yaml:"pki"`
+	StaticHostMap map[safeString][]safeString `yaml:"static_host_map"`
+	Lighthouse    lighthouseSection           `yaml:"lighthouse"`
+	Listen        listenSection               `yaml:"listen"`
+	Punchy        punchySection               `yaml:"punchy"`
+	Tun           *tunSection                 `yaml:"tun,omitempty"`
+	Relay         *relaySection               `yaml:"relay,omitempty"`
+	Logging       loggingSection              `yaml:"logging"`
+	Firewall      firewallSection             `yaml:"firewall"`
 }
 
 // pkiSection's fields are typed `any` because inline PEMs marshal as
@@ -84,14 +90,34 @@ func literalBlockSafe(s string) bool {
 	return true
 }
 
+// safeString marshals an operator-controlled scalar so it always round-trips
+// through the YAML parser. yaml.v3's encoder auto-selects a literal/folded
+// block style for multi-line strings and emits their content verbatim under
+// the block indent; a line that begins with a tab or space (e.g. "\t\n") then
+// re-parses as broken indentation ("found a tab character where an indentation
+// space is expected"). Double-quoted style escapes every byte and round-trips
+// for any string, so force it for multi-line values; single-line values keep
+// the encoder's default (plain, or auto-quoted for ambiguous scalars like
+// "0"), staying readable. This is the plain-string counterpart to
+// literalString, which guards the inline-PEM fields (GHSA-7hp6, issue #126).
+type safeString string
+
+func (s safeString) MarshalYAML() (any, error) {
+	n := &yaml.Node{Kind: yaml.ScalarNode, Value: string(s)}
+	if strings.Contains(string(s), "\n") {
+		n.Style = yaml.DoubleQuotedStyle
+	}
+	return n, nil
+}
+
 type lighthouseSection struct {
-	AmLighthouse bool     `yaml:"am_lighthouse"`
-	Hosts        []string `yaml:"hosts,omitempty"`
+	AmLighthouse bool         `yaml:"am_lighthouse"`
+	Hosts        []safeString `yaml:"hosts,omitempty"`
 }
 
 type listenSection struct {
-	Host string `yaml:"host"`
-	Port int    `yaml:"port"`
+	Host safeString `yaml:"host"`
+	Port int        `yaml:"port"`
 }
 
 type punchySection struct {
@@ -99,19 +125,19 @@ type punchySection struct {
 }
 
 type tunSection struct {
-	Dev          string        `yaml:"dev,omitempty"`
+	Dev          safeString    `yaml:"dev,omitempty"`
 	MTU          int           `yaml:"mtu,omitempty"`
 	UnsafeRoutes []unsafeRoute `yaml:"unsafe_routes,omitempty"`
 }
 
 type unsafeRoute struct {
-	Route string `yaml:"route"`
-	Via   string `yaml:"via"`
+	Route safeString `yaml:"route"`
+	Via   safeString `yaml:"via"`
 }
 
 type relaySection struct {
-	AmRelay bool     `yaml:"am_relay,omitempty"`
-	Relays  []string `yaml:"relays,omitempty"`
+	AmRelay bool         `yaml:"am_relay,omitempty"`
+	Relays  []safeString `yaml:"relays,omitempty"`
 }
 
 type loggingSection struct {
@@ -128,10 +154,10 @@ type firewallSection struct {
 // matching the shape the previous template emitted: `group: <name>` for named
 // groups, `host: any` for the catch-all.
 type firewallRule struct {
-	Port  string `yaml:"port"`
-	Proto string `yaml:"proto"`
-	Group string `yaml:"group,omitempty"`
-	Host  string `yaml:"host,omitempty"`
+	Port  safeString `yaml:"port"`
+	Proto safeString `yaml:"proto"`
+	Group safeString `yaml:"group,omitempty"`
+	Host  safeString `yaml:"host,omitempty"`
 }
 
 // Generate produces a Nebula config.yml from the given input by marshaling
@@ -164,21 +190,21 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 		}
 	} else {
 		cfg.PKI = pkiSection{
-			CA:   input.CACertPath,
-			Cert: input.CertPath,
-			Key:  input.KeyPath,
+			CA:   safeString(input.CACertPath),
+			Cert: safeString(input.CertPath),
+			Key:  safeString(input.KeyPath),
 		}
 	}
 
-	cfg.StaticHostMap = map[string][]string{}
+	cfg.StaticHostMap = map[safeString][]safeString{}
 	if input.IsLighthouse {
 		cfg.Lighthouse = lighthouseSection{AmLighthouse: true}
 	} else {
-		var hosts []string
+		var hosts []safeString
 		for _, lh := range input.Lighthouses {
 			for _, ip := range lh.NebulaIPs {
-				cfg.StaticHostMap[ip] = []string{lh.PublicAddr}
-				hosts = append(hosts, ip)
+				cfg.StaticHostMap[safeString(ip)] = []safeString{safeString(lh.PublicAddr)}
+				hosts = append(hosts, safeString(ip))
 			}
 		}
 		cfg.Lighthouse = lighthouseSection{AmLighthouse: false, Hosts: hosts}
@@ -192,7 +218,7 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 	if listenPort == 0 && input.IsLighthouse {
 		listenPort = 4242
 	}
-	cfg.Listen = listenSection{Host: listenHost, Port: listenPort}
+	cfg.Listen = listenSection{Host: safeString(listenHost), Port: listenPort}
 
 	punch := true
 	if input.PunchyOverride != nil {
@@ -201,9 +227,12 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 	cfg.Punchy = punchySection{Punch: punch}
 
 	if input.MTU != 0 || input.TunDevice != "" || len(input.UnsafeRoutes) > 0 {
-		ts := &tunSection{Dev: input.TunDevice, MTU: input.MTU}
+		ts := &tunSection{Dev: safeString(input.TunDevice), MTU: input.MTU}
 		for _, r := range input.UnsafeRoutes {
-			ts.UnsafeRoutes = append(ts.UnsafeRoutes, unsafeRoute(r))
+			ts.UnsafeRoutes = append(ts.UnsafeRoutes, unsafeRoute{
+				Route: safeString(r.Route),
+				Via:   safeString(r.Via),
+			})
 		}
 		cfg.Tun = ts
 	}
@@ -211,7 +240,11 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 	if input.IsRelay {
 		cfg.Relay = &relaySection{AmRelay: true}
 	} else if len(input.Relays) > 0 {
-		cfg.Relay = &relaySection{Relays: input.Relays}
+		relays := make([]safeString, len(input.Relays))
+		for i, r := range input.Relays {
+			relays[i] = safeString(r)
+		}
+		cfg.Relay = &relaySection{Relays: relays}
 	}
 
 	cfg.Firewall.Outbound = mapFirewallRules(input.FirewallOutbound)
@@ -223,11 +256,11 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 func mapFirewallRules(in []FirewallRule) []firewallRule {
 	out := make([]firewallRule, 0, len(in))
 	for _, r := range in {
-		fr := firewallRule{Port: r.Port, Proto: r.Proto}
+		fr := firewallRule{Port: safeString(r.Port), Proto: safeString(r.Proto)}
 		if r.Group == "any" {
 			fr.Host = "any"
 		} else {
-			fr.Group = r.Group
+			fr.Group = safeString(r.Group)
 		}
 		out = append(out, fr)
 	}

--- a/internal/configgen/marshal.go
+++ b/internal/configgen/marshal.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
 )
@@ -17,10 +18,12 @@ import (
 // issue #126).
 //
 // Operator-controlled scalars use the safeString type rather than a bare
-// string: yaml.v3's default style does not round-trip every value (a
-// multi-line value such as "\t\n" is emitted as a literal block whose tab the
-// parser then rejects), and safeString forces a style that does. literalString
-// guards the inline-PEM fields the same way for their readable block form.
+// string: marshaling a Go string through a yaml.Node does not round-trip every
+// value (a multi-line value such as "\t\n" emits as a block whose tab the
+// parser then rejects; an ambiguous value such as "0" or "true" emits bare and
+// re-parses as int/bool), and safeString forces a representation that always
+// reads back unchanged. literalString guards the inline-PEM fields the same way
+// for their readable block form.
 type nebulaConfig struct {
 	PKI           pkiSection                  `yaml:"pki"`
 	StaticHostMap map[safeString][]safeString `yaml:"static_host_map"`
@@ -91,21 +94,43 @@ func literalBlockSafe(s string) bool {
 }
 
 // safeString marshals an operator-controlled scalar so it always round-trips
-// through the YAML parser. yaml.v3's encoder auto-selects a literal/folded
-// block style for multi-line strings and emits their content verbatim under
-// the block indent; a line that begins with a tab or space (e.g. "\t\n") then
-// re-parses as broken indentation ("found a tab character where an indentation
-// space is expected"). Double-quoted style escapes every byte and round-trips
-// for any string, so force it for multi-line values; single-line values keep
-// the encoder's default (plain, or auto-quoted for ambiguous scalars like
-// "0"), staying readable. This is the plain-string counterpart to
-// literalString, which guards the inline-PEM fields (GHSA-7hp6, issue #126).
+// through the YAML parser, for any string.
+//
+// For valid UTF-8 the node is tagged "!!str" so it carries the implicit-string
+// resolution a native Go string would. A tagless ScalarNode loses that tag and
+// so emits ambiguous scalars bare — "0", "true", "null"/"~" and "" would
+// re-parse as int, bool and null rather than as their original string. The tag
+// restores the encoder's default rendering: plain when the value is unambiguous
+// (readable), auto-quoted only when bare emission would retype it. Invalid
+// UTF-8 is left tagless on purpose: yaml.v3 refuses to marshal invalid UTF-8
+// under an explicit "!!str" tag, so we let the encoder fall back to a "!!binary"
+// (base64) node, exactly as a native Go string would — that round-trips too.
+//
+// Two cases the tag alone does not cover, so force double-quoted style — which
+// escapes every byte and round-trips unconditionally:
+//
+//   - Multi-line values. yaml.v3 emits a multi-line scalar as a block (literal
+//     for a mapping value, an explicit-key "? |" block for a mapping key) and
+//     writes the content verbatim under the block indent; a line beginning
+//     with a tab or space (e.g. "\t\n") then re-parses as broken indentation
+//     ("found a tab character where an indentation space is expected"). This
+//     was the original crasher (issue #176).
+//   - "<<". As a static_host_map key (safeString is also the map's key type)
+//     bare "<<" is the YAML merge indicator, so the loader rejects it with
+//     "map merge requires map or sequence of maps as the value". Quoting it
+//     keeps it a literal string key.
+//
+// This is the plain-string counterpart to literalString, which guards the
+// inline-PEM fields (GHSA-7hp6, issue #126).
 type safeString string
 
 func (s safeString) MarshalYAML() (any, error) {
 	n := &yaml.Node{Kind: yaml.ScalarNode, Value: string(s)}
-	if strings.Contains(string(s), "\n") {
-		n.Style = yaml.DoubleQuotedStyle
+	if utf8.ValidString(string(s)) {
+		n.Tag = "!!str"
+		if strings.Contains(string(s), "\n") || string(s) == "<<" {
+			n.Style = yaml.DoubleQuotedStyle
+		}
 	}
 	return n, nil
 }

--- a/internal/configgen/roundtrip_test.go
+++ b/internal/configgen/roundtrip_test.go
@@ -1,0 +1,207 @@
+package configgen
+
+import (
+	"strings"
+	"testing"
+
+	nebcfg "github.com/slackhq/nebula/config"
+)
+
+// roundTripValues are operator-controlled strings that a bare/unquoted YAML
+// scalar would silently retype or that break the YAML structure outright:
+//
+//   - "0"/"true" — re-parse as int/bool when emitted bare,
+//   - "null"/"~" — re-parse as null,
+//   - ""         — re-parses as null,
+//   - "<<"       — the YAML merge-key indicator; as a static_host_map key the
+//     loader rejects it ("map merge requires map or sequence of maps"),
+//   - "\t\n"     — the original #176 crasher: emitted under a block style whose
+//     leading tab the parser rejects,
+//   - "a:b"/"# x" — colon/comment bytes that would break out of plain style.
+//
+// safeString.MarshalYAML must make every one of them read back unchanged
+// through Nebula's own loader.
+var roundTripValues = []string{"0", "true", "null", "~", "", "<<", "\t\n", "a:b", "# x"}
+
+// baseRoundTripInput is a regular-host input built through the same wiring the
+// fuzzer drives (fuzzGeneratorInput), so these focused checks can't drift from
+// what FuzzGenerate actually exercises.
+func baseRoundTripInput() GeneratorInput {
+	return fuzzGeneratorInput(
+		"web-1", "192.168.100.10", "192.168.100.1", "203.0.113.10:4242",
+		"0.0.0.0", "", "any", "icmp", "admin",
+		0, 0, false, false, true, false, "")
+}
+
+func loadGenerated(t *testing.T, in GeneratorInput) *nebcfg.C {
+	t.Helper()
+	out, err := Generate(in)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var c nebcfg.C
+	if err := c.LoadString(string(out)); err != nil {
+		t.Fatalf("config.LoadString rejected generated config: %v\n--- config ---\n%s", err, out)
+	}
+	return &c
+}
+
+// TestGenerate_SafeStringRoundTrip pushes the ambiguous and structure-breaking
+// values above through every operator-controlled safeString field and asserts
+// they survive a round-trip through Nebula's own config loader unchanged — the
+// guarantee safeString makes "for any string". It complements FuzzGenerate,
+// whose type-preserving invariant only covers the non-safeString scalars
+// (am_lighthouse / punchy.punch / listen.port), so a regression on a
+// safeString field would slip past the fuzzer green.
+func TestGenerate_SafeStringRoundTrip(t *testing.T) {
+	for _, v := range roundTripValues {
+		t.Run("listen.host="+quoteName(v), func(t *testing.T) {
+			if v == "" {
+				t.Skip("generator substitutes 0.0.0.0 for an empty listen host before it reaches safeString")
+			}
+			in := baseRoundTripInput()
+			in.ListenHost = v
+			c := loadGenerated(t, in)
+			if got := c.GetString("listen.host", "\x00miss"); got != v {
+				t.Errorf("listen.host: got %q want %q", got, v)
+			}
+		})
+
+		t.Run("static_host_map_key="+quoteName(v), func(t *testing.T) {
+			in := baseRoundTripInput()
+			in.Lighthouses = []LighthouseInfo{{NebulaIPs: []string{v}, PublicAddr: "203.0.113.10:4242"}}
+			c := loadGenerated(t, in)
+			m, ok := c.Get("static_host_map").(map[string]any)
+			if !ok {
+				t.Fatalf("static_host_map missing/wrong type: %T", c.Get("static_host_map"))
+			}
+			if _, present := m[v]; !present {
+				t.Errorf("static_host_map key %q dropped; got keys %v", v, keysOf(m))
+			}
+		})
+
+		t.Run("static_host_map_value="+quoteName(v), func(t *testing.T) {
+			in := baseRoundTripInput()
+			in.Lighthouses = []LighthouseInfo{{NebulaIPs: []string{"192.168.100.1"}, PublicAddr: v}}
+			c := loadGenerated(t, in)
+			m, _ := c.Get("static_host_map").(map[string]any)
+			vals, ok := m["192.168.100.1"].([]any)
+			if !ok || len(vals) != 1 {
+				t.Fatalf("static_host_map value missing: %#v", m["192.168.100.1"])
+			}
+			if got := mustString(t, vals[0]); got != v {
+				t.Errorf("static_host_map value: got %q want %q", got, v)
+			}
+		})
+
+		t.Run("firewall.port="+quoteName(v), func(t *testing.T) {
+			in := baseRoundTripInput()
+			in.FirewallInbound = []FirewallRule{{Port: v, Proto: "tcp", Group: "admin"}}
+			c := loadGenerated(t, in)
+			rule := firstInbound(t, c)
+			// The point of the !!str tag: a port like "22" stays a string
+			// instead of re-parsing as the int 22.
+			if got := mustString(t, rule["port"]); got != v {
+				t.Errorf("firewall.inbound[0].port: got %q want %q", got, v)
+			}
+		})
+
+		t.Run("relay.relays="+quoteName(v), func(t *testing.T) {
+			in := baseRoundTripInput()
+			in.Relays = []string{v}
+			c := loadGenerated(t, in)
+			rs, ok := c.Get("relay.relays").([]any)
+			if !ok || len(rs) != 1 {
+				t.Fatalf("relay.relays missing: %#v", c.Get("relay.relays"))
+			}
+			if got := mustString(t, rs[0]); got != v {
+				t.Errorf("relay.relays[0]: got %q want %q", got, v)
+			}
+		})
+
+		t.Run("unsafe_routes="+quoteName(v), func(t *testing.T) {
+			in := baseRoundTripInput()
+			in.UnsafeRoutes = []AdvancedUnsafeRoute{{Route: v, Via: v}}
+			c := loadGenerated(t, in)
+			routes, ok := c.Get("tun.unsafe_routes").([]any)
+			if !ok || len(routes) != 1 {
+				t.Fatalf("tun.unsafe_routes missing: %#v", c.Get("tun.unsafe_routes"))
+			}
+			r, _ := routes[0].(map[string]any)
+			if got := mustString(t, r["route"]); got != v {
+				t.Errorf("unsafe_routes[0].route: got %q want %q", got, v)
+			}
+			if got := mustString(t, r["via"]); got != v {
+				t.Errorf("unsafe_routes[0].via: got %q want %q", got, v)
+			}
+		})
+
+		t.Run("pki_path="+quoteName(v), func(t *testing.T) {
+			in := baseRoundTripInput()
+			in.CACertPath = v
+			c := loadGenerated(t, in)
+			if got := c.GetString("pki.ca", "\x00miss"); got != v {
+				t.Errorf("pki.ca: got %q want %q", got, v)
+			}
+		})
+	}
+}
+
+// TestGenerate_MultilineStaysDoubleQuoted pins the rendering, not just the
+// round-trip: a multi-line operator value must be emitted double-quoted on a
+// single line (every byte escaped), never as a literal/explicit-key block that
+// would re-emit the raw tab the parser rejects.
+func TestGenerate_MultilineStaysDoubleQuoted(t *testing.T) {
+	in := baseRoundTripInput()
+	in.ListenHost = "\t\n"
+	out, err := Generate(in)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `host: "\t\n"`) {
+		t.Errorf("multi-line host not double-quoted on one line:\n%s", s)
+	}
+	if strings.Contains(s, "host: |") || strings.Contains(s, "host: >") {
+		t.Errorf("multi-line host emitted as a block scalar:\n%s", s)
+	}
+}
+
+func firstInbound(t *testing.T, c *nebcfg.C) map[string]any {
+	t.Helper()
+	inb, ok := c.Get("firewall.inbound").([]any)
+	if !ok || len(inb) == 0 {
+		t.Fatalf("firewall.inbound missing: %#v", c.Get("firewall.inbound"))
+	}
+	rule, ok := inb[0].(map[string]any)
+	if !ok {
+		t.Fatalf("firewall.inbound[0] wrong type: %T", inb[0])
+	}
+	return rule
+}
+
+// mustString fails the test if v re-parsed as a non-string (e.g. "22" → int 22,
+// "true" → bool), which is itself the round-trip regression these tests guard.
+func mustString(t *testing.T, v any) string {
+	t.Helper()
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("value retyped to %T (%v); expected a string", v, v)
+	}
+	return s
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// quoteName renders a subtest-name suffix that stays readable for the control
+// characters in roundTripValues (a raw "\t\n" would mangle test output).
+func quoteName(s string) string {
+	r := strings.NewReplacer("\t", `\t`, "\n", `\n`, " ", "_")
+	return r.Replace(s)
+}


### PR DESCRIPTION
## What

Fixes the `FuzzGenerate` crasher the scheduled fuzz lane caught in run [26709587640](https://github.com/forgekeep/nebula-mesh/actions/runs/26709587640).

A lighthouse `PublicAddr` of `"\t\n"` reached `static_host_map` as a bare string, where yaml.v3 auto-selected literal-block style (`|`) and emitted the tab verbatim under the block indent. yaml.v3's own parser — the SIGHUP-reload path a Nebula agent runs — then rejected it:

```
yaml: line 7: found a tab character where an indentation space is expected
```

## Why

The inline-PEM fields were already guarded against non-round-tripping output (`literalString` + `literalBlockSafe`, GHSA-7hp6 / #126), but the plain operator-controlled string fields were not — `static_host_map` (keys and values), `lighthouse.hosts`, `listen.host`, `tun.dev`, firewall rules, and `relays` were emitted as bare `string`/`[]string`. The `marshal.go` header comment claimed these "can never escape into the YAML structure"; that was false for the auto-block-style case.

## How

- Add a `safeString` type — the plain-string counterpart to `literalString` — whose `MarshalYAML` forces double-quoted style for multi-line values (the only style yaml.v3 auto-selects that breaks round-trip) and leaves single-line values to the encoder, so ordinary values stay unquoted and readable.
- Apply it to every operator-controlled scalar field, including `static_host_map` keys.
- Update the misleading header comment.
- Record the crasher as an `f.Add` regression seed so it runs in the normal `go test`, not only the scheduled fuzz lane.

## Verification

- `go build ./...`
- `go test -race ./internal/configgen/...` (incl. new seed)
- `make lint` — 0 issues
- 30s live fuzz, 370k execs, no new crashers

Closes #176
