### PR TITLE
fix(agent): bound enroll/poll HTTP requests with a client timeout (#193)

### DIFF
--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -100,7 +100,10 @@ func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath strin
 		return fmt.Errorf("build enrollment request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	// Never use http.DefaultClient (no timeout): a connected-but-silent
+	// server would hang the enroll/re-enroll path indefinitely (#193).
+	client := &http.Client{Timeout: defaultAgentHTTPTimeout}
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("enrollment request: %w", err)
 	}

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -107,6 +107,12 @@ func errorsAs(err error, target any) bool {
 	return false
 }
 
+// defaultAgentHTTPTimeout bounds a single outbound agent HTTP request (enroll
+// or poll) so a connected-but-unresponsive server cannot stall the call
+// indefinitely (#193). http.DefaultClient has no timeout, so it is never used
+// for agent requests.
+const defaultAgentHTTPTimeout = 30 * time.Second
+
 // PollerConfig holds configuration for the Poller.
 type PollerConfig struct {
 	ServerURL      string
@@ -115,6 +121,9 @@ type PollerConfig struct {
 	SigningKeyPath string
 	Interval       time.Duration
 	PIDFile        string
+	// HTTPTimeout bounds a single poll request. Zero or negative falls back
+	// to defaultAgentHTTPTimeout.
+	HTTPTimeout time.Duration
 }
 
 // Poller periodically checks the management server for updates.
@@ -123,6 +132,7 @@ type Poller struct {
 	logger     *slog.Logger
 	signalFunc func() error // for testing: override SIGHUP sending
 	signingKey ed25519.PrivateKey
+	httpClient *http.Client
 }
 
 // NewPoller creates a new Poller and loads the Ed25519 signing key needed to
@@ -137,10 +147,15 @@ func NewPoller(cfg PollerConfig, logger *slog.Logger) (*Poller, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load signing key: %w", err)
 	}
+	timeout := cfg.HTTPTimeout
+	if timeout <= 0 {
+		timeout = defaultAgentHTTPTimeout
+	}
 	p := &Poller{
 		config:     cfg,
 		logger:     logger,
 		signingKey: priv,
+		httpClient: &http.Client{Timeout: timeout},
 	}
 	p.signalFunc = func() error {
 		return signalNebulaFromPID(cfg.PIDFile)
@@ -208,7 +223,7 @@ func (p *Poller) poll(ctx context.Context) error {
 	if err := p.signRequest(req); err != nil {
 		return fmt.Errorf("sign poll request: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("poll request: %w", err)
 	}

--- a/internal/agent/poller_test.go
+++ b/internal/agent/poller_test.go
@@ -291,6 +291,40 @@ func TestPoll_RespectsContext(t *testing.T) {
 	}
 }
 
+// TestPoll_HTTPTimeout verifies that a single poll honors the configured
+// client timeout even when the request context carries no deadline (the
+// daemon case, #193). Before the fix poll() used http.DefaultClient, which
+// has no timeout, so an unresponsive-but-connected server hung the loop
+// forever.
+func TestPoll_HTTPTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // never respond until the client gives up
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	p := newTestPoller(t, PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    time.Hour,
+		HTTPTimeout: 100 * time.Millisecond,
+	})
+
+	// context.Background() never cancels — only the client timeout can bound
+	// the call.
+	start := time.Now()
+	err := p.poll(context.Background())
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected timeout error from unresponsive server")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("poll did not honor HTTPTimeout; took %v", elapsed)
+	}
+}
+
 func TestAtomicWriteFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.txt")


### PR DESCRIPTION
## Summary

Fixes #193.

The agent's enrollment and polling HTTP calls used `http.DefaultClient`, which has no `Timeout`, together with a context that carries no per-request deadline (the daemon poll loop runs on the long-lived process context). A management server that accepts the TCP connection but never responds would hang the call indefinitely — the `time.Ticker` then drops every subsequent tick, and the agent silently stops receiving config updates / rekey signals until the process is killed. Enrollment had the same flaw.

## Changes

- `internal/agent/poller.go`: give `Poller` a dedicated `http.Client` with a configurable timeout. New `PollerConfig.HTTPTimeout` (zero/negative falls back to `defaultAgentHTTPTimeout` = 30s). `poll()` now uses `p.httpClient` instead of `http.DefaultClient`.
- `internal/agent/enroll.go`: `Enroll` uses a timeout-bounded `http.Client` instead of `http.DefaultClient`.
- `internal/agent/poller_test.go`: regression test `TestPoll_HTTPTimeout` — a poll against an unresponsive server returns promptly even when the request context has no deadline.

## Testing

- `go build ./...`
- `go vet ./internal/agent/`
- `go test -race ./internal/agent/` — green
- `go test ./...` — green
- `make lint` — 0 issues
