### PR TITLE
fix(config): create parent dir in SaveServerConfig before CreateTemp

### DIFF
--- a/internal/config/save_server_config_mkdir_test.go
+++ b/internal/config/save_server_config_mkdir_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSaveServerConfig_CreatesParentDir pins #215: SaveServerConfig must create
+// the parent directory before writing the temp file, so `nebula-mgmt init`
+// into a config path under a not-yet-existing directory succeeds (the agent
+// path already does this via SaveAgentConfig).
+func TestSaveServerConfig_CreatesParentDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "etc", "nebula-mgmt")
+	path := filepath.Join(dir, "server.yml")
+
+	if err := SaveServerConfig(path, &ServerConfig{}); err != nil {
+		t.Fatalf("SaveServerConfig into non-existent dir: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -473,6 +473,9 @@ func SaveServerConfig(path string, cfg *ServerConfig) error {
 	}
 
 	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
 	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
 	if err != nil {
 		return fmt.Errorf("create temp config: %w", err)


### PR DESCRIPTION
Closes #215.

`SaveServerConfig` called `os.CreateTemp(dir, ...)` without ensuring `dir` existed, so `nebula-mgmt init --config <path>` failed with "no such file or directory" when the config path pointed at a not-yet-existing directory (e.g. `/etc/nebula-mgmt/server.yml`). `SaveAgentConfig` already does `os.MkdirAll` first; apply the same pattern.

Test writes a config into a nested non-existent dir and asserts success. Build, `go test ./internal/config/`, pinned golangci-lint green.