### PR TITLE
fix(web): equalize login timing for OIDC accounts

### DIFF
--- a/internal/web/login_timing_test.go
+++ b/internal/web/login_timing_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 
@@ -57,6 +58,17 @@ func TestLogin_ConstantTimeAcrossAccountStates(t *testing.T) {
 	}
 	mkOp("op-active", "alice", models.OperatorStatusActive)
 	mkOp("op-disabled", "bob", models.OperatorStatusDisabled)
+	// An OIDC-provisioned account stores the "oidc" sentinel instead of a
+	// bcrypt hash (oidc.go), so the real compare fails instantly with
+	// ErrHashTooShort — the dummy compare must cover that path too.
+	if err := s.CreateOperator(ctx, &models.Operator{
+		ID: "op-oidc", Username: "carol", PasswordHash: "oidc", Role: "user",
+		Status: models.OperatorStatusActive, AuthProvider: models.OperatorAuthOIDC,
+		OIDCIssuer: "https://idp.example.com", OIDCSubject: "carol-sub",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	sm := NewSessionManager(s)
 
@@ -71,10 +83,19 @@ func TestLogin_ConstantTimeAcrossAccountStates(t *testing.T) {
 		}
 		return time.Since(start)
 	}
+	// The baseline is the genuine-bcrypt path the others are compared
+	// against; take the median of three samples so a single scheduler
+	// outlier can't skew the floor and flake the test under CI load.
+	medianBaseline := func(user, pass string) time.Duration {
+		ds := []time.Duration{measure(user, pass), measure(user, pass), measure(user, pass)}
+		sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+		return ds[1]
+	}
 
-	baseline := measure("alice", "wrong-password") // genuine bcrypt verify
-	missing := measure("ghost", "whatever")        // unknown username
-	inactive := measure("bob", "whatever")         // disabled account
+	baseline := medianBaseline("alice", "wrong-password") // genuine bcrypt verify (median of 3)
+	missing := measure("ghost", "whatever")               // unknown username
+	inactive := measure("bob", "whatever")                // disabled account
+	oidc := measure("carol", "whatever")                  // active OIDC account ("oidc" sentinel hash)
 
 	floor := baseline / 2
 	if missing < floor {
@@ -82,5 +103,8 @@ func TestLogin_ConstantTimeAcrossAccountStates(t *testing.T) {
 	}
 	if inactive < floor {
 		t.Errorf("inactive-account login too fast: %v < %v (half of baseline %v) — timing oracle", inactive, floor, baseline)
+	}
+	if oidc < floor {
+		t.Errorf("OIDC-account login too fast: %v < %v (half of baseline %v) — timing oracle distinguishes OIDC accounts", oidc, floor, baseline)
 	}
 }

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -100,6 +100,14 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 		return LoginResult{}, false, nil
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {
+		if !errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+			// The stored value is not a usable bcrypt hash — e.g. the "oidc"
+			// sentinel on OIDC-provisioned accounts — so the compare above
+			// returned without doing any KDF work. Run the dummy compare so
+			// an active OIDC username is indistinguishable from a wrong
+			// password (#180).
+			_ = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password))
+		}
 		// Wrong password is a normal auth failure (bool=false), not a system
 		// error to surface to the caller.
 		return LoginResult{}, false, nil //nolint:nilerr


### PR DESCRIPTION
OIDC-provisioned operators store the "oidc" sentinel instead of a
bcrypt hash, so the password compare in Login fails instantly with
ErrHashTooShort — no KDF work. The #180 dummy-hash equalizer only
covered the unknown-username and inactive-account paths, leaving a
timing oracle that distinguishes active OIDC accounts (microseconds)
from wrong passwords and unknown usernames (~full bcrypt cost).

Run the dummy compare whenever the stored hash is unusable (any compare
error other than ErrMismatchedHashAndPassword), and extend the
constant-time login test with an OIDC-account case. The new assertion
fails against the previous code (16.8µs vs a ~23ms floor on this
machine) and passes with the fix.
