### PR TITLE
fix(store): make ConsumeToken UPDATE conditional on used=0 + check RowsAffected

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1604,9 +1604,21 @@ func (s *SQLiteStore) ConsumeToken(ctx context.Context, token string) (*models.E
 	}
 
 	now := time.Now()
-	_, err = tx.ExecContext(ctx, `UPDATE enrollment_tokens SET used = 1, used_at = ? WHERE id = ?`, now, t.ID)
+	// Couple the used==0 check into the write itself rather than relying on
+	// the SELECT above plus WAL snapshot semantics. If a racing transaction
+	// consumed the token between our SELECT and here, RowsAffected is 0 and we
+	// surface ErrTokenUsed instead of an opaque error — and the guard survives
+	// a future journal-mode / driver change. Mirrors ConsumeTokenAndEnrollHost.
+	res, err := tx.ExecContext(ctx, `UPDATE enrollment_tokens SET used = 1, used_at = ? WHERE id = ? AND used = 0`, now, t.ID)
 	if err != nil {
 		return nil, fmt.Errorf("consume token: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("consume token rows affected: %w", err)
+	}
+	if n == 0 {
+		return nil, ErrTokenUsed
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
## Summary

`ConsumeToken` (`internal/store/sqlite.go`) ran `UPDATE ... WHERE id = ?` with no `used = 0` guard and never checked `RowsAffected`. Double-spend prevention rested entirely on SQLite WAL snapshot semantics:

- a racing transaction surfaced an opaque `"consume token"` 500 instead of `ErrTokenUsed`, and
- switching journal mode or DB driver would silently reintroduce a real double-enrollment.

## Change

Couple the `used = 0` check into the write (`WHERE id = ? AND used = 0`) and return `ErrTokenUsed` when `RowsAffected` is 0 — mirroring the existing `ConsumeTokenAndEnrollHost`.

## Tests

The exactly-once invariant is pinned by the existing `TestConsumeToken_AtomicUnderConcurrency` (10 goroutines, exactly one winner) plus `TestConsumeToken_AlreadyUsed`/`Success`/`Expired`/`NotFound`; all green under `-race`. The `RowsAffected == 0` branch is defense-in-depth — under SQLite WAL the lost-race writer hits `SQLITE_BUSY_SNAPSHOT` first, so the guard primarily protects against a future journal-mode/driver change.

`go test -race ./internal/store/` green, lint clean.

Closes #197