### PR TITLE
fix(agent): zeroize private keys after enrollment writes them to disk

### DIFF
--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
+
+	"github.com/forgekeep/nebula-mesh/internal/keystore"
 )
 
 // SigningPublicKeyPEMType is the PEM block type used by the agent for its
@@ -44,6 +46,30 @@ func Reenroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath str
 	return Enroll(ctx, serverURL, token, dataDir, signingKeyPath)
 }
 
+// enrollmentSecrets collects every heap copy of private key material made
+// during enrollment so one deferred wipe covers them all. Fields are filled
+// as the corresponding buffers are created; wipe zeroizes whatever has been
+// set, matching the server-side standard (caMgr.Wipe, GHSA-8h84 / #181).
+type enrollmentSecrets struct {
+	privKey        []byte // X25519 private key (32-byte scalar)
+	privKeyPEM     []byte // PEM encoding of privKey
+	signingPriv    []byte // ed25519.PrivateKey (seed + public half)
+	signingPrivPEM []byte // PEM encoding of signingPriv
+}
+
+func (s *enrollmentSecrets) wipe() {
+	keystore.Zeroize(s.privKey)
+	keystore.Zeroize(s.privKeyPEM)
+	keystore.Zeroize(s.signingPriv)
+	keystore.Zeroize(s.signingPrivPEM)
+}
+
+// enrollSecretsObserverForTest, when non-nil, receives the secrets container
+// on Enroll's way out, before the deferred wipe runs. Tests use it to alias
+// the live buffers and assert they read as zeros after Enroll returns.
+// Production code never sets it.
+var enrollSecretsObserverForTest func(*enrollmentSecrets)
+
 // Enroll performs the enrollment flow: generates keypair, sends public key
 // to the server with the token, saves received cert and config to dataDir,
 // and writes the Ed25519 signing private key to signingKeyPath.
@@ -65,12 +91,23 @@ func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath strin
 	if err := preflightWritable(filepath.Dir(signingKeyPath)); err != nil {
 		return fmt.Errorf("signing key dir: %w", err)
 	}
-	// Generate X25519 keypair (for the Nebula handshake cert).
-	privKey := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, privKey); err != nil {
+	// Generate X25519 keypair (for the Nebula handshake cert). The private
+	// material exists in this function only long enough to reach disk —
+	// wipe every heap copy on every return path so the Nebula host key and
+	// the PoP signing key don't linger (core dump / swap exposure),
+	// matching the server-side zeroization standard (GHSA-8h84, #181).
+	secrets := &enrollmentSecrets{}
+	defer func() {
+		if enrollSecretsObserverForTest != nil {
+			enrollSecretsObserverForTest(secrets)
+		}
+		secrets.wipe()
+	}()
+	secrets.privKey = make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, secrets.privKey); err != nil {
 		return fmt.Errorf("generate private key: %w", err)
 	}
-	pubKey, err := curve25519.X25519(privKey, curve25519.Basepoint)
+	pubKey, err := curve25519.X25519(secrets.privKey, curve25519.Basepoint)
 	if err != nil {
 		return fmt.Errorf("derive public key: %w", err)
 	}
@@ -80,6 +117,7 @@ func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath strin
 	if err != nil {
 		return fmt.Errorf("generate signing keypair: %w", err)
 	}
+	secrets.signingPriv = signingPriv
 
 	// Encode keys to PEM.
 	pubKeyPEM := cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, pubKey)
@@ -132,9 +170,10 @@ func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath strin
 		return fmt.Errorf("create data dir: %w", err)
 	}
 
-	// Save private key
-	privKeyPEM := cert.MarshalPrivateKeyToPEM(cert.Curve_CURVE25519, privKey)
-	if err := os.WriteFile(filepath.Join(dataDir, "host.key"), privKeyPEM, 0o600); err != nil {
+	// Save private key. The PEM encoding is a second heap copy of the
+	// secret — tracked in secrets and wiped with the raw bytes.
+	secrets.privKeyPEM = cert.MarshalPrivateKeyToPEM(cert.Curve_CURVE25519, secrets.privKey)
+	if err := os.WriteFile(filepath.Join(dataDir, "host.key"), secrets.privKeyPEM, 0o600); err != nil {
 		return fmt.Errorf("write host key: %w", err)
 	}
 
@@ -143,8 +182,8 @@ func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath strin
 	if err := os.MkdirAll(filepath.Dir(signingKeyPath), 0o750); err != nil {
 		return fmt.Errorf("create signing key dir: %w", err)
 	}
-	signingPrivPEM := pem.EncodeToMemory(&pem.Block{Type: SigningPrivateKeyPEMType, Bytes: signingPriv})
-	if err := os.WriteFile(signingKeyPath, signingPrivPEM, 0o600); err != nil {
+	secrets.signingPrivPEM = pem.EncodeToMemory(&pem.Block{Type: SigningPrivateKeyPEMType, Bytes: secrets.signingPriv})
+	if err := os.WriteFile(signingKeyPath, secrets.signingPrivPEM, 0o600); err != nil {
 		return fmt.Errorf("write signing key: %w", err)
 	}
 

--- a/internal/agent/enroll_zeroize_test.go
+++ b/internal/agent/enroll_zeroize_test.go
@@ -1,0 +1,118 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func allZero(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// captureEnrollSecrets installs the test observer and returns a pointer that
+// receives the live secrets container when Enroll returns. The observer runs
+// before the deferred wipe, so the captured slices alias the real buffers and
+// read as zeros only if the wipe actually ran.
+func captureEnrollSecrets(t *testing.T) **enrollmentSecrets {
+	t.Helper()
+	var captured *enrollmentSecrets
+	enrollSecretsObserverForTest = func(s *enrollmentSecrets) {
+		if !allZero(s.privKey) || !allZero(s.signingPriv) {
+			// Sanity: the secrets are still live at observation time —
+			// otherwise the zero assertions below would pass vacuously.
+			captured = s
+			return
+		}
+		t.Error("secrets already zero before the deferred wipe — observer mis-ordered")
+	}
+	t.Cleanup(func() { enrollSecretsObserverForTest = nil })
+	return &captured
+}
+
+// TestEnroll_ZeroizesPrivateKeys verifies that after a successful enrollment
+// every heap copy of the X25519 host key and the Ed25519 signing key (raw and
+// PEM) has been overwritten with zeros (L4, 2026-06-12 audit; same standard
+// as the server's caMgr.Wipe — GHSA-8h84 / #181).
+func TestEnroll_ZeroizesPrivateKeys(t *testing.T) {
+	dir := t.TempDir()
+	signingKeyPath := filepath.Join(t.TempDir(), "host.signing.key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := EnrollResponse{
+			CertificatePEM:   "-----BEGIN NEBULA CERTIFICATE-----\ntest-cert\n-----END NEBULA CERTIFICATE-----",
+			CACertificatePEM: "-----BEGIN NEBULA CERTIFICATE-----\ntest-ca\n-----END NEBULA CERTIFICATE-----",
+			ConfigYAML:       "pki:\n  ca: /etc/nebula/ca.crt\n",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	captured := captureEnrollSecrets(t)
+	if err := Enroll(context.Background(), server.URL, "test-token", dir, signingKeyPath); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	assertSecretsWiped(t, *captured)
+}
+
+// TestEnroll_ZeroizesPrivateKeysOnError pins the error path: a server-side
+// failure after key generation must still wipe the generated material.
+func TestEnroll_ZeroizesPrivateKeysOnError(t *testing.T) {
+	dir := t.TempDir()
+	signingKeyPath := filepath.Join(t.TempDir(), "host.signing.key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"token expired"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	captured := captureEnrollSecrets(t)
+	if err := Enroll(context.Background(), server.URL, "stale-token", dir, signingKeyPath); err == nil {
+		t.Fatal("expected enrollment error")
+	}
+	if *captured == nil {
+		t.Fatal("observer not invoked")
+	}
+	// On the early-error path only the raw keys exist; PEM fields are nil
+	// and Zeroize(nil) is a no-op.
+	if !allZero((*captured).privKey) {
+		t.Error("X25519 private key not zeroized on error path")
+	}
+	if !allZero((*captured).signingPriv) {
+		t.Error("Ed25519 signing key not zeroized on error path")
+	}
+}
+
+func assertSecretsWiped(t *testing.T, s *enrollmentSecrets) {
+	t.Helper()
+	if s == nil {
+		t.Fatal("observer not invoked")
+	}
+	checks := []struct {
+		name string
+		buf  []byte
+	}{
+		{"privKey", s.privKey},
+		{"privKeyPEM", s.privKeyPEM},
+		{"signingPriv", s.signingPriv},
+		{"signingPrivPEM", s.signingPrivPEM},
+	}
+	for _, c := range checks {
+		if len(c.buf) == 0 {
+			t.Errorf("%s never populated — assertion vacuous", c.name)
+			continue
+		}
+		if !allZero(c.buf) {
+			t.Errorf("%s not zeroized after Enroll", c.name)
+		}
+	}
+}


### PR DESCRIPTION
The server side wipes plaintext CA keys on every return path
(caMgr.Wipe, GHSA-8h84 / #181, #196), but the agent left its X25519
host key and Ed25519 PoP signing key — raw bytes and PEM encodings —
live on the heap after enrollment, exposed to core dumps, swap, and
heap inspection on the agent host for the life of the process.

Collect all four buffers in an enrollmentSecrets container wiped by a
single defer, covering both the success path and the error path where
keys were generated but the server rejected the request. A test
observer hook captures the live buffers so tests can assert they read
as zeros after Enroll returns; removing the wipe call fails both new
tests.
