### PR TITLE
fix: cap /ui request bodies + HTTP timeouts and DB pool bounds (#185)

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -258,10 +258,12 @@ func Serve(configPath string, insecureHTTP bool) error {
 	mux := buildMux(webUI, apiSrv)
 
 	httpServer := &http.Server{
-		Addr:         cfg.Listen,
-		Handler:      securityHeaders(mux),
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		Addr:              cfg.Listen,
+		Handler:           securityHeaders(mux),
+		ReadTimeout:       10 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	// Graceful shutdown

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -70,6 +70,13 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	// queries hit the same store.
 	if dbPath == ":memory:" {
 		db.SetMaxOpenConns(1)
+	} else {
+		// Bound the pool for file-backed databases so a burst of concurrent
+		// requests cannot spawn unbounded connections/goroutines contending on
+		// SQLite locks (#185).
+		db.SetMaxOpenConns(25)
+		db.SetMaxIdleConns(5)
+		db.SetConnMaxLifetime(5 * time.Minute)
 	}
 
 	// Ping forces at least one connection open so a DSN-pragma failure

--- a/internal/web/body_cap_test.go
+++ b/internal/web/body_cap_test.go
@@ -1,0 +1,40 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestMaxBodySize_RejectsOversizedUIPost verifies the #185 cap: an
+// unauthenticated /ui POST whose body exceeds the limit is rejected with 413
+// before any form parsing reads it into memory.
+func TestMaxBodySize_RejectsOversizedUIPost(t *testing.T) {
+	web, _ := newTestWeb(t)
+	big := strings.Repeat("a", (1<<20)+1024) // > 1 MiB cap
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(big))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	web.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized /ui/login POST: status = %d, want 413", rec.Code)
+	}
+}
+
+// TestMaxBodySize_AllowsNormalUIPost guards against the cap rejecting normal
+// form submissions (it must only fire on oversized bodies).
+func TestMaxBodySize_AllowsNormalUIPost(t *testing.T) {
+	web, _ := newTestWeb(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader("username=x&password=y"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	web.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusRequestEntityTooLarge {
+		t.Fatalf("normal /ui/login POST wrongly rejected as too large (413)")
+	}
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -231,8 +231,34 @@ func New(s store.Store, logger *slog.Logger) (*Web, error) {
 	return w, nil
 }
 
+// maxBodySize caps request bodies for the web router. A declared
+// Content-Length over the limit is rejected up front with 413; bodies without
+// a declared length are wrapped with http.MaxBytesReader so a chunked upload
+// still cannot exceed the cap. Closes the gap where unauthenticated /ui form
+// POSTs (login/register) had no limit (#185).
+func (w *Web) maxBodySize(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			if r.ContentLength > maxBytes {
+				http.Error(rw, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			if r.Body != nil {
+				r.Body = http.MaxBytesReader(rw, r.Body, maxBytes)
+			}
+			next.ServeHTTP(rw, r)
+		})
+	}
+}
+
 func (w *Web) setupRoutes() {
 	r := chi.NewRouter()
+
+	// Cap request bodies on every /ui route (#185). The web router serves
+	// unauthenticated form POSTs (/ui/login, /ui/register); without a limit,
+	// ParseForm reads the whole body into memory, so an unauthenticated client
+	// could exhaust RAM. Mirrors the API server's maxBodySize.
+	r.Use(w.maxBodySize(1 << 20))
 
 	// Static files
 	staticSub, _ := fs.Sub(staticFS, "static")


### PR DESCRIPTION
Closes #185 (2nd-pass security audit, #178).

## Problem
The web router served unauthenticated form POSTs (`/ui/login`, `/ui/register`) with **no request-body limit** — the API router already caps at 1MB. `ParseForm` reads the whole body into memory, so an unauthenticated client could stream gigabytes and exhaust RAM.

## Change
- **`internal/web`**: `maxBodySize` middleware (1 MiB) as the first `/ui` handler — Content-Length over the limit → 413; otherwise wrap with `http.MaxBytesReader`. Mirrors `internal/api`.
- **`internal/cli/serve.go`**: add `ReadHeaderTimeout` (5s) + `IdleTimeout` (60s) to the `http.Server` (Slowloris / idle-conn hardening; `ReadTimeout` already bounds total read).
- **`internal/store/sqlite.go`**: bound the pool for file-backed DBs (MaxOpenConns 25 / MaxIdleConns 5 / ConnMaxLifetime 5m).

## Tests
Oversized `/ui/login` POST → 413; normal POST not rejected. `go test -race ./...` green; `golangci-lint` clean.