### PR TITLE
fix(api): gate /debug/vars, opt-in auth for /metrics, redact /readyz (#187)

### DIFF
--- a/configs/server.example.yml
+++ b/configs/server.example.yml
@@ -36,6 +36,11 @@ allow_self_registration: false
 # /debug/vars regardless.
 # metrics:
 #   prometheus: true
+#   # Gate /metrics behind the same bearer auth as the API (#187). Default
+#   # false keeps unauthenticated scraping; set true when the server is
+#   # reachable beyond a trusted network — metric labels expose host/network/CA
+#   # IDs. /debug/vars is always bearer-gated.
+#   require_auth: false
 
 # Cert-expiry alerter (issue #41). Disabled by default. When enabled, a
 # periodic scanner fans out alerts for hosts whose current certificate

--- a/internal/api/debug_metrics_auth_test.go
+++ b/internal/api/debug_metrics_auth_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// #187: /debug/vars and (optionally) /metrics must be gated; /readyz must not
+// leak internal error detail.
+
+func TestReadyz_DoesNotLeakInternalError(t *testing.T) {
+	srv, st := newTestServer(t)
+	st.Close() // force store.Ping to fail
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if _, leaked := body["error"]; leaked {
+		t.Errorf("/readyz leaked internal error detail: %q", body["error"])
+	}
+	if body["status"] != "unavailable" {
+		t.Errorf("status field = %q, want unavailable", body["status"])
+	}
+}
+
+func TestDebugVars_RequiresAuth(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	noAuth := httptest.NewRequest(http.MethodGet, "/debug/vars", nil)
+	wn := httptest.NewRecorder()
+	srv.ServeHTTP(wn, noAuth)
+	if wn.Code != http.StatusUnauthorized {
+		t.Fatalf("/debug/vars without auth: status = %d, want 401", wn.Code)
+	}
+
+	authed := httptest.NewRequest(http.MethodGet, "/debug/vars", nil)
+	authRequest(authed)
+	wa := httptest.NewRecorder()
+	srv.ServeHTTP(wa, authed)
+	if wa.Code != http.StatusOK {
+		t.Fatalf("/debug/vars with auth: status = %d, want 200", wa.Code)
+	}
+}
+
+func TestMetrics_PublicByDefault(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("/metrics default (no auth): status = %d, want 200", w.Code)
+	}
+}
+
+func TestMetrics_RequireAuth_Gates(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.WithMetricsRequireAuth(true)
+
+	noAuth := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	wn := httptest.NewRecorder()
+	srv.ServeHTTP(wn, noAuth)
+	if wn.Code != http.StatusUnauthorized {
+		t.Fatalf("/metrics with require_auth, no token: status = %d, want 401", wn.Code)
+	}
+
+	authed := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	authRequest(authed)
+	wa := httptest.NewRecorder()
+	srv.ServeHTTP(wa, authed)
+	if wa.Code != http.StatusOK {
+		t.Fatalf("/metrics with require_auth, valid token: status = %d, want 200", wa.Code)
+	}
+}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -181,6 +181,7 @@ func TestMetricsEndpoint_HostsGauge(t *testing.T) {
 func TestExpvarEndpoint_LegacyPath(t *testing.T) {
 	srv, _ := newTestServer(t)
 	r := httptest.NewRequest(http.MethodGet, "/debug/vars", nil)
+	authRequest(r) // /debug/vars is bearer-gated since #187
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, r)
 	if w.Code != http.StatusOK {
@@ -224,6 +225,7 @@ func TestMetricsEndpoint_DisabledByOption(t *testing.T) {
 	}
 
 	r2 := httptest.NewRequest(http.MethodGet, "/debug/vars", nil)
+	authRequest(r2) // /debug/vars is bearer-gated since #187
 	w2 := httptest.NewRecorder()
 	srv.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	logger             *slog.Logger
 	metrics            *metrics
 	metricsEnabled     bool
+	metricsRequireAuth bool
 	hostSeen           HostSeenEmitter
 	limiter            *ratelimit.Limiter
 	passwordPolicy     auth.Policy
@@ -129,6 +130,13 @@ func (s *Server) WithMetricsEnabled(enabled bool) {
 	s.setupRoutes()
 }
 
+// WithMetricsRequireAuth gates /metrics behind bearer auth when true (#187).
+// Must be called before the router is exercised — re-wires the routes.
+func (s *Server) WithMetricsRequireAuth(require bool) {
+	s.metricsRequireAuth = require
+	s.setupRoutes()
+}
+
 // HostSeenEmitter is invoked after every successful agent poll so the Web
 // UI can stream a live "host X just polled" event over its SSE endpoint.
 // hostID is the DB id, lastSeen is the wall-clock timestamp the agent's
@@ -161,10 +169,12 @@ func (s *Server) setupRoutes() {
 	r.Get("/health", s.handleHealth) // legacy alias
 	r.Get("/healthz", s.handleHealth)
 	r.Get("/readyz", s.handleReady)
-	if s.metricsEnabled {
+	// /metrics is public by default; when metrics.require_auth is set it moves
+	// into the bearer-protected group below (#187) — the labels expose
+	// host/network/CA IDs and operational counters.
+	if s.metricsEnabled && !s.metricsRequireAuth {
 		r.Method("GET", "/metrics", promhttp.HandlerFor(s.metrics.reg, promhttp.HandlerOpts{}))
 	}
-	r.Method("GET", "/debug/vars", expvar.Handler())
 	r.Group(func(r chi.Router) {
 		r.Use(s.rateLimitMiddleware("enroll"))
 		r.Post("/api/v1/enroll", s.handleEnroll)
@@ -178,6 +188,15 @@ func (s *Server) setupRoutes() {
 	r.Group(func(r chi.Router) {
 		r.Use(s.rateLimitMiddleware("api"))
 		r.Use(bearerAuth(s.store))
+
+		// Debug/diagnostics are bearer-gated (#187): expvar leaks memstats and
+		// the process command line, and /metrics labels expose host/network/CA
+		// IDs when require_auth is on.
+		r.Method("GET", "/debug/vars", expvar.Handler())
+		if s.metricsEnabled && s.metricsRequireAuth {
+			r.Method("GET", "/metrics", promhttp.HandlerFor(s.metrics.reg, promhttp.HandlerOpts{}))
+		}
+
 		r.Post("/api/v1/networks", s.handleCreateNetwork)
 		r.Get("/api/v1/networks", s.handleListNetworks)
 		r.Get("/api/v1/networks/{id}", s.handleGetNetwork)
@@ -229,7 +248,10 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := contextWithTimeout(r.Context(), 2*time.Second)
 	defer cancel()
 	if err := s.store.Ping(ctx); err != nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "unavailable", "error": err.Error()})
+		// Log the cause server-side but do not echo internal error detail
+		// (DB path/driver) to unauthenticated readiness probes (#187).
+		s.logger.Error("readiness check failed", "error", err)
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "unavailable"})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -135,6 +135,7 @@ func Serve(configPath string, insecureHTTP bool) error {
 	// Create API server
 	apiSrv := api.NewServer(s, logger)
 	apiSrv.WithMetricsEnabled(cfg.Metrics.PrometheusEnabled())
+	apiSrv.WithMetricsRequireAuth(cfg.Metrics.RequireAuth)
 	apiSrv.WithEnrollmentTokenTTL(cfg.EnrollmentTokenTTLDuration())
 
 	// Build a single rate limiter shared by API and Web. The Web UI runs

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -251,13 +251,18 @@ func (a AlertsConfig) ThresholdDuration() time.Duration {
 	return d
 }
 
-// MetricsConfig toggles the Prometheus exporter. Legacy Go expvar stays on
-// /debug/vars regardless.
+// MetricsConfig toggles the Prometheus exporter and whether it requires auth.
 type MetricsConfig struct {
 	// Prometheus is a pointer so an unset value (yaml omitted) is treated
 	// as the default (true). A user setting `prometheus: false` cleanly
 	// disables the exporter.
 	Prometheus *bool `yaml:"prometheus,omitempty"`
+
+	// RequireAuth gates the /metrics endpoint behind the same bearer auth as
+	// the API (#187). Default false keeps unauthenticated scraping working;
+	// set true when the server is reachable beyond a trusted network, since
+	// the metric labels expose host/network/CA IDs and operational counters.
+	RequireAuth bool `yaml:"require_auth,omitempty"`
 }
 
 // PrometheusEnabled returns whether the Prometheus exporter should be served.


### PR DESCRIPTION
Closes #187 (2nd-pass security audit, #178).

Three root-mux endpoints sat outside the bearer-auth group:

- **`/debug/vars`** (expvar) was unauthenticated — exposed memstats + the process command line. Now **bearer-gated**.
- **`/readyz`** echoed the raw `store.Ping` error (DB path/driver) to unauthenticated probes. Now logs server-side and returns `{"status":"unavailable"}` only.
- **`/metrics`** labels expose host/network/CA IDs + operational counters (and the IDs weaken the UUID-unguessability the IDOR threat model relied on). Added **`metrics.require_auth`** (default `false` → scraping unchanged); when `true`, `/metrics` moves into the bearer-protected group. Prometheus scrapes with `bearer_token`.

## Tests
`/debug/vars` requires auth; `/metrics` public by default and gated under `require_auth`; `/readyz` omits the error field on failure. Updated two existing tests that asserted `/debug/vars` was public. `go test -race ./...` green; lint clean.