### PR TITLE
fix(store,api,web): empty operator role defaults to user, not admin

### DIFF
--- a/internal/api/operators.go
+++ b/internal/api/operators.go
@@ -38,6 +38,15 @@ func (s *Server) handleCreateOperator(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "username and password are required")
 		return
 	}
+	// An omitted role means least privilege; anything else must be a known
+	// role so a typo can't silently land on a store-level default.
+	if req.Role == "" {
+		req.Role = models.OperatorRoleUser
+	}
+	if !models.ValidOperatorRole(req.Role) {
+		writeError(w, http.StatusBadRequest, "role must be \"admin\" or \"user\"")
+		return
+	}
 	if err := s.passwordPolicy.Validate(req.Password, strings.ToLower(req.Username)); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/api/operators_test.go
+++ b/internal/api/operators_test.go
@@ -33,6 +33,9 @@ func TestOperatorLifecycle_CreateListDisable(t *testing.T) {
 	if created.Username != "bob" {
 		t.Errorf("username = %q, want bob", created.Username)
 	}
+	if created.Role != models.OperatorRoleUser {
+		t.Errorf("omitted role = %q, want %q (least privilege)", created.Role, models.OperatorRoleUser)
+	}
 
 	// List should include bob
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/operators", nil)
@@ -70,11 +73,29 @@ func TestOperatorLifecycle_CreateListDisable(t *testing.T) {
 	}
 }
 
-func TestOperatorAPIKey_CreateAndUse(t *testing.T) {
+func TestCreateOperator_UnknownRoleRejected(t *testing.T) {
 	srv, _ := newTestServer(t)
 
 	body, _ := json.Marshal(map[string]string{
-		"username": "carol", "password": "secret123",
+		"username": "mallory", "password": "supersecret", "role": "superadmin",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators", bytes.NewBuffer(body))
+	authRequest(req)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("create with role=superadmin status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOperatorAPIKey_CreateAndUse(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	// Explicit admin: an omitted role defaults to "user" (least privilege),
+	// so the key must be created with role=admin to pass the admin-gated
+	// operators list check below.
+	body, _ := json.Marshal(map[string]string{
+		"username": "carol", "password": "secret123", "role": "admin",
 	})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/operators", bytes.NewBuffer(body))
 	authRequest(req)

--- a/internal/config/oidc_validate_test.go
+++ b/internal/config/oidc_validate_test.go
@@ -47,6 +47,15 @@ func TestOIDCConfig_Validate(t *testing.T) {
 			name: "enabled + unset default_role + allowed_emails set accepted (allowlist gates access; runtime defaults to user)",
 			cfg:  &OIDCConfig{Enabled: true, AllowedEmails: []string{"alice@example.com"}},
 		},
+		{
+			// An allowlist is set so the admin-escalation guard is satisfied;
+			// the role itself is still invalid and must be rejected so the
+			// misconfig fails at startup, not at the first OIDC login where
+			// CreateOperator's allowlist would 500.
+			name:      "enabled + unknown default_role rejected even with allowlist",
+			cfg:       &OIDCConfig{Enabled: true, DefaultRole: "operator", AllowedEmails: []string{"alice@example.com"}},
+			wantError: "not a valid role",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
 )
 
 // CAAutoRotateConfig configures the CA auto-rotation scanner: interval between scans,
@@ -377,6 +379,14 @@ func (o *OIDCConfig) Validate() error {
 		if iss.Scheme != "https" && !hostIsPrivate(iss.Hostname()) {
 			return fmt.Errorf("oidc.issuer must use https for a non-loopback host (got %q)", o.Issuer)
 		}
+	}
+	// A non-empty default_role must be a role CreateOperator accepts.
+	// Otherwise the misconfiguration is silent until the first OIDC login,
+	// where provisioning fails the store's allowlist and the operator gets
+	// a 500 with no account created — fail loudly at startup instead.
+	if o.DefaultRole != "" && !models.ValidOperatorRole(o.DefaultRole) {
+		return fmt.Errorf("oidc.default_role %q is not a valid role; use %q or %q",
+			o.DefaultRole, models.OperatorRoleAdmin, models.OperatorRoleUser)
 	}
 	roleUnsetOrAdmin := o.DefaultRole == "" || o.DefaultRole == "admin"
 	noAllowlist := len(o.AllowedGroups) == 0 && len(o.AllowedEmails) == 0

--- a/internal/models/operator.go
+++ b/internal/models/operator.go
@@ -18,6 +18,18 @@ const (
 	OperatorAuthOIDC  OperatorAuthProvider = "oidc"
 )
 
+// Operator roles. Operator.Role is a plain string; these are the only two
+// values the server accepts.
+const (
+	OperatorRoleAdmin = "admin"
+	OperatorRoleUser  = "user"
+)
+
+// ValidOperatorRole reports whether r is a known operator role.
+func ValidOperatorRole(r string) bool {
+	return r == OperatorRoleAdmin || r == OperatorRoleUser
+}
+
 // Operator is an administrative user of the management server.
 type Operator struct {
 	ID           string               `json:"id"`

--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -56,8 +56,14 @@ func (s *SQLiteStore) CreateOperator(ctx context.Context, op *models.Operator) e
 	if op.Status == "" {
 		op.Status = models.OperatorStatusActive
 	}
+	// Least privilege: a caller that wants an admin must say so. Defaulting
+	// the empty string to admin would let any future caller that forgets to
+	// set Role self-provision an administrator.
 	if op.Role == "" {
-		op.Role = "admin"
+		op.Role = models.OperatorRoleUser
+	}
+	if !models.ValidOperatorRole(op.Role) {
+		return fmt.Errorf("invalid operator role %q", op.Role)
 	}
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO operators (id, username, display_name, password_hash, auth_provider, status, role, oidc_issuer, oidc_subject, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -103,8 +109,14 @@ func (s *SQLiteStore) SeedInitialAdminOperator(ctx context.Context, op *models.O
 	if op.Status == "" {
 		op.Status = models.OperatorStatusActive
 	}
+	// The seed only ever runs against an empty operators table, and the
+	// first operator must be able to administer the server — admin is the
+	// correct default here, unlike CreateOperator.
 	if op.Role == "" {
-		op.Role = "admin"
+		op.Role = models.OperatorRoleAdmin
+	}
+	if !models.ValidOperatorRole(op.Role) {
+		return false, fmt.Errorf("invalid operator role %q", op.Role)
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)

--- a/internal/store/sqlite_operators_test.go
+++ b/internal/store/sqlite_operators_test.go
@@ -37,8 +37,42 @@ func TestCreateOperator_Defaults(t *testing.T) {
 	if got.AuthProvider != models.OperatorAuthLocal {
 		t.Errorf("auth_provider = %q, want local", got.AuthProvider)
 	}
-	if got.Role != "admin" {
-		t.Errorf("role = %q, want admin", got.Role)
+	// Least privilege: an empty role must NOT default to admin — a caller
+	// that wants an admin has to say so (SeedInitialAdminOperator does).
+	if got.Role != models.OperatorRoleUser {
+		t.Errorf("role = %q, want %q", got.Role, models.OperatorRoleUser)
+	}
+}
+
+func TestCreateOperator_RejectsUnknownRole(t *testing.T) {
+	s := newTestStore(t)
+	err := s.CreateOperator(context.Background(), &models.Operator{
+		ID: "op-mallory", Username: "mallory", PasswordHash: "bcrypt$hash",
+		Role: "superadmin",
+	})
+	if err == nil {
+		t.Fatal("CreateOperator accepted unknown role \"superadmin\"")
+	}
+}
+
+func TestSeedInitialAdminOperator_EmptyRoleDefaultsToAdmin(t *testing.T) {
+	s := newTestStore(t)
+	op := &models.Operator{
+		ID: "op-seed", Username: "root", PasswordHash: "bcrypt$hash",
+	}
+	seeded, err := s.SeedInitialAdminOperator(context.Background(), op, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !seeded {
+		t.Fatal("seed did not run on empty table")
+	}
+	got, err := s.GetOperator(context.Background(), "op-seed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Role != models.OperatorRoleAdmin {
+		t.Errorf("seeded role = %q, want %q", got.Role, models.OperatorRoleAdmin)
 	}
 }
 

--- a/internal/web/operators.go
+++ b/internal/web/operators.go
@@ -66,6 +66,12 @@ func (w *Web) handleOperatorCreate(rw http.ResponseWriter, r *http.Request) {
 	if password == "" {
 		form.Errors["password"] = "Required"
 	}
+	// The form's select only offers the known roles, but the value is
+	// client-controlled — reject anything else here rather than surfacing
+	// the store's error as a 500.
+	if !models.ValidOperatorRole(form.Role) {
+		form.Errors["role"] = "Must be admin or user"
+	}
 
 	// If any required fields are missing, render error and return.
 	if len(form.Errors) > 0 {

--- a/internal/web/operators_test.go
+++ b/internal/web/operators_test.go
@@ -225,6 +225,41 @@ func TestOperators_CreateRejectsWeakPassword(t *testing.T) {
 	}
 }
 
+// TestOperators_CreateRejectsUnknownRole pins the web-form role allowlist: a
+// crafted POST with a role outside {admin,user} is rejected with a 400 inline
+// error rather than surfacing the store's error as a 500. Mirrors the API-side
+// TestCreateOperator_UnknownRoleRejected.
+func TestOperators_CreateRejectsUnknownRole(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	cookie := mintSession(t, s, "root", "admin")
+
+	csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/operators", []*http.Cookie{cookie})
+
+	form := url.Values{
+		"username":         {"mallory"},
+		"password":         {strongPassword},
+		"password_confirm": {strongPassword},
+		"role":             {"superadmin"},
+		"_csrf":            {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/operators", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range updatedCookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "admin or user") {
+		t.Errorf("expected role error, got %s", rec.Body.String())
+	}
+	if _, err := s.GetOperatorByUsername(context.Background(), "mallory"); err == nil {
+		t.Error("operator with invalid role must not be persisted")
+	}
+}
+
 func TestOperators_CreateInlineErrors_PerField(t *testing.T) {
 	w, s := newOperatorsWeb(t)
 	cookie := mintSession(t, s, "root", "admin")


### PR DESCRIPTION
CreateOperator silently promoted an empty Role to admin. No current
caller hits that branch (register, the operator form, and OIDC
provisioning all set an explicit role), but any future caller that
forgets to set Role would self-provision an administrator — the same
silent-default shape as the empty-username bug fixed in #223.

- CreateOperator: empty role now defaults to user (least privilege)
  and unknown roles are rejected. SeedInitialAdminOperator keeps the
  admin default — it only runs against an empty operators table, and
  the first operator must be able to administer the server — and gains
  the same unknown-role rejection.
- POST /api/v1/operators previously persisted req.Role verbatim; it now
  validates against the known roles and returns 400 for anything else,
  so a typo can't land on a store-level default.
- The operator-create form validates the client-controlled role value
  instead of surfacing the store error as a 500.
- OIDCConfig.Validate rejects a default_role outside {admin,user} at
  startup, so a custom/typo default_role fails loudly instead of 500ing
  every OIDC provisioning login against the new store allowlist.
- New models.OperatorRoleAdmin/OperatorRoleUser constants and
  models.ValidOperatorRole.

The API-key lifecycle test now creates its operator with an explicit
admin role; it exercises admin-gated endpoints and previously relied on
the implicit admin default.
