### PR TITLE
fix(cli): check discarded io.ReadAll errors on response bodies

### DIFF
--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -54,7 +54,10 @@ func CACreate(serverURL, apiKey, name, duration string) error {
 			slog.Error("close response body", "error", err)
 		}
 	}()
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(respBody))
 	}
@@ -128,7 +131,10 @@ func CARotate(serverURL, apiKey, id string) error {
 			slog.Error("close response body", "error", err)
 		}
 	}()
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(respBody))
 	}

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -119,7 +119,10 @@ func doHostAction(serverURL, apiKey, method, path string, wantStatus int, verb s
 		}
 	}()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
 	if resp.StatusCode != wantStatus {
 		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}

--- a/internal/cli/user.go
+++ b/internal/cli/user.go
@@ -52,7 +52,10 @@ func UserCreate(serverURL, apiKey, username, password, displayName, role string)
 			slog.Error("close response body", "error", err)
 		}
 	}()
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(respBody))
 	}
@@ -135,7 +138,10 @@ func APIKeyCreate(serverURL, apiKey, operatorID, name string) error {
 			slog.Error("close response body", "error", err)
 		}
 	}()
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed (HTTP %d): %s", resp.StatusCode, string(respBody))
 	}


### PR DESCRIPTION
Closes #213.

ca.go, user.go and host.go (`doHostAction`) read the response body with `respBody, _ := io.ReadAll(...)`, discarding the error. A read that fails mid-stream returns a partial slice, so the discarded error surfaced later as a misleading "decode response" JSON error or a truncated HTTP-failure message instead of the real I/O failure.

Check the error and wrap it, mirroring the existing correct pattern in `host.go:HostCreate` (line 58).

Build, vet, `go test ./internal/cli/` and pinned golangci-lint all green.