### PR TITLE
fix(alerts): enforce the webhook SSRF guard at delivery time

### DIFF
--- a/internal/alerts/sinks.go
+++ b/internal/alerts/sinks.go
@@ -7,9 +7,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/forgekeep/nebula-mesh/internal/store"
@@ -50,10 +55,21 @@ func (a *AuditSink) Notify(ctx context.Context, ev Alert) error {
 // in the X-Nebula-Signature header (sha256=<hex>). If HMACSecret is empty,
 // the signature header is omitted — useful for trusted-internal alertmanager
 // endpoints behind mTLS where signing is redundant.
+//
+// Unless AllowPrivate is set, deliveries are SSRF-guarded at request time:
+// the dialer rejects connections to private/loopback/link-local addresses
+// after DNS resolution, and redirects re-apply the same check per hop. This
+// complements the config-load check in validateWebhookURL, which cannot see
+// what a hostname resolves to at delivery time or where a redirect points.
 type WebhookSink struct {
 	URL        string
 	HMACSecret string
 	HTTPClient *http.Client
+	// AllowPrivate disables the request-time private-address guard,
+	// mirroring alerts.allow_private_webhook for intentional internal
+	// sinks. Only consulted when HTTPClient is nil — a caller-supplied
+	// client manages its own transport policy.
+	AllowPrivate bool
 }
 
 // SignatureHeader is the HTTP header webhook receivers should inspect to
@@ -87,21 +103,84 @@ func (w *WebhookSink) Notify(ctx context.Context, ev Alert) error {
 
 	client := w.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: 10 * time.Second}
+		client = newWebhookClient(w.AllowPrivate)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("webhook POST: %w", err)
 	}
 	defer func() {
+		// Drain the (small) body before closing so the underlying
+		// connection can return to the keep-alive pool for reuse rather
+		// than being discarded mid-response.
+		_, _ = io.Copy(io.Discard, resp.Body)
 		if err := resp.Body.Close(); err != nil {
-			// nothing meaningful to do — drain failed but the upstream
-			// status was already captured.
-			_ = err
+			_ = err // status already captured; nothing actionable on close failure
 		}
 	}()
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("webhook returned HTTP %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// errPrivateWebhookAddr is returned by the guarded dialer when a webhook
+// delivery would connect to a non-public address.
+var errPrivateWebhookAddr = errors.New("webhook delivery to private/loopback/link-local address blocked (SSRF guard); set alerts.allow_private_webhook: true for an intentional internal sink")
+
+// isBlockedWebhookAddr reports whether addr is a non-public destination the
+// webhook guard must refuse: loopback, private, link-local, or unspecified.
+// An IPv4-mapped IPv6 address is first unmapped to its v4 form — netip's
+// predicates classify most mapped forms correctly, but ::ffff:0.0.0.0 reads
+// as non-unspecified while 0.0.0.0 routes to localhost on connect, so Unmap
+// makes the check form-independent. Mirrors config.hostIsPrivate; the two
+// must stay in sync.
+func isBlockedWebhookAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return addr.IsLoopback() || addr.IsPrivate() || addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() || addr.IsUnspecified()
+}
+
+// newWebhookClient builds the sink's default HTTP client. With the guard
+// active (allowPrivate false), the address check runs in the dialer's
+// Control hook — after DNS resolution, on the literal IP being connected
+// to — so a hostname that was public at config load but resolves privately
+// at delivery time (DNS rebinding), and any redirect hop, are both caught.
+// CheckRedirect re-applies because each redirect triggers a fresh dial
+// through the same transport; the explicit hop cap mirrors http's default.
+func newWebhookClient(allowPrivate bool) *http.Client {
+	if allowPrivate {
+		return &http.Client{Timeout: 10 * time.Second}
+	}
+	dialer := &net.Dialer{
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("webhook dial %q: %w", address, err)
+			}
+			addr, err := netip.ParseAddr(host)
+			if err != nil {
+				return fmt.Errorf("webhook dial %q: %w", address, err)
+			}
+			if isBlockedWebhookAddr(addr) {
+				return errPrivateWebhookAddr
+			}
+			return nil
+		},
+	}
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: dialer.DialContext,
+		},
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("webhook: too many redirects")
+			}
+			// Each hop dials through the guarded transport, so the
+			// private-address check re-applies automatically; nothing
+			// further to validate here.
+			return nil
+		},
+	}
 }

--- a/internal/alerts/sinks_test.go
+++ b/internal/alerts/sinks_test.go
@@ -7,8 +7,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"sync"
 	"testing"
@@ -136,5 +138,123 @@ func TestWebhookSink_ReceiverError_PropagatesError(t *testing.T) {
 	err := sink.Notify(context.Background(), Alert{HostID: "h", NotAfter: time.Now()})
 	if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
 		t.Errorf("expected error mentioning HTTP 500, got %v", err)
+	}
+}
+
+// TestWebhookSink_GuardedClient_BlocksPrivateAddress pins the request-time
+// SSRF guard (L11, 2026-06-12 audit): with no caller-supplied client, a
+// delivery that would connect to a loopback/private address fails in the
+// dialer — after DNS resolution, so a hostname that resolves privately at
+// delivery time is caught even if it looked public at config load.
+func TestWebhookSink_GuardedClient_BlocksPrivateAddress(t *testing.T) {
+	// httptest binds 127.0.0.1, exactly the class the guard must reject.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("guarded webhook client reached a loopback receiver")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := &WebhookSink{URL: srv.URL} // nil HTTPClient → guarded default
+	err := sink.Notify(context.Background(), Alert{HostID: "h", NotAfter: time.Now()})
+	if err == nil {
+		t.Fatal("expected SSRF-guard error for loopback delivery")
+	}
+	if !strings.Contains(err.Error(), "SSRF guard") {
+		t.Errorf("err = %v, want SSRF-guard message", err)
+	}
+}
+
+// TestWebhookSink_GuardedClient_BlocksRedirectToPrivate verifies a redirect
+// to a private target is not followed there. Both hops are loopback in a
+// test environment, so the outer (redirecting) hop runs with the guard
+// relaxed via a transport that admits exactly its address — the redirect
+// hop then dials through the guarded path and must be refused.
+func TestWebhookSink_GuardedClient_BlocksRedirectToPrivate(t *testing.T) {
+	inner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("redirect target reached through SSRF guard")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer inner.Close()
+
+	outer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, inner.URL, http.StatusFound)
+	}))
+	defer outer.Close()
+
+	// Same client shape as newWebhookClient(false), with the dialer
+	// admitting only the outer hop's address so the test can model
+	// "public first hop, private redirect target" on loopback.
+	guarded := newWebhookClient(false)
+	transport, ok := guarded.Transport.(*http.Transport)
+	if !ok {
+		t.Skipf("redirect test needs a *http.Transport, got %T", guarded.Transport)
+	}
+	base := transport.DialContext
+	outerAddr := strings.TrimPrefix(outer.URL, "http://")
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if address == outerAddr {
+			return (&net.Dialer{}).DialContext(ctx, network, address)
+		}
+		return base(ctx, network, address)
+	}
+
+	sink := &WebhookSink{URL: outer.URL, HTTPClient: guarded}
+	err := sink.Notify(context.Background(), Alert{HostID: "h", NotAfter: time.Now()})
+	if err == nil {
+		t.Fatal("expected SSRF-guard error on the redirect hop")
+	}
+	if !strings.Contains(err.Error(), "SSRF guard") {
+		t.Errorf("err = %v, want SSRF-guard message", err)
+	}
+}
+
+// TestWebhookSink_AllowPrivate_DeliversToLoopback pins the opt-out:
+// alerts.allow_private_webhook flows into the sink and restores the
+// pre-guard behavior for intentional internal receivers.
+func TestWebhookSink_AllowPrivate_DeliversToLoopback(t *testing.T) {
+	var delivered bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		delivered = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := &WebhookSink{URL: srv.URL, AllowPrivate: true}
+	if err := sink.Notify(context.Background(), Alert{HostID: "h", NotAfter: time.Now()}); err != nil {
+		t.Fatalf("Notify with AllowPrivate: %v", err)
+	}
+	if !delivered {
+		t.Error("alert not delivered despite AllowPrivate")
+	}
+}
+
+// TestIsBlockedWebhookAddr pins the dial-time predicate, including the
+// IPv4-mapped IPv6 forms that the bare netip predicates miss (notably
+// ::ffff:0.0.0.0, which routes to localhost on connect).
+func TestIsBlockedWebhookAddr(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"10.0.0.5", true},
+		{"192.168.1.1", true},
+		{"169.254.169.254", true},
+		{"0.0.0.0", true},
+		{"::1", true},
+		{"::", true},
+		{"::ffff:127.0.0.1", true},
+		{"::ffff:10.0.0.5", true},
+		{"::ffff:169.254.169.254", true},
+		{"::ffff:0.0.0.0", true}, // the gap the Unmap closes
+		{"203.0.113.10", false},
+		{"::ffff:203.0.113.10", false},
+		{"2001:db8::1", false},
+	}
+	for _, tc := range cases {
+		got := isBlockedWebhookAddr(netip.MustParseAddr(tc.addr))
+		if got != tc.want {
+			t.Errorf("isBlockedWebhookAddr(%q) = %v, want %v", tc.addr, got, tc.want)
+		}
 	}
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -281,8 +281,9 @@ func Serve(configPath string, insecureHTTP bool) error {
 		sinks := []alerts.Sink{&alerts.AuditSink{Store: s}}
 		if cfg.Alerts.WebhookURL != "" {
 			sinks = append(sinks, &alerts.WebhookSink{
-				URL:        cfg.Alerts.WebhookURL,
-				HMACSecret: cfg.Alerts.WebhookHMACSecret,
+				URL:          cfg.Alerts.WebhookURL,
+				HMACSecret:   cfg.Alerts.WebhookHMACSecret,
+				AllowPrivate: cfg.Alerts.AllowPrivateWebhook,
 			})
 		}
 		scanner := &alerts.Scanner{

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -163,14 +163,19 @@ func hostIsPrivate(host string) bool {
 	if err != nil {
 		return false
 	}
+	// Unmap an IPv4-mapped IPv6 form so the predicates classify it by its
+	// embedded v4 address (covers ::ffff:0.0.0.0, which netip otherwise
+	// reads as non-unspecified while 0.0.0.0 routes to localhost).
+	addr = addr.Unmap()
 	return addr.IsLoopback() || addr.IsPrivate() || addr.IsLinkLocalUnicast() ||
 		addr.IsLinkLocalMulticast() || addr.IsUnspecified()
 }
 
 // validateWebhookURL guards the alert webhook against SSRF (#188): the URL must
 // be http/https with a host, and (unless allowPrivate) must not target a
-// private/loopback/link-local address. DNS names are not resolved here, so this
-// is a config-load guard, not a full request-time SSRF defense.
+// private/loopback/link-local address. DNS names are not resolved here — this
+// is the config-load layer; the delivery-time layer (post-resolution dialer
+// guard + per-redirect-hop re-check) lives in the alerts WebhookSink.
 func validateWebhookURL(rawURL string, allowPrivate bool) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {

--- a/internal/config/ssrf_validate_test.go
+++ b/internal/config/ssrf_validate_test.go
@@ -22,6 +22,10 @@ func TestValidateWebhookURL(t *testing.T) {
 		{name: "metadata link-local rejected", url: "http://169.254.169.254/latest/meta-data/", wantErr: true},
 		{name: "loopback allowed with opt-out", url: "http://127.0.0.1:9093/x", allowPrivate: true, wantErr: false},
 		{name: "private allowed with opt-out", url: "http://10.0.0.5/x", allowPrivate: true, wantErr: false},
+		// IPv4-mapped IPv6 forms must classify by the embedded v4 address.
+		{name: "mapped loopback rejected", url: "http://[::ffff:127.0.0.1]:9093/x", wantErr: true},
+		{name: "mapped private rejected", url: "http://[::ffff:10.0.0.5]/x", wantErr: true},
+		{name: "mapped unspecified rejected", url: "http://[::ffff:0.0.0.0]/x", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
validateWebhookURL rejects literal private/loopback/link-local hosts at
config load but deliberately does not resolve DNS, and the sender was a
bare http.Client following redirects freely — so a hostname public at
load could resolve privately at delivery time (DNS rebinding), and a
public endpoint answering 302 could steer the POST at
169.254.169.254 or other internal services. Deployer-trusted input and
a status-code-only response bound the impact; this is defense in depth
(self-documented residual of #188).

Run the private-address check in the dialer's Control hook — after DNS
resolution, on the literal IP being connected to — so rebinding and
every redirect hop (each dials through the same transport) are both
covered, with an explicit 10-hop redirect cap. The check unmaps
IPv4-mapped IPv6 addresses first so ::ffff:0.0.0.0 (which routes to
localhost on connect) and other mapped forms classify by their v4
address; the same Unmap is applied to the config-load hostIsPrivate
guard. The shared predicate is factored into isBlockedWebhookAddr and
unit-tested across both v4 and mapped forms.

The alerts.allow_private_webhook opt-out disables the delivery-time
guard too, keeping one knob for intentional internal sinks. A
caller-supplied HTTPClient keeps its own transport policy, so the
existing httptest-based sink tests are unaffected. The response body is
drained before Close so the keep-alive connection can be reused.
