### PR TITLE
fix(web): reject login with empty username instead of defaulting to admin

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -82,9 +82,6 @@ func (w *Web) handleLoginPage(rw http.ResponseWriter, r *http.Request) {
 
 func (w *Web) handleLogin(rw http.ResponseWriter, r *http.Request) {
 	username := r.FormValue("username")
-	if username == "" {
-		username = "admin"
-	}
 	password := r.FormValue("password")
 	result, ok, err := w.session.Login(rw, r, username, password)
 	if err != nil {

--- a/internal/web/login_test.go
+++ b/internal/web/login_test.go
@@ -1,0 +1,47 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogin_EmptyUsernameRejected verifies that POST /ui/login with an
+// empty username is denied even when the password matches the admin
+// account. The handler must not substitute a default username
+// (GHSA-gvjh-8rm7-23h3 hardening).
+func TestLogin_EmptyUsernameRejected(t *testing.T) {
+	w, _ := newTestWeb(t)
+
+	getReq := httptest.NewRequest(http.MethodGet, "/ui/login", nil)
+	getRec := httptest.NewRecorder()
+	w.ServeHTTP(getRec, getReq)
+	csrfCookie := getCSRFCookieFromResponse(getRec)
+	require.NotNil(t, csrfCookie, "expected CSRF cookie from GET /ui/login")
+
+	for _, username := range []string{"", "   "} {
+		form := url.Values{
+			"username": {username},
+			"password": {testPassword},
+			"_csrf":    {csrfCookie.Value},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.AddCookie(csrfCookie)
+		rec := httptest.NewRecorder()
+		w.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code,
+			"login with username %q must re-render the login page, not redirect", username)
+		require.Contains(t, rec.Body.String(), "Invalid username or password",
+			"login with username %q must be denied", username)
+		for _, c := range rec.Result().Cookies() {
+			require.NotEqual(t, sessionCookieName, c.Name,
+				"login with username %q must not issue a session cookie", username)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Remove the implicit `username = "admin"` fallback in the web login handler. An empty username now gets the standard "Invalid username or password" response from the existing `SessionManager.Login` guard instead of being silently converted into a login attempt against the admin account.

## Context

Reported in GHSA-gvjh-8rm7-23h3, which we closed as **not a vulnerability**: the default admin username is public (seeded by bootstrap, prefilled in the login form), the full bcrypt + TOTP verification path still applied, and the reporter's own CVSS vector scores 0.0. The fallback was a compatibility shim from the single-password to multi-operator auth migration (#22) and no longer serves a purpose — but implicit identity substitution in an auth handler is poor hygiene, so it goes.

## Changes

- `internal/web/handlers.go`: drop the empty-username fallback in `handleLogin`.
- `internal/web/login_test.go`: new test asserting that login with an empty or whitespace username is denied, re-renders the login page, and issues no session cookie.

## Testing

- `go test -race ./...` — green
- `make lint` — 0 issues
- TDD: the new test fails on `main` (empty username + valid admin password logs in with a 303) and passes with the fix.
