### PR TITLE
fix(api,web): audit network creation and firewall policy updates

### DIFF
--- a/internal/api/audit_property_test.go
+++ b/internal/api/audit_property_test.go
@@ -35,7 +35,14 @@ func TestAuditRows_AllProductionPathsConform(t *testing.T) {
 	srv, st := newTestServer(t)
 	ctx := context.Background()
 
+	// network.create — the sweep's own fixture network emits it.
 	netID := createNetwork(t, srv)
+
+	// network.firewall.update — rewrite the network's firewall policy,
+	// exercising the full-ruleset details payload.
+	mustDo(t, srv, http.MethodPut, "/api/v1/networks/"+netID+"/firewall",
+		[]byte(`{"inbound":[{"port":"443","proto":"tcp","group":"servers"}],"outbound":[{"port":"any","proto":"any","group":"all"}]}`),
+		http.StatusOK)
 
 	// host.create — normal create.
 	hostID := mustCreateHost(t, srv, netID, "audit-h1", "192.168.100.50")
@@ -149,6 +156,8 @@ var auditActionsExercisedByCoverageSweep = []string{
 	auditHostDelete,
 	auditCACreated,
 	auditCADeleted,
+	auditNetworkCreate,
+	auditNetworkFirewallUpdate,
 	auditOperatorCreate,
 	auditOperatorDisable,
 	auditOperatorEnable,

--- a/internal/api/audit_validator_test.go
+++ b/internal/api/audit_validator_test.go
@@ -40,6 +40,8 @@ var knownAuditActions = map[string]struct{}{
 	auditCACreated:                 {},
 	auditCADeleted:                 {},
 	auditCARotated:                 {},
+	auditNetworkCreate:             {},
+	auditNetworkFirewallUpdate:     {},
 	auditOperatorCreate:            {},
 	auditOperatorDisable:           {},
 	auditOperatorEnable:            {},

--- a/internal/api/firewall.go
+++ b/internal/api/firewall.go
@@ -127,6 +127,9 @@ func (s *Server) handleUpdateFirewall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Details carry the full new ruleset: firewall policy rewrites are
+	// exactly the mutations a forensic reader needs verbatim.
+	s.recordAuditAction(r.Context(), auditNetworkFirewallUpdate, networkID, string(rulesJSON))
 	s.logger.Info("firewall rules updated", "network", networkID)
 	writeJSON(w, http.StatusOK, req)
 }

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -64,6 +64,8 @@ const (
 	auditCACreated                 = "ca.created"
 	auditCADeleted                 = "ca.deleted"
 	auditCARotated                 = "ca.rotated"
+	auditNetworkCreate             = "network.create"
+	auditNetworkFirewallUpdate     = "network.firewall.update"
 	auditOperatorCreate            = "operator.create"
 	auditOperatorDisable           = "operator.disable"
 	auditOperatorEnable            = "operator.enable"
@@ -191,6 +193,7 @@ func newMetrics(s store.Store) *metrics {
 	for _, action := range []string{
 		auditHostCreate, auditHostDelete, auditHostUpdate, auditHostBlock, auditHostUnblock,
 		auditCACreated, auditCADeleted, auditCARotated,
+		auditNetworkCreate, auditNetworkFirewallUpdate,
 		auditOperatorCreate, auditOperatorDisable, auditOperatorEnable,
 		auditOperatorAPIKeyCreate, auditOperatorAPIKeyRevoke,
 		auditSettingsEnforce2FA,

--- a/internal/api/networks.go
+++ b/internal/api/networks.go
@@ -50,6 +50,7 @@ func (s *Server) handleCreateNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.recordAuditAction(r.Context(), auditNetworkCreate, network.ID, network.Name)
 	writeJSON(w, http.StatusCreated, network)
 }
 

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -1294,6 +1294,7 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	_ = w.store.AddAuditEntry(r.Context(), op.Username, "network.create", network.ID, network.Name)
 	http.Redirect(rw, r, "/ui/networks", http.StatusSeeOther)
 }
 

--- a/internal/web/operator_ca_gating_test.go
+++ b/internal/web/operator_ca_gating_test.go
@@ -109,6 +109,20 @@ func TestNetworkCreate_UserWithSingleCA(t *testing.T) {
 	if nets[0].CAID != ca.ID {
 		t.Errorf("network CAID = %q, want %q", nets[0].CAID, ca.ID)
 	}
+
+	// The web create path must write a network.create audit row — the API
+	// audit-coverage sweep only exercises the API handler, so this is the
+	// only guard against the UI path silently stopping auditing.
+	entries, err := s.ListAuditEntries(context.Background(), store.AuditFilter{Action: "network.create", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d network.create audit rows, want 1", len(entries))
+	}
+	if entries[0].Resource != nets[0].ID {
+		t.Errorf("audit resource = %q, want network id %q", entries[0].Resource, nets[0].ID)
+	}
 }
 
 // TestNetworkCreate_UserMustPickWhenMultipleCAs — operators with more


### PR DESCRIPTION
Every host, CA, operator, and settings mutation writes an audit entry,
but handleCreateNetwork and handleUpdateFirewall did not (the firewall
handler only logged at info level), contradicting threat-model E1
("mutating actions write an audit-log entry"). An admin could create
networks and rewrite firewall policy with no trail — and firewall
policy is exactly the mutation a forensic reader most wants verbatim.

Add network.create (API + web UI form) and network.firewall.update
(API; the UI has no firewall editor). The firewall entry's details
field carries the full new ruleset JSON. Both actions are registered in
the metrics pre-seed, the known-actions enum, and the audit coverage
sweep, which now drives a firewall update as well.
