### PR TITLE
test(security): add local multi-operator offensive test bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 
 /configs/server.local.yml
 /local-data/
+
+# local offensive test bench (#208)
+.bench/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOLANGCI_VERSION ?= v2.12.0
 TOOLS_BIN := $(CURDIR)/.tools
 GOLANGCI_LINT := $(TOOLS_BIN)/golangci-lint
 
-.PHONY: all build test vet lint ci tools clean tidy
+.PHONY: all build test vet lint ci tools clean tidy bench-up bench-down bench-clean
 
 all: lint test build
 
@@ -35,3 +35,13 @@ clean:
 
 tidy:
 	go mod tidy
+
+# Local multi-operator offensive test bench (#208). See hack/offensive-bench/README.md.
+bench-up:
+	hack/offensive-bench/bench.sh up
+
+bench-down:
+	hack/offensive-bench/bench.sh down
+
+bench-clean:
+	hack/offensive-bench/bench.sh clean

--- a/hack/offensive-bench/README.md
+++ b/hack/offensive-bench/README.md
@@ -1,0 +1,119 @@
+# Offensive test bench
+
+A reproducible local bench for manual offensive testing of `nebula-mgmt`
+(#208). It stands up a throwaway instance on loopback and seeds a realistic
+multi-operator topology so you can attack tenancy, authz, issuance, and poll
+scoping by hand.
+
+> Developer tool only. It runs a plaintext loopback instance with a throwaway
+> master key under `./.bench`. Never point it at real data.
+
+## What it provisions
+
+- `nebula-mgmt` on `127.0.0.1:8080`, fresh SQLite DB, random master key.
+- **admin** — seeded by `init`; UI login `admin` / `bench-admin-pass`.
+- **alice** (role `user`) — API key, owns CA `alice-ca`.
+- **bob** (role `user`) — API key, owns CA `bob-ca`.
+- **admin-owned**: networks `net-a` (`10.10.0.0/24`), `net-b` (`10.20.0.0/24`);
+  hosts `host-a1`, `host-a2` (blocked — status only), `host-b1`.
+
+Networks and host creation are admin-only, and a host inherits its network's CA,
+so the cleanly scriptable tenant boundary is **CA ownership** (alice-ca vs
+bob-ca) plus the **admin-role gates**. The two non-admin operators each own a
+disjoint CA — the setup for cross-tenant and privilege-escalation checks.
+
+## Run
+
+```sh
+make bench-up          # or: hack/offensive-bench/bench.sh up
+source .bench/creds.env
+# ... run the checks below ...
+make bench-down        # stop server   (make bench-clean to also wipe ./.bench)
+```
+
+`creds.env` exports `BENCH_SERVER`, `BENCH_ADMIN_KEY`, and per-operator
+`BENCH_ALICE_*` / `BENCH_BOB_*` (key, CA, network, host IDs).
+
+A helper for authenticated calls:
+
+```sh
+as() { key="$1"; shift; curl -s -H "Authorization: Bearer $key" "$@"; }
+```
+
+## Offensive checklist (mapped to the #178 objectives)
+
+A helper for HTTP status:
+
+```sh
+code() { curl -s -o /dev/null -w '%{http_code}\n' "$@"; }
+```
+
+### Objective 4 — tenant isolation (cross-tenant IDOR)
+Bob (non-admin) must not read another operator's CA, nor admin-owned hosts.
+
+```sh
+# bob reads alice's CA → expect 403, and bob's CA list never shows alice's CA
+code -H "Authorization: Bearer $BENCH_BOB_KEY" "$BENCH_SERVER/api/v1/cas/$BENCH_ALICE_CA"   # 403
+as "$BENCH_BOB_KEY" "$BENCH_SERVER/api/v1/cas" | grep -c "$BENCH_ALICE_CA"                   # 0
+# bob reads an admin-owned host → expect 403/404, and bob's host list is empty of it
+code -H "Authorization: Bearer $BENCH_BOB_KEY" "$BENCH_SERVER/api/v1/hosts/$BENCH_HOST_A1"   # 403
+as "$BENCH_BOB_KEY" "$BENCH_SERVER/api/v1/hosts" | grep -c "$BENCH_HOST_A1"                  # 0
+```
+
+### Objective 2 — host-management takeover
+Bob must not block / rotate / re-enroll / mint a bundle for a host he does not own.
+
+```sh
+for path in block unblock rotate-cert reenroll mobile-bundle enrollment-token; do
+  printf '%-16s ' "$path"
+  code -X POST -H "Authorization: Bearer $BENCH_BOB_KEY" \
+       "$BENCH_SERVER/api/v1/hosts/$BENCH_HOST_A1/$path"   # expect 403
+done
+# bob editing an admin-owned network's firewall → expect 403
+code -X PUT -H "Authorization: Bearer $BENCH_BOB_KEY" \
+   -H 'Content-Type: application/json' -d '{"inbound":[],"outbound":[]}' \
+   "$BENCH_SERVER/api/v1/networks/$BENCH_NET_A/firewall"
+```
+
+### Auth bypass / privilege escalation
+```sh
+# no key / garbage key → 401
+curl -s -o /dev/null -w '%{http_code}\n' "$BENCH_SERVER/api/v1/hosts"
+as deadbeef -o /dev/null -w '%{http_code}\n' "$BENCH_SERVER/api/v1/hosts"
+# non-admin hitting admin-only endpoints → 403
+as "$BENCH_BOB_KEY" -o /dev/null -w '%{http_code}\n' "$BENCH_SERVER/api/v1/operators"
+as "$BENCH_BOB_KEY" -o /dev/null -w '%{http_code}\n' "$BENCH_SERVER/api/v1/audit-log"
+as "$BENCH_BOB_KEY" -o /dev/null -w '%{http_code}\n' "$BENCH_SERVER/api/v1/settings"
+```
+
+### Objective 1 — key extraction (at-rest inspection)
+CA private keys must be encrypted at rest; the master key must not be in the DB.
+
+```sh
+# No PEM private-key material in the DB; CA key columns are ciphertext.
+strings .bench/data/nebula.db | grep -i 'PRIVATE KEY' && echo 'LEAK' || echo 'no plaintext key'
+```
+
+### Objective 3 — network access / poll scoping
+The blocklist an agent receives must be scoped to its own CA (#203).
+
+The bench blocks a **pending** host (`host-a2`), which changes status only — a
+blocklist row is written when a host with a *certificate* is blocked, so this
+check needs an enrolled agent. To exercise it:
+
+1. Enroll a `nebula-agent` against `net-a` so the host gets a certificate.
+2. Block that host (`nebula-mgmt host block ...`).
+3. Inspect the row and confirm `ca_id` is the network's CA, not empty/global:
+
+```sh
+sqlite3 .bench/data/nebula.db "SELECT fingerprint, ca_id FROM blocklist;"
+```
+
+4. Poll `/api/v1/agent/updates` from an agent under a *different* CA and confirm
+   that fingerprint is **absent** from its `blocklist` field.
+
+## Notes
+
+- Re-running `up` while the server is up is refused; run `down` first.
+- Logs: `.bench/mgmt.log`. The workdir (`./.bench`) is git-ignored-friendly —
+  delete it with `make bench-clean`.

--- a/hack/offensive-bench/bench.sh
+++ b/hack/offensive-bench/bench.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# Local multi-operator offensive test bench for nebula-mesh (#208).
+#
+# Stands up a nebula-mgmt instance on loopback, seeds an admin plus two
+# non-admin operators — each with their own CA, network, and hosts — and writes
+# a creds file you can `source` to drive manual offensive checks (auth bypass,
+# cross-tenant IDOR, issuance abuse, poll scoping). See README.md for the
+# checklist mapped to the #178 objectives.
+#
+# Usage:
+#   hack/offensive-bench/bench.sh up      # build, init, serve, provision
+#   hack/offensive-bench/bench.sh creds   # print the creds file
+#   hack/offensive-bench/bench.sh status  # server health + provisioned IDs
+#   hack/offensive-bench/bench.sh down    # stop the server, keep the workdir
+#   hack/offensive-bench/bench.sh clean   # stop and delete the workdir
+#
+# Everything lives under WORK (default ./.bench, override with BENCH_WORK).
+# This is a developer tool for a throwaway loopback instance — never point it
+# at real data.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="${BENCH_WORK:-$REPO_ROOT/.bench}"
+LISTEN="${BENCH_LISTEN:-127.0.0.1:8080}"
+SERVER="http://$LISTEN"
+CONFIG="$WORK/config.yml"
+CREDS="$WORK/creds.env"
+PIDFILE="$WORK/mgmt.pid"
+LOG="$WORK/mgmt.log"
+MGMT="$WORK/bin/nebula-mgmt"
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# id_of extracts the "(ID: xxx)" field printed by the create commands.
+id_of() { sed -n 's/.*(ID: \([^,)]*\).*/\1/p' | head -n1; }
+
+require() { command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1"; }
+
+mgmt() { NEBULA_MGMT_MASTER_KEY="$MASTER_KEY" "$MGMT" "$@"; }
+
+# api runs a provisioning command with the given operator key and returns stdout.
+api() { mgmt "$@"; }
+
+gen_master_key() {
+	# 32 random bytes, base64 — the exact MasterKeySize the keystore expects.
+	if command -v openssl >/dev/null 2>&1; then
+		openssl rand -base64 32
+	else
+		head -c 32 /dev/urandom | base64
+	fi
+}
+
+build() {
+	log "building nebula-mgmt"
+	mkdir -p "$WORK/bin" "$WORK/data"
+	( cd "$REPO_ROOT" && go build -o "$MGMT" ./cmd/nebula-mgmt )
+}
+
+write_config() {
+	cat >"$CONFIG" <<YAML
+listen: "$LISTEN"
+data_dir: "$WORK/data"
+db_path: "$WORK/data/nebula.db"
+ui_password: "bench-admin-pass"
+log_level: "info"
+allow_self_registration: false
+YAML
+}
+
+wait_ready() {
+	log "waiting for $SERVER/readyz"
+	for _ in $(seq 1 50); do
+		if curl -fsS "$SERVER/readyz" >/dev/null 2>&1; then return 0; fi
+		sleep 0.2
+	done
+	die "server did not become ready — see $LOG"
+}
+
+# new_operator <username>: creates a non-admin operator, mints its API key, and
+# creates a CA owned by that operator. Networks/hosts are admin-only (a host
+# inherits its network's CA), so operator isolation is exercised through CA
+# ownership — the cleanly testable tenant boundary on the API/CLI surface.
+# Echoes:  <opID> <opKey> <caID>
+new_operator() {
+	local user="$1"
+	local opID opKey caID
+	opID=$(api user create -server "$SERVER" -api-key "$ADMIN_KEY" \
+		-username "$user" -password 'Bench-Operator-Pass-1!' -role user | id_of)
+	[ -n "$opID" ] || die "could not create operator $user"
+	opKey=$(api apikey create -server "$SERVER" -api-key "$ADMIN_KEY" \
+		-operator "$opID" -name "$user-key" | sed -n 's/^Token (shown once): //p')
+	[ -n "$opKey" ] || die "could not mint api key for $user"
+	caID=$(api ca create -server "$SERVER" -api-key "$opKey" -name "$user-ca" | id_of)
+	[ -n "$caID" ] || die "could not create CA for $user"
+	echo "$opID $opKey $caID"
+}
+
+new_network() {
+	local name="$1" cidr="$2"
+	api network create -server "$SERVER" -api-key "$ADMIN_KEY" -name "$name" -cidr "$cidr" | id_of
+}
+
+new_host() {
+	local net="$1" name="$2" ip="$3"
+	api host create -server "$SERVER" -api-key "$ADMIN_KEY" \
+		-network "$net" -name "$name" -ip "$ip" | id_of
+}
+
+cmd_up() {
+	require go; require curl
+	mkdir -p "$WORK"
+	[ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null && die "bench already running (pid $(cat "$PIDFILE")); run 'down' first"
+
+	build
+	MASTER_KEY="$(gen_master_key)"
+	write_config
+
+	log "init: migrate db + seed admin (capturing the one-time admin key)"
+	local init_out
+	init_out=$(mgmt init -config "$CONFIG")
+	ADMIN_KEY=$(echo "$init_out" | awk 'f{print;exit} /Admin API key/{f=1}')
+	[ -n "$ADMIN_KEY" ] || die "could not capture admin API key from init output"
+
+	log "serve (background) → $LOG"
+	NEBULA_MGMT_MASTER_KEY="$MASTER_KEY" nohup "$MGMT" serve -config "$CONFIG" >"$LOG" 2>&1 &
+	echo $! >"$PIDFILE"
+	wait_ready
+
+	log "provisioning non-admin operators alice + bob (each owns a CA)"
+	read -r ALICE_ID ALICE_KEY ALICE_CA < <(new_operator alice)
+	read -r BOB_ID BOB_KEY BOB_CA < <(new_operator bob)
+
+	log "provisioning admin-owned networks + hosts"
+	local NET_A NET_B H_A1 H_A2 H_B1
+	NET_A=$(new_network net-a 10.10.0.0/24)
+	NET_B=$(new_network net-b 10.20.0.0/24)
+	H_A1=$(new_host "$NET_A" host-a1 10.10.0.10)
+	H_A2=$(new_host "$NET_A" host-a2 10.10.0.11)
+	H_B1=$(new_host "$NET_B" host-b1 10.20.0.10)
+
+	# Status-only block: a pending host has no certificate fingerprint yet, so
+	# no blocklist row is written (the CA-scoped blocklist check needs an
+	# enrolled host — see README). This still gives you a blocked-status host.
+	log "blocking host-a2 (status change)"
+	api host block -server "$SERVER" -api-key "$ADMIN_KEY" -id "$H_A2" >/dev/null || true
+
+	cat >"$CREDS" <<ENV
+# Source me:  source $CREDS
+# admin owns the networks + hosts; alice and bob are non-admin operators that
+# each own a CA. Tenant isolation is exercised via CA ownership and the
+# admin-only gates (see hack/offensive-bench/README.md).
+export BENCH_SERVER="$SERVER"
+export BENCH_MASTER_KEY="$MASTER_KEY"
+export BENCH_ADMIN_KEY="$ADMIN_KEY"
+export BENCH_ALICE_ID="$ALICE_ID"
+export BENCH_ALICE_KEY="$ALICE_KEY"
+export BENCH_ALICE_CA="$ALICE_CA"
+export BENCH_BOB_ID="$BOB_ID"
+export BENCH_BOB_KEY="$BOB_KEY"
+export BENCH_BOB_CA="$BOB_CA"
+export BENCH_NET_A="$NET_A"
+export BENCH_NET_B="$NET_B"
+export BENCH_HOST_A1="$H_A1"
+export BENCH_HOST_A2_BLOCKED="$H_A2"
+export BENCH_HOST_B1="$H_B1"
+ENV
+
+	log "ready. admin UI: $SERVER/ui  (admin / bench-admin-pass)"
+	log "creds written → $CREDS"
+	echo
+	cmd_creds
+	echo
+	log "next: source $CREDS  then see hack/offensive-bench/README.md"
+}
+
+cmd_creds() { [ -f "$CREDS" ] || die "no creds file — run 'up' first"; cat "$CREDS"; }
+
+cmd_status() {
+	if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+		log "server running (pid $(cat "$PIDFILE")) at $SERVER"
+		curl -fsS "$SERVER/readyz" >/dev/null 2>&1 && echo "  /readyz: ok" || echo "  /readyz: NOT ok"
+	else
+		log "server not running"
+	fi
+	[ -f "$CREDS" ] && { echo; grep -E '^export' "$CREDS"; }
+}
+
+cmd_down() {
+	if [ -f "$PIDFILE" ]; then
+		local pid; pid="$(cat "$PIDFILE")"
+		if kill -0 "$pid" 2>/dev/null; then log "stopping server (pid $pid)"; kill "$pid" 2>/dev/null || true; fi
+		rm -f "$PIDFILE"
+	else
+		log "no pidfile; nothing to stop"
+	fi
+}
+
+cmd_clean() { cmd_down; log "removing $WORK"; rm -rf "$WORK"; }
+
+case "${1:-}" in
+	up)     cmd_up ;;
+	creds)  cmd_creds ;;
+	status) cmd_status ;;
+	down)   cmd_down ;;
+	clean)  cmd_clean ;;
+	*) echo "usage: $0 {up|creds|status|down|clean}" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

A reproducible local bench (#208) for manual offensive testing of `nebula-mgmt`. It stands up a throwaway loopback instance, seeds an admin plus two non-admin operators (each owning a CA) and admin-owned networks/hosts, and writes a creds file you can `source` to drive attacks.

## Contents

- `hack/offensive-bench/bench.sh` — `up` / `down` / `clean` / `creds` / `status`. Builds the binary, generates a master key, `init`s + seeds, serves on `127.0.0.1:8080`, provisions, and writes `.bench/creds.env`.
- `hack/offensive-bench/README.md` — curl checklist mapped to the #178 objectives: auth bypass, privilege escalation, cross-CA tenant isolation, host-management takeover, at-rest key inspection, poll/blocklist scoping.
- `Makefile`: `bench-up` / `bench-down` / `bench-clean`.
- `.gitignore`: `.bench/`.

## Model note

Network and host creation are admin-only and a host inherits its network's CA, so the cleanly scriptable tenant boundary is **CA ownership** (alice-ca vs bob-ca) plus the **admin-role gates** — the bench is built around that rather than per-operator networks.

## Verification

Ran end-to-end locally: provisioning succeeds; every documented check returns the expected code — no-key/garbage → 401; non-admin on operators/audit-log/settings/network-create → 403; bob vs alice's CA → 403 (and absent from bob's CA list); bob vs admin host block/rotate/mobile-bundle/firewall → 403; no plaintext private key in the DB. `shellcheck` clean, `bash -n` clean. No Go code changed.

Closes #208