### PR TITLE
fix(web): constant-time login to prevent username enumeration (#180)

### DIFF
--- a/internal/web/login_timing_test.go
+++ b/internal/web/login_timing_test.go
@@ -1,0 +1,86 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// TestDummyPasswordHashCost pins the timing-equalizer hash to the same cost as
+// production password hashes, so the dummy compare really does take ~the same
+// time as a real one (#180).
+func TestDummyPasswordHashCost(t *testing.T) {
+	cost, err := bcrypt.Cost(dummyPasswordHash)
+	if err != nil {
+		t.Fatalf("bcrypt.Cost(dummyPasswordHash): %v", err)
+	}
+	if cost != bcrypt.DefaultCost {
+		t.Fatalf("dummy hash cost = %d, want bcrypt.DefaultCost (%d)", cost, bcrypt.DefaultCost)
+	}
+}
+
+// TestLogin_ConstantTimeAcrossAccountStates verifies the unknown-username and
+// inactive-account paths spend comparable time to the real password-verify
+// path. Uses a relative bound (>= half the genuine bcrypt path) so it is
+// independent of machine speed: without the dummy compare these paths return
+// in microseconds and the test fails (#180).
+func TestLogin_ConstantTimeAcrossAccountStates(t *testing.T) {
+	ctx := context.Background()
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("correct-horse"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mkOp := func(id, name string, status models.OperatorStatus) {
+		if err := s.CreateOperator(ctx, &models.Operator{
+			ID: id, Username: name, PasswordHash: string(hash), Role: "admin",
+			Status: status, AuthProvider: models.OperatorAuthLocal,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkOp("op-active", "alice", models.OperatorStatusActive)
+	mkOp("op-disabled", "bob", models.OperatorStatusDisabled)
+
+	sm := NewSessionManager(s)
+
+	// Warm up so lazy initialisation does not skew the first measurement.
+	_ = bcrypt.CompareHashAndPassword(hash, []byte("warmup"))
+
+	measure := func(user, pass string) time.Duration {
+		req := httptest.NewRequest(http.MethodPost, "/ui/login", nil)
+		start := time.Now()
+		if _, ok, _ := sm.Login(httptest.NewRecorder(), req, user, pass); ok {
+			t.Fatalf("login for %q unexpectedly succeeded", user)
+		}
+		return time.Since(start)
+	}
+
+	baseline := measure("alice", "wrong-password") // genuine bcrypt verify
+	missing := measure("ghost", "whatever")        // unknown username
+	inactive := measure("bob", "whatever")         // disabled account
+
+	floor := baseline / 2
+	if missing < floor {
+		t.Errorf("unknown-username login too fast: %v < %v (half of baseline %v) — timing oracle for enumeration", missing, floor, baseline)
+	}
+	if inactive < floor {
+		t.Errorf("inactive-account login too fast: %v < %v (half of baseline %v) — timing oracle", inactive, floor, baseline)
+	}
+}

--- a/internal/web/ratelimit_test.go
+++ b/internal/web/ratelimit_test.go
@@ -33,9 +33,14 @@ func newRateLimitWeb(t *testing.T) *Web {
 
 func TestRateLimit_BlocksAfterBurst(t *testing.T) {
 	w := newRateLimitWeb(t)
+	// Rate is deliberately tiny so the burst-exhaustion assertion is independent
+	// of how long each request takes. Login now spends ~bcrypt time even for an
+	// unknown username (#180 constant-time login), which under -race is hundreds
+	// of ms; a 1 req/s refill would hand back a token mid-test and admit the 3rd
+	// request. A negligible refill rate isolates pure burst behavior.
 	w.WithRateLimiter(ratelimit.New(ratelimit.Config{
 		Enabled: true,
-		Groups:  map[string]ratelimit.GroupConfig{"auth": {Rate: 1, Burst: 2}},
+		Groups:  map[string]ratelimit.GroupConfig{"auth": {Rate: 0.001, Burst: 2}},
 	}))
 
 	csrfToken, csrfCookies := getCSRFTokenFromCookies(t, w, "/ui/login", nil)

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -23,6 +23,20 @@ const (
 	pendingTOTPMaxLife = 5 * time.Minute
 )
 
+// dummyPasswordHash is compared against the submitted password on the
+// login paths that have no real hash to check — unknown username or an
+// inactive account — so a failed login takes the same ~bcrypt time
+// regardless of whether the account exists (#180, username enumeration).
+// Generated once at the same cost as production hashes (bcrypt.DefaultCost,
+// see handlers.go/operators.go) so it tracks any future cost change.
+var dummyPasswordHash = func() []byte {
+	h, err := bcrypt.GenerateFromPassword([]byte("nebula-mesh login timing equalizer"), bcrypt.DefaultCost)
+	if err != nil {
+		panic("bcrypt dummy hash: " + err.Error())
+	}
+	return h
+}()
+
 // SessionManager handles DB-backed cookie sessions for operator users.
 type SessionManager struct {
 	store        store.Store
@@ -72,12 +86,17 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 	}
 	op, err := sm.store.GetOperatorByUsername(r.Context(), username)
 	if errors.Is(err, store.ErrNotFound) {
+		// Equalize timing with the password-verify path below so a missing
+		// account is indistinguishable from a wrong password (#180).
+		_ = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password))
 		return LoginResult{}, false, nil
 	}
 	if err != nil {
 		return LoginResult{}, false, fmt.Errorf("lookup operator: %w", err)
 	}
 	if op.Status != models.OperatorStatusActive {
+		// Same constant-time treatment for a disabled/non-active account.
+		_ = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password))
 		return LoginResult{}, false, nil
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {


### PR DESCRIPTION
Closes #180 (hardening from the security audit, #178).

## Problem
`SessionManager.Login` returned immediately for an unknown username (and an inactive account), but ran bcrypt (~tens of ms) for an existing, active account. The timing gap allowed statistical enumeration of valid operator usernames despite rate limiting.

## Fix
Compare the submitted password against a fixed dummy bcrypt hash on both short-circuit paths (unknown user, inactive account) before returning, so a failed login takes ~the same time regardless of whether the account exists. The dummy hash is generated once at `bcrypt.DefaultCost` (the cost used for real hashes), so it tracks any future cost change.

## Tests
- Pin the dummy-hash cost to `bcrypt.DefaultCost`.
- Relative-timing test: the unknown-username and inactive-account paths take ≥ half the genuine password-verify time (machine-independent; fails if the dummy compare is removed).
- `TestRateLimit_BlocksAfterBurst`: lowered the refill rate so its burst-exhaustion assertion no longer depends on login being near-instant (login now legitimately spends ~bcrypt time, which under `-race` is hundreds of ms and would otherwise refill a token mid-test).

`go test -race ./...` green; `golangci-lint` clean.