### PR TITLE
fix(api): bound host name and groups before signing (#186)

### DIFF
--- a/internal/api/host_field_limits_test.go
+++ b/internal/api/host_field_limits_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// #186: host Name and Groups are embedded in the signed cert and distributed
+// mesh-wide, so they must be length- and count-bounded at the API.
+
+func createHostStatus(t *testing.T, srv *Server, req createHostRequest) int {
+	t.Helper()
+	body, _ := json.Marshal(req)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(r)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Code
+}
+
+func TestCreateHost_RejectsOversizedName(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	code := createHostStatus(t, srv, createHostRequest{
+		NetworkID: netID,
+		Name:      strings.Repeat("a", maxHostNameLen+1),
+		NebulaIPs: []string{"192.168.100.10"},
+	})
+	if code != http.StatusBadRequest {
+		t.Fatalf("oversized name: status = %d, want 400", code)
+	}
+}
+
+func TestCreateHost_RejectsTooManyGroups(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	groups := make([]string, maxHostGroups+1)
+	for i := range groups {
+		groups[i] = "g"
+	}
+	code := createHostStatus(t, srv, createHostRequest{
+		NetworkID: netID,
+		Name:      "many-groups",
+		NebulaIPs: []string{"192.168.100.11"},
+		Groups:    groups,
+	})
+	if code != http.StatusBadRequest {
+		t.Fatalf("too many groups: status = %d, want 400", code)
+	}
+}
+
+func TestCreateHost_RejectsOversizedGroupName(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	code := createHostStatus(t, srv, createHostRequest{
+		NetworkID: netID,
+		Name:      "long-group",
+		NebulaIPs: []string{"192.168.100.12"},
+		Groups:    []string{strings.Repeat("g", maxGroupNameLen+1)},
+	})
+	if code != http.StatusBadRequest {
+		t.Fatalf("oversized group name: status = %d, want 400", code)
+	}
+}
+
+func TestCreateHost_AllowsAtLimits(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	groups := make([]string, maxHostGroups)
+	for i := range groups {
+		groups[i] = strings.Repeat("g", maxGroupNameLen)
+	}
+	code := createHostStatus(t, srv, createHostRequest{
+		NetworkID: netID,
+		Name:      strings.Repeat("a", maxHostNameLen),
+		NebulaIPs: []string{"192.168.100.13"},
+		Groups:    groups,
+	})
+	if code != http.StatusCreated {
+		t.Fatalf("at-limit values: status = %d, want 201", code)
+	}
+}

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -41,6 +41,40 @@ type updateHostRequest struct {
 	Advanced   *models.HostAdvanced `json:"advanced,omitempty"`
 }
 
+// Bounds on host fields that are embedded in the signed Nebula certificate and
+// then distributed to every peer; without caps an operator could bloat certs
+// mesh-wide (#186). Generous relative to real use, but bounded.
+const (
+	maxHostNameLen  = 255
+	maxGroupNameLen = 64
+	maxHostGroups   = 64
+)
+
+// validateHostName bounds the host name length.
+func validateHostName(name string) error {
+	if len(name) > maxHostNameLen {
+		return fmt.Errorf("name must be at most %d characters", maxHostNameLen)
+	}
+	return nil
+}
+
+// validateHostGroups bounds the group count and each group's length, and keeps
+// the existing non-empty rule.
+func validateHostGroups(groups []string) error {
+	if len(groups) > maxHostGroups {
+		return fmt.Errorf("at most %d groups allowed, got %d", maxHostGroups, len(groups))
+	}
+	for _, g := range groups {
+		if strings.TrimSpace(g) == "" {
+			return fmt.Errorf("group names must not be empty")
+		}
+		if len(g) > maxGroupNameLen {
+			return fmt.Errorf("group name must be at most %d characters", maxGroupNameLen)
+		}
+	}
+	return nil
+}
+
 func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 	var req createHostRequest
 	if err := decodeJSONStrict(r, &req); err != nil {
@@ -144,11 +178,13 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 	if host.Groups == nil {
 		host.Groups = []string{}
 	}
-	for _, g := range host.Groups {
-		if strings.TrimSpace(g) == "" {
-			writeError(w, http.StatusBadRequest, "group names must not be empty")
-			return
-		}
+	if err := validateHostName(host.Name); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validateHostGroups(host.Groups); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	rawToken := uuid.New().String()
@@ -576,6 +612,10 @@ func (s *Server) handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "name must not be empty")
 			return
 		}
+		if err := validateHostName(name); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		host.Name = name
 	}
 
@@ -593,11 +633,9 @@ func (s *Server) handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Groups != nil {
-		for _, g := range *req.Groups {
-			if strings.TrimSpace(g) == "" {
-				writeError(w, http.StatusBadRequest, "group names must not be empty")
-				return
-			}
+		if err := validateHostGroups(*req.Groups); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		host.Groups = *req.Groups
 	}


### PR DESCRIPTION
Closes #186 (2nd-pass security audit, #178).

## Problem
`handleCreateHost`/`handleUpdateHost` checked only that the name and each group were non-empty — no limit on name length, per-group length, or group **count**. These fields are embedded in the signed Nebula certificate and distributed to every peer, so an operator could bloat certs mesh-wide.

## Change
`validateHostName` (≤ 255) and `validateHostGroups` (≤ 64 groups, each ≤ 64 chars, still non-empty), called in create and **per-field** in update (so an unrelated update to a legacy oversized host is not rejected). Not an injection vector — `configgen` marshals via `yaml.v3`, which escapes control chars.

## Tests
Create rejects oversized name / too many groups / oversized group name; accepts values exactly at the limits. `go test -race ./...` green; lint clean.