### PR TITLE
fix(agent): poll immediately on poller start instead of waiting a full interval

### DIFF
--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -185,25 +185,49 @@ func (p *Poller) Run(ctx context.Context) error {
 	ticker := time.NewTicker(p.config.Interval)
 	defer ticker.Stop()
 
+	// Poll once immediately so a freshly (re)started agent — host reboot,
+	// package upgrade, crash recovery — learns about pending cert rotations,
+	// config changes, revocation, or rekey requests without waiting a full
+	// interval (#228). The same terminal-signal policy as the ticker branch
+	// applies, so a revoked/rekey host stops here too.
+	if ctx.Err() == nil {
+		if err := p.handlePollResult(p.poll(ctx)); err != nil {
+			return err
+		}
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			p.logger.Info("poll loop stopped")
 			return ctx.Err()
 		case <-ticker.C:
-			if err := p.poll(ctx); err != nil {
-				if IsRevoked(err) {
-					p.logger.Error("poll loop stopped by server revocation signal", "error", err)
-					return err
-				}
-				if IsRekey(err) {
-					p.logger.Info("server requested rekey; stopping poll loop so caller can re-enroll")
-					return err
-				}
-				p.logger.Error("poll failed", "error", err)
+			if err := p.handlePollResult(p.poll(ctx)); err != nil {
+				return err
 			}
 		}
 	}
+}
+
+// handlePollResult applies the terminal-signal policy shared by the immediate
+// startup poll and the ticker loop, so the two paths cannot drift. It returns a
+// non-nil error only when the loop must stop: a server revocation (403/410) or
+// a rekey request. Transient errors are logged and nil is returned so the
+// caller keeps polling.
+func (p *Poller) handlePollResult(err error) error {
+	if err == nil {
+		return nil
+	}
+	if IsRevoked(err) {
+		p.logger.Error("poll loop stopped by server revocation signal", "error", err)
+		return err
+	}
+	if IsRekey(err) {
+		p.logger.Info("server requested rekey; stopping poll loop so caller can re-enroll")
+		return err
+	}
+	p.logger.Error("poll failed", "error", err)
+	return nil
 }
 
 // PollOnce performs a single signed poll iteration and returns. The enroll

--- a/internal/agent/poller_immediate_poll_test.go
+++ b/internal/agent/poller_immediate_poll_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestPoller_PollsImmediatelyOnStart is the #228 regression: a freshly started
+// poller must hit the server right away rather than waiting a full interval.
+// The interval is set far longer than the run window, so any request reaching
+// the server proves the immediate poll fired before the first tick.
+func TestPoller_PollsImmediatelyOnStart(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{HasUpdates: false, Blocklist: []string{}})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	p := newTestPoller(t, PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    10 * time.Second, // far longer than the run window below
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	if got := hits.Load(); got < 1 {
+		t.Fatalf("poller made %d requests; want >= 1 immediate poll before the first %s tick", got, 10*time.Second)
+	}
+}


### PR DESCRIPTION
## Summary

`Poller.Run` created a ticker and only polled on `ticker.C`. After any daemon (re)start — host reboot, package upgrade, crash recovery — the first poll happened a full `poll_interval` later, so the agent stayed unaware of pending cert rotations, config changes, revocation, or rekey requests for that window. With the long intervals configured for large fleets this is a real recovery gap. (Enrollment's one-off confirmation poll doesn't help the restart case.)

## Change

- Poll once immediately on `Run` entry, then fall into the ticker loop.
- Extract the revocation/rekey/transient-error handling into `handlePollResult`, used by both the immediate poll and the ticker branch, so the terminal-signal policy cannot drift. A revoked (403/410) or rekey-requested host now stops on the startup poll too.
- Guard the immediate poll with `ctx.Err() == nil` so an already-cancelled context is a clean no-op.

## Test

`TestPoller_PollsImmediatelyOnStart`: interval set to 10s, run window 300ms — any request reaching the server proves the immediate poll fired before the first tick. Fails on the old code (ticker never fires in the window).

> Note: touches `internal/agent/poller.go` alongside #224 and #225 — expect a trivial rebase if those land first.

Closes #228
