### PR TITLE
chore: bump Go toolchain to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 FROM golang:${GO_VERSION}-alpine AS build
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/forgekeep/nebula-mesh
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc


### PR DESCRIPTION
govulncheck flags two stdlib vulnerabilities reachable from this code,
both fixed in go1.26.4:

- GO-2026-5039 (net/textproto): reachable via io.ReadAll ->
  ReadMIMEHeader in internal/cli/user.go
- GO-2026-5037 (crypto/x509 hostname parsing): reachable via
  ListenAndServe certificate verification in internal/cli/serve.go and
  internal/cli/network.go

After the bump, govulncheck ./... reports no reachable vulnerabilities.
