### PR TITLE
fix(cli): validate --server URL before issuing requests

### DIFF
--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -34,6 +34,9 @@ type caRotateResponse struct {
 
 // CACreate creates a new CA via the API.
 func CACreate(serverURL, apiKey, name, duration string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	if name == "" {
 		return fmt.Errorf("--name is required")
 	}
@@ -72,6 +75,9 @@ func CACreate(serverURL, apiKey, name, duration string) error {
 
 // CAList prints the CAs visible to the caller.
 func CAList(serverURL, apiKey string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL+"/api/v1/cas", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
@@ -113,6 +119,9 @@ func CADelete(serverURL, apiKey, id string) error {
 
 // CARotate rotates a CA via the API.
 func CARotate(serverURL, apiKey, id string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	if apiKey == "" {
 		return fmt.Errorf("--api-key is required")
 	}

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -14,6 +14,9 @@ import (
 
 // HostCreate creates a host via the API.
 func HostCreate(serverURL, apiKey, networkID, name, nebulaIP, role string, groups []string, publicIP string, listenPort int) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	// Convert single nebulaIP to the new nebula_ips array format
 	nebullaIPs := []string{nebulaIP}
 	if nebulaIP == "" {
@@ -96,6 +99,9 @@ func HostUnblock(serverURL, apiKey, hostID string) error {
 }
 
 func doHostAction(serverURL, apiKey, method, path string, wantStatus int, verb string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	if apiKey == "" {
 		return fmt.Errorf("--api-key is required")
 	}
@@ -133,6 +139,9 @@ func doHostAction(serverURL, apiKey, method, path string, wantStatus int, verb s
 
 // HostList lists hosts via the API.
 func HostList(serverURL, apiKey, networkID string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	u := serverURL + "/api/v1/hosts"
 	if networkID != "" {
 		u += "?network_id=" + url.QueryEscape(networkID)

--- a/internal/cli/network.go
+++ b/internal/cli/network.go
@@ -12,6 +12,9 @@ import (
 
 // NetworkCreate creates a network via the API.
 func NetworkCreate(serverURL, apiKey, name, cidr string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	// Convert single CIDR to the new cidrs array format
 	cidrs := []string{cidr}
 	if cidr == "" {
@@ -67,6 +70,9 @@ func NetworkCreate(serverURL, apiKey, name, cidr string) error {
 
 // NetworkList lists networks via the API.
 func NetworkList(serverURL, apiKey string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL+"/api/v1/networks", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)

--- a/internal/cli/server_url.go
+++ b/internal/cli/server_url.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// validateServerURL rejects a --server value that is not a well-formed
+// http(s) URL with a host. It deliberately allows private/loopback hosts:
+// the CLI's whole purpose is to talk to a management server, which usually
+// lives on localhost or an internal network (the default is
+// http://localhost:8080). The guard stops scheme-confusion and malformed
+// targets (file://, missing host, no scheme) from redirecting the operator's
+// API key to an attacker-controlled endpoint — the exfil vector in #214.
+func validateServerURL(serverURL string) error {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("invalid --server URL %q: %w", serverURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid --server URL %q: scheme must be http or https", serverURL)
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("invalid --server URL %q: missing host", serverURL)
+	}
+	return nil
+}

--- a/internal/cli/server_url_test.go
+++ b/internal/cli/server_url_test.go
@@ -1,0 +1,31 @@
+package cli
+
+import "testing"
+
+func TestValidateServerURL(t *testing.T) {
+	valid := []string{
+		"http://localhost:8080",
+		"https://mgmt.example.com",
+		"http://10.0.0.1:8080", // private/loopback is allowed: that's the CLI's normal target
+		"https://192.168.1.5",
+	}
+	for _, s := range valid {
+		if err := validateServerURL(s); err != nil {
+			t.Errorf("validateServerURL(%q) = %v, want nil", s, err)
+		}
+	}
+
+	invalid := []string{
+		"",                       // empty
+		"localhost:8080",         // no scheme -> parsed as scheme "localhost", no host
+		"ftp://mgmt.example.com", // wrong scheme
+		"file:///etc/passwd",     // wrong scheme, exfil vector
+		"http://",                // missing host
+		"://nohost",              // unparseable scheme
+	}
+	for _, s := range invalid {
+		if err := validateServerURL(s); err == nil {
+			t.Errorf("validateServerURL(%q) = nil, want error", s)
+		}
+	}
+}

--- a/internal/cli/user.go
+++ b/internal/cli/user.go
@@ -27,6 +27,9 @@ type userResponse struct {
 
 // UserCreate creates a new operator via the API.
 func UserCreate(serverURL, apiKey, username, password, displayName, role string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	if username == "" || password == "" {
 		return fmt.Errorf("--username and --password are required")
 	}
@@ -69,6 +72,9 @@ func UserCreate(serverURL, apiKey, username, password, displayName, role string)
 
 // UserList lists operators via the API.
 func UserList(serverURL, apiKey string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL+"/api/v1/operators", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
@@ -121,6 +127,9 @@ type apiKeyCreateResponse struct {
 // APIKeyCreate creates a new per-operator API key. The plaintext key is
 // printed once.
 func APIKeyCreate(serverURL, apiKey, operatorID, name string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	body, _ := json.Marshal(map[string]string{"name": name})
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/operators/"+operatorID+"/api-keys", bytes.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
Closes #214.

CLI commands concatenated the operator-supplied `--server` value straight into request URLs with no validation, so a malformed or attacker-chosen value (`file://`, a bare host, a non-http scheme) could redirect the Authorization-bearing request to an unintended endpoint and leak the API key.

`validateServerURL` requires a parseable http/https URL with a host. Private/loopback hosts stay allowed on purpose — the CLI's normal target is a localhost or internal management server (default `http://localhost:8080`). Every exported CLI entry point is guarded; Host/User mutations and CA/API-key deletes funnel through `doHostAction`, guarded once.

Unit test covers valid (incl. private/loopback) and invalid (empty, no scheme, ftp/file scheme, missing host) inputs. Build, vet, `go test ./internal/cli/`, pinned golangci-lint green.