### PR TITLE
docs(agent): fix sidecar example to use published nebula-agent image

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -145,8 +145,10 @@ itself).
 
 ### 3. Docker / sidecar
 
-The agent ships in the same image as the server. A typical sidecar definition
-shares `/etc/nebula` between `nebula` and the agent container:
+The agent is published as its own image, `ghcr.io/forgekeep/nebula-agent`
+(the server ships separately as `ghcr.io/forgekeep/nebula-mgmt`). The agent
+image already runs `run --config /etc/nebula-agent/agent.yml` by default, so a
+sidecar just shares `/etc/nebula` between `nebula` and the agent container:
 
 ```yaml
 # docker-compose snippet
@@ -157,9 +159,7 @@ services:
     network_mode: host
     cap_add: [NET_ADMIN]
   nebula-agent:
-    image: ghcr.io/forgekeep/nebula-mesh:latest
-    entrypoint: ["/usr/local/bin/nebula-agent"]
-    command: ["--config", "/etc/nebula-agent/agent.yml"]
+    image: ghcr.io/forgekeep/nebula-agent:latest
     volumes:
       - nebula-conf:/etc/nebula
       - ./agent.yml:/etc/nebula-agent/agent.yml:ro


### PR DESCRIPTION
## Summary

The Docker / sidecar section of `docs/agent.md` referenced `ghcr.io/forgekeep/nebula-mesh`, which is never published. goreleaser ships two images: `ghcr.io/forgekeep/nebula-agent` (agent) and `ghcr.io/forgekeep/nebula-mgmt` (server). Following the old example produced an image-pull error; "fixing" it with the server image fails too, since that image has no `nebula-agent` binary.

## Change

- Use `ghcr.io/forgekeep/nebula-agent:latest` in the compose snippet.
- Drop the `entrypoint`/`command` override — the agent image already defaults to `run --config /etc/nebula-agent/agent.yml` (verified in `deploy/docker/Dockerfile.agent`).
- Remove the inaccurate "ships in the same image as the server" sentence and name the two real images.

No remaining `ghcr.io/forgekeep/nebula-mesh` references in `docs/` or `README.md`.

Closes #226
