### PR TITLE
fix(cli): add request timeout to CLI HTTP client

### DIFF
--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -48,7 +48,7 @@ func CACreate(serverURL, apiKey, name, duration string) error {
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
@@ -84,7 +84,7 @@ func CAList(serverURL, apiKey string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
@@ -131,7 +131,7 @@ func CARotate(serverURL, apiKey, id string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"net/http"
+	"time"
+)
+
+// defaultCLIHTTPTimeout bounds a single CLI request so an unresponsive or
+// unreachable management server cannot hang the command indefinitely. Mirrors
+// the agent daemon's per-request timeout (#193); http.DefaultClient has none.
+const defaultCLIHTTPTimeout = 30 * time.Second
+
+// httpClient is the shared client for every CLI request. It exists solely to
+// carry the timeout that http.DefaultClient lacks.
+var httpClient = &http.Client{Timeout: defaultCLIHTTPTimeout}

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -48,7 +48,7 @@ func HostCreate(serverURL, apiKey, networkID, name, nebulaIP, role string, group
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
@@ -115,7 +115,7 @@ func doHostAction(serverURL, apiKey, method, path string, wantStatus int, verb s
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
@@ -153,7 +153,7 @@ func HostList(serverURL, apiKey, networkID string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}

--- a/internal/cli/network.go
+++ b/internal/cli/network.go
@@ -37,7 +37,7 @@ func NetworkCreate(serverURL, apiKey, name, cidr string) error {
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
@@ -79,7 +79,7 @@ func NetworkList(serverURL, apiKey string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}

--- a/internal/cli/user.go
+++ b/internal/cli/user.go
@@ -46,7 +46,7 @@ func UserCreate(serverURL, apiKey, username, password, displayName, role string)
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
@@ -81,7 +81,7 @@ func UserList(serverURL, apiKey string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
@@ -138,7 +138,7 @@ func APIKeyCreate(serverURL, apiKey, operatorID, name string) error {
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}


### PR DESCRIPTION
Closes #216.

CLI commands issued requests via `http.DefaultClient` (no timeout) with `context.Background()` (no deadline), so an unresponsive or unreachable management server hung the command indefinitely. The agent daemon was already fixed for this in #193.

Every CLI request now goes through a shared `http.Client` with a 30s timeout (`defaultCLIHTTPTimeout`), mirroring the agent's per-request bound. Build, vet, `go test ./internal/cli/`, pinned golangci-lint green.