### PR TITLE
fix(pki): zeroize decrypted CA key when manager construction fails (#181)

### DIFF
--- a/internal/pki/resolver.go
+++ b/internal/pki/resolver.go
@@ -60,5 +60,19 @@ func (r *CAResolver) LoadByID(ctx context.Context, caID string) (*CAManager, err
 	if err != nil {
 		return nil, fmt.Errorf("decrypt CA %s key: %w", caID, err)
 	}
-	return LoadCAFromMaterial([]byte(c.CertPEM), ed25519.PrivateKey(keyBytes))
+	return loadCAOrZeroize([]byte(c.CertPEM), keyBytes)
+}
+
+// loadCAOrZeroize builds a CAManager from freshly-decrypted key material,
+// transferring ownership of keyBytes to the manager on success (the caller
+// later clears it via CAManager.Wipe). If construction fails — e.g. the cert
+// is unparseable or not a CA — the plaintext key never reaches a manager, so
+// it is zeroized here rather than left on the heap for the GC (#181).
+func loadCAOrZeroize(certPEM, keyBytes []byte) (*CAManager, error) {
+	mgr, err := LoadCAFromMaterial(certPEM, ed25519.PrivateKey(keyBytes))
+	if err != nil {
+		keystore.Zeroize(keyBytes)
+		return nil, err
+	}
+	return mgr, nil
 }

--- a/internal/pki/zeroize_on_error_test.go
+++ b/internal/pki/zeroize_on_error_test.go
@@ -1,0 +1,66 @@
+package pki
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"testing"
+	"time"
+)
+
+// TestLoadCAOrZeroize_WipesKeyOnError verifies that when CAManager construction
+// fails after the key has already been decrypted, the plaintext key bytes are
+// zeroized rather than left on the heap (#181).
+func TestLoadCAOrZeroize_WipesKeyOnError(t *testing.T) {
+	key := bytes.Repeat([]byte{0xAB}, ed25519.PrivateKeySize)
+
+	mgr, err := loadCAOrZeroize([]byte("-----BEGIN GARBAGE-----\nnope\n-----END GARBAGE-----\n"), key)
+	if err == nil {
+		t.Fatal("expected error for unparseable cert PEM")
+	}
+	if mgr != nil {
+		t.Fatalf("expected nil manager on error, got %v", mgr)
+	}
+	for i, b := range key {
+		if b != 0 {
+			t.Fatalf("key not zeroized on error path: byte %d = %#x", i, b)
+		}
+	}
+}
+
+// TestLoadCAOrZeroize_PreservesKeyOnSuccess verifies the success path transfers
+// the key to the manager intact — the fix must NOT wipe a live signing key.
+func TestLoadCAOrZeroize_PreservesKeyOnSuccess(t *testing.T) {
+	src, err := NewCA("zeroize-test", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM, err := src.CACertPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := append(ed25519.PrivateKey(nil), src.RawKey()...) // copy so we own it
+
+	mgr, err := loadCAOrZeroize(certPEM, key)
+	if err != nil {
+		t.Fatalf("unexpected error on valid material: %v", err)
+	}
+	if mgr == nil {
+		t.Fatal("expected a manager on success")
+	}
+	if allZero(key) {
+		t.Fatal("success path wiped the key — would break signing")
+	}
+	// The manager must hold the same (aliased) key, ready to sign.
+	if !bytes.Equal(mgr.RawKey(), key) {
+		t.Fatal("manager key does not match input key")
+	}
+}
+
+func allZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes #181 (hardening from the security audit, #178).

## Problem
`CAResolver.LoadByID` handed the freshly-decrypted CA private key straight to `LoadCAFromMaterial`. On success the manager owns the key (cleared later via `CAManager.Wipe`), but if `LoadCAFromMaterial` failed — unparseable cert, non-CA cert, wrong key length — the plaintext key was left on the heap unzeroized until GC.

## Fix
Route construction through `loadCAOrZeroize`, which wipes the key bytes on the error path and transfers ownership untouched on success.

Note: a blanket `defer keystore.Zeroize(keyBytes)` would be wrong — `LoadCAFromMaterial` **aliases** the slice into `CAManager.caKey` rather than copying it, so an unconditional wipe would clear the live signing key. The wipe must happen only when the key never reaches a manager.

## Tests
- Error path: a caller-owned key slice is all-zeros after `loadCAOrZeroize` fails on a bad cert.
- Success path: the key is preserved and the returned manager signs with it (guards against accidentally wiping a live key).

`go test -race ./...` green; `golangci-lint` clean.