### PR TITLE
fix(api): scope agent-poll blocklist to the host's CA (cross-tenant leak)

### DIFF
--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -171,8 +171,10 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 		s.hostSeen(host.ID, now, host.NetworkID)
 	}
 
-	// Get blocklist
-	blocklist, err := s.store.GetBlocklist(r.Context())
+	// Get the blocklist scoped to this host's CA — an agent only needs to reject
+	// peers under its own CA, and shipping the global list leaks other tenants'
+	// revoked fingerprints across the boundary (#203).
+	blocklist, err := s.store.GetBlocklistForCA(r.Context(), host.CAID)
 	if err != nil {
 		s.logger.Error("get blocklist", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to get blocklist")

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -218,6 +218,16 @@ func (s *SQLiteStore) repairBlocklistCAID(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_blocklist_ca ON blocklist(ca_id)`); err != nil {
 		return err
 	}
+	// Backfill ca_id for legacy rows whose owning host still exists, so the
+	// per-CA poll scope (#203) covers entries written before ca_id was set.
+	// Orphan rows (host already deleted, host_id NULL) stay '' and are treated
+	// as a broadcast fail-safe by GetBlocklistForCA.
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE blocklist
+		    SET ca_id = COALESCE((SELECT h.ca_id FROM hosts h WHERE h.id = blocklist.host_id), '')
+		  WHERE ca_id = '' AND host_id IS NOT NULL`); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1174,8 +1184,8 @@ func (s *SQLiteStore) BlockHostAndAddToBlocklist(ctx context.Context, id, reason
 	if h.CertFingerprint != "" {
 		var hostIDVal any = id
 		_, err = tx.ExecContext(ctx,
-			`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at) VALUES (?, ?, ?, ?)`,
-			h.CertFingerprint, hostIDVal, reason, time.Now(),
+			`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at, ca_id) VALUES (?, ?, ?, ?, ?)`,
+			h.CertFingerprint, hostIDVal, reason, time.Now(), h.CAID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("add to blocklist: %w", err)
@@ -1294,8 +1304,8 @@ func (s *SQLiteStore) DeleteHostAndBlockCert(ctx context.Context, id, reason str
 	if h.CertFingerprint != "" {
 		var hostIDVal any = id
 		_, err = tx.ExecContext(ctx,
-			`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at) VALUES (?, ?, ?, ?)`,
-			h.CertFingerprint, hostIDVal, reason, time.Now(),
+			`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at, ca_id) VALUES (?, ?, ?, ?, ?)`,
+			h.CertFingerprint, hostIDVal, reason, time.Now(), h.CAID,
 		)
 		if err != nil {
 			return fmt.Errorf("add to blocklist: %w", err)
@@ -1925,9 +1935,12 @@ func (s *SQLiteStore) AddToBlocklist(ctx context.Context, fingerprint, hostID, r
 	if hostID != "" {
 		hostIDVal = hostID
 	}
+	// Resolve ca_id from the host so the entry is CA-scoped (#203). When hostID
+	// is empty the subquery yields NULL → COALESCE keeps it '' (broadcast).
 	_, err := s.db.ExecContext(ctx,
-		`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at) VALUES (?, ?, ?, ?)`,
-		fingerprint, hostIDVal, reason, time.Now(),
+		`INSERT OR REPLACE INTO blocklist (fingerprint, host_id, reason, created_at, ca_id)
+		 VALUES (?, ?, ?, ?, COALESCE((SELECT ca_id FROM hosts WHERE id = ?), ''))`,
+		fingerprint, hostIDVal, reason, time.Now(), hostIDVal,
 	)
 	if err != nil {
 		return fmt.Errorf("add to blocklist: %w", err)
@@ -1947,6 +1960,35 @@ func (s *SQLiteStore) GetBlocklist(ctx context.Context) ([]string, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT fingerprint FROM blocklist ORDER BY fingerprint`)
 	if err != nil {
 		return nil, fmt.Errorf("get blocklist: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("close rows", "error", err)
+		}
+	}()
+
+	result := make([]string, 0)
+	for rows.Next() {
+		var fp string
+		if err := rows.Scan(&fp); err != nil {
+			return nil, fmt.Errorf("scan fingerprint: %w", err)
+		}
+		result = append(result, fp)
+	}
+	return result, rows.Err()
+}
+
+// GetBlocklistForCA returns the revoked fingerprints scoped to a single CA — the
+// set an agent under that CA needs to reject peers, without leaking other
+// operators' revocations across the tenant boundary (#203). Rows with an empty
+// ca_id (legacy/orphan entries from before the column was populated, whose
+// owning host is already deleted so the CA can't be recovered) are included as a
+// fail-safe so revocation is never silently weakened.
+func (s *SQLiteStore) GetBlocklistForCA(ctx context.Context, caID string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT fingerprint FROM blocklist WHERE ca_id = ? OR ca_id = '' ORDER BY fingerprint`, caID)
+	if err != nil {
+		return nil, fmt.Errorf("get blocklist for ca: %w", err)
 	}
 	defer func() {
 		if err := rows.Close(); err != nil {

--- a/internal/store/sqlite_blocklist_scope_test.go
+++ b/internal/store/sqlite_blocklist_scope_test.go
@@ -1,0 +1,86 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// blockedHostFixture creates an enrolled host under caID with the given cert
+// fingerprint and adds it to the blocklist, returning nothing — the assertions
+// run against the store.
+func blockedHostFixture(t *testing.T, s *SQLiteStore, id, caID, fp, ip string) {
+	t.Helper()
+	ctx := context.Background()
+	h := &models.Host{
+		ID: id, NetworkID: "net_test1", Name: id, CAID: caID,
+		NebulaIPs: []string{ip}, Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+	h.CertFingerprint = fp
+	if err := s.UpdateHost(ctx, h); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.BlockHostAndAddToBlocklist(ctx, h.ID, "test block"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func contains(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGetBlocklistForCA_ScopesByCA verifies that the per-CA blocklist returned
+// to a polling agent contains only its own CA's revoked fingerprints, not those
+// of other operators' CAs — closing the cross-tenant disclosure where the poll
+// handler shipped the global blocklist to every host (#203).
+func TestGetBlocklistForCA_ScopesByCA(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	createTestNetwork(t, s)
+
+	blockedHostFixture(t, s, "h-ca1", "ca-1", "fp-ca1", "192.168.100.21")
+	blockedHostFixture(t, s, "h-ca2", "ca-2", "fp-ca2", "192.168.100.22")
+
+	bl1, err := s.GetBlocklistForCA(ctx, "ca-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(bl1, "fp-ca1") {
+		t.Errorf("CA-1 blocklist should contain its own fingerprint fp-ca1, got %v", bl1)
+	}
+	if contains(bl1, "fp-ca2") {
+		t.Errorf("CA-1 blocklist leaks CA-2's fingerprint fp-ca2: %v", bl1)
+	}
+
+	bl2, err := s.GetBlocklistForCA(ctx, "ca-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(bl2, "fp-ca2") {
+		t.Errorf("CA-2 blocklist should contain fp-ca2, got %v", bl2)
+	}
+	if contains(bl2, "fp-ca1") {
+		t.Errorf("CA-2 blocklist leaks CA-1's fingerprint fp-ca1: %v", bl2)
+	}
+
+	// The admin/global view still sees everything.
+	all, err := s.GetBlocklist(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(all, "fp-ca1") || !contains(all, "fp-ca2") {
+		t.Errorf("global blocklist should contain both fingerprints, got %v", all)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -101,6 +101,7 @@ type Store interface {
 	AddToBlocklist(ctx context.Context, fingerprint, hostID, reason string) error
 	RemoveFromBlocklist(ctx context.Context, fingerprint string) error
 	GetBlocklist(ctx context.Context) ([]string, error)
+	GetBlocklistForCA(ctx context.Context, caID string) ([]string, error)
 
 	// Config versioning
 	BumpNetworkConfigVersion(ctx context.Context, networkID string) error


### PR DESCRIPTION
## Summary

The agent poll handler (`internal/api/updates.go`) shipped the **global** blocklist (`GetBlocklist`) to every polling agent, so a host in one network received the revoked certificate fingerprints of **all** operators' CAs — a cross-tenant information disclosure (opaque SHA-256 fingerprints + revocation count/timing metadata). The schema already carried a `blocklist.ca_id` column (migration 009) but neither the write nor the read path used it.

## Change

- Populate `ca_id` on every blocklist insert from the host's CA: `BlockHostAndAddToBlocklist`, `DeleteHostAndBlockCert` (captured before the host row is deleted), and `AddToBlocklist` (via subquery from host_id).
- Backfill `ca_id` for legacy rows whose owning host still exists, in `repairBlocklistCAID`.
- Add `GetBlocklistForCA(caID)` and switch the poll handler to it. Rows with an empty `ca_id` (pre-fix orphans whose host is already deleted, so the CA can't be recovered) are included as a **fail-safe** so revocation is never silently weakened.
- The admin `/api/v1/blocklist` endpoint and the internal `fingerprintInBlocklist` containment check keep the global view (admin sees all; the bool check is not a disclosure).

## Tests

- `TestGetBlocklistForCA_ScopesByCA` — a host blocked under CA-1 and one under CA-2; the per-CA view returns only its own fingerprint and never the other's, while the global `GetBlocklist` still returns both.

`go test -race ./...` green, lint clean.

## Severity

Low — cross-tenant disclosure of opaque fingerprints + metadata, no host names/IPs/secrets. Hardening / tenant-isolation.

Closes #203