### PR TITLE
ci(security): gate PRs on standalone gosec + govulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
           version: v2.12
           args: --timeout=5m
 
+      - name: gosec (standalone)
+        run: make gosec
+
+      - name: govulncheck
+        run: make govulncheck
+
   docker:
     name: docker build
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,15 @@ Thanks for considering a contribution to nebula-mesh.
 
 ```sh
 go mod tidy
-golangci-lint run ./...
-go test -v -race ./...
+make lint          # pinned golangci-lint (.tools/)
+make test          # go test -race ./...
+make gosec         # standalone gosec security audit
+make govulncheck   # reachable-vulnerability scan
 ```
 
-All three must pass. CI runs the same set.
+All must pass — `make ci` runs the full set, and CI runs the same.
+Security tooling (`gosec`, `govulncheck`) is pinned in the `Makefile`; gosec
+exclusions mirror `.golangci.yml` (the canonical rationale).
 
 ## Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,21 @@
 # Keep GOLANGCI_VERSION in sync with .github/workflows/ci.yml
 GOLANGCI_VERSION ?= v2.12.0
+GOSEC_VERSION ?= v2.22.9
+GOVULNCHECK_VERSION ?= v1.1.4
 
 TOOLS_BIN := $(CURDIR)/.tools
 GOLANGCI_LINT := $(TOOLS_BIN)/golangci-lint
+GOSEC := $(TOOLS_BIN)/gosec
+GOVULNCHECK := $(TOOLS_BIN)/govulncheck
 
-.PHONY: all build test vet lint ci tools clean tidy bench-up bench-down bench-clean
+# Standalone gosec excludes mirror the gosec block in .golangci.yml — that file
+# holds the canonical rationale; keep the two in sync (#165). G306 is excluded
+# here (golangci configures it to allow 0644); all writes use explicit perms.
+# G407 false positives (random nonce flagged as hardcoded) are suppressed inline
+# via #nosec in internal/keystore.
+GOSEC_EXCLUDES := G104,G115,G124,G710,G306
+
+.PHONY: all build test vet lint gosec govulncheck ci tools clean tidy bench-up bench-down bench-clean
 
 all: lint test build
 
@@ -21,7 +32,23 @@ test:
 lint: tools
 	$(GOLANGCI_LINT) run --timeout=5m ./...
 
-ci: vet build test lint
+ci: vet build test lint gosec govulncheck
+
+# Standalone gosec audit, independent of golangci-lint's bundled subset (#165).
+gosec: $(GOSEC)
+	$(GOSEC) -exclude=$(GOSEC_EXCLUDES) -quiet ./...
+
+$(GOSEC):
+	@mkdir -p $(TOOLS_BIN)
+	GOBIN="$(TOOLS_BIN)" go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
+
+# Reachable-vulnerability scan of the dependency graph (#209).
+govulncheck: $(GOVULNCHECK)
+	$(GOVULNCHECK) ./...
+
+$(GOVULNCHECK):
+	@mkdir -p $(TOOLS_BIN)
+	GOBIN="$(TOOLS_BIN)" go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
 
 tools:
 	@mkdir -p $(TOOLS_BIN)

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -109,7 +109,7 @@ Trust zones, from least to most trusted:
 - **Transport**: TLS by default; non-loopback plaintext bind refused unless opted in (#179).
 - **Crypto**: AES-256-GCM throughout; GCM tag binds AAD/nonce (envelope attacks refuted); key material zeroized (#181, #196).
 - **Input**: strict JSON decode, body caps, length bounds on cert-embedded fields (#186, #195).
-- **Tooling baseline**: `golangci-lint` (pinned) + ADR-0009 generative fuzzing in CI; `govulncheck` + standalone `gosec` pending (#209, #165).
+- **Tooling baseline**: `golangci-lint` (pinned), standalone `gosec`, and `govulncheck` gate every PR, plus ADR-0009 generative fuzzing in CI.
 
 ## 6. Residual risks & accepted trade-offs
 

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -98,7 +98,7 @@ func (m *Master) WrapDEK(dek []byte) (WrappedKey, error) {
 	if _, err := rand.Read(nonce); err != nil {
 		return WrappedKey{}, fmt.Errorf("rand nonce: %w", err)
 	}
-	ct := m.aead.Seal(nil, nonce, dek, nil)
+	ct := m.aead.Seal(nil, nonce, dek, nil) // #nosec G407 -- nonce is freshly generated via crypto/rand immediately above, not a hardcoded value
 	return WrappedKey{Ciphertext: ct, Nonce: nonce}, nil
 }
 
@@ -132,7 +132,7 @@ func SealWithDEK(dek, plaintext []byte) (WrappedBlob, error) {
 	if _, err := rand.Read(nonce); err != nil {
 		return WrappedBlob{}, err
 	}
-	ct := aead.Seal(nil, nonce, plaintext, nil)
+	ct := aead.Seal(nil, nonce, plaintext, nil) // #nosec G407 -- nonce is freshly generated via crypto/rand immediately above, not a hardcoded value
 	return WrappedBlob{Ciphertext: ct, Nonce: nonce}, nil
 }
 


### PR DESCRIPTION
## Summary

Completes the security tooling baseline (#209) and implements the standalone-gosec proposal (#165): `gosec` and `govulncheck` now gate every PR.

## Change

- **Makefile**: pinned `gosec` (v2.22.9) + `govulncheck` (v1.1.4) targets, installed into `.tools/` like `golangci-lint`; both added to `make ci`.
- **CI**: `make gosec` + `make govulncheck` steps folded into the required `build / test / lint` job, so they gate immediately (no ruleset change needed).
- **Exclusions**: standalone gosec excludes mirror the `gosec` block in `.golangci.yml` (the canonical rationale) — `GOSEC_EXCLUDES` in the Makefile points there to avoid a diverging suppression list.
- **Findings triaged**: the only standalone-gosec findings beyond the golangci subset were two **G407** false positives in `internal/keystore` — gosec flags the `nonce` passed to `aead.Seal` as a possibly-hardcoded IV, but it is freshly generated via `crypto/rand` on the line above. Suppressed with justified inline `#nosec G407`.
- **govulncheck**: 0 reachable vulnerabilities (14 in required modules, none called).
- **Docs**: CONTRIBUTING quick-checks + threat-model tooling line updated.

## Verification

`make gosec` → exit 0 (clean), `make govulncheck` → exit 0, `make lint` → 0 issues, build + vet clean. Tools pinned and reproducible locally and in CI.

Closes #209
Closes #165