### PR TITLE
fix(api,mobilebundle): apply stored firewall rules to generated configs

### DIFF
--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -291,22 +291,20 @@ func (s *Server) renderHostConfig(ctx context.Context, host *models.Host) ([]byt
 		}
 	}
 
+	fwInbound, fwOutbound := s.firewallRulesForGenerator(ctx, host.NetworkID)
+
 	input := configgen.GeneratorInput{
-		HostName:     host.Name,
-		NebulaIPs:    host.NebulaIPs,
-		IsLighthouse: host.IsLighthouse,
-		IsRelay:      host.IsRelay,
-		CACertPath:   "/etc/nebula/ca.crt",
-		CertPath:     "/etc/nebula/host.crt",
-		KeyPath:      "/etc/nebula/host.key",
-		ListenPort:   host.ListenPort,
-		Lighthouses:  lighthouses,
-		FirewallInbound: []configgen.FirewallRule{
-			{Port: "any", Proto: "icmp", Group: "any"},
-		},
-		FirewallOutbound: []configgen.FirewallRule{
-			{Port: "any", Proto: "any", Group: "any"},
-		},
+		HostName:         host.Name,
+		NebulaIPs:        host.NebulaIPs,
+		IsLighthouse:     host.IsLighthouse,
+		IsRelay:          host.IsRelay,
+		CACertPath:       "/etc/nebula/ca.crt",
+		CertPath:         "/etc/nebula/host.crt",
+		KeyPath:          "/etc/nebula/host.key",
+		ListenPort:       host.ListenPort,
+		Lighthouses:      lighthouses,
+		FirewallInbound:  fwInbound,
+		FirewallOutbound: fwOutbound,
 	}
 	if adv := host.Advanced; adv != nil {
 		input.PunchyOverride = adv.Punchy

--- a/internal/api/firewall.go
+++ b/internal/api/firewall.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/forgekeep/nebula-mesh/internal/configgen"
 	"github.com/forgekeep/nebula-mesh/internal/store"
 )
 
@@ -146,4 +148,28 @@ func (s *Server) getFirewallRules(r *http.Request, networkID string) (*firewallR
 		return nil, fmt.Errorf("unmarshal firewall rules: %w", err)
 	}
 	return &rules, nil
+}
+
+// firewallRulesForGenerator resolves the network's stored firewall policy into
+// generator rules for renderHostConfig. A network with no stored policy gets
+// the safe baseline (ICMP inbound / allow-all outbound). A stored policy that
+// is unusable — malformed, or a rule missing a selector that would render a
+// config Nebula rejects — also falls back to the baseline, logged at Warn so
+// the operator can see their policy is not being applied rather than having
+// agents silently fail to load config.
+func (s *Server) firewallRulesForGenerator(ctx context.Context, networkID string) (inbound, outbound []configgen.FirewallRule) {
+	val, err := s.store.GetNetworkConfig(ctx, networkID, "firewall")
+	if errors.Is(err, store.ErrNotFound) {
+		return configgen.DefaultFirewallInbound, configgen.DefaultFirewallOutbound
+	}
+	if err != nil {
+		s.logger.Error("load firewall rules; using default baseline", "network", networkID, "error", err)
+		return configgen.DefaultFirewallInbound, configgen.DefaultFirewallOutbound
+	}
+	in, out, ferr := configgen.FirewallRulesFromJSON(val)
+	if ferr != nil {
+		s.logger.Warn("network firewall policy unusable; agents get the default baseline (icmp inbound / allow-all outbound)",
+			"network", networkID, "error", ferr)
+	}
+	return in, out
 }

--- a/internal/api/firewall_render_test.go
+++ b/internal/api/firewall_render_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// renderTestHost inserts a minimal enrolled host into netID and returns it.
+func renderTestHost(t *testing.T, srv *Server, netID string) *models.Host {
+	t.Helper()
+	host := &models.Host{
+		ID: "fw-host", NetworkID: netID, Name: "fw-peer",
+		NebulaIPs: []string{"192.168.100.20"}, Groups: []string{},
+		Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := srv.store.CreateHost(context.Background(), host); err != nil {
+		t.Fatal(err)
+	}
+	return host
+}
+
+// TestRenderHostConfig_AppliesStoredFirewallRules is the M1 regression: a
+// network's stored firewall policy must reach the generated agent config.
+// Before the fix the renderer hardcoded icmp-inbound/allow-all-outbound and
+// ignored getFirewallRules entirely, so an operator's policy was accepted and
+// echoed by the API but never enforced. The distinctive group name cannot
+// appear in the hardcoded default, so its presence proves the stored rule was
+// rendered.
+func TestRenderHostConfig_AppliesStoredFirewallRules(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	const policy = `{"inbound":[{"port":"443","proto":"tcp","group":"auditors-only"}],` +
+		`"outbound":[{"port":"any","proto":"any","group":"any"}]}`
+	if err := srv.store.SetNetworkConfig(ctx, netID, "firewall", policy); err != nil {
+		t.Fatal(err)
+	}
+
+	host := renderTestHost(t, srv, netID)
+	cfg, err := srv.renderHostConfig(ctx, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(cfg)
+	if !strings.Contains(out, "auditors-only") {
+		t.Errorf("rendered config does not contain the stored firewall group; rules were not applied\n%s", out)
+	}
+	if !strings.Contains(out, `port: "443"`) {
+		t.Errorf("rendered config does not contain the stored firewall port\n%s", out)
+	}
+}
+
+// TestRenderHostConfig_DefaultFirewallWhenNoneStored pins that a network with
+// no firewall policy keeps the safe baseline (icmp inbound), so the fix does
+// not silently change behavior for networks that never configured rules.
+func TestRenderHostConfig_DefaultFirewallWhenNoneStored(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	host := renderTestHost(t, srv, netID)
+	cfg, err := srv.renderHostConfig(ctx, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(cfg)
+	if !strings.Contains(out, "icmp") {
+		t.Errorf("rendered config missing the default icmp inbound rule\n%s", out)
+	}
+	if strings.Contains(out, "auditors-only") {
+		t.Errorf("rendered config unexpectedly contains a custom group with no policy stored\n%s", out)
+	}
+}
+
+// TestRenderHostConfig_UnusableFirewallFallsBackToDefault pins that a stored
+// policy with an empty group (the work-322fy footgun, reachable via pre-#200
+// data) does NOT render a config Nebula rejects: the renderer falls back to
+// the safe baseline rather than emitting a rule with neither group nor host.
+func TestRenderHostConfig_UnusableFirewallFallsBackToDefault(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	const bad = `{"inbound":[{"port":"22","proto":"tcp","group":""}],"outbound":[]}`
+	if err := srv.store.SetNetworkConfig(ctx, netID, "firewall", bad); err != nil {
+		t.Fatal(err)
+	}
+
+	host := renderTestHost(t, srv, netID)
+	cfg, err := srv.renderHostConfig(ctx, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(cfg)
+	// Fell back to the baseline (icmp inbound), and the broken rule's port is
+	// not present (it would have rendered a group-less, host-less rule).
+	if !strings.Contains(out, "icmp") {
+		t.Errorf("expected fallback to default icmp baseline\n%s", out)
+	}
+	if strings.Contains(out, `port: "22"`) {
+		t.Errorf("unusable rule was rendered instead of falling back\n%s", out)
+	}
+}

--- a/internal/configgen/firewall.go
+++ b/internal/configgen/firewall.go
@@ -1,0 +1,82 @@
+package configgen
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DefaultFirewallInbound and DefaultFirewallOutbound are the baseline policy a
+// host receives when its network has no stored firewall rules, or the stored
+// rules are unusable: ICMP-only inbound (ping) and allow-all outbound. These
+// are the values the management server emitted for every host before
+// per-network firewall rules were wired through to generated configs.
+var (
+	DefaultFirewallInbound  = []FirewallRule{{Port: "any", Proto: "icmp", Group: "any"}}
+	DefaultFirewallOutbound = []FirewallRule{{Port: "any", Proto: "any", Group: "any"}}
+)
+
+// storedFirewallRules mirrors the JSON the management API persists under the
+// network_config "firewall" key.
+type storedFirewallRules struct {
+	Inbound  []storedFirewallRule `json:"inbound"`
+	Outbound []storedFirewallRule `json:"outbound"`
+}
+
+type storedFirewallRule struct {
+	Port  string `json:"port"`
+	Proto string `json:"proto"`
+	Group string `json:"group"`
+}
+
+// FirewallRulesFromJSON converts the management API's stored firewall JSON
+// into generator rules.
+//
+// It returns the safe defaults together with a nil error when jsonStr is
+// empty or declares no rules at all — a network with no policy legitimately
+// gets the baseline, which is not an error condition.
+//
+// It returns the safe defaults together with a non-nil error when the JSON is
+// malformed or any rule is unusable (an empty port, proto, or group). The
+// empty group in particular is the work-322fy footgun: Nebula rejects a rule
+// with neither group nor host, failing the whole config on load. Returning
+// the defaults rather than the bad rules guarantees that wiring a network's
+// stored policy into a host config can never produce an agent config Nebula
+// refuses to load; the non-nil error lets the caller surface that the
+// operator's policy is being dropped.
+func FirewallRulesFromJSON(jsonStr string) (inbound, outbound []FirewallRule, err error) {
+	if jsonStr == "" {
+		return DefaultFirewallInbound, DefaultFirewallOutbound, nil
+	}
+	var stored storedFirewallRules
+	if uerr := json.Unmarshal([]byte(jsonStr), &stored); uerr != nil {
+		return DefaultFirewallInbound, DefaultFirewallOutbound, fmt.Errorf("parse firewall rules: %w", uerr)
+	}
+	if len(stored.Inbound) == 0 && len(stored.Outbound) == 0 {
+		return DefaultFirewallInbound, DefaultFirewallOutbound, nil
+	}
+	in, ierr := convertStoredRules("inbound", stored.Inbound)
+	if ierr != nil {
+		return DefaultFirewallInbound, DefaultFirewallOutbound, ierr
+	}
+	out, oerr := convertStoredRules("outbound", stored.Outbound)
+	if oerr != nil {
+		return DefaultFirewallInbound, DefaultFirewallOutbound, oerr
+	}
+	return in, out, nil
+}
+
+func convertStoredRules(direction string, in []storedFirewallRule) ([]FirewallRule, error) {
+	out := make([]FirewallRule, 0, len(in))
+	for i, r := range in {
+		// Mirror the API write-time validation: a rule missing any selector
+		// would render a config Nebula rejects (empty group/host) or an
+		// ambiguous match (empty port/proto).
+		if r.Port == "" || r.Proto == "" || r.Group == "" {
+			return nil, fmt.Errorf("%s rule %d: port, proto, and group must all be non-empty", direction, i)
+		}
+		// storedFirewallRule and FirewallRule share the same field layout;
+		// the conversion drops only the json tags.
+		out = append(out, FirewallRule(r))
+	}
+	return out, nil
+}

--- a/internal/configgen/firewall_test.go
+++ b/internal/configgen/firewall_test.go
@@ -1,0 +1,104 @@
+package configgen
+
+import "testing"
+
+func TestFirewallRulesFromJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		json        string
+		wantErr     bool
+		wantInbound []FirewallRule
+		wantOutLen  int
+	}{
+		{
+			name:        "empty string -> defaults, no error",
+			json:        "",
+			wantInbound: DefaultFirewallInbound,
+			wantOutLen:  len(DefaultFirewallOutbound),
+		},
+		{
+			name:        "both empty arrays -> defaults, no error",
+			json:        `{"inbound":[],"outbound":[]}`,
+			wantInbound: DefaultFirewallInbound,
+			wantOutLen:  len(DefaultFirewallOutbound),
+		},
+		{
+			name:        "valid rules applied verbatim",
+			json:        `{"inbound":[{"port":"443","proto":"tcp","group":"web"}],"outbound":[{"port":"any","proto":"any","group":"any"}]}`,
+			wantInbound: []FirewallRule{{Port: "443", Proto: "tcp", Group: "web"}},
+			wantOutLen:  1,
+		},
+		{
+			name:        "inbound rules with empty outbound rendered faithfully",
+			json:        `{"inbound":[{"port":"22","proto":"tcp","group":"admin"}],"outbound":[]}`,
+			wantInbound: []FirewallRule{{Port: "22", Proto: "tcp", Group: "admin"}},
+			wantOutLen:  0,
+		},
+		{
+			name:        "malformed JSON -> defaults + error",
+			json:        `{not json`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+			wantOutLen:  len(DefaultFirewallOutbound),
+		},
+		{
+			name:        "empty group (work-322fy footgun) -> defaults + error",
+			json:        `{"inbound":[{"port":"22","proto":"tcp","group":""}],"outbound":[]}`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+			wantOutLen:  len(DefaultFirewallOutbound),
+		},
+		{
+			name:        "empty port -> defaults + error",
+			json:        `{"inbound":[],"outbound":[{"port":"","proto":"any","group":"any"}]}`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+			wantOutLen:  len(DefaultFirewallOutbound),
+		},
+		{
+			name:        "empty proto -> defaults + error",
+			json:        `{"inbound":[{"port":"22","proto":"","group":"admin"}],"outbound":[]}`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+			wantOutLen:  len(DefaultFirewallOutbound),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in, out, err := FirewallRulesFromJSON(tc.json)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if len(in) != len(tc.wantInbound) {
+				t.Fatalf("inbound len = %d, want %d", len(in), len(tc.wantInbound))
+			}
+			for i := range tc.wantInbound {
+				if in[i] != tc.wantInbound[i] {
+					t.Errorf("inbound[%d] = %+v, want %+v", i, in[i], tc.wantInbound[i])
+				}
+			}
+			if len(out) != tc.wantOutLen {
+				t.Errorf("outbound len = %d, want %d", len(out), tc.wantOutLen)
+			}
+		})
+	}
+}
+
+// TestFirewallRulesFromJSON_DefaultsAreLoadable guards that the baseline the
+// fallback returns actually renders into a Nebula-loadable config (no empty
+// group/host), so the "fall back to default on bad input" safety net can't
+// itself produce a broken config.
+func TestFirewallRulesFromJSON_DefaultsRenderValidRules(t *testing.T) {
+	in, out, err := FirewallRulesFromJSON(`{"inbound":[{"port":"x","proto":"y","group":""}]}`)
+	if err == nil {
+		t.Fatal("expected error for empty-group rule")
+	}
+	mapped := mapFirewallRules(in)
+	mapped = append(mapped, mapFirewallRules(out)...)
+	for _, r := range mapped {
+		if r.Group == "" && r.Host == "" {
+			t.Errorf("default rule has neither group nor host (Nebula would reject): %+v", r)
+		}
+	}
+}

--- a/internal/mobilebundle/builder.go
+++ b/internal/mobilebundle/builder.go
@@ -124,22 +124,28 @@ func Build(ctx context.Context, s store.Store, resolver interface {
 		return nil, fmt.Errorf("list lighthouses: %w", err)
 	}
 
+	// Resolve the network's firewall policy. Mirrors the agent enroll path
+	// (api.renderHostConfig): a network with no stored policy, or an unusable
+	// one, falls back to the safe baseline so the bundle is always loadable.
+	// This builder has no logger, so the unusable case is silently defaulted;
+	// FirewallRulesFromJSON returns the baseline either way.
+	fwInbound, fwOutbound := configgen.DefaultFirewallInbound, configgen.DefaultFirewallOutbound
+	if val, cfgErr := s.GetNetworkConfig(ctx, host.NetworkID, "firewall"); cfgErr == nil {
+		fwInbound, fwOutbound, _ = configgen.FirewallRulesFromJSON(val)
+	}
+
 	// Generate config.
 	input := configgen.GeneratorInput{
-		HostName:     host.Name,
-		NebulaIPs:    host.NebulaIPs,
-		IsLighthouse: host.IsLighthouse,
-		IsRelay:      host.IsRelay,
-		Lighthouses:  lighthouses,
-		CACertPEM:    string(caPEM),
-		CertPEM:      string(certPEM),
-		KeyPEM:       string(privPEM),
-		FirewallInbound: []configgen.FirewallRule{
-			{Port: "any", Proto: "icmp", Group: "any"},
-		},
-		FirewallOutbound: []configgen.FirewallRule{
-			{Port: "any", Proto: "any", Group: "any"},
-		},
+		HostName:         host.Name,
+		NebulaIPs:        host.NebulaIPs,
+		IsLighthouse:     host.IsLighthouse,
+		IsRelay:          host.IsRelay,
+		Lighthouses:      lighthouses,
+		CACertPEM:        string(caPEM),
+		CertPEM:          string(certPEM),
+		KeyPEM:           string(privPEM),
+		FirewallInbound:  fwInbound,
+		FirewallOutbound: fwOutbound,
 	}
 	if adv := host.Advanced; adv != nil {
 		input.PunchyOverride = adv.Punchy

--- a/internal/mobilebundle/builder_test.go
+++ b/internal/mobilebundle/builder_test.go
@@ -2,6 +2,7 @@ package mobilebundle
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -282,4 +283,42 @@ func contains(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestBuild_AppliesStoredFirewallRules pins that a mobile bundle carries the
+// network's stored firewall policy, the same as the agent enroll path. Before
+// the M1 fix the builder hardcoded icmp-inbound/allow-all-outbound, so a
+// configured policy never reached mobile hosts either.
+func TestBuild_AppliesStoredFirewallRules(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := store.NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, s.Migrate(ctx))
+
+	ca, err := pki.NewCA("test-ca", 365*24*time.Hour)
+	require.NoError(t, err)
+	resolver := &StubCAResolver{ca: ca}
+
+	network := &models.Network{ID: "net-fw", Name: "fw-network", CIDRs: []string{"10.0.0.0/8"}}
+	require.NoError(t, s.CreateNetwork(ctx, network))
+
+	const policy = `{"inbound":[{"port":"8443","proto":"tcp","group":"mobile-only"}],` +
+		`"outbound":[{"port":"any","proto":"any","group":"any"}]}`
+	require.NoError(t, s.SetNetworkConfig(ctx, network.ID, "firewall", policy))
+
+	host := &models.Host{
+		ID: "mobile-fw", Name: "phone-fw", NetworkID: network.ID,
+		NebulaIPs: []string{"10.0.0.9"}, Kind: models.HostKindMobile,
+		Variant: models.HostVariantIOS, Role: models.HostRoleHost,
+		Status: models.HostStatusPending, CAID: "test-ca-id", Groups: []string{"mobile"},
+	}
+	require.NoError(t, s.CreateHost(ctx, host))
+	seedActiveCAOwner(t, s, host.CAID)
+
+	bundle, err := Build(ctx, s, resolver, host)
+	require.NoError(t, err)
+	if !strings.Contains(string(bundle), "mobile-only") {
+		t.Errorf("mobile bundle does not contain the stored firewall group; rules not applied\n%s", bundle)
+	}
 }


### PR DESCRIPTION
Operator firewall rules were accepted, validated, persisted, and echoed
by the management API, and updating them bumped the network config
version to trigger an agent re-render — but the two config-generation
sites (renderHostConfig and the mobile-bundle builder) hardcoded
icmp-inbound / allow-all-outbound and never read the stored policy. So
every agent re-rendered the same hardcoded firewall regardless of what
the operator configured: a policy that looked applied but never reached
a host.

This was an incomplete feature, not a deliberate design — commit
25c6c5b ("add lighthouse config propagation, firewall rules, audit
log") documents the intent ("config version bumped on firewall update",
"agents detect config changes via version comparison") and wired the
whole propagation pipeline; only the final read-the-rules step was
missing. host.Advanced does not override the firewall and Nebula's
firewall is default-deny, so until now every generated mesh accepted
only ICMP inbound with no working way to change it.

Both render sites now resolve the network's stored policy via the new
configgen.FirewallRulesFromJSON. A network with no stored policy keeps
the previous baseline (ICMP inbound / allow-all outbound), so behavior
is unchanged for networks that never configured rules. A stored policy
that is malformed or contains a rule missing a selector — the empty
group is the work-322fy footgun: Nebula rejects a rule with neither
group nor host and fails the whole config on load — falls back to that
same baseline rather than emitting a config the agent cannot load (the
API enroll path logs this at Warn; the loggerless mobile-bundle builder
defaults silently). Such rules are only reachable from pre-#200 stored
data, since the write path now rejects empty groups.

Behavior change for operators: a network with a stored, valid firewall
policy will see it take effect on agents' next poll after upgrade.
