### PR TITLE
fix(ratelimit): key on rightmost X-Forwarded-For entry, not leftmost

### DIFF
--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -112,20 +112,21 @@ func (l *Limiter) Allow(ip, group string) (allowed bool, retryAfter time.Duratio
 }
 
 // ClientIP returns the effective IP for the request. When the limiter
-// is configured to trust X-Forwarded-For, the leftmost public address
-// wins; otherwise RemoteAddr is used.
+// is configured to trust X-Forwarded-For, the rightmost address wins:
+// that entry was appended by the reverse proxy in front of this server,
+// while everything to its left arrived in the client's own header and
+// is attacker-controlled. Entries left of the rightmost are never
+// consulted — falling back leftward on a parse failure would let a
+// client choose its own rate-limit key with "spoofed, garbage". If the
+// rightmost entry does not parse, or trust_proxy_header is off,
+// RemoteAddr is used.
 func (l *Limiter) ClientIP(r *http.Request) string {
 	if l != nil && l.cfg.TrustProxyHeader {
 		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 			parts := strings.Split(xff, ",")
-			for _, p := range parts {
-				p = strings.TrimSpace(p)
-				if p == "" {
-					continue
-				}
-				if ip := net.ParseIP(p); ip != nil {
-					return ip.String()
-				}
+			last := strings.TrimSpace(parts[len(parts)-1])
+			if ip := net.ParseIP(last); ip != nil {
+				return ip.String()
 			}
 		}
 	}

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -75,11 +75,59 @@ func TestClientIP_TrustProxyHeader(t *testing.T) {
 		Groups:           map[string]GroupConfig{"auth": {Rate: 5, Burst: 10}},
 	})
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.RemoteAddr = "127.0.0.1:5555"
-	r.Header.Set("X-Forwarded-For", "203.0.113.10, 10.0.0.1")
-	if got := l.ClientIP(r); got != "203.0.113.10" {
-		t.Errorf("ClientIP = %q, want 203.0.113.10 (leftmost X-Forwarded-For)", got)
+	tests := []struct {
+		name string
+		xff  string
+		want string
+	}{
+		{
+			name: "single entry appended by proxy",
+			xff:  "203.0.113.10",
+			want: "203.0.113.10",
+		},
+		{
+			// The proxy appends the connecting client's IP on the
+			// right; anything to the left arrived in the client's own
+			// header and must not be trusted.
+			name: "rightmost wins over client-supplied entries",
+			xff:  "198.51.100.99, 203.0.113.10",
+			want: "203.0.113.10",
+		},
+		{
+			// A client rotating a fake leftmost entry per request must
+			// still key on the address the proxy saw.
+			name: "spoofed leftmost entry ignored",
+			xff:  "10.99.99.99, 203.0.113.10",
+			want: "203.0.113.10",
+		},
+		{
+			// No leftward fallback: an unparseable rightmost entry
+			// must not let the client pick its own key from a left
+			// entry — fall through to RemoteAddr instead.
+			name: "unparseable rightmost falls back to RemoteAddr, not leftward",
+			xff:  "198.51.100.99, not-an-ip",
+			want: "127.0.0.1",
+		},
+		{
+			name: "empty rightmost falls back to RemoteAddr",
+			xff:  "198.51.100.99,",
+			want: "127.0.0.1",
+		},
+		{
+			name: "IPv6 rightmost",
+			xff:  "198.51.100.99, 2001:db8::7",
+			want: "2001:db8::7",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = "127.0.0.1:5555"
+			r.Header.Set("X-Forwarded-For", tc.xff)
+			if got := l.ClientIP(r); got != tc.want {
+				t.Errorf("ClientIP(xff=%q) = %q, want %q", tc.xff, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
With trust_proxy_header enabled, ClientIP returned the first parseable
X-Forwarded-For entry. The comment claimed the leftmost public address
wins, but there was no public/trust check — and the leftmost entry is
the one the client itself sends. A reverse proxy appends the connecting
address on the right (nginx's $proxy_add_x_forwarded_for, the shipped
snippets in deploy/reverse-proxy/), so an attacker could rotate a fake
leftmost value per request to evade the per-IP auth, enroll, and
agent_poll buckets, and poison the masked IP recorded in audit entries.

Trust the rightmost entry instead: it is the only one written by the
proxy we trust. There is deliberately no leftward fallback when the
rightmost entry fails to parse — that would reopen the same bypass —
the limiter falls back to RemoteAddr instead.
