### PR TITLE
fix(config): SSRF guards for alerts.webhook_url and oidc.issuer (#188)

### DIFF
--- a/configs/server.example.yml
+++ b/configs/server.example.yml
@@ -57,6 +57,10 @@ allow_self_registration: false
 #   threshold: "72h"
 #   webhook_url: "https://alertmanager.example.com/api/v2/alerts"
 #   webhook_hmac_secret: "change-me"
+#   # webhook_url must be http(s) and, by default, a routable (non-private)
+#   # host — an SSRF guard (#188). Set true for a co-located/internal sink
+#   # (e.g. Alertmanager on a private address).
+#   allow_private_webhook: false
 
 # Per-IP rate limiter (issue #52). Enabled by default; set `enabled: false`
 # in trusted networks. When the management server runs behind a reverse

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -149,6 +150,44 @@ func listenIsLoopback(listen string) bool {
 	return addr.IsLoopback()
 }
 
+// hostIsPrivate reports whether host is a loopback, private, link-local, or
+// unspecified address — i.e. not a routable public host. The link-local case
+// covers the cloud-metadata endpoint (169.254.169.254). Hostnames that don't
+// parse as an IP are treated as public (DNS is intentionally not resolved at
+// config-load time), except the literal "localhost".
+func hostIsPrivate(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	return addr.IsLoopback() || addr.IsPrivate() || addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() || addr.IsUnspecified()
+}
+
+// validateWebhookURL guards the alert webhook against SSRF (#188): the URL must
+// be http/https with a host, and (unless allowPrivate) must not target a
+// private/loopback/link-local address. DNS names are not resolved here, so this
+// is a config-load guard, not a full request-time SSRF defense.
+func validateWebhookURL(rawURL string, allowPrivate bool) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("alerts.webhook_url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("alerts.webhook_url: scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("alerts.webhook_url: missing host")
+	}
+	if !allowPrivate && hostIsPrivate(u.Hostname()) {
+		return fmt.Errorf("alerts.webhook_url: %q is a private/loopback/link-local address; set alerts.allow_private_webhook: true for an intentional internal sink", u.Hostname())
+	}
+	return nil
+}
+
 // CookieSecureResolved returns the effective Secure-cookie flag for this
 // configuration. Explicit value wins; if unset, infer from the presence
 // of TLS material on the server itself.
@@ -223,6 +262,12 @@ type AlertsConfig struct {
 	Threshold         string `yaml:"threshold,omitempty"`
 	WebhookURL        string `yaml:"webhook_url,omitempty"`
 	WebhookHMACSecret string `yaml:"webhook_hmac_secret,omitempty"`
+
+	// AllowPrivateWebhook permits webhook_url to point at a loopback/private/
+	// link-local address. Default false rejects such targets at startup as an
+	// SSRF guard (#188); set true for an intentional internal sink (e.g. a
+	// co-located Alertmanager).
+	AllowPrivateWebhook bool `yaml:"allow_private_webhook,omitempty"`
 }
 
 // IntervalDuration returns Interval as a time.Duration. Falls back to 5m
@@ -320,6 +365,19 @@ func (o *OIDCConfig) Validate() error {
 	if o == nil || !o.Enabled {
 		return nil
 	}
+	// The issuer's discovery doc + JWKS are fetched over this URL at startup
+	// (#188). Require https for a non-loopback issuer so the fetch can't be
+	// downgraded or aimed at an internal http service; loopback issuers (local
+	// dev IdPs like dex) may use http.
+	if o.Issuer != "" {
+		iss, err := url.Parse(o.Issuer)
+		if err != nil {
+			return fmt.Errorf("oidc.issuer: %w", err)
+		}
+		if iss.Scheme != "https" && !hostIsPrivate(iss.Hostname()) {
+			return fmt.Errorf("oidc.issuer must use https for a non-loopback host (got %q)", o.Issuer)
+		}
+	}
 	roleUnsetOrAdmin := o.DefaultRole == "" || o.DefaultRole == "admin"
 	noAllowlist := len(o.AllowedGroups) == 0 && len(o.AllowedEmails) == 0
 	if roleUnsetOrAdmin && noAllowlist {
@@ -384,6 +442,12 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 
 	if err := cfg.OIDC.Validate(); err != nil {
 		return nil, err
+	}
+
+	if cfg.Alerts.Enabled && cfg.Alerts.WebhookURL != "" {
+		if err := validateWebhookURL(cfg.Alerts.WebhookURL, cfg.Alerts.AllowPrivateWebhook); err != nil {
+			return nil, err
+		}
 	}
 
 	if cfg.CAAutoRotate.Enabled {

--- a/internal/config/ssrf_validate_test.go
+++ b/internal/config/ssrf_validate_test.go
@@ -1,0 +1,68 @@
+package config
+
+import "testing"
+
+// #188: SSRF guards for alerts.webhook_url and oidc.issuer.
+
+func TestValidateWebhookURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		allowPrivate bool
+		wantErr      bool
+	}{
+		{name: "public https ok", url: "https://hooks.example.com/x", wantErr: false},
+		{name: "public http ok", url: "http://alerts.example.com/x", wantErr: false},
+		{name: "non-http scheme rejected", url: "file:///etc/passwd", wantErr: true},
+		{name: "gopher rejected", url: "gopher://evil/x", wantErr: true},
+		{name: "missing host rejected", url: "https://", wantErr: true},
+		{name: "loopback rejected", url: "http://127.0.0.1:9093/x", wantErr: true},
+		{name: "localhost rejected", url: "http://localhost/x", wantErr: true},
+		{name: "private rejected", url: "http://10.0.0.5/x", wantErr: true},
+		{name: "metadata link-local rejected", url: "http://169.254.169.254/latest/meta-data/", wantErr: true},
+		{name: "loopback allowed with opt-out", url: "http://127.0.0.1:9093/x", allowPrivate: true, wantErr: false},
+		{name: "private allowed with opt-out", url: "http://10.0.0.5/x", allowPrivate: true, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWebhookURL(tt.url, tt.allowPrivate)
+			if tt.wantErr && err == nil {
+				t.Fatalf("validateWebhookURL(%q, %v) = nil, want error", tt.url, tt.allowPrivate)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateWebhookURL(%q, %v) = %v, want nil", tt.url, tt.allowPrivate, err)
+			}
+		})
+	}
+}
+
+func TestOIDCValidate_IssuerScheme(t *testing.T) {
+	base := func(issuer string) *OIDCConfig {
+		return &OIDCConfig{
+			Enabled:     true,
+			Issuer:      issuer,
+			DefaultRole: "user", // avoid tripping the admin-allowlist check
+		}
+	}
+	tests := []struct {
+		name    string
+		issuer  string
+		wantErr bool
+	}{
+		{name: "https public ok", issuer: "https://idp.example.com/realm", wantErr: false},
+		{name: "http public rejected", issuer: "http://idp.example.com/realm", wantErr: true},
+		{name: "http loopback ok (dev)", issuer: "http://localhost:5556/dex", wantErr: false},
+		{name: "http 127.0.0.1 ok (dev)", issuer: "http://127.0.0.1:5556/dex", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := base(tt.issuer).Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("issuer %q: Validate() = nil, want error", tt.issuer)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("issuer %q: Validate() = %v, want nil", tt.issuer, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #188 (2nd-pass security audit, #178).

Both URLs are admin-config-only but were unvalidated.

- **`alerts.webhook_url`** (the alerts sink POSTs to it): validated at config load — must be http/https with a host, and must not target a private/loopback/link-local address (covers cloud-metadata `169.254.169.254`) unless **`alerts.allow_private_webhook: true`** for an intentional internal sink (e.g. co-located Alertmanager).
- **`oidc.issuer`** (discovery doc + JWKS fetched at startup): must use **https** for a non-loopback host; loopback issuers (local dev IdPs like dex) may use http.

DNS names are not resolved at load time, so this is a config-load guard, not a full request-time SSRF defense — documented as such.

## Tests
Webhook scheme/host/private-range matrix incl. the opt-out; OIDC issuer https-required-except-loopback. `go test -race ./...` green; lint clean.