### PR TITLE
fix(web,store): make TOTP codes one-time within their validity window

### DIFF
--- a/internal/store/migrations/020_operator_totp_timestep.down.sql
+++ b/internal/store/migrations/020_operator_totp_timestep.down.sql
@@ -1,0 +1,7 @@
+-- Down migration: removes per-operator TOTP replay protection.
+--
+-- After downgrade the totp_last_timestep column is gone, so an attacker who
+-- observed a valid TOTP code can replay it within its ~90s acceptance window
+-- (period 30s, skew 1) until the column is restored. Operator rows are
+-- otherwise unaffected.
+ALTER TABLE operators DROP COLUMN totp_last_timestep;

--- a/internal/store/migrations/020_operator_totp_timestep.up.sql
+++ b/internal/store/migrations/020_operator_totp_timestep.up.sql
@@ -1,0 +1,6 @@
+-- Track the last TOTP timestep each operator successfully authenticated
+-- with, so an observed code cannot be replayed inside its ~90s acceptance
+-- window (period 30s, skew 1). RFC 6238 §5.2 requires the verifier to
+-- reject a second use of the same or an earlier timestep; recovery codes
+-- were already consumed atomically but TOTP codes were not.
+ALTER TABLE operators ADD COLUMN totp_last_timestep INTEGER NOT NULL DEFAULT 0;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -25,6 +25,7 @@ var (
 	ErrRekeyAlreadyPending = errors.New("rekey already pending")
 	ErrReplayedNonce       = errors.New("replayed nonce")
 	ErrIPTaken             = errors.New("nebula ip already assigned in network")
+	ErrTOTPReplayed        = errors.New("totp timestep already used")
 )
 
 // SQLiteStore implements Store using SQLite.
@@ -127,6 +128,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		"017_pop_nonces.up.sql",
 		"018_host_address_network_uniqueness.up.sql",
 		"019_session_token_hash.up.sql",
+		"020_operator_totp_timestep.up.sql",
 	}
 
 	// Tracking table. Created once; idempotent on subsequent starts.

--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -378,6 +378,31 @@ func (s *SQLiteStore) ReplaceOperatorRecoveryCodes(ctx context.Context, id strin
 	return tx.Commit()
 }
 
+// ConsumeOperatorTOTPTimestep advances the operator's last-accepted TOTP
+// timestep to ts, but only if ts is strictly greater than the stored value —
+// the same atomic verify-and-mark shape as ConsumeOperatorRecoveryCode, so
+// two concurrent logins presenting the same code cannot both win. Returns
+// ErrTOTPReplayed when ts has already been used (or an older one accepted
+// after it), which the caller must treat as an authentication failure
+// (RFC 6238 §5.2).
+func (s *SQLiteStore) ConsumeOperatorTOTPTimestep(ctx context.Context, id string, ts int64) error {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE operators SET totp_last_timestep=? WHERE id=? AND totp_last_timestep < ?`,
+		ts, id, ts,
+	)
+	if err != nil {
+		return fmt.Errorf("consume totp timestep: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("consume totp timestep rows: %w", err)
+	}
+	if rows == 0 {
+		return ErrTOTPReplayed
+	}
+	return nil
+}
+
 // ConsumeOperatorRecoveryCode marks the given hash as consumed if it exists
 // and is unused. Returns ErrNotFound otherwise.
 func (s *SQLiteStore) ConsumeOperatorRecoveryCode(ctx context.Context, id, codeHash string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -150,6 +150,11 @@ type Store interface {
 
 	// Operator TOTP / recovery codes
 	SetOperatorTOTP(ctx context.Context, id, secret string, enabled bool) error
+	// ConsumeOperatorTOTPTimestep atomically records the TOTP timestep a
+	// code was accepted at, rejecting (ErrTOTPReplayed) any timestep at or
+	// below the last accepted one so an observed code cannot be replayed
+	// within its validity window (RFC 6238 §5.2).
+	ConsumeOperatorTOTPTimestep(ctx context.Context, id string, ts int64) error
 	ReplaceOperatorRecoveryCodes(ctx context.Context, id string, codeHashes []string) error
 	ConsumeOperatorRecoveryCode(ctx context.Context, id, codeHash string) error
 	ListOperatorRecoveryCodes(ctx context.Context, id string) ([]string, error)

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -127,8 +127,26 @@ func (w *Web) handleTOTPLogin(rw http.ResponseWriter, r *http.Request) {
 
 	ok := false
 	usedRecovery := false
-	if code != "" && verifyTOTP(op.TOTPSecret, code) {
-		ok = true
+	if ts, valid := verifyTOTPWithTimestep(op.TOTPSecret, code); code != "" && valid {
+		// Consume the matched timestep atomically (same shape as recovery
+		// codes below): a code is one-time within its acceptance window, so
+		// an observed/phished code cannot be replayed and two concurrent
+		// logins presenting the same code cannot both pass (RFC 6238 §5.2).
+		err := w.store.ConsumeOperatorTOTPTimestep(r.Context(), op.ID, ts)
+		switch {
+		case err == nil:
+			ok = true
+		case errors.Is(err, store.ErrTOTPReplayed):
+			// Code already used this window — a denied login, handled below.
+		default:
+			// A real store failure must not masquerade as a wrong code:
+			// surface it as a 500 and log, rather than silently denying a
+			// valid second factor with no operator-side signal.
+			w.recordLogin(loginResultError, loginFactorTOTP)
+			w.logger.Error("consume totp timestep", "error", err)
+			http.Error(rw, "internal error", http.StatusInternalServerError)
+			return
+		}
 	} else if recovery != "" {
 		// Consume atomically: the single UPDATE both verifies and
 		// marks-used in one statement, which is the one-time
@@ -373,7 +391,8 @@ func (w *Web) handleTwoFAEnable(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	code := strings.TrimSpace(r.FormValue("code"))
-	if !verifyTOTP(op.TOTPSecret, code) {
+	ts, valid := verifyTOTPWithTimestep(op.TOTPSecret, code)
+	if !valid {
 		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.enable_failed", op.ID, "")
 		w.renderForRequest(rw, r, "twofa.html", map[string]any{
 			"Active":      "2fa",
@@ -386,6 +405,14 @@ func (w *Web) handleTwoFAEnable(rw http.ResponseWriter, r *http.Request) {
 			"Error": "Invalid code; try again",
 		})
 		return
+	}
+	// Best-effort consume: marks the setup code's timestep used so it
+	// cannot double as the next login's second factor. Unlike the login
+	// path this is not an auth gate (the session is already
+	// authenticated), so a replay error here doesn't block enablement.
+	if err := w.store.ConsumeOperatorTOTPTimestep(r.Context(), op.ID, ts); err != nil &&
+		!errors.Is(err, store.ErrTOTPReplayed) {
+		w.logger.Error("consume totp timestep on enable", "error", err)
 	}
 	if err := w.store.SetOperatorTOTP(r.Context(), op.ID, op.TOTPSecret, true); err != nil {
 		w.logger.Error("enable totp", "error", err)

--- a/internal/web/totp.go
+++ b/internal/web/totp.go
@@ -3,10 +3,12 @@ package web
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base32"
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
@@ -31,22 +33,42 @@ func generateTOTPSecret(username string) (otpauthURL, secret string, err error) 
 	return key.URL(), key.Secret(), nil
 }
 
-// verifyTOTP validates a 6-digit code against the operator's secret.
-func verifyTOTP(secret, code string) bool {
+// totpPeriod is the TOTP timestep length. The acceptance window is
+// ±totpSkew timesteps around now.
+const (
+	totpPeriod = 30
+	totpSkew   = 1
+)
+
+// verifyTOTPWithTimestep validates a 6-digit code and, on success, returns
+// the timestep (Unix time / period) the code matched. Callers that gate
+// authentication must persist the timestep via ConsumeOperatorTOTPTimestep
+// so the same code cannot be replayed within its ±skew acceptance window.
+// totp.ValidateCustom does not expose which step matched, so each candidate
+// step in the window is checked individually with the same parameters.
+func verifyTOTPWithTimestep(secret, code string) (int64, bool) {
 	code = strings.TrimSpace(code)
 	if secret == "" || code == "" {
-		return false
+		return 0, false
 	}
-	ok, err := totp.ValidateCustom(code, secret, timeNow(), totp.ValidateOpts{
-		Period:    30,
-		Skew:      1,
-		Digits:    otp.DigitsSix,
-		Algorithm: otp.AlgorithmSHA1,
-	})
-	if err != nil {
-		return false
+	now := timeNow()
+	step := now.Unix() / totpPeriod
+	for delta := int64(-totpSkew); delta <= totpSkew; delta++ {
+		candidate := step + delta
+		want, err := totp.GenerateCodeCustom(secret, time.Unix(candidate*totpPeriod, 0), totp.ValidateOpts{
+			Period:    totpPeriod,
+			Skew:      0,
+			Digits:    otp.DigitsSix,
+			Algorithm: otp.AlgorithmSHA1,
+		})
+		if err != nil {
+			return 0, false
+		}
+		if subtle.ConstantTimeCompare([]byte(want), []byte(code)) == 1 {
+			return candidate, true
+		}
 	}
-	return ok
+	return 0, false
 }
 
 // generateRecoveryCodes returns N random 10-character codes (uppercase

--- a/internal/web/totp_replay_test.go
+++ b/internal/web/totp_replay_test.go
@@ -1,0 +1,210 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// totpConsumeErrStore wraps a real store and forces a non-replay error out of
+// ConsumeOperatorTOTPTimestep, leaving every other method (sessions, operator
+// lookup) delegating to the embedded store so the login flow still works up to
+// the consume.
+type totpConsumeErrStore struct {
+	store.Store
+	err error
+}
+
+func (s totpConsumeErrStore) ConsumeOperatorTOTPTimestep(ctx context.Context, id string, ts int64) error {
+	return s.err
+}
+
+// totpLoginAttempt drives the full password+TOTP login flow with the given
+// code and reports whether it ended authenticated (redirect to /ui/).
+func totpLoginAttempt(t *testing.T, w *Web, code string) bool {
+	t.Helper()
+	csrfToken, cookies := getCSRFTokenFromCookies(t, w, "/ui/login", nil)
+	form := url.Values{
+		"username": {testUsername},
+		"password": {testPassword},
+		"_csrf":    {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("password step status = %d", rec.Code)
+	}
+	cookies = append(cookies, rec.Result().Cookies()...)
+
+	csrfToken, cookies = getCSRFTokenFromCookies(t, w, "/ui/login/totp", cookies)
+	form = url.Values{
+		"code":  {code},
+		"_csrf": {csrfToken},
+	}
+	req = httptest.NewRequest(http.MethodPost, "/ui/login/totp", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	return rec.Code == http.StatusSeeOther && rec.Header().Get("Location") == "/ui/"
+}
+
+// TestLogin_TOTPCodeNotReplayable pins the one-time property (L5,
+// 2026-06-12 audit): a code that authenticated once must be rejected on a
+// second login within the same acceptance window, like a consumed recovery
+// code. Without the timestep ledger both attempts succeed.
+func TestLogin_TOTPCodeNotReplayable(t *testing.T) {
+	w, _ := newTestWeb(t)
+	_, code := enableTOTPForAdmin(t, w)
+
+	if !totpLoginAttempt(t, w, code) {
+		t.Fatal("first login with fresh code failed")
+	}
+	if totpLoginAttempt(t, w, code) {
+		t.Fatal("second login with the SAME code succeeded — TOTP replay within validity window")
+	}
+}
+
+// TestLogin_TOTPNextWindowCodeStillWorks guards against over-rejection: the
+// replay ledger must only block the consumed timestep, not lock the operator
+// out of subsequent windows.
+func TestLogin_TOTPNextWindowCodeStillWorks(t *testing.T) {
+	w, _ := newTestWeb(t)
+	secret, code := enableTOTPForAdmin(t, w)
+
+	if !totpLoginAttempt(t, w, code) {
+		t.Fatal("first login failed")
+	}
+
+	// A code from the next timestep must authenticate. Generate it for
+	// now+period and shift the verifier's clock forward to match.
+	next := timeNow().Add(totpPeriod * time.Second)
+	nextCode, err := totp.GenerateCode(secret, next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := timeNow
+	timeNow = func() time.Time { return next }
+	t.Cleanup(func() { timeNow = orig })
+
+	if !totpLoginAttempt(t, w, nextCode) {
+		t.Fatal("login with next-window code failed — replay guard over-rejects")
+	}
+}
+
+// TestConsumeOperatorTOTPTimestep_CAS pins the store-level contract: strictly
+// increasing timesteps consume; the same or an older timestep returns
+// ErrTOTPReplayed.
+func TestConsumeOperatorTOTPTimestep_CAS(t *testing.T) {
+	w, _ := newTestWeb(t)
+	ctx := context.Background()
+	st := w.store
+
+	if err := st.ConsumeOperatorTOTPTimestep(ctx, "admin-test-id", 1000); err != nil {
+		t.Fatalf("first consume: %v", err)
+	}
+	if err := st.ConsumeOperatorTOTPTimestep(ctx, "admin-test-id", 1000); err == nil {
+		t.Fatal("same timestep consumed twice")
+	} else if !errors.Is(err, store.ErrTOTPReplayed) {
+		t.Fatalf("err = %v, want ErrTOTPReplayed", err)
+	}
+	if err := st.ConsumeOperatorTOTPTimestep(ctx, "admin-test-id", 999); err == nil {
+		t.Fatal("older timestep accepted after newer one")
+	}
+	if err := st.ConsumeOperatorTOTPTimestep(ctx, "admin-test-id", 1001); err != nil {
+		t.Fatalf("next timestep: %v", err)
+	}
+}
+
+// TestLogin_TOTPStoreErrorIs500NotDenial pins that a real store failure during
+// timestep consume surfaces as a 500, not a silent "Invalid TOTP code"
+// denial — an operator hitting a DB blip must get a distinguishable error,
+// and the failure must not look like a wrong code.
+func TestLogin_TOTPStoreErrorIs500NotDenial(t *testing.T) {
+	baseStore, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { baseStore.Close() })
+	if err := baseStore.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.MinCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := baseStore.CreateOperator(context.Background(), &models.Operator{
+		ID: "admin-test-id", Username: testUsername, DisplayName: "Administrator",
+		PasswordHash: string(hash), Role: "admin",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, secret, err := generateTOTPSecret(testUsername)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := baseStore.SetOperatorTOTP(context.Background(), "admin-test-id", secret, true); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapped := totpConsumeErrStore{Store: baseStore, err: errors.New("database is locked")}
+	w, err := New(wrapped, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Password step → pending_totp session.
+	csrfToken, cookies := getCSRFTokenFromCookies(t, w, "/ui/login", nil)
+	form := url.Values{"username": {testUsername}, "password": {testPassword}, "_csrf": {csrfToken}}
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("password step = %d, want 303", rec.Code)
+	}
+	cookies = append(cookies, rec.Result().Cookies()...)
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	csrfToken, cookies = getCSRFTokenFromCookies(t, w, "/ui/login/totp", cookies)
+	form = url.Values{"code": {code}, "_csrf": {csrfToken}}
+	req = httptest.NewRequest(http.MethodPost, "/ui/login/totp", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("totp step with store error = %d, want 500; body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "Invalid TOTP code") {
+		t.Error("store error rendered as an invalid-code denial; must be a 500")
+	}
+}

--- a/internal/web/totp_test.go
+++ b/internal/web/totp_test.go
@@ -28,11 +28,13 @@ func TestGenerateAndVerifyTOTP(t *testing.T) {
 	timeNow = func() time.Time { return now }
 	t.Cleanup(func() { timeNow = time.Now })
 
-	if !verifyTOTP(secret, code) {
-		t.Error("expected verifyTOTP to accept current code")
+	// verifyTOTPWithTimestep is the entry point all production callers use;
+	// exercise it directly rather than a thin bool-only wrapper.
+	if _, ok := verifyTOTPWithTimestep(secret, code); !ok {
+		t.Error("expected current code to verify")
 	}
-	if verifyTOTP(secret, "000000") {
-		t.Error("verifyTOTP accepted bogus code")
+	if _, ok := verifyTOTPWithTimestep(secret, "000000"); ok {
+		t.Error("bogus code verified")
 	}
 }
 


### PR DESCRIPTION
verifyTOTP accepted the same 6-digit code repeatedly across its ~90s
window (period 30s, skew 1): no consumed-code or last-timestep state
was kept, so an attacker who observed one live code (shoulder-surf,
phish) and held the victim's pending-TOTP cookie could replay it.
Recovery codes were already consumed atomically; TOTP codes were not.
RFC 6238 §5.2 requires the verifier to reject reuse.

Migration 020 adds operators.totp_last_timestep, and
ConsumeOperatorTOTPTimestep advances it with the same atomic
compare-and-set shape as ConsumeOperatorRecoveryCode (UPDATE ... WHERE
totp_last_timestep < ?), so two concurrent logins presenting the same
code cannot both pass. verifyTOTPWithTimestep reports which timestep
matched — totp.ValidateCustom doesn't expose that, so each candidate
step in the ±skew window is checked with a constant-time compare.

The login handler consumes the timestep as part of authentication; a
store failure there now surfaces as a 500 rather than masquerading as a
wrong-code denial. The 2FA-enable handler consumes best-effort so the
setup code cannot double as the next login's second factor. New tests
pin replay rejection (fails against the previous handler), next-window
acceptance, the store-level CAS contract, and the store-error-is-500
path.
