### PR TITLE
fix(agent): honor nebula_config_path for rendered config writes

### DIFF
--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -112,7 +112,7 @@ func runUnified(ctx context.Context, args []string, stderr io.Writer) error {
 		certPath := filepath.Join(cfg.DataDir, "host.crt")
 		if _, err := os.Stat(certPath); errors.Is(err, os.ErrNotExist) {
 			logger.Info("enrolling host", "server", cfg.ServerURL, "data_dir", cfg.DataDir, "signing_key", cfg.SigningKeyPath)
-			if err := agent.Enroll(ctx, cfg.ServerURL, *token, cfg.DataDir, cfg.SigningKeyPath); err != nil {
+			if err := agent.Enroll(ctx, cfg.ServerURL, *token, cfg.DataDir, cfg.SigningKeyPath, cfg.NebulaConfigPath); err != nil {
 				return fmt.Errorf("enrollment failed: %w", err)
 			}
 			logger.Info("enrollment successful")
@@ -274,12 +274,13 @@ func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logg
 			return fmt.Errorf("read certificate fingerprint: %w", err)
 		}
 		poller, err := agent.NewPoller(agent.PollerConfig{
-			ServerURL:      cfg.ServerURL,
-			Fingerprint:    fingerprint,
-			DataDir:        cfg.DataDir,
-			SigningKeyPath: cfg.SigningKeyPath,
-			Interval:       cfg.PollInterval,
-			PIDFile:        cfg.NebulaPIDFile,
+			ServerURL:        cfg.ServerURL,
+			Fingerprint:      fingerprint,
+			DataDir:          cfg.DataDir,
+			SigningKeyPath:   cfg.SigningKeyPath,
+			Interval:         cfg.PollInterval,
+			PIDFile:          cfg.NebulaPIDFile,
+			NebulaConfigPath: cfg.NebulaConfigPath,
 		}, logger)
 		if err != nil {
 			return fmt.Errorf("create poller: %w", err)
@@ -301,7 +302,7 @@ func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logg
 			var re *agent.RekeyError
 			_ = errors.As(runErr, &re)
 			logger.Info("performing server-requested rekey")
-			if err := agent.Reenroll(ctx, cfg.ServerURL, re.Token, cfg.DataDir, cfg.SigningKeyPath); err != nil {
+			if err := agent.Reenroll(ctx, cfg.ServerURL, re.Token, cfg.DataDir, cfg.SigningKeyPath, cfg.NebulaConfigPath); err != nil {
 				return fmt.Errorf("rekey enrollment: %w", err)
 			}
 			continue
@@ -324,6 +325,7 @@ func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) err
 	serverURL := fs.String("server", "", "management server URL (required)")
 	token := fs.String("token", "", "enrollment token (required; never persisted)")
 	dataDir := fs.String("data-dir", "/etc/nebula", "Nebula data directory")
+	nebulaConfigPath := fs.String("nebula-config-path", "", "path Nebula reads its rendered config from; defaults to <data-dir>/config.yml")
 	signingKeyPath := fs.String("signing-key-path", "", "Ed25519 PoP signing key path; defaults to <config-dir>/host.signing.key")
 	pollInterval := fs.Duration("poll-interval", 30*time.Second, "poll interval written to agent.yml")
 	force := fs.Bool("force", false, "overwrite an existing enrollment")
@@ -358,8 +360,17 @@ func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) err
 		}
 	}
 
+	// Resolve the rendered-config path once: an explicit --nebula-config-path
+	// wins, otherwise it defaults to <data-dir>/config.yml. The same value is
+	// passed to Enroll (initial write) and recorded in agent.yml so the daemon
+	// rewrites the same file (#224) — no longer hardcoded to data-dir/config.yml.
+	resolvedConfigPath := *nebulaConfigPath
+	if resolvedConfigPath == "" {
+		resolvedConfigPath = filepath.Join(*dataDir, "config.yml")
+	}
+
 	_, _ = fmt.Fprintf(stdout, "enrolling with %s...\n", *serverURL)
-	if err := agent.Enroll(ctx, *serverURL, *token, *dataDir, *signingKeyPath); err != nil {
+	if err := agent.Enroll(ctx, *serverURL, *token, *dataDir, *signingKeyPath, resolvedConfigPath); err != nil {
 		return fmt.Errorf("enrollment failed: %w", err)
 	}
 
@@ -369,7 +380,7 @@ func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) err
 	cfg.DataDir = *dataDir
 	cfg.SigningKeyPath = *signingKeyPath
 	cfg.PollInterval = *pollInterval
-	cfg.NebulaConfigPath = filepath.Join(*dataDir, "config.yml")
+	cfg.NebulaConfigPath = resolvedConfigPath
 	if err := config.SaveAgentConfig(*configPath, cfg); err != nil {
 		return fmt.Errorf("write %s: %w", *configPath, err)
 	}
@@ -386,11 +397,12 @@ func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) err
 	}
 	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	poller, err := agent.NewPoller(agent.PollerConfig{
-		ServerURL:      cfg.ServerURL,
-		Fingerprint:    fingerprint,
-		DataDir:        cfg.DataDir,
-		SigningKeyPath: cfg.SigningKeyPath,
-		Interval:       cfg.PollInterval,
+		ServerURL:        cfg.ServerURL,
+		Fingerprint:      fingerprint,
+		DataDir:          cfg.DataDir,
+		SigningKeyPath:   cfg.SigningKeyPath,
+		Interval:         cfg.PollInterval,
+		NebulaConfigPath: cfg.NebulaConfigPath,
 	}, logger)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "warning: poller init failed: %v\n", err)

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -301,6 +301,8 @@ The `enroll` subcommand:
 
 The token is single-use and never persisted to disk. Pass `--force` to overwrite an existing enrollment (e.g. after key compromise) — without `--force` the command refuses to clobber `host.crt` / `agent.yml`.
 
+To write the rendered Nebula config somewhere other than `<data-dir>/config.yml` (e.g. when Nebula reads its config from a custom path), pass `--nebula-config-path`. The value is recorded as `nebula_config_path` in `agent.yml`, and both the initial enrollment and the running daemon write the config there.
+
 After a successful enrollment the agent owns the following files:
 
 | Path | Mode | Owner | Contents |

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -42,8 +42,8 @@ type EnrollResponse struct {
 // fresh (rekey) or bound to an unenrolled host (initial enroll), so the
 // agent path is identical. Exposed separately so the cmd-side rekey loop
 // reads cleanly.
-func Reenroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath string) error {
-	return Enroll(ctx, serverURL, token, dataDir, signingKeyPath)
+func Reenroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath, nebulaConfigPath string) error {
+	return Enroll(ctx, serverURL, token, dataDir, signingKeyPath, nebulaConfigPath)
 }
 
 // enrollmentSecrets collects every heap copy of private key material made
@@ -71,22 +71,34 @@ func (s *enrollmentSecrets) wipe() {
 var enrollSecretsObserverForTest func(*enrollmentSecrets)
 
 // Enroll performs the enrollment flow: generates keypair, sends public key
-// to the server with the token, saves received cert and config to dataDir,
-// and writes the Ed25519 signing private key to signingKeyPath.
+// to the server with the token, saves received cert (and CA cert) to dataDir,
+// writes the rendered Nebula config to nebulaConfigPath, and writes the
+// Ed25519 signing private key to signingKeyPath.
+//
+// nebulaConfigPath is the path Nebula actually reads its config from; an empty
+// value falls back to dataDir/config.yml for backward compatibility. Honoring
+// it keeps the initial enroll write and the running daemon's rewrites pointed
+// at the same file (#224); the daemon resolves the same path in poller.go.
 //
 // signingKeyPath is intentionally separate from dataDir — Nebula's data dir
 // holds Nebula-owned secrets (host.key / host.crt / ca.crt / config.yml),
 // while the agent's PoP signing key (ADR 0004) is the agent's concern and
 // lives next to agent.yml (default /etc/nebula-agent/host.signing.key). The
 // parent directory of signingKeyPath is created with mode 0o755 if missing.
-func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath string) error {
+func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath, nebulaConfigPath string) error {
 	if signingKeyPath == "" {
 		return fmt.Errorf("signingKeyPath is required")
 	}
-	// Pre-flight: verify both directories are writable BEFORE the POST
+	if nebulaConfigPath == "" {
+		nebulaConfigPath = filepath.Join(dataDir, "config.yml")
+	}
+	// Pre-flight: verify every target directory is writable BEFORE the POST
 	// so a permission error does not burn the single-use enrollment token.
 	if err := preflightWritable(dataDir); err != nil {
 		return fmt.Errorf("data dir: %w", err)
+	}
+	if err := preflightWritable(filepath.Dir(nebulaConfigPath)); err != nil {
+		return fmt.Errorf("nebula config dir: %w", err)
 	}
 	if err := preflightWritable(filepath.Dir(signingKeyPath)); err != nil {
 		return fmt.Errorf("signing key dir: %w", err)
@@ -201,7 +213,7 @@ func Enroll(ctx context.Context, serverURL, token, dataDir, signingKeyPath strin
 	// nebula IPs, lighthouse list, firewall rules, paths to key/cert
 	// files). No secrets in the file itself; the actual private key
 	// lives in host.key, written above at 0o600.
-	if err := os.WriteFile(filepath.Join(dataDir, "config.yml"), []byte(enrollResp.ConfigYAML), 0o640); err != nil { // #nosec G306 -- rendered Nebula config: host name, IPs, lighthouse, firewall rules, paths to key/cert files — no secrets; the actual private key is host.key (0o600)
+	if err := os.WriteFile(nebulaConfigPath, []byte(enrollResp.ConfigYAML), 0o640); err != nil { // #nosec G306 -- rendered Nebula config: host name, IPs, lighthouse, firewall rules, paths to key/cert files — no secrets; the actual private key is host.key (0o600)
 		return fmt.Errorf("write config: %w", err)
 	}
 

--- a/internal/agent/enroll_preflight_test.go
+++ b/internal/agent/enroll_preflight_test.go
@@ -35,7 +35,7 @@ func TestEnroll_PreflightFailsBeforeServerCall(t *testing.T) {
 	dataDir := t.TempDir()
 	signingKeyPath := filepath.Join(readOnly, "agent", "host.signing.key")
 
-	err := Enroll(context.Background(), server.URL, "test-token", dataDir, signingKeyPath)
+	err := Enroll(context.Background(), server.URL, "test-token", dataDir, signingKeyPath, "")
 	if err == nil {
 		t.Fatal("expected error for unwritable signing key dir, got nil")
 		return

--- a/internal/agent/enroll_test.go
+++ b/internal/agent/enroll_test.go
@@ -54,7 +54,7 @@ func TestEnroll_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err := Enroll(context.Background(), server.URL, "test-token", dir, signingKeyPath)
+	err := Enroll(context.Background(), server.URL, "test-token", dir, signingKeyPath, "")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestEnroll_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err := Enroll(context.Background(), server.URL, "bad-token", t.TempDir(), filepath.Join(t.TempDir(), "host.signing.key"))
+	err := Enroll(context.Background(), server.URL, "bad-token", t.TempDir(), filepath.Join(t.TempDir(), "host.signing.key"), "")
 	if err == nil {
 		t.Fatal("expected error for server error response, got nil")
 	}

--- a/internal/agent/enroll_zeroize_test.go
+++ b/internal/agent/enroll_zeroize_test.go
@@ -58,7 +58,7 @@ func TestEnroll_ZeroizesPrivateKeys(t *testing.T) {
 	defer server.Close()
 
 	captured := captureEnrollSecrets(t)
-	if err := Enroll(context.Background(), server.URL, "test-token", dir, signingKeyPath); err != nil {
+	if err := Enroll(context.Background(), server.URL, "test-token", dir, signingKeyPath, ""); err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
 	assertSecretsWiped(t, *captured)
@@ -76,7 +76,7 @@ func TestEnroll_ZeroizesPrivateKeysOnError(t *testing.T) {
 	defer server.Close()
 
 	captured := captureEnrollSecrets(t)
-	if err := Enroll(context.Background(), server.URL, "stale-token", dir, signingKeyPath); err == nil {
+	if err := Enroll(context.Background(), server.URL, "stale-token", dir, signingKeyPath, ""); err == nil {
 		t.Fatal("expected enrollment error")
 	}
 	if *captured == nil {

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -121,6 +121,11 @@ type PollerConfig struct {
 	SigningKeyPath string
 	Interval       time.Duration
 	PIDFile        string
+	// NebulaConfigPath is where the rendered Nebula config.yml is written.
+	// Empty falls back to DataDir/config.yml. Honors agent.yml's
+	// nebula_config_path so the daemon writes the config to the file Nebula
+	// actually reads, not always DataDir/config.yml (#224).
+	NebulaConfigPath string
 	// HTTPTimeout bounds a single poll request. Zero or negative falls back
 	// to defaultAgentHTTPTimeout.
 	HTTPTimeout time.Duration
@@ -314,10 +319,10 @@ func (p *Poller) poll(ctx context.Context) error {
 	}
 
 	if updates.ConfigYAML != nil {
-		if err := atomicWriteFile(filepath.Join(p.config.DataDir, "config.yml"), []byte(*updates.ConfigYAML), 0o644); err != nil {
+		if err := atomicWriteFile(p.nebulaConfigPath(), []byte(*updates.ConfigYAML), 0o644); err != nil {
 			return fmt.Errorf("write config: %w", err)
 		}
-		p.logger.Info("config updated")
+		p.logger.Info("config updated", "path", p.nebulaConfigPath())
 		needsReload = true
 	}
 
@@ -356,6 +361,17 @@ func (p *Poller) signRequest(req *http.Request) error {
 	req.Header.Set(corepop.HeaderNonce, nonce)
 	req.Header.Set(corepop.HeaderSignature, agentpop.EncodeSignature(sig))
 	return nil
+}
+
+// nebulaConfigPath resolves where the rendered Nebula config is written: the
+// configured NebulaConfigPath, or DataDir/config.yml when unset. Mirrors the
+// fallback Enroll applies so the daemon and the initial enroll write target the
+// same file (#224).
+func (p *Poller) nebulaConfigPath() string {
+	if p.config.NebulaConfigPath != "" {
+		return p.config.NebulaConfigPath
+	}
+	return filepath.Join(p.config.DataDir, "config.yml")
 }
 
 // atomicWriteFile writes data to a temp file, syncs it, then renames to the target path.

--- a/internal/agent/poller_nebula_config_path_test.go
+++ b/internal/agent/poller_nebula_config_path_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestPoller_WritesConfigToNebulaConfigPath is the #224 regression: when a
+// custom NebulaConfigPath is set, a config update must land at that path, not
+// at DataDir/config.yml. Before the fix the poller wrote DataDir/config.yml
+// unconditionally and silently ignored the configured path.
+func TestPoller_WritesConfigToNebulaConfigPath(t *testing.T) {
+	rendered := "pki:\n  cert: /etc/nebula/host.crt\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
+			HasUpdates: true,
+			ConfigYAML: &rendered,
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	customDir := t.TempDir()
+	customPath := filepath.Join(customDir, "nebula.yml")
+
+	p := newTestPoller(t, PollerConfig{
+		ServerURL:        server.URL,
+		Fingerprint:      "test-fp",
+		DataDir:          dir,
+		NebulaConfigPath: customPath,
+		Interval:         time.Hour, // immediate poll on Run is enough
+	})
+	p.signalFunc = func() error { return nil } // no real Nebula to SIGHUP
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	if _, err := os.Stat(customPath); err != nil {
+		t.Fatalf("rendered config not written to NebulaConfigPath %s: %v", customPath, err)
+	}
+	got, err := os.ReadFile(customPath) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("read custom config: %v", err)
+	}
+	if string(got) != rendered {
+		t.Errorf("custom config content = %q, want %q", got, rendered)
+	}
+	// It must NOT have been written to the legacy DataDir/config.yml.
+	if _, err := os.Stat(filepath.Join(dir, "config.yml")); err == nil {
+		t.Error("config was also written to DataDir/config.yml; NebulaConfigPath was ignored")
+	}
+}
+
+// TestPoller_NebulaConfigPathFallback covers the empty-path default: the
+// rendered config lands at DataDir/config.yml for backward compatibility.
+func TestPoller_NebulaConfigPathFallback(t *testing.T) {
+	rendered := "static_host_map: {}\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
+			HasUpdates: true,
+			ConfigYAML: &rendered,
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	p := newTestPoller(t, PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    time.Hour,
+	})
+	p.signalFunc = func() error { return nil }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	if _, err := os.Stat(filepath.Join(dir, "config.yml")); err != nil {
+		t.Fatalf("rendered config not written to default DataDir/config.yml: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`AgentConfig.NebulaConfigPath` (`nebula_config_path`) is documented as the path the agent overwrites atomically (default `/etc/nebula/config.yml`), but the runtime never read it. The poller always wrote `DataDir/config.yml`, and enroll did the same — then overwrote the saved field with `DataDir/config.yml`. With the default layout the two paths coincide, so the bug was invisible; any deployment that sets a custom `nebula_config_path` silently got the config written elsewhere and Nebula never picked up cert/config updates.

## Change

- `PollerConfig` gains `NebulaConfigPath`; the poller resolves it via `nebulaConfigPath()` (fallback `DataDir/config.yml`) and writes the rendered config there.
- `Enroll` takes the resolved config path (empty ⇒ `DataDir/config.yml`), writes the initial config there, and pre-flights its parent dir so a bad path fails **before** the single-use token is spent.
- `cmd/nebula-agent` threads `NebulaConfigPath` through the daemon poller, the enroll confirmation poll, the inline `--token` enroll, and `Reenroll`. `runEnroll` gains a `--nebula-config-path` flag and records the resolved value instead of hardcoding `DataDir/config.yml`.
- `docs/agent.md`: document the new `--nebula-config-path` enroll flag.

## Tests

- `TestPoller_WritesConfigToNebulaConfigPath`: custom path → config lands there, **not** at `DataDir/config.yml` (fails on old code).
- `TestPoller_NebulaConfigPathFallback`: empty path still writes `DataDir/config.yml`.

`go test -race` (agent, config, cmd/nebula-agent) and `make lint` green.

> Note: touches `internal/agent/poller.go` alongside #228 and #225 — expect a trivial rebase if those land first.

Closes #224
