### PR TITLE
fix(keystore): zeroize decoded master-key bytes in NewMasterFromBase64

### DIFF
--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -34,8 +34,9 @@ type Master struct {
 }
 
 // NewMasterFromBase64 builds a Master from a base64-encoded 32-byte key.
-// The decoded bytes are stored only inside the AEAD; callers may zero
-// their original buffer immediately after this call.
+// The decoded bytes are copied into the AEAD key schedule by NewMaster, so the
+// transient plaintext copy is zeroized before returning rather than left on the
+// heap for the GC to reclaim (and possibly reuse).
 func NewMasterFromBase64(b64 string) (*Master, error) {
 	if b64 == "" {
 		return nil, ErrInvalidMasterKey
@@ -44,6 +45,7 @@ func NewMasterFromBase64(b64 string) (*Master, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidMasterKey, err)
 	}
+	defer Zeroize(raw)
 	return NewMaster(raw)
 }
 

--- a/internal/keystore/keystore_test.go
+++ b/internal/keystore/keystore_test.go
@@ -25,6 +25,56 @@ func TestMaster_FromBase64_RejectsWrongLength(t *testing.T) {
 	}
 }
 
+// TestNewMaster_CopiesKeyMaterial proves NewMaster copies its input into the
+// AEAD key schedule rather than aliasing it. This is the precondition that
+// makes NewMasterFromBase64 safe to zeroize its decoded buffer right after the
+// call (#196): wiping the caller's buffer must not corrupt the Master.
+func TestNewMaster_CopiesKeyMaterial(t *testing.T) {
+	raw := bytes.Repeat([]byte{0xab}, MasterKeySize)
+	m, err := NewMaster(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Caller wipes the source buffer immediately after construction.
+	Zeroize(raw)
+
+	// The Master must still wrap/unwrap correctly.
+	dek, wrapped, err := m.GenerateDEK()
+	if err != nil {
+		t.Fatalf("GenerateDEK after source wipe: %v", err)
+	}
+	unwrapped, err := m.UnwrapDEK(wrapped)
+	if err != nil {
+		t.Fatalf("UnwrapDEK after source wipe: %v", err)
+	}
+	if !bytes.Equal(dek, unwrapped) {
+		t.Error("dek round-trip mismatch after source key wipe — Master aliased its input")
+	}
+}
+
+// TestNewMasterFromBase64_RoundTrip guards that decoding + zeroizing the
+// transient buffer still yields a fully functional Master (#196).
+func TestNewMasterFromBase64_RoundTrip(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x5a}, MasterKeySize))
+	m, err := NewMasterFromBase64(b64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dek, wrapped, err := m.GenerateDEK()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unwrapped, err := m.UnwrapDEK(wrapped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(dek, unwrapped) {
+		t.Error("dek round-trip mismatch via base64-constructed master")
+	}
+}
+
 func TestWrapUnwrap_RoundTrip(t *testing.T) {
 	m := newTestMaster(t)
 	dek, wrapped, err := m.GenerateDEK()


### PR DESCRIPTION
## Summary

`NewMasterFromBase64` (`internal/keystore/keystore.go`) handed the base64-decoded master key (KEK) to `NewMaster` and then let the transient buffer go out of scope un-wiped, leaving a plaintext copy of the 32-byte KEK on the heap until GC reclaimed (and possibly reused) the page. Inconsistent with the aggressive CA-key zeroization applied elsewhere (recent GHSA hardening).

## Change

`defer Zeroize(raw)` after decode. `aes.NewCipher` copies the key into the cipher key schedule, so wiping the transient buffer right after `NewMaster` is safe.

## Tests

- `TestNewMaster_CopiesKeyMaterial` — proves `NewMaster` copies (does not alias) its input, the precondition that makes the wipe safe.
- `TestNewMasterFromBase64_RoundTrip` — decode + zeroize still yields a functional Master.

`go test -race ./internal/keystore/` green, lint clean.

Closes #196