### PR TITLE
fix(api): stop auditing pre-auth malformed agent polls

### DIFF
--- a/internal/api/audit_property_test.go
+++ b/internal/api/audit_property_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	corepop "github.com/forgekeep/nebula-mesh/internal/pop"
 	"github.com/forgekeep/nebula-mesh/internal/store"
 )
 
@@ -102,12 +104,19 @@ func TestAuditRows_AllProductionPathsConform(t *testing.T) {
 	mustDo(t, srv, http.MethodPatch, "/api/v1/settings",
 		[]byte(`{"enforce_2fa":true}`), http.StatusOK)
 
-	// host.auth.failed — a signed-poll with missing headers exercises
-	// the empty-resource exception (no host known yet).
+	// host.auth.failed — a signed-poll with headers present but an
+	// unknown fingerprint exercises the empty-resource exception (no
+	// host row matched). The headers-missing branch deliberately does
+	// NOT audit (unauthenticated flood vector, see updates.go).
+	pollReq := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+	pollReq.Header.Set(corepop.HeaderFingerprint, "no-such-fingerprint")
+	pollReq.Header.Set(corepop.HeaderTimestamp, time.Now().UTC().Format(time.RFC3339))
+	pollReq.Header.Set(corepop.HeaderNonce, "sweep-nonce")
+	pollReq.Header.Set(corepop.HeaderSignature, "c3dlZXA=")
 	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil))
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("signed-poll missing-headers: status = %d, want 400", rec.Code)
+	srv.ServeHTTP(rec, pollReq)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("signed-poll unknown-fingerprint: status = %d, want 401", rec.Code)
 	}
 
 	// Read back every audit row and validate each.

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -43,7 +43,12 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 	nonce := r.Header.Get(corepop.HeaderNonce)
 	signatureB64 := r.Header.Get(corepop.HeaderSignature)
 	if fingerprint == "" || timestamp == "" || nonce == "" || signatureB64 == "" {
-		s.recordAuditAction(r.Context(), auditHostAuthFailed, "", authReasonBadSignature)
+		// Deliberately NOT audited: this branch needs no valid token,
+		// fingerprint, or signature, so writing a DB row per request lets
+		// an unauthenticated sender bloat the audit table at line rate,
+		// bounded only by the agent_poll bucket. Flood visibility stays
+		// available via the HTTP request counter (route + status 400);
+		// every branch after the fingerprint lookup still audits.
 		writeError(w, http.StatusBadRequest, "missing_signature")
 		return
 	}

--- a/internal/api/updates_signed_poll_audit_test.go
+++ b/internal/api/updates_signed_poll_audit_test.go
@@ -20,8 +20,9 @@ import (
 // audit_validator_test.go). Pins the (reason code, resource shape)
 // contract for the signed-poll audit trail — operators key off these
 // strings when filtering the audit log, so a drift here is observable
-// to anyone running detection rules. All 11 audit-failed branches are
-// covered.
+// to anyone running detection rules. Every audit-failed branch is
+// covered; the pre-lookup missing-headers branch intentionally does
+// not audit (see TestSignedPoll_MissingHeadersNotAudited).
 func TestSignedPoll_AuditRowPerBranch(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -29,15 +30,6 @@ func TestSignedPoll_AuditRowPerBranch(t *testing.T) {
 		wantReason   string
 		wantResource string // "" means: must be empty (early-stage branch)
 	}{
-		{
-			name: "missing_headers",
-			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
-				return httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil),
-					http.StatusBadRequest
-			},
-			wantReason:   authReasonBadSignature,
-			wantResource: "",
-		},
 		{
 			name: "unknown_fingerprint",
 			setup: func(t *testing.T, srv *Server) (*http.Request, int) {
@@ -229,6 +221,32 @@ func TestSignedPoll_AuditRowPerBranch(t *testing.T) {
 			wantResource: "<non-empty-host-id>",
 		},
 	}
+
+	t.Run("missing_headers_not_audited", func(t *testing.T) {
+		// A poll missing the PoP headers needs no token, fingerprint, or
+		// signature, so an unauthenticated sender could bloat the audit
+		// table at line rate if this branch wrote a row per request
+		// (L10, 2026-06-12 audit). It must answer 400 without auditing.
+		srv, st := newTestServer(t)
+		ctx := context.Background()
+
+		before, err := st.ListAuditEntries(ctx, store.AuditFilter{Limit: 100})
+		if err != nil {
+			t.Fatal(err)
+		}
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", w.Code)
+		}
+		after, err := st.ListAuditEntries(ctx, store.AuditFilter{Limit: 100})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(after) != len(before) {
+			t.Errorf("missing-headers poll wrote %d audit rows, want 0 (unauthenticated flood vector)", len(after)-len(before))
+		}
+	})
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
A poll missing any of the four PoP headers wrote a host.auth.failed
audit row before any host lookup or signature verification. The branch
needs no token, fingerprint, or signature, so an unauthenticated
sender could bloat the audit table at line rate, bounded only by the
agent_poll rate-limit bucket (60/s per IP).

Drop the DB write for that branch only; every branch after the
fingerprint lookup still audits, and floods remain visible via the
HTTP request counter (route + status 400). The audit coverage sweep
now drives host.auth.failed through the unknown-fingerprint branch
instead, and a new test pins that the missing-headers poll writes no
audit row.
