### PR TITLE
fix(keystore,pki): bind CA-key envelopes to their ca_id with GCM AAD

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -107,7 +107,7 @@ Trust zones, from least to most trusted:
 ## 5. Cross-cutting mitigations
 
 - **Transport**: TLS by default; non-loopback plaintext bind refused unless opted in (#179).
-- **Crypto**: AES-256-GCM throughout; GCM tag binds AAD/nonce (envelope attacks refuted); key material zeroized (#181, #196).
+- **Crypto**: AES-256-GCM throughout; both CA-key envelope layers bind the owning `ca_id` as AAD, so an envelope copied between CA rows fails to decrypt (envelopes sealed before the binding load via a nil-AAD fallback and are backstopped by a key/cert public-key consistency check at load); key material zeroized (#181, #196).
 - **Input**: strict JSON decode, body caps, length bounds on cert-embedded fields (#186, #195).
 - **Tooling baseline**: `golangci-lint` (pinned), standalone `gosec`, and `govulncheck` gate every PR, plus ADR-0009 generative fuzzing in CI.
 

--- a/internal/api/cas.go
+++ b/internal/api/cas.go
@@ -107,13 +107,17 @@ func (s *Server) handleCreateCA(w http.ResponseWriter, r *http.Request) {
 	rawKey := mgr.RawKey()
 	defer keystore.Zeroize(rawKey)
 
-	dek, wrappedDEK, err := s.master.GenerateDEK()
+	// The CA ID is minted before sealing because both envelope layers bind
+	// it as AAD — a (DEK, key-material) pair copied into another CA's row
+	// must fail to decrypt rather than sign under the wrong cert.
+	caID := uuid.New().String()
+	dek, wrappedDEK, err := s.master.GenerateDEK([]byte(caID))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to generate DEK")
 		return
 	}
 	defer keystore.Zeroize(dek)
-	wrappedKey, err := keystore.SealWithDEK(dek, rawKey)
+	wrappedKey, err := keystore.SealWithDEK(dek, rawKey, []byte(caID))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to encrypt CA key")
 		return
@@ -130,7 +134,7 @@ func (s *Server) handleCreateCA(w http.ResponseWriter, r *http.Request) {
 	}
 	now := time.Now()
 	c := &models.CA{
-		ID:                   uuid.New().String(),
+		ID:                   caID,
 		Name:                 req.Name,
 		OwnerOperatorID:      actor.ID,
 		CertPEM:              string(certPEM),

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -77,46 +77,52 @@ type WrappedBlob struct {
 	Nonce      []byte
 }
 
-// GenerateDEK returns a fresh DEK plus its master-key-wrapped form.
-// Callers MUST zeroise the returned plaintext DEK as soon as it is no
-// longer needed.
-func (m *Master) GenerateDEK() (plaintext []byte, wrapped WrappedKey, err error) {
+// GenerateDEK returns a fresh DEK plus its master-key-wrapped form, with
+// the wrap bound to aad (the owning CA's ID — see WrapDEK). Callers MUST
+// zeroise the returned plaintext DEK as soon as it is no longer needed.
+func (m *Master) GenerateDEK(aad []byte) (plaintext []byte, wrapped WrappedKey, err error) {
 	dek := make([]byte, DEKSize)
 	if _, err := rand.Read(dek); err != nil {
 		return nil, WrappedKey{}, fmt.Errorf("rand dek: %w", err)
 	}
-	wrapped, err = m.WrapDEK(dek)
+	wrapped, err = m.WrapDEK(dek, aad)
 	if err != nil {
 		return nil, WrappedKey{}, err
 	}
 	return dek, wrapped, nil
 }
 
-// WrapDEK encrypts a DEK under the master key.
-func (m *Master) WrapDEK(dek []byte) (WrappedKey, error) {
+// WrapDEK encrypts a DEK under the master key. aad is bound into the GCM
+// tag — callers pass the owning CA's ID so a wrapped DEK copied into
+// another CA's row fails to decrypt instead of pairing that CA's cert
+// with a foreign signing key (DB-write envelope swap).
+func (m *Master) WrapDEK(dek, aad []byte) (WrappedKey, error) {
 	nonce := make([]byte, NonceSize)
 	if _, err := rand.Read(nonce); err != nil {
 		return WrappedKey{}, fmt.Errorf("rand nonce: %w", err)
 	}
-	ct := m.aead.Seal(nil, nonce, dek, nil) // #nosec G407 -- nonce is freshly generated via crypto/rand immediately above, not a hardcoded value
+	ct := m.aead.Seal(nil, nonce, dek, aad) // #nosec G407 -- nonce is freshly generated via crypto/rand immediately above, not a hardcoded value
 	return WrappedKey{Ciphertext: ct, Nonce: nonce}, nil
 }
 
-// UnwrapDEK decrypts a DEK previously wrapped with WrapDEK. The returned
-// plaintext lives only until the caller zeroises it.
-func (m *Master) UnwrapDEK(w WrappedKey) ([]byte, error) {
+// UnwrapDEK decrypts a DEK previously wrapped with WrapDEK under the same
+// aad. The returned plaintext lives only until the caller zeroises it.
+// Pass nil aad only for envelopes written before the binding existed (see
+// the legacy fallback in pki.CAResolver.LoadByID).
+func (m *Master) UnwrapDEK(w WrappedKey, aad []byte) ([]byte, error) {
 	if len(w.Nonce) != NonceSize {
 		return nil, fmt.Errorf("wrapped dek nonce: %d bytes, want %d", len(w.Nonce), NonceSize)
 	}
-	pt, err := m.aead.Open(nil, w.Nonce, w.Ciphertext, nil)
+	pt, err := m.aead.Open(nil, w.Nonce, w.Ciphertext, aad)
 	if err != nil {
 		return nil, fmt.Errorf("unwrap dek: %w", err)
 	}
 	return pt, nil
 }
 
-// SealWithDEK encrypts a payload under the given DEK using AES-256-GCM.
-func SealWithDEK(dek, plaintext []byte) (WrappedBlob, error) {
+// SealWithDEK encrypts a payload under the given DEK using AES-256-GCM,
+// binding aad (the owning CA's ID) into the tag — see WrapDEK.
+func SealWithDEK(dek, plaintext, aad []byte) (WrappedBlob, error) {
 	if len(dek) != DEKSize {
 		return WrappedBlob{}, fmt.Errorf("dek length: %d, want %d", len(dek), DEKSize)
 	}
@@ -132,12 +138,13 @@ func SealWithDEK(dek, plaintext []byte) (WrappedBlob, error) {
 	if _, err := rand.Read(nonce); err != nil {
 		return WrappedBlob{}, err
 	}
-	ct := aead.Seal(nil, nonce, plaintext, nil) // #nosec G407 -- nonce is freshly generated via crypto/rand immediately above, not a hardcoded value
+	ct := aead.Seal(nil, nonce, plaintext, aad) // #nosec G407 -- nonce is freshly generated via crypto/rand immediately above, not a hardcoded value
 	return WrappedBlob{Ciphertext: ct, Nonce: nonce}, nil
 }
 
-// OpenWithDEK decrypts a WrappedBlob using the given DEK.
-func OpenWithDEK(dek []byte, w WrappedBlob) ([]byte, error) {
+// OpenWithDEK decrypts a WrappedBlob using the given DEK and the aad it
+// was sealed with (nil only for pre-binding legacy envelopes).
+func OpenWithDEK(dek []byte, w WrappedBlob, aad []byte) ([]byte, error) {
 	if len(dek) != DEKSize {
 		return nil, fmt.Errorf("dek length: %d, want %d", len(dek), DEKSize)
 	}
@@ -152,7 +159,7 @@ func OpenWithDEK(dek []byte, w WrappedBlob) ([]byte, error) {
 	if len(w.Nonce) != NonceSize {
 		return nil, fmt.Errorf("wrapped blob nonce: %d bytes, want %d", len(w.Nonce), NonceSize)
 	}
-	pt, err := aead.Open(nil, w.Nonce, w.Ciphertext, nil)
+	pt, err := aead.Open(nil, w.Nonce, w.Ciphertext, aad)
 	if err != nil {
 		return nil, fmt.Errorf("open with dek: %w", err)
 	}

--- a/internal/keystore/keystore_test.go
+++ b/internal/keystore/keystore_test.go
@@ -40,11 +40,11 @@ func TestNewMaster_CopiesKeyMaterial(t *testing.T) {
 	Zeroize(raw)
 
 	// The Master must still wrap/unwrap correctly.
-	dek, wrapped, err := m.GenerateDEK()
+	dek, wrapped, err := m.GenerateDEK([]byte("ca-test"))
 	if err != nil {
 		t.Fatalf("GenerateDEK after source wipe: %v", err)
 	}
-	unwrapped, err := m.UnwrapDEK(wrapped)
+	unwrapped, err := m.UnwrapDEK(wrapped, []byte("ca-test"))
 	if err != nil {
 		t.Fatalf("UnwrapDEK after source wipe: %v", err)
 	}
@@ -62,11 +62,11 @@ func TestNewMasterFromBase64_RoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dek, wrapped, err := m.GenerateDEK()
+	dek, wrapped, err := m.GenerateDEK([]byte("ca-test"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	unwrapped, err := m.UnwrapDEK(wrapped)
+	unwrapped, err := m.UnwrapDEK(wrapped, []byte("ca-test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestNewMasterFromBase64_RoundTrip(t *testing.T) {
 
 func TestWrapUnwrap_RoundTrip(t *testing.T) {
 	m := newTestMaster(t)
-	dek, wrapped, err := m.GenerateDEK()
+	dek, wrapped, err := m.GenerateDEK([]byte("ca-test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestWrapUnwrap_RoundTrip(t *testing.T) {
 		t.Fatalf("nonce length = %d", len(wrapped.Nonce))
 	}
 
-	unwrapped, err := m.UnwrapDEK(wrapped)
+	unwrapped, err := m.UnwrapDEK(wrapped, []byte("ca-test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,19 +99,19 @@ func TestWrapUnwrap_RoundTrip(t *testing.T) {
 
 func TestSealOpen_RoundTrip(t *testing.T) {
 	m := newTestMaster(t)
-	dek, _, err := m.GenerateDEK()
+	dek, _, err := m.GenerateDEK([]byte("ca-test"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	pt := []byte("super-secret CA private key material")
-	blob, err := SealWithDEK(dek, pt)
+	blob, err := SealWithDEK(dek, pt, []byte("ca-test"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if bytes.Contains(blob.Ciphertext, pt) {
 		t.Fatal("plaintext appeared inside ciphertext")
 	}
-	out, err := OpenWithDEK(dek, blob)
+	out, err := OpenWithDEK(dek, blob, []byte("ca-test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,20 +122,20 @@ func TestSealOpen_RoundTrip(t *testing.T) {
 
 func TestOpen_RejectsTamperedCiphertext(t *testing.T) {
 	m := newTestMaster(t)
-	dek, _, _ := m.GenerateDEK()
-	blob, _ := SealWithDEK(dek, []byte("payload"))
+	dek, _, _ := m.GenerateDEK([]byte("ca-test"))
+	blob, _ := SealWithDEK(dek, []byte("payload"), []byte("ca-test"))
 	blob.Ciphertext[0] ^= 0xff
-	if _, err := OpenWithDEK(dek, blob); err == nil {
+	if _, err := OpenWithDEK(dek, blob, []byte("ca-test")); err == nil {
 		t.Error("expected error for tampered ciphertext")
 	}
 }
 
 func TestUnwrapDEK_RejectsWrongMaster(t *testing.T) {
 	m1 := newTestMaster(t)
-	_, wrapped, _ := m1.GenerateDEK()
+	_, wrapped, _ := m1.GenerateDEK([]byte("ca-test"))
 
 	other, _ := NewMaster(bytes.Repeat([]byte{0xcd}, MasterKeySize))
-	if _, err := other.UnwrapDEK(wrapped); err == nil {
+	if _, err := other.UnwrapDEK(wrapped, []byte("ca-test")); err == nil {
 		t.Error("expected error when unwrapping with the wrong master key")
 	}
 }
@@ -147,5 +147,48 @@ func TestZeroize(t *testing.T) {
 		if v != 0 {
 			t.Errorf("zeroize left %d", v)
 		}
+	}
+}
+
+// TestUnwrapDEK_RejectsWrongAAD pins the ca_id binding (L6, 2026-06-12
+// audit): an envelope wrapped for one CA must not open under another CA's
+// ID — the DB-write swap this binding exists to stop.
+func TestUnwrapDEK_RejectsWrongAAD(t *testing.T) {
+	m := newTestMaster(t)
+	_, wrapped, err := m.GenerateDEK([]byte("ca-A"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.UnwrapDEK(wrapped, []byte("ca-B")); err == nil {
+		t.Error("DEK wrapped for ca-A opened under ca-B's AAD")
+	}
+	if _, err := m.UnwrapDEK(wrapped, nil); err == nil {
+		t.Error("DEK wrapped with AAD opened with nil AAD")
+	}
+	if _, err := m.UnwrapDEK(wrapped, []byte("ca-A")); err != nil {
+		t.Errorf("DEK failed to open under its own AAD: %v", err)
+	}
+}
+
+// TestOpenWithDEK_RejectsWrongAAD mirrors the same property for the inner
+// (DEK → key material) layer.
+func TestOpenWithDEK_RejectsWrongAAD(t *testing.T) {
+	m := newTestMaster(t)
+	dek, _, err := m.GenerateDEK([]byte("ca-A"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := SealWithDEK(dek, []byte("key material"), []byte("ca-A"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenWithDEK(dek, blob, []byte("ca-B")); err == nil {
+		t.Error("blob sealed for ca-A opened under ca-B's AAD")
+	}
+	if _, err := OpenWithDEK(dek, blob, nil); err == nil {
+		t.Error("blob sealed with AAD opened with nil AAD")
+	}
+	if _, err := OpenWithDEK(dek, blob, []byte("ca-A")); err != nil {
+		t.Errorf("blob failed to open under its own AAD: %v", err)
 	}
 }

--- a/internal/pki/autoprovision.go
+++ b/internal/pki/autoprovision.go
@@ -74,17 +74,19 @@ func MintAndStoreCA(ctx context.Context, s MintStore, master *keystore.Master, l
 		return nil, false, fmt.Errorf("create CA: %w", err)
 	}
 
-	// Extract and encrypt the private key.
+	// Extract and encrypt the private key. The CA ID is minted before
+	// sealing because both envelope layers bind it as AAD.
+	caID := uuid.New().String()
 	rawKey := mgr.RawKey()
 	defer keystore.Zeroize(rawKey)
 
-	dek, wrappedDEK, err := master.GenerateDEK()
+	dek, wrappedDEK, err := master.GenerateDEK([]byte(caID))
 	if err != nil {
 		return nil, false, fmt.Errorf("generate DEK: %w", err)
 	}
 	defer keystore.Zeroize(dek)
 
-	wrappedKey, err := keystore.SealWithDEK(dek, rawKey)
+	wrappedKey, err := keystore.SealWithDEK(dek, rawKey, []byte(caID))
 	if err != nil {
 		return nil, false, fmt.Errorf("seal key: %w", err)
 	}
@@ -106,7 +108,7 @@ func MintAndStoreCA(ctx context.Context, s MintStore, master *keystore.Master, l
 	// Construct the CA model and persist.
 	now := time.Now()
 	ca := &models.CA{
-		ID:                   uuid.New().String(),
+		ID:                   caID,
 		Name:                 req.Name,
 		OwnerOperatorID:      req.Operator.ID,
 		CertPEM:              string(certPEM),

--- a/internal/pki/ca.go
+++ b/internal/pki/ca.go
@@ -57,6 +57,14 @@ func LoadCAFromMaterial(certPEM []byte, rawKey ed25519.PrivateKey) (*CAManager, 
 	if len(rawKey) != ed25519.PrivateKeySize {
 		return nil, fmt.Errorf("raw key length: %d, want %d", len(rawKey), ed25519.PrivateKeySize)
 	}
+	// The private key must actually be the one the cert certifies — a
+	// mismatch means the DB row pairs this cert with a foreign key (e.g. a
+	// pre-AAD envelope swapped between CA rows) and every cert signed with
+	// it would fail peer validation. Refuse at load instead of minting
+	// unusable certificates.
+	if pub, ok := rawKey.Public().(ed25519.PublicKey); !ok || !pub.Equal(ed25519.PublicKey(c.PublicKey())) {
+		return nil, fmt.Errorf("CA private key does not match certificate public key")
+	}
 	return &CAManager{caCert: c, caKey: rawKey}, nil
 }
 

--- a/internal/pki/resolver.go
+++ b/internal/pki/resolver.go
@@ -44,19 +44,31 @@ func (r *CAResolver) LoadByID(ctx context.Context, caID string) (*CAManager, err
 	if err != nil {
 		return nil, fmt.Errorf("load CA %s: %w", caID, err)
 	}
-	dek, err := r.master.UnwrapDEK(keystore.WrappedKey{
+	// Try the ca_id-bound envelope first; fall back to nil AAD for
+	// envelopes sealed before the binding existed. The fallback does not
+	// reopen the swap it guards against: an AAD-bound envelope copied from
+	// another CA's row fails both opens (its tag covers the source CA's
+	// ID), and a swapped-in legacy envelope is caught by the public-key
+	// consistency check in LoadCAFromMaterial.
+	wrappedDEK := keystore.WrappedKey{
 		Ciphertext: c.EncryptedKeyDEK,
 		Nonce:      c.NonceDEK,
-	})
+	}
+	aad := []byte(caID)
+	dek, err := r.master.UnwrapDEK(wrappedDEK, aad)
 	if err != nil {
-		return nil, fmt.Errorf("unwrap DEK for CA %s: %w", caID, err)
+		dek, err = r.master.UnwrapDEK(wrappedDEK, nil)
+		if err != nil {
+			return nil, fmt.Errorf("unwrap DEK for CA %s: %w", caID, err)
+		}
+		aad = nil
 	}
 	defer keystore.Zeroize(dek)
 
 	keyBytes, err := keystore.OpenWithDEK(dek, keystore.WrappedBlob{
 		Ciphertext: c.EncryptedKeyMaterial,
 		Nonce:      c.NonceKey,
-	})
+	}, aad)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt CA %s key: %w", caID, err)
 	}

--- a/internal/pki/resolver_test.go
+++ b/internal/pki/resolver_test.go
@@ -263,3 +263,91 @@ func TestCAResolver_LoadByID_CorruptedKeyMaterialFails(t *testing.T) {
 		})
 	}
 }
+
+// TestCAResolver_LoadByID_RejectsSwappedEnvelope pins the ca_id AAD binding
+// (L6, 2026-06-12 audit): copying CA-B's matched (encrypted DEK, encrypted
+// key material) pair into CA-A's row must fail at decrypt. Without the
+// binding a DB-write swap decrypts cleanly and pairs CA-A's cert with CA-B's
+// signing key.
+func TestCAResolver_LoadByID_RejectsSwappedEnvelope(t *testing.T) {
+	s := newTestStore(t)
+	m := newTestMaster(t)
+	caA := mintCAInStore(t, s, m, "op-swap-a")
+	caB := mintCAInStore(t, s, m, "op-swap-b")
+
+	// Attacker with DB write but no master key: graft B's envelope onto
+	// A's row, keeping A's id and cert.
+	grafted := *caA
+	grafted.EncryptedKeyDEK = append([]byte(nil), caB.EncryptedKeyDEK...)
+	grafted.NonceDEK = append([]byte(nil), caB.NonceDEK...)
+	grafted.EncryptedKeyMaterial = append([]byte(nil), caB.EncryptedKeyMaterial...)
+	grafted.NonceKey = append([]byte(nil), caB.NonceKey...)
+
+	if _, err := pki.NewCAResolver(fakeCAStore{ca: &grafted}, m).LoadByID(context.Background(), caA.ID); err == nil {
+		t.Fatal("LoadByID returned a manager from an envelope swapped between CA rows")
+	}
+}
+
+// TestCAResolver_LoadByID_LegacyNilAADEnvelope verifies the migration path:
+// an envelope sealed before the AAD binding (nil AAD) still loads, provided
+// the key matches the certificate.
+func TestCAResolver_LoadByID_LegacyNilAADEnvelope(t *testing.T) {
+	s := newTestStore(t)
+	m := newTestMaster(t)
+	ca := mintCAInStore(t, s, m, "op-legacy")
+
+	// Re-seal the CA's true key the pre-binding way (nil AAD) to model a
+	// row written by an older release.
+	mgr, err := pki.NewCAResolver(s, m).LoadByID(context.Background(), ca.ID)
+	if err != nil {
+		t.Fatalf("load freshly minted CA: %v", err)
+	}
+	rawKey := append([]byte(nil), mgr.RawKey()...)
+	mgr.Wipe()
+
+	dek, wrappedDEK, err := m.GenerateDEK(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrappedKey, err := keystore.SealWithDEK(dek, rawKey, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := *ca
+	legacy.EncryptedKeyDEK = wrappedDEK.Ciphertext
+	legacy.NonceDEK = wrappedDEK.Nonce
+	legacy.EncryptedKeyMaterial = wrappedKey.Ciphertext
+	legacy.NonceKey = wrappedKey.Nonce
+
+	mgr2, err := pki.NewCAResolver(fakeCAStore{ca: &legacy}, m).LoadByID(context.Background(), ca.ID)
+	if err != nil {
+		t.Fatalf("legacy nil-AAD envelope refused: %v", err)
+	}
+	defer mgr2.Wipe()
+	if !bytes.Equal(mgr2.RawKey(), rawKey) {
+		t.Error("legacy envelope round-trip recovered a different key")
+	}
+}
+
+// TestLoadCAFromMaterial_RejectsMismatchedKey pins the public-key consistency
+// check: a parseable cert paired with a different CA's (valid-length) key
+// must be refused at load, not surface later as unusable certificates. This
+// is the backstop that covers a legacy-envelope swap, where no AAD exists to
+// catch it.
+func TestLoadCAFromMaterial_RejectsMismatchedKey(t *testing.T) {
+	s := newTestStore(t)
+	m := newTestMaster(t)
+	caA := mintCAInStore(t, s, m, "op-mismatch-a")
+	caB := mintCAInStore(t, s, m, "op-mismatch-b")
+
+	mgrB, err := pki.NewCAResolver(s, m).LoadByID(context.Background(), caB.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyB := append([]byte(nil), mgrB.RawKey()...)
+	mgrB.Wipe()
+
+	if _, err := pki.LoadCAFromMaterial([]byte(caA.CertPEM), keyB); err == nil {
+		t.Fatal("LoadCAFromMaterial accepted CA-A's cert with CA-B's key")
+	}
+}

--- a/internal/pki/rotate.go
+++ b/internal/pki/rotate.go
@@ -60,17 +60,19 @@ func RotateAndStoreCA(
 		return nil, fmt.Errorf("create CA: %w", err)
 	}
 
-	// Extract and encrypt the private key.
+	// Extract and encrypt the private key. The successor's ID is minted
+	// before sealing because both envelope layers bind it as AAD.
+	newID := uuid.New().String()
 	rawKey := mgr.RawKey()
 	defer keystore.Zeroize(rawKey)
 
-	dek, wrappedDEK, err := master.GenerateDEK()
+	dek, wrappedDEK, err := master.GenerateDEK([]byte(newID))
 	if err != nil {
 		return nil, fmt.Errorf("generate DEK: %w", err)
 	}
 	defer keystore.Zeroize(dek)
 
-	wrappedKey, err := keystore.SealWithDEK(dek, rawKey)
+	wrappedKey, err := keystore.SealWithDEK(dek, rawKey, []byte(newID))
 	if err != nil {
 		return nil, fmt.Errorf("seal key: %w", err)
 	}
@@ -92,7 +94,7 @@ func RotateAndStoreCA(
 	// Construct the new CA model and persist.
 	now := time.Now()
 	newCA := &models.CA{
-		ID:                   uuid.New().String(),
+		ID:                   newID,
 		Name:                 newName,
 		OwnerOperatorID:      oldCA.OwnerOperatorID,
 		CertPEM:              string(certPEM),

--- a/internal/pki/rotate_test.go
+++ b/internal/pki/rotate_test.go
@@ -58,6 +58,15 @@ func TestRotateAndStoreCA_HappyPath(t *testing.T) {
 	assert.NotNil(t, persisted.PredecessorID)
 	assert.Equal(t, *persisted.PredecessorID, ca1.ID)
 
+	// The rotation path seals the successor's key with the new ca_id as AAD;
+	// confirm the round-trip by loading it back through the resolver, which
+	// unwraps under ca2.ID. A mismatched AAD between seal and open would
+	// surface here as a decrypt failure, not later as unusable certs.
+	mgr, err := pki.NewCAResolver(s, master).LoadByID(context.Background(), ca2.ID)
+	require.NoError(t, err)
+	defer mgr.Wipe()
+	assert.NotEmpty(t, mgr.RawKey(), "rotated CA key did not decrypt under its own ca_id AAD")
+
 	// Verify audit entry.
 	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Limit: 100})
 	require.NoError(t, err)

--- a/internal/web/cas.go
+++ b/internal/web/cas.go
@@ -97,14 +97,17 @@ func (w *Web) mintCAForOperator(ctx context.Context, op *models.Operator, name s
 	rawKey := mgr.RawKey()
 	defer keystore.Zeroize(rawKey)
 
-	dek, wrappedDEK, err := w.caMaster.GenerateDEK()
+	// Mint the CA ID before sealing: both envelope layers bind it as AAD
+	// so an envelope copied into another CA's row fails to decrypt.
+	caID := uuid.New().String()
+	dek, wrappedDEK, err := w.caMaster.GenerateDEK([]byte(caID))
 	if err != nil {
 		w.logger.Error("generate dek", "error", err)
 		return nil, err
 	}
 	defer keystore.Zeroize(dek)
 
-	wrappedKey, err := keystore.SealWithDEK(dek, rawKey)
+	wrappedKey, err := keystore.SealWithDEK(dek, rawKey, []byte(caID))
 	if err != nil {
 		w.logger.Error("seal ca key", "error", err)
 		return nil, err
@@ -124,7 +127,7 @@ func (w *Web) mintCAForOperator(ctx context.Context, op *models.Operator, name s
 
 	now := time.Now()
 	ca := &models.CA{
-		ID:                   uuid.New().String(),
+		ID:                   caID,
 		Name:                 name,
 		OwnerOperatorID:      op.ID,
 		CertPEM:              string(certPEM),


### PR DESCRIPTION
threat-model.md claimed "GCM tag binds AAD/nonce (envelope attacks
refuted)", but all four Seal/Open calls passed nil AAD: neither the
master->DEK wrap nor the DEK->key-material seal was bound to the owning
CA. An attacker with DB write access (no master key) could copy a
matched (encrypted_key_dek, encrypted_key_material) pair from CA-B's
row into CA-A's; LoadByID decrypted B's key and paired it with A's
cert, and LoadCAFromMaterial never noticed the mismatch — the failure
only surfaced later as certificates no peer validates.

Both envelope layers now bind the owning CA's ID as AAD, so the swap
fails at decrypt. Every mint path (API, web, rotation, auto-provision)
allocates the CA ID before sealing. LoadByID falls back to nil AAD for
envelopes sealed before the binding — which cannot reopen the swap: an
AAD-bound envelope fails both opens under a foreign row, and a legacy
swap is caught by the new public-key consistency check in
LoadCAFromMaterial (private key must match the cert it's paired with).
Legacy envelopes pick up the binding when the CA is next rotated.

threat-model.md now describes the actual mechanism. New tests pin
wrong-AAD rejection at both layers, the cross-row swap, the legacy
nil-AAD load, and the key/cert mismatch refusal.
