### PR TITLE
fix(fsutil): fsync parent directory after atomic rename for crash safety

### DIFF
--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	agentpop "github.com/forgekeep/nebula-mesh/internal/agent/pop"
+	"github.com/forgekeep/nebula-mesh/internal/fsutil"
 	corepop "github.com/forgekeep/nebula-mesh/internal/pop"
 )
 
@@ -303,7 +304,7 @@ func (p *Poller) poll(ctx context.Context) error {
 	needsReload := false
 
 	if updates.CertificatePEM != nil {
-		if err := atomicWriteFile(filepath.Join(p.config.DataDir, "host.crt"), []byte(*updates.CertificatePEM), 0o644); err != nil {
+		if err := fsutil.AtomicWriteFile(filepath.Join(p.config.DataDir, "host.crt"), []byte(*updates.CertificatePEM), 0o644); err != nil {
 			return fmt.Errorf("write cert: %w", err)
 		}
 		p.logger.Info("certificate updated")
@@ -311,7 +312,7 @@ func (p *Poller) poll(ctx context.Context) error {
 	}
 
 	if updates.CACertPEM != nil {
-		if err := atomicWriteFile(filepath.Join(p.config.DataDir, "ca.crt"), []byte(*updates.CACertPEM), 0o644); err != nil {
+		if err := fsutil.AtomicWriteFile(filepath.Join(p.config.DataDir, "ca.crt"), []byte(*updates.CACertPEM), 0o644); err != nil {
 			return fmt.Errorf("write CA cert: %w", err)
 		}
 		p.logger.Info("CA certificate updated")
@@ -319,7 +320,7 @@ func (p *Poller) poll(ctx context.Context) error {
 	}
 
 	if updates.ConfigYAML != nil {
-		if err := atomicWriteFile(p.nebulaConfigPath(), []byte(*updates.ConfigYAML), 0o644); err != nil {
+		if err := fsutil.AtomicWriteFile(p.nebulaConfigPath(), []byte(*updates.ConfigYAML), 0o644); err != nil {
 			return fmt.Errorf("write config: %w", err)
 		}
 		p.logger.Info("config updated", "path", p.nebulaConfigPath())
@@ -372,51 +373,6 @@ func (p *Poller) nebulaConfigPath() string {
 		return p.config.NebulaConfigPath
 	}
 	return filepath.Join(p.config.DataDir, "config.yml")
-}
-
-// atomicWriteFile writes data to a temp file, syncs it, then renames to the target path.
-func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
-	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-
-	// cleanup removes temp file on failure; set to nil after successful rename
-	cleanup := func() {
-		if removeErr := os.Remove(tmpPath); removeErr != nil && !os.IsNotExist(removeErr) {
-			slog.Error("remove temp file", "path", tmpPath, "error", removeErr)
-		}
-	}
-
-	if _, err := tmp.Write(data); err != nil {
-		if closeErr := tmp.Close(); closeErr != nil {
-			slog.Error("close temp file after write error", "path", tmpPath, "error", closeErr)
-		}
-		cleanup()
-		return fmt.Errorf("write temp file: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		if closeErr := tmp.Close(); closeErr != nil {
-			slog.Error("close temp file after sync error", "path", tmpPath, "error", closeErr)
-		}
-		cleanup()
-		return fmt.Errorf("sync temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return fmt.Errorf("close temp file: %w", err)
-	}
-	if err := os.Chmod(tmpPath, perm); err != nil {
-		cleanup()
-		return fmt.Errorf("chmod temp file: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		cleanup()
-		return fmt.Errorf("rename temp to target: %w", err)
-	}
-	return nil
 }
 
 // signalNebulaFromPID reads the PID from file and sends SIGHUP to the nebula process.

--- a/internal/agent/poller_test.go
+++ b/internal/agent/poller_test.go
@@ -325,45 +325,6 @@ func TestPoll_HTTPTimeout(t *testing.T) {
 	}
 }
 
-func TestAtomicWriteFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "test.txt")
-
-	if err := atomicWriteFile(path, []byte("hello"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != "hello" {
-		t.Errorf("content = %q, want hello", data)
-	}
-
-	if err := atomicWriteFile(path, []byte("world"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	data, err = os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != "world" {
-		t.Errorf("content = %q, want world", data)
-	}
-
-	entries, _ := os.ReadDir(dir)
-	if len(entries) != 1 {
-		t.Errorf("expected 1 file in dir, got %d", len(entries))
-	}
-}
-
-func TestAtomicWriteFile_InvalidDir(t *testing.T) {
-	err := atomicWriteFile("/nonexistent/dir/file.txt", []byte("data"), 0o644)
-	if err == nil {
-		t.Error("expected error for nonexistent dir")
-	}
-}
-
 func TestSignalNebula_ReadsPIDFile(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "nebula.pid")
 	if err := os.WriteFile(pidFile, []byte("99999999"), 0o644); err != nil {

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/forgekeep/nebula-mesh/internal/fsutil"
 )
 
 type AgentConfig struct {
@@ -134,36 +136,10 @@ func SaveAgentConfig(path string, cfg *AgentConfig) error {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
-
-	tmp, err := os.CreateTemp(dir, ".agent.yml.*")
-	if err != nil {
-		return fmt.Errorf("create temp config: %w", err)
-	}
-	tmpName := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpName) }
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return fmt.Errorf("write temp config: %w", err)
-	}
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return fmt.Errorf("chmod temp config: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return fmt.Errorf("sync temp config: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return fmt.Errorf("close temp config: %w", err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		cleanup()
-		return fmt.Errorf("rename temp config: %w", err)
+	// 0o600: agent.yml records the server URL and paths but no secrets; still
+	// owner-only since it is the agent's private config.
+	if err := fsutil.AtomicWriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write config: %w", err)
 	}
 	return nil
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -12,6 +12,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/forgekeep/nebula-mesh/internal/fsutil"
 	"github.com/forgekeep/nebula-mesh/internal/models"
 )
 
@@ -491,34 +492,9 @@ func SaveServerConfig(path string, cfg *ServerConfig) error {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
-	if err != nil {
-		return fmt.Errorf("create temp config: %w", err)
-	}
-	tmpPath := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpPath) }
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return fmt.Errorf("write temp config: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return fmt.Errorf("sync temp config: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return fmt.Errorf("close temp config: %w", err)
-	}
-	if err := os.Chmod(tmpPath, 0o600); err != nil {
-		cleanup()
-		return fmt.Errorf("chmod temp config: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		cleanup()
-		return fmt.Errorf("rename temp config: %w", err)
+	// 0o600: server.yml may hold sensitive operational settings; owner-only.
+	if err := fsutil.AtomicWriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write config: %w", err)
 	}
 	return nil
 }

--- a/internal/fsutil/atomic.go
+++ b/internal/fsutil/atomic.go
@@ -73,7 +73,8 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 // directory fsync is unsupported on some platforms/filesystems, so errors are
 // logged at warn level rather than propagated.
 func syncDir(dir string) {
-	d, err := os.Open(dir)
+	d, err := os.Open(dir) // #nosec G304 -- dir is the parent of an operator-controlled config/data path, opened only to fsync the directory entry; no file contents are read
+
 	if err != nil {
 		slog.Warn("open dir for fsync", "dir", dir, "error", err)
 		return

--- a/internal/fsutil/atomic.go
+++ b/internal/fsutil/atomic.go
@@ -1,0 +1,87 @@
+// Package fsutil holds small filesystem helpers shared across the agent and
+// server. AtomicWriteFile is the durable temp-file → rename pattern that the
+// agent's config writer and both config savers previously each reimplemented
+// (#225), now in one place that also fsyncs the parent directory.
+package fsutil
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteFile writes data to path atomically and durably. It creates a temp
+// file in the same directory, fsyncs the file, chmods it to perm, renames it
+// over the target, then fsyncs the parent directory so the rename itself
+// survives a crash.
+//
+// The trailing directory fsync is the crash-safety fix: on Linux/Unix the
+// rename is not durable until the directory entry is flushed, so after power
+// loss the target file could revert to its old content — or, for a first-time
+// write, disappear — even though Write, Sync, and Rename all reported success
+// (#225). The directory sync is best-effort (some filesystems and platforms do
+// not support it) and runs only after the rename has succeeded, so a failure
+// there is logged rather than returned: failing here would be misleading when
+// the new data is already in place.
+func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	// cleanup removes the temp file on any failure before the rename lands.
+	cleanup := func() {
+		if removeErr := os.Remove(tmpPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			slog.Error("remove temp file", "path", tmpPath, "error", removeErr)
+		}
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		if closeErr := tmp.Close(); closeErr != nil {
+			slog.Error("close temp file after write error", "path", tmpPath, "error", closeErr)
+		}
+		cleanup()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		if closeErr := tmp.Close(); closeErr != nil {
+			slog.Error("close temp file after sync error", "path", tmpPath, "error", closeErr)
+		}
+		cleanup()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		cleanup()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename temp to target: %w", err)
+	}
+	syncDir(dir)
+	return nil
+}
+
+// syncDir flushes the directory entry so a prior rename is durable. Best-effort:
+// directory fsync is unsupported on some platforms/filesystems, so errors are
+// logged at warn level rather than propagated.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		slog.Warn("open dir for fsync", "dir", dir, "error", err)
+		return
+	}
+	if err := d.Sync(); err != nil {
+		slog.Warn("fsync dir", "dir", dir, "error", err)
+	}
+	if err := d.Close(); err != nil {
+		slog.Warn("close dir after fsync", "dir", dir, "error", err)
+	}
+}

--- a/internal/fsutil/atomic_test.go
+++ b/internal/fsutil/atomic_test.go
@@ -1,0 +1,88 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestAtomicWriteFile_WritesAndOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+
+	if err := AtomicWriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("content = %q, want hello", data)
+	}
+
+	if err := AtomicWriteFile(path, []byte("world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "world" {
+		t.Errorf("content = %q, want world", data)
+	}
+
+	// No temp residue: the directory holds exactly the target file.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 file in dir, got %d", len(entries))
+	}
+}
+
+func TestAtomicWriteFile_AppliesPerm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file modes not meaningful on windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+
+	if err := AtomicWriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("perm = %o, want 600", got)
+	}
+}
+
+func TestAtomicWriteFile_InvalidDir(t *testing.T) {
+	err := AtomicWriteFile("/nonexistent/dir/file.txt", []byte("data"), 0o644)
+	if err == nil {
+		t.Error("expected error for nonexistent dir")
+	}
+}
+
+// TestAtomicWriteFile_NoTempResidueOnFailure ensures a failed write does not
+// leave a stray temp file behind. We trigger failure by pointing at a path
+// whose parent does not exist (CreateTemp fails before any temp is made), and
+// also exercise the happy path leaving no .tmp.* siblings.
+func TestAtomicWriteFile_NoTempResidueOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	if err := AtomicWriteFile(path, []byte("k: v\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "config.yml" {
+			t.Errorf("unexpected leftover entry %q (temp residue?)", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The atomic-write helpers followed `temp → write → fsync(file) → rename` but never fsynced the **parent directory**. On Linux/Unix the rename is not durable until the directory entry is flushed: after a power loss the target file can revert to its old content — or, for a first-time write, disappear — even though the write reported success.

This matters most in the agent: a host that loses power right after a cert rotation could come back with a new `host.crt` but an old `config.yml`, leaving Nebula in a mixed state until the next poll happens to rewrite the missing piece.

## Change

- New `internal/fsutil.AtomicWriteFile(path, data, perm)` — one shared helper replacing three copies of the dance, with a parent-directory fsync after the rename.
- The directory sync is best-effort (unsupported on some filesystems; a failure after a successful rename would be misleading), so it is logged at warn level, not returned.
- Call sites converted:
  - agent `host.crt` / `ca.crt` / `config.yml` writes (`poller.go`, was the local `atomicWriteFile`),
  - `SaveAgentConfig`,
  - `SaveServerConfig`.
- The old per-file helper and its tests move into the `fsutil` package.

## Tests

`internal/fsutil`: write + overwrite, perm applied, no temp residue on success, error on nonexistent dir. Existing agent/config save tests still pass.

`go test -race` (fsutil, agent, config) and `make lint` green.

> Note: touches `internal/agent/poller.go` alongside #228 and #224 — expect a trivial rebase if those land first.

Closes #225
