### PR TITLE
fix(web): URL-escape store error text in CA redirect target (#194)

### DIFF
--- a/internal/web/cas.go
+++ b/internal/web/cas.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -264,6 +265,15 @@ func (w *Web) handleCARetire(rw http.ResponseWriter, r *http.Request) {
 	http.Redirect(rw, r, "/ui/cas/"+c.ID, http.StatusSeeOther)
 }
 
+// redirectCAError sends the operator back to the CA detail page with a
+// human-readable error in the query string. msg is URL-escaped so store-layer
+// text containing URL-significant characters (e.g. a network name with '&',
+// '#', or spaces) cannot corrupt the redirect target (#194). The detail
+// handler reads it back via Query().Get("error"), which reverses the escape.
+func redirectCAError(rw http.ResponseWriter, r *http.Request, caID, msg string) {
+	http.Redirect(rw, r, "/ui/cas/"+caID+"?error="+url.QueryEscape(msg), http.StatusSeeOther)
+}
+
 func (w *Web) handleCADelete(rw http.ResponseWriter, r *http.Request) {
 	c, ok := w.loadAccessibleCA(rw, r)
 	if !ok {
@@ -272,8 +282,7 @@ func (w *Web) handleCADelete(rw http.ResponseWriter, r *http.Request) {
 	if err := w.store.DeleteCA(r.Context(), c.ID); err != nil {
 		// Common case: still attached to one or more networks. Surface
 		// the store-layer message inline rather than a generic 500.
-		http.Redirect(rw, r, "/ui/cas/"+c.ID+"?error="+
-			http.StatusText(http.StatusConflict)+": "+err.Error(), http.StatusSeeOther)
+		redirectCAError(rw, r, c.ID, http.StatusText(http.StatusConflict)+": "+err.Error())
 		return
 	}
 	if op := w.session.CurrentOperator(r); op != nil {
@@ -290,9 +299,7 @@ func (w *Web) handleCARotate(rw http.ResponseWriter, r *http.Request) {
 	newCA, err := pki.RotateAndStoreCA(r.Context(), w.store, w.caMaster, w.logger, c)
 	if err != nil {
 		w.logger.Error("rotate ca", "error", err)
-		http.Redirect(rw, r, "/ui/cas/"+c.ID+"?error="+
-			http.StatusText(http.StatusInternalServerError)+": "+err.Error(),
-			http.StatusSeeOther)
+		redirectCAError(rw, r, c.ID, http.StatusText(http.StatusInternalServerError)+": "+err.Error())
 		return
 	}
 	if op := w.session.CurrentOperator(r); op != nil {

--- a/internal/web/cas_test.go
+++ b/internal/web/cas_test.go
@@ -12,6 +12,31 @@ import (
 	"github.com/forgekeep/nebula-mesh/internal/models"
 )
 
+// TestRedirectCAError_EscapesMessage verifies that store-layer error text is
+// URL-escaped before it is placed in the redirect query string (#194), so
+// URL-significant characters (a network name with '#', '&', spaces) cannot
+// truncate or split the redirect target — and that the message still
+// round-trips back to the original via Query().Get.
+func TestRedirectCAError_EscapesMessage(t *testing.T) {
+	const msg = "Conflict: still attached to net#1 & net 2"
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/ui/cas/abc/delete", nil)
+
+	redirectCAError(rw, r, "abc", msg)
+
+	loc := rw.Header().Get("Location")
+	if strings.ContainsAny(loc, "# ") || strings.Contains(loc, "&") {
+		t.Fatalf("unescaped URL-significant char leaked into Location: %q", loc)
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("Location is not a valid URL: %v", err)
+	}
+	if got := u.Query().Get("error"); got != msg {
+		t.Fatalf("error param round-trip mismatch: got %q, want %q", got, msg)
+	}
+}
+
 func TestCAs_NonOwner_Forbidden(t *testing.T) {
 	w, s := newOperatorsWeb(t)
 	aliceCookie := mintSession(t, s, "alice", "user")


### PR DESCRIPTION
## Summary

Fixes #194.

`handleCADelete` and `handleCARotate` concatenated `err.Error()` directly into the `?error=` query string of the redirect `Location`. A store error whose message contained a URL-significant character — e.g. a network name with `&`, `#`, or a space (`"still attached to net#1 & net 2"`) — truncated or split the query string, so the operator saw a corrupted or empty error message. A message with CRLF would additionally be a header-injection attempt.

## Changes

- `internal/web/cas.go`: extract a `redirectCAError` helper used by both call sites; it runs the message through `url.QueryEscape`. The detail handler already reads the value back via `Query().Get("error")`, which reverses the escape, so display is unchanged for normal messages.
- `internal/web/cas_test.go`: `TestRedirectCAError_EscapesMessage` asserts no URL-significant character leaks into `Location` and the message round-trips back to the original.

## Testing

- `go build ./...`
- `go vet ./internal/web/`
- `go test -race ./internal/web/` — green
- `go test ./...` — green (22 packages)
- `make lint` — 0 issues
