### PR TITLE
docs(readme): bump pinned VERSION to v0.4.0 and guard against doc rot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,16 @@ jobs:
       - name: govulncheck
         run: make govulncheck
 
+  readme-version:
+    name: readme version pin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # need tags to compare the pinned VERSION against
+      - name: check README pin is not behind latest release
+        run: bash scripts/check-readme-version.sh
+
   docker:
     name: docker build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On a fresh Debian / Ubuntu VM (`amd64`):
 
 ```sh
 # 1. Install the server.
-VERSION=0.3.6
+VERSION=0.4.0
 curl -fsSLO "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSION}/nebula-mgmt_${VERSION}_linux_amd64.deb"
 sudo apt install -y "./nebula-mgmt_${VERSION}_linux_amd64.deb"
 
@@ -122,12 +122,14 @@ nebula-mesh ships **two** static binaries. Install whichever you need on each ma
 | `nebula-mgmt` | one server (the control plane) |
 | `nebula-agent` | every Nebula host, next to `nebula` |
 
-Pick an install method below. The examples assume `VERSION=0.3.6` — replace with the latest from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest). Each release ships a `checksums.txt` (SHA-256).
+Pick an install method below. The examples assume `VERSION=0.4.0` — always replace with the latest from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest). Each release ships a `checksums.txt` (SHA-256).
+
+> ⚠️ **Install the latest release.** Versions older than the newest tag may be missing published security fixes — see the [security advisories](https://github.com/forgekeep/nebula-mesh/security/advisories). Do not pin to an old version unless you have verified it carries every advisory fix you need.
 
 ### Debian / Ubuntu (`.deb`)
 
 ```sh
-VERSION=0.3.6
+VERSION=0.4.0
 ARCH=$(dpkg --print-architecture)   # amd64 | arm64 | armhf (agent only)
 
 # Server (control plane):
@@ -142,7 +144,7 @@ sudo apt install -y "./nebula-agent_${VERSION}_linux_${ARCH}.deb"
 ### RHEL / Fedora / Rocky / Alma (`.rpm`)
 
 ```sh
-VERSION=0.3.6
+VERSION=0.4.0
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
 sudo rpm -i "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSION}/nebula-mgmt_${VERSION}_linux_${ARCH}.rpm"
@@ -156,7 +158,7 @@ sudo rpm -i "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSI
 Download a tarball from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest) and extract:
 
 ```sh
-VERSION=0.3.6
+VERSION=0.4.0
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 

--- a/scripts/check-readme-version.sh
+++ b/scripts/check-readme-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Fail when README.md pins an install VERSION older than the latest release tag.
+#
+# Closes the doc-rot gap from #227: the install snippets hardcode `VERSION=x.y.z`
+# that nobody remembers to bump, so users copy-paste an outdated release that may
+# lack published security fixes. This guard runs in CI and fails the build the
+# moment a pin falls behind the newest tag. A pin equal to or ahead of the latest
+# tag passes, so the release flow can bump README in the same PR that cuts the tag.
+#
+# Portable across BSD (macOS) and GNU (CI) sort: version compare uses numeric
+# field sort, not `sort -V`.
+set -euo pipefail
+
+readme="${1:-README.md}"
+
+latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n1)"
+if [ -z "${latest_tag:-}" ]; then
+  echo "no release tags found; skipping README version check"
+  exit 0
+fi
+latest="${latest_tag#v}"
+
+pins="$(grep -oE 'VERSION=[0-9]+\.[0-9]+\.[0-9]+' "$readme" | sed 's/VERSION=//' | sort -u || true)"
+if [ -z "${pins}" ]; then
+  echo "no VERSION= pins found in ${readme}; nothing to check"
+  exit 0
+fi
+
+# ver_lt A B -> exit 0 when A < B (strictly older).
+ver_lt() {
+  [ "$1" != "$2" ] &&
+    [ "$(printf '%s\n%s\n' "$1" "$2" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)" = "$1" ]
+}
+
+status=0
+for p in ${pins}; do
+  if ver_lt "$p" "$latest"; then
+    echo "::error::README pins VERSION=${p}, older than latest release v${latest}"
+    status=1
+  else
+    echo "ok: README pin ${p} >= latest release ${latest}"
+  fi
+done
+exit "${status}"


### PR DESCRIPTION
## Summary

README install snippets pinned `VERSION=0.3.6` in four places while the latest release is `v0.4.0`. Published advisories are fixed only in newer releases (e.g. GHSA-339v-266x-79xr in v0.3.7), so a user copy-pasting the install commands pulled a build with known, published vulnerabilities — the worst kind of doc rot for a security-oriented project.

## Change

- Bump every `VERSION=` pin to `0.4.0` (4 snippets + the intro line).
- Add a warning callout that older versions may lack published security fixes, linking the [advisories page](https://github.com/forgekeep/nebula-mesh/security/advisories).
- **Guard against recurrence**: `scripts/check-readme-version.sh` fails when any README `VERSION=` pin is older than the latest release tag, wired as a `readme-version` CI job (`fetch-depth: 0` for tags). A pin equal to or ahead of the latest tag passes, so the release flow can bump README in the same PR that cuts the tag.

The guard is portable (numeric field sort, not `sort -V`) and was tested both ways locally: passes at `0.4.0` (== latest), fails on a `0.3.6` pin.

Closes #227
