### PR TITLE
fix(store): derive audit-log id from crypto/rand, not UnixNano

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2183,7 +2185,16 @@ func (s *SQLiteStore) SetNetworkConfigAndBumpVersion(ctx context.Context, networ
 // --- Audit Log ---
 
 func (s *SQLiteStore) AddAuditEntry(ctx context.Context, actor, action, resource, details string) error {
-	id := fmt.Sprintf("audit_%d", time.Now().UnixNano())
+	// The id must not be timestamp-derived: two concurrent writes landing
+	// on the same nanosecond would collide on the PRIMARY KEY, and every
+	// caller fire-and-forgets this method's error, so the losing row would
+	// vanish silently. 16 random bytes make collisions cryptographically
+	// negligible.
+	suffix := make([]byte, 16)
+	if _, err := rand.Read(suffix); err != nil {
+		return fmt.Errorf("audit entry id: %w", err)
+	}
+	id := "audit_" + hex.EncodeToString(suffix)
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO audit_log (id, actor, action, resource, details) VALUES (?, ?, ?, ?, ?)`,
 		id, actor, action, resource, details,

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -497,6 +498,45 @@ func TestBlocklist_AddAndGet(t *testing.T) {
 }
 
 // --- Audit Log ---
+
+// TestAddAuditEntry_ConcurrentWritesAllPersist drives parallel AddAuditEntry
+// calls and asserts every row lands. With a timestamp-derived id two writes
+// in the same nanosecond collided on the PRIMARY KEY and the loser vanished
+// silently (every production caller discards this method's error).
+func TestAddAuditEntry_ConcurrentWritesAllPersist(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const writers = 8
+	const perWriter = 25
+	errs := make(chan error, writers*perWriter)
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				errs <- s.AddAuditEntry(ctx, "admin", "concurrent_action",
+					fmt.Sprintf("w%d_r%d", w, i), "")
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("AddAuditEntry: %v", err)
+		}
+	}
+
+	entries, err := s.ListAuditEntries(ctx, AuditFilter{Action: "concurrent_action", Limit: 1000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != writers*perWriter {
+		t.Errorf("persisted rows = %d, want %d (silent row loss)", len(entries), writers*perWriter)
+	}
+}
 
 func TestListAuditEntries_WithLimit(t *testing.T) {
 	s := newTestStore(t)


### PR DESCRIPTION
AddAuditEntry built its PRIMARY KEY from time.Now().UnixNano(), so two
concurrent writes landing on the same nanosecond collided and the
second INSERT failed — and every production caller fire-and-forgets
this method's error, so the security-relevant row vanished with no
trace. The new concurrent-writers test reproduces the collision
reliably against the old id scheme (UNIQUE constraint failure within a
few hundred parallel writes).

Use 16 random bytes (hex) for the id suffix. The etok_/cert_ UnixNano
patterns elsewhere in this file run inside transactions whose errors
propagate, so they fail loud rather than silently and are left as-is.
