### PR TITLE
fix(agent): refuse plaintext http:// server_url unless explicitly opted out

### DIFF
--- a/cmd/nebula-agent/enroll_test.go
+++ b/cmd/nebula-agent/enroll_test.go
@@ -269,6 +269,32 @@ func TestEnrollSubcommand_RequiresServerAndToken(t *testing.T) {
 	}
 }
 
+// TestEnrollSubcommand_RefusesPlaintextHTTP pins the https-required guard on
+// the enroll path: a cleartext non-loopback --server is refused before the
+// single-use token leaves the process (no config or key files are written).
+// httptest URLs are loopback, so every other enroll test passes the guard
+// untouched; --insecure-http opts out.
+func TestEnrollSubcommand_RefusesPlaintextHTTP(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	err := run(ctx, []string{
+		"enroll", "--config", cfgPath,
+		"--server", "http://mgmt.example.com:8080", "--token", "tok",
+		"--data-dir", filepath.Join(dir, "nebula"),
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "refusing plaintext http") {
+		t.Fatalf("plaintext non-loopback --server: err = %v, want https-required refusal", err)
+	}
+	if _, statErr := os.Stat(cfgPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("config written despite refused URL: stat = %v", statErr)
+	}
+}
+
 // TestRun_LeavesStandbyAfterFilesAppear — start runUnified in idle, then
 // from a goroutine drop the enrollment artifacts into place and confirm
 // the daemon transitions to the poll loop (mock server records a signed

--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -95,6 +95,7 @@ func runUnified(ctx context.Context, args []string, stderr io.Writer) error {
 	dataDir := fs.String("data-dir", "", "override data directory (one-shot flow only)")
 	pollInterval := fs.Duration("poll-interval", 0, "override poll interval (one-shot flow only)")
 	updateConfig := fs.Bool("update-config", false, "overwrite on-disk config with CLI flags")
+	insecureHTTP := fs.Bool("insecure-http", false, "allow a plaintext http:// server URL on a non-loopback host (enrollment token and Nebula config transit in cleartext)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -104,7 +105,7 @@ func runUnified(ctx context.Context, args []string, stderr io.Writer) error {
 	// One-shot enroll+poll path — explicit operator intent on the command
 	// line. Preserves the pre-#88 behavior.
 	if *token != "" && *serverURL != "" {
-		cfg, err := resolveConfig(*configPath, *serverURL, *dataDir, *pollInterval, *updateConfig, stderr)
+		cfg, err := resolveConfig(*configPath, *serverURL, *dataDir, *pollInterval, *updateConfig, *insecureHTTP, stderr)
 		if err != nil {
 			return err
 		}
@@ -139,6 +140,16 @@ func awaitEnrollment(ctx context.Context, logger *slog.Logger, configPath string
 	cfg, reason := checkEnrollment(configPath)
 	if cfg != nil {
 		return cfg, nil
+	}
+	// A config file that exists but fails to load is a misconfiguration the
+	// operator must act on — most notably the https-required guard refusing
+	// a pre-existing plaintext server_url after an upgrade — not the routine
+	// "not enrolled yet" state. Surface it at Warn with the load error and
+	// the remediation, so it doesn't read as a normal standby.
+	if _, statErr := os.Stat(configPath); statErr == nil {
+		if _, loadErr := config.LoadAgentConfig(configPath); loadErr != nil {
+			logger.Warn("nebula-agent standby — config present but rejected; fix it or set allow_insecure_http to opt out", "error", loadErr, "config", configPath, "tick", standbyTick)
+		}
 	}
 	logger.Info("nebula-agent standby — run `nebula-agent enroll --server URL --token TOK` to bind", "reason", reason, "config", configPath, "tick", standbyTick)
 	ticker := time.NewTicker(standbyTick)
@@ -184,7 +195,7 @@ func checkEnrollment(configPath string) (*config.AgentConfig, string) {
 // resolveConfig loads the on-disk config or creates one from CLI flags.
 // CLI flags conflicting with an existing config are warned about unless
 // --update-config is set, in which case they overwrite the file.
-func resolveConfig(path, serverURL, dataDir string, pollInterval time.Duration, updateConfig bool, stderr io.Writer) (*config.AgentConfig, error) {
+func resolveConfig(path, serverURL, dataDir string, pollInterval time.Duration, updateConfig, insecureHTTP bool, stderr io.Writer) (*config.AgentConfig, error) {
 	if _, err := os.Stat(path); err == nil {
 		cfg, err := config.LoadAgentConfig(path)
 		if err != nil {
@@ -207,12 +218,15 @@ func resolveConfig(path, serverURL, dataDir string, pollInterval time.Duration, 
 	}
 	cfg := config.DefaultAgentConfig()
 	cfg.ServerURL = serverURL
+	cfg.AllowInsecureHTTP = insecureHTTP
 	if dataDir != "" {
 		cfg.DataDir = dataDir
 	}
 	if pollInterval > 0 {
 		cfg.PollInterval = pollInterval
 	}
+	// SaveAgentConfig validates the URL (https-required guard), so a
+	// refused URL fails here — before the enrollment token is sent.
 	if err := config.SaveAgentConfig(path, cfg); err != nil {
 		return nil, fmt.Errorf("write config: %w", err)
 	}
@@ -313,11 +327,17 @@ func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) err
 	signingKeyPath := fs.String("signing-key-path", "", "Ed25519 PoP signing key path; defaults to <config-dir>/host.signing.key")
 	pollInterval := fs.Duration("poll-interval", 30*time.Second, "poll interval written to agent.yml")
 	force := fs.Bool("force", false, "overwrite an existing enrollment")
+	insecureHTTP := fs.Bool("insecure-http", false, "allow a plaintext http:// server URL on a non-loopback host (enrollment token and Nebula config transit in cleartext)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if *serverURL == "" || *token == "" {
 		return fmt.Errorf("--server and --token are required")
+	}
+	// Validate before agent.Enroll so a refused URL never carries the
+	// single-use enrollment token over cleartext.
+	if err := config.ValidateAgentServerURL(*serverURL, *insecureHTTP); err != nil {
+		return err
 	}
 	if *signingKeyPath == "" {
 		*signingKeyPath = filepath.Join(filepath.Dir(*configPath), "host.signing.key")
@@ -345,6 +365,7 @@ func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) err
 
 	cfg := config.DefaultAgentConfig()
 	cfg.ServerURL = *serverURL
+	cfg.AllowInsecureHTTP = *insecureHTTP
 	cfg.DataDir = *dataDir
 	cfg.SigningKeyPath = *signingKeyPath
 	cfg.PollInterval = *pollInterval

--- a/cmd/nebula-agent/main_test.go
+++ b/cmd/nebula-agent/main_test.go
@@ -24,7 +24,7 @@ func TestResolveConfig_FileExists_FlagsIgnored(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	cfg, err := resolveConfig(cfgPath, "https://cli.example.com", "", 0, false, &stderr)
+	cfg, err := resolveConfig(cfgPath, "https://cli.example.com", "", 0, false, false, &stderr)
 	if err != nil {
 		t.Fatalf("resolveConfig: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestResolveConfig_FileExists_UpdateConfigOverwrites(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	cfg, err := resolveConfig(cfgPath, "https://new.example.com", "", 0, true, &stderr)
+	cfg, err := resolveConfig(cfgPath, "https://new.example.com", "", 0, true, false, &stderr)
 	if err != nil {
 		t.Fatalf("resolveConfig: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestResolveConfig_FileMissing_WritesFromFlags(t *testing.T) {
 	cfgPath := filepath.Join(dir, "sub", "agent.yml")
 
 	var stderr bytes.Buffer
-	cfg, err := resolveConfig(cfgPath, "https://fresh.example.com", filepath.Join(dir, "nebula"), 15*time.Second, false, &stderr)
+	cfg, err := resolveConfig(cfgPath, "https://fresh.example.com", filepath.Join(dir, "nebula"), 15*time.Second, false, false, &stderr)
 	if err != nil {
 		t.Fatalf("resolveConfig: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestResolveConfig_FileMissing_NoServer_Errors(t *testing.T) {
 	cfgPath := filepath.Join(dir, "agent.yml")
 
 	var stderr bytes.Buffer
-	_, err := resolveConfig(cfgPath, "", "", 0, false, &stderr)
+	_, err := resolveConfig(cfgPath, "", "", 0, false, false, &stderr)
 	if err == nil {
 		t.Fatal("expected error when config missing and --server unset")
 	}
@@ -122,7 +122,7 @@ func TestResolveConfig_DoesNotPersistToken(t *testing.T) {
 	var stderr bytes.Buffer
 	// We never pass token into resolveConfig — but assert the file content
 	// contains nothing token-shaped to lock the invariant from issue #67.
-	_, err := resolveConfig(cfgPath, "https://srv.example.com", "", 0, false, &stderr)
+	_, err := resolveConfig(cfgPath, "https://srv.example.com", "", 0, false, false, &stderr)
 	if err != nil {
 		t.Fatalf("resolveConfig: %v", err)
 	}
@@ -182,6 +182,38 @@ func TestRun_StandbyWhenCertMissing(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "standby") {
 		t.Errorf("stderr should mention standby; got %q", stderr.String())
+	}
+}
+
+// TestRun_StandbyWarnsOnRejectedHTTPConfig — an upgraded host whose
+// pre-guard agent.yml carries a plaintext http:// non-loopback server_url
+// must not silently park in standby. The daemon load path refuses the
+// config and the standby entry logs the rejection at Warn with the
+// remediation, so the operator sees why polling never starts.
+func TestRun_StandbyWarnsOnRejectedHTTPConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	// Write the file directly: SaveAgentConfig would reject the http:// URL,
+	// so this models a config written by an older release.
+	yaml := "server_url: \"http://mgmt.example.com:8080\"\ndata_dir: \"" + filepath.Join(dir, "nebula") + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := run(ctx, []string{"--config", cfgPath}, &stderr, &stderr)
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context deadline/cancel", err)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "config present but rejected") {
+		t.Errorf("stderr should warn that the config was rejected; got %q", out)
+	}
+	if !strings.Contains(out, "allow_insecure_http") {
+		t.Errorf("stderr should name the opt-out; got %q", out)
 	}
 }
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -249,12 +249,13 @@ signing_key_path: "/etc/nebula-agent/host.signing.key"  # Ed25519 PoP signing ke
 
 | Field | Default | Notes |
 |---|---|---|
-| `server_url` | (required) | Must be reachable from the host. HTTPS is strongly recommended. |
+| `server_url` | (required) | Must be reachable from the host. Must be `https://` unless the host is loopback — a plaintext `http://` URL on any other host is refused at startup because the enrollment token and rendered Nebula config would transit in cleartext. |
 | `data_dir` | `/etc/nebula` | Owned by `root:root` 0700. Holds `host.key` (0600), `host.crt`, `ca.crt`, `config.yml`. |
 | `poll_interval` | `30s` | Lower values reduce convergence time but increase server load. 5s–5m is the practical range. |
 | `nebula_config_path` | `/etc/nebula/config.yml` | The agent overwrites this file atomically. |
 | `nebula_pid_file` | (empty) | When set and the file holds a numeric PID, the agent sends `SIGHUP` after every successful write. |
 | `signing_key_path` | `/etc/nebula-agent/host.signing.key` | Ed25519 PoP signing key (ADR 0004). Override for non-root setups so the parent directory is writable by the agent user. |
+| `allow_insecure_http` | `false` | Opts out of the `https`-required guard on `server_url` (or pass `--insecure-http`). Only for isolated lab networks; credentials transit in the clear. |
 
 ## Enrollment
 

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/netip"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -17,6 +19,14 @@ type AgentConfig struct {
 	PollInterval     time.Duration `yaml:"poll_interval"`
 	NebulaConfigPath string        `yaml:"nebula_config_path"`
 	NebulaPIDFile    string        `yaml:"nebula_pid_file"`
+
+	// AllowInsecureHTTP opts out of the https-required guard on server_url.
+	// Without it a plaintext http:// URL is only accepted for loopback
+	// hosts — over any other network the enrollment token, certificates,
+	// and the Nebula config the agent installs would transit in cleartext,
+	// where an on-path attacker can steal the token or inject a malicious
+	// config. Mirrors the server's allow_insecure_http (#179).
+	AllowInsecureHTTP bool `yaml:"allow_insecure_http,omitempty"`
 }
 
 // DefaultAgentConfig returns a config populated with the defaults the agent
@@ -45,21 +55,74 @@ func LoadAgentConfig(path string) (*AgentConfig, error) {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
-	if cfg.ServerURL == "" {
-		return nil, errors.New("server_url is required")
+	if err := ValidateAgentServerURL(cfg.ServerURL, cfg.AllowInsecureHTTP); err != nil {
+		return nil, err
 	}
 
 	return cfg, nil
 }
 
+// ValidateAgentServerURL guards the agent's management-server URL. The URL
+// must be http/https with a host. A plaintext http:// URL is accepted only
+// for a loopback host (local testing, an on-host TLS-terminating proxy)
+// unless allowInsecure opts out — everywhere else the enrollment token and
+// the host's rendered Nebula config would transit a real network in
+// cleartext. The CLI and the server already carry the equivalent guards
+// (#219, #179); this covers the agent.
+//
+// Exposed as a function rather than only a load-time check so the enroll
+// path can validate the --server flag before the token is sent, when no
+// config file exists yet.
+func ValidateAgentServerURL(serverURL string, allowInsecure bool) error {
+	if serverURL == "" {
+		return errors.New("server_url is required")
+	}
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("invalid server_url %q: %w", serverURL, err)
+	}
+	switch u.Scheme {
+	case "https":
+		// Always fine.
+	case "http":
+		if !allowInsecure && !hostIsLoopback(u.Hostname()) {
+			return fmt.Errorf("refusing plaintext http server_url %q: the enrollment token and rendered Nebula config would transit in cleartext; use https, or set allow_insecure_http: true (--insecure-http) to opt out", serverURL)
+		}
+	default:
+		return fmt.Errorf("invalid server_url %q: scheme must be http or https", serverURL)
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("invalid server_url %q: missing host", serverURL)
+	}
+	return nil
+}
+
+// hostIsLoopback reports whether host is the literal "localhost" or a
+// loopback IP. Other hostnames are treated as non-loopback without
+// resolving DNS, so the guard fails safe. Deliberately narrower than
+// hostIsPrivate (server.go): a private-range address still crosses a real
+// network, where cleartext is exactly the exposure this guard exists for.
+func hostIsLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	return addr.IsLoopback()
+}
+
 // SaveAgentConfig writes cfg to path atomically (tmp + fsync + rename) with
 // mode 0600. The parent directory is created with mode 0755 if missing.
+// The server URL is validated with the same rules as LoadAgentConfig so a
+// config that would be refused at the next startup is never written.
 func SaveAgentConfig(path string, cfg *AgentConfig) error {
 	if cfg == nil {
 		return errors.New("nil config")
 	}
-	if cfg.ServerURL == "" {
-		return errors.New("server_url is required")
+	if err := ValidateAgentServerURL(cfg.ServerURL, cfg.AllowInsecureHTTP); err != nil {
+		return err
 	}
 
 	data, err := yaml.Marshal(cfg)

--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -192,3 +192,59 @@ func TestSaveAgentConfig_RejectsEmpty(t *testing.T) {
 		t.Fatal("expected error for missing server_url")
 	}
 }
+
+func TestValidateAgentServerURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		url           string
+		allowInsecure bool
+		wantErr       bool
+	}{
+		{name: "https accepted", url: "https://mgmt.example.com:8080"},
+		{name: "http non-loopback refused", url: "http://mgmt.example.com:8080", wantErr: true},
+		{name: "http private-range still refused", url: "http://10.0.0.5:8080", wantErr: true},
+		{name: "http localhost allowed", url: "http://localhost:8080"},
+		{name: "http 127.0.0.1 allowed", url: "http://127.0.0.1:8080"},
+		{name: "http [::1] allowed", url: "http://[::1]:8080"},
+		{name: "http non-loopback with opt-out", url: "http://mgmt.example.com:8080", allowInsecure: true},
+		{name: "non-http scheme refused", url: "file:///etc/passwd", wantErr: true},
+		{name: "missing host refused", url: "https://", wantErr: true},
+		{name: "empty refused", url: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAgentServerURL(tc.url, tc.allowInsecure)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateAgentServerURL(%q, allowInsecure=%v) error = %v, wantErr %v", tc.url, tc.allowInsecure, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoadAgentConfig_PlaintextHTTPRefused pins the load-time guard: an
+// on-disk config pointing at a cleartext non-loopback URL fails to load
+// unless allow_insecure_http is set.
+func TestLoadAgentConfig_PlaintextHTTPRefused(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	data := []byte("server_url: \"http://mgmt.example.com:8080\"\n")
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadAgentConfig(cfgPath); err == nil {
+		t.Fatal("expected error for plaintext non-loopback server_url, got nil")
+	}
+
+	data = []byte("server_url: \"http://mgmt.example.com:8080\"\nallow_insecure_http: true\n")
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadAgentConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("opt-out config refused: %v", err)
+	}
+	if !cfg.AllowInsecureHTTP {
+		t.Error("AllowInsecureHTTP not loaded from YAML")
+	}
+}


### PR DESCRIPTION
The CLI validates --server (#219) and the server refuses cleartext
binds on routable addresses (#179), but the agent accepted any
non-empty server_url. With http://, enrollment POSTs the single-use
token in cleartext and every poll fetches config_yml + certificate_pem
over an unauthenticated channel — an on-path attacker can steal the
token, harvest the certificate, or inject a malicious config.yml that
the agent writes to disk and SIGHUPs Nebula to load.

ValidateAgentServerURL requires https, allowing http only for loopback
hosts (local testing, an on-host TLS-terminating proxy) — deliberately
narrower than the server's private-range allowance, since a private
address still crosses a real network. The explicit opt-out mirrors the
server: allow_insecure_http in agent.yml or --insecure-http on the
daemon and enroll commands.

Both LoadAgentConfig and SaveAgentConfig validate, and the enroll path
checks the flag before agent.Enroll, so a refused URL never carries the
token. httptest servers are loopback, so existing tests pass the guard
unchanged.

An already-enrolled host whose pre-guard config carries an http:// URL
would otherwise park silently in standby after a binary upgrade; the
daemon now logs the rejection at Warn with the remediation so it does
not read as a routine not-enrolled-yet state.
