### PR TITLE
fix(web): invalidate operator sessions on admin password reset (CWE-613)

### DIFF
--- a/internal/web/operators.go
+++ b/internal/web/operators.go
@@ -234,6 +234,13 @@ func (w *Web) handleOperatorResetPassword(rw http.ResponseWriter, r *http.Reques
 		http.Error(rw, "internal error", http.StatusInternalServerError)
 		return
 	}
+	// Terminate the operator's existing sessions so a reset meant to lock out
+	// a compromised credential actually revokes access (CWE-613), mirroring the
+	// cascade in DisableOperator. The password is already changed; log on
+	// failure but do not abort.
+	if err := w.store.DeleteOperatorSessionsByOperator(r.Context(), id); err != nil {
+		w.logger.Error("invalidate sessions on password reset", "error", err)
+	}
 	actor := actorUsername(r, w.session)
 	_ = w.store.AddAuditEntry(r.Context(), actor, "operator.reset_password", id, op.Username)
 	http.Redirect(rw, r, "/ui/operators/"+id, http.StatusSeeOther) // #nosec G710 -- same-origin redirect: hardcoded /ui/operators/ prefix ensures Location stays on the current host regardless of id contents

--- a/internal/web/reset_password_sessions_test.go
+++ b/internal/web/reset_password_sessions_test.go
@@ -1,0 +1,53 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// TestOperators_ResetPassword_InvalidatesSessions verifies that an admin
+// resetting an operator's password terminates that operator's existing web
+// sessions. Otherwise an attacker holding a pre-reset session cookie keeps
+// access after the reset whose whole purpose is to revoke it (#204, CWE-613).
+// Mirrors the session cascade already in DisableOperator.
+func TestOperators_ResetPassword_InvalidatesSessions(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	admin := mintSession(t, s, "root", "admin")
+
+	// Target operator with a live session — the "attacker-held" cookie.
+	victim := mintSession(t, s, "bob", "user")
+
+	// Precondition: bob's session is valid before the reset.
+	if _, err := s.GetOperatorBySession(context.Background(), victim.Value); err != nil {
+		t.Fatalf("precondition: bob session should be valid, got %v", err)
+	}
+
+	// Admin resets bob's password.
+	csrfToken, cookies := getCSRFTokenFromCookies(t, w, "/ui/operators/op-bob", []*http.Cookie{admin})
+	form := url.Values{
+		"password": {strongPassword + "X"},
+		"_csrf":    {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators/op-bob/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("reset password: status = %d, want 303; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// bob's pre-reset session must now be invalid.
+	if _, err := s.GetOperatorBySession(context.Background(), victim.Value); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("bob session should be invalidated after reset, got err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`handleOperatorResetPassword` (`internal/web/operators.go`) changed the operator's password hash but never invalidated existing web sessions. An attacker holding a pre-reset session cookie kept full access after an admin reset the password to lock them out (CWE-613, Insufficient Session Expiration).

## Change

Call `DeleteOperatorSessionsByOperator` after `UpdateOperatorPassword`, mirroring the session cascade in `DisableOperator`. The password is already changed at that point, so a session-delete failure is logged but does not abort. API keys are left to the explicit disable/revoke flows (they are not password-derived).

## Tests

- `TestOperators_ResetPassword_InvalidatesSessions` — a live operator session is valid before the reset and `ErrNotFound` after.

`go test -race ./internal/web/` green, lint clean.

Closes #204