### PR TITLE
chore(cli,models): check json.Marshal errors and fix function typo

### DIFF
--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -40,7 +40,10 @@ func CACreate(serverURL, apiKey, name, duration string) error {
 	if name == "" {
 		return fmt.Errorf("--name is required")
 	}
-	body, _ := json.Marshal(caCreateRequest{Name: name, Duration: duration})
+	body, err := json.Marshal(caCreateRequest{Name: name, Duration: duration})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/cas", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)

--- a/internal/cli/user.go
+++ b/internal/cli/user.go
@@ -130,7 +130,10 @@ func APIKeyCreate(serverURL, apiKey, operatorID, name string) error {
 	if err := validateServerURL(serverURL); err != nil {
 		return err
 	}
-	body, _ := json.Marshal(map[string]string{"name": name})
+	body, err := json.Marshal(map[string]string{"name": name})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL+"/api/v1/operators/"+operatorID+"/api-keys", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)

--- a/internal/models/hostdiff.go
+++ b/internal/models/hostdiff.go
@@ -38,7 +38,7 @@ func HostDiff(before, after *Host) ([]byte, bool, error) {
 		}
 	}
 
-	if !nebulIPsEqual(before.NebulaIPs, after.NebulaIPs) {
+	if !nebulaIPsEqual(before.NebulaIPs, after.NebulaIPs) {
 		changes["nebula_ips"] = map[string]any{
 			"before": before.NebulaIPs,
 			"after":  after.NebulaIPs,
@@ -149,8 +149,8 @@ func HostDiff(before, after *Host) ([]byte, bool, error) {
 	return jsonBytes, true, nil
 }
 
-// nebulIPsEqual compares two IP slices for equality (order matters).
-func nebulIPsEqual(a, b []string) bool {
+// nebulaIPsEqual compares two IP slices for equality (order matters).
+func nebulaIPsEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}


### PR DESCRIPTION
Closes #217.

Two low-risk cleanups from the code review:

- `ca.go` (CACreate) and `user.go` (APIKeyCreate) discarded the `json.Marshal` error. Risk is low (simple serializable types), but check it for consistency with `UserCreate` and the rest of the package.
- Rename `nebulIPsEqual` -> `nebulaIPsEqual` in `hostdiff.go` to match the `NebulaIPs` field and the `fieldNameEqual` convention of its siblings.

Build, vet, tests, pinned golangci-lint green.