### PR TITLE
feat(ops): add backup and restore commands (SQLite + encrypted CA keys + manifest)

### DIFF
--- a/cmd/nebula-mgmt/main.go
+++ b/cmd/nebula-mgmt/main.go
@@ -371,14 +371,47 @@ func runNetworkList(args []string) error {
 
 func runOps(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: nebula-mgmt ops <mint-admin-key>")
+		return fmt.Errorf("usage: nebula-mgmt ops <mint-admin-key|backup|restore>")
 	}
 	switch args[0] {
 	case "mint-admin-key":
 		return runOpsMintAdminKey(args[1:])
+	case "backup":
+		return runOpsBackup(args[1:])
+	case "restore":
+		return runOpsRestore(args[1:])
 	default:
 		return fmt.Errorf("unknown ops subcommand: %s", args[0])
 	}
+}
+
+func runOpsBackup(args []string) error {
+	fs := flag.NewFlagSet("ops backup", flag.ExitOnError)
+	configPath := fs.String("config", "", "config file path (required)")
+	output := fs.String("output", "", "backup archive path (required)")
+	passphrase := fs.String("passphrase", "", "encrypt the archive with this passphrase (optional)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *configPath == "" || *output == "" {
+		return fmt.Errorf("--config and --output are required")
+	}
+	return cli.OpsBackup(*configPath, *output, *passphrase, versionStr)
+}
+
+func runOpsRestore(args []string) error {
+	fs := flag.NewFlagSet("ops restore", flag.ExitOnError)
+	configPath := fs.String("config", "", "config file path (required)")
+	input := fs.String("input", "", "backup archive path (required)")
+	passphrase := fs.String("passphrase", "", "passphrase for an encrypted archive")
+	force := fs.Bool("force", false, "replace an existing database (moved aside to <db>.pre-restore)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *configPath == "" || *input == "" {
+		return fmt.Errorf("--config and --input are required")
+	}
+	return cli.OpsRestore(*configPath, *input, *passphrase, *force)
 }
 
 func runOpsMintAdminKey(args []string) error {

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,94 @@
+# Backup and restore
+
+The control plane keeps everything a mesh cannot afford to lose in one SQLite
+database: CA metadata and **encrypted** CA private keys, operators, API keys,
+enrollment tokens, the audit trail, and all network/host state. `nebula-mgmt
+ops backup` and `nebula-mgmt ops restore` make a consistent snapshot of that
+database a first-class, scriptable operation instead of a hand-rolled
+`sqlite3 .backup`.
+
+## What a backup contains — and what it does not
+
+A backup is a single gzipped tar archive holding:
+
+- a `manifest.json` (archive format version, binary version, schema version, timestamp), and
+- a `nebula.db` snapshot taken with SQLite's `VACUUM INTO`, which is consistent under WAL.
+
+It deliberately does **not** contain:
+
+- **The master key** (`NEBULA_MGMT_MASTER_KEY`). CA private keys in the snapshot
+  are encrypted under it; without the key the archive is inert. Store and rotate
+  the master key separately — a backup plus the master key is what restores a
+  mesh, and keeping them apart is what lets you ship archives to less-trusted
+  storage.
+- **`server.yml`.** Treat the server config as configuration-as-code (version
+  control, your config-management tool), not backup payload.
+
+## Taking a backup
+
+```sh
+nebula-mgmt ops backup --config /etc/nebula-mgmt/server.yml --output /backups/nebula-$(date +%F).tar.gz
+```
+
+`--output` must not already exist (the command refuses to overwrite a backup).
+
+For archives leaving trusted storage, encrypt with a passphrase
+(AES-256-GCM, scrypt KDF):
+
+```sh
+nebula-mgmt ops backup --config /etc/nebula-mgmt/server.yml \
+  --output /backups/nebula-$(date +%F).tar.gz.enc --passphrase "$BACKUP_PASSPHRASE"
+```
+
+Backups are safe to take while the server is running.
+
+### Cadence
+
+Back up after any change to CAs, operators, or networks, and on a schedule
+(e.g. a daily cron or systemd timer) sized to how much host/enrollment churn you
+can afford to replay. Keep the master key and the archives in separate trust
+domains.
+
+## Restoring
+
+Restore into a host whose `server.yml` points at the data dir you want to
+populate, with the **same** `NEBULA_MGMT_MASTER_KEY` the backup was taken under:
+
+```sh
+export NEBULA_MGMT_MASTER_KEY=...   # the original key
+nebula-mgmt ops restore --config /etc/nebula-mgmt/server.yml --input /backups/nebula-2026-06-13.tar.gz
+```
+
+Restore guards against the common foot-guns:
+
+- It **refuses to overwrite an existing database**. Pass `--force` to replace
+  one; the current database is moved to `<db_path>.pre-restore` (and stale
+  `-wal`/`-shm` files are cleared) before the snapshot is written.
+- It **runs migrations forward** when the backup's schema is older than the
+  binary, so an old archive restores cleanly onto a newer release.
+- It **verifies the master key can decrypt every restored CA** and fails loudly
+  if it cannot — you find out at restore time, not at the first certificate
+  signing. A mismatched key leaves the restored database in place but exits
+  non-zero with a clear message.
+
+For an encrypted archive, pass the same `--passphrase` used to create it.
+
+## Restore drill
+
+Practice the restore before you need it:
+
+1. On a throwaway host, point `server.yml` at an empty data dir.
+2. `export NEBULA_MGMT_MASTER_KEY=...` with the production key.
+3. `nebula-mgmt ops restore --config … --input <latest backup>`.
+4. Confirm the "verified N CA key(s) decrypt under the master key" line and that
+   `nebula-mgmt ca list` / `nebula-mgmt host list` show the expected state.
+
+A backup you have never restored is a hypothesis, not a backup.
+
+## Migrating to a new server
+
+1. Take a backup on the old server.
+2. Install `nebula-mgmt` on the new server and write its `server.yml`.
+3. Copy the archive and set `NEBULA_MGMT_MASTER_KEY` to the original key.
+4. `nebula-mgmt ops restore --config … --input …`.
+5. Start the server and verify agents continue to poll and rotate.

--- a/internal/backup/archive.go
+++ b/internal/backup/archive.go
@@ -1,0 +1,310 @@
+// Package backup creates and restores consistent snapshots of the nebula-mgmt
+// control-plane database. A backup is a gzipped tar holding a manifest and a
+// SQLite snapshot taken with VACUUM INTO (correct under WAL), optionally
+// AES-256-GCM encrypted under an operator passphrase so archives can be shipped
+// to untrusted storage (#229).
+//
+// The master key is deliberately NOT part of the archive: the encrypted CA
+// private keys in the snapshot are useless without it, so restore requires the
+// operator to supply the same NEBULA_MGMT_MASTER_KEY out of band. The caller
+// (internal/cli) verifies that key can actually decrypt the restored CAs before
+// declaring success.
+package backup
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	// FormatVersion is the archive layout version recorded in the manifest.
+	FormatVersion = 1
+
+	manifestName = "manifest.json"
+	dbEntryName  = "nebula.db"
+
+	// encMagic prefixes a passphrase-encrypted archive and doubles as the GCM
+	// additional authenticated data, binding the format to the ciphertext.
+	encMagic = "NMBK1\n"
+
+	// maxArchiveBytes caps how much we read from an archive on restore, a
+	// guard against a hostile/truncated archive exhausting memory. The whole
+	// archive is held in memory (GCM needs the full plaintext), which is fine
+	// for a single-VM SQLite control plane but is the practical size ceiling.
+	maxArchiveBytes = 2 << 30 // 2 GiB
+
+	scryptN = 1 << 15
+	scryptR = 8
+	scryptP = 1
+	saltLen = 16
+)
+
+// Sentinel errors callers can match on.
+var (
+	ErrPassphraseRequired = errors.New("archive is encrypted: a passphrase is required")
+	ErrDecryptFailed      = errors.New("decryption failed: wrong passphrase or corrupt archive")
+	ErrCorruptArchive     = errors.New("backup archive is corrupt or truncated")
+	ErrUnsupportedFormat  = errors.New("unsupported backup format version")
+	ErrMissingDB          = errors.New("backup archive does not contain a database snapshot")
+)
+
+// Manifest is the metadata stored alongside the database snapshot.
+type Manifest struct {
+	FormatVersion int       `json:"format_version"`
+	AppVersion    string    `json:"app_version"`
+	SchemaVersion string    `json:"schema_version"`
+	CreatedAt     time.Time `json:"created_at"`
+	DBFilename    string    `json:"db_filename"`
+}
+
+// Meta is the caller-supplied metadata recorded into the manifest.
+type Meta struct {
+	AppVersion    string    // binary version that produced the backup
+	SchemaVersion string    // latest applied migration name
+	Now           time.Time // backup timestamp (injected for deterministic tests)
+}
+
+// Create writes a consistent, gzipped tar snapshot of db to w. When passphrase
+// is non-empty the whole archive is AES-256-GCM encrypted (scrypt KDF) and
+// prefixed with the magic header. tmpDir is where the transient VACUUM INTO
+// snapshot is written — pass a directory on the same filesystem as the DB; it
+// is removed before Create returns.
+func Create(ctx context.Context, db *sql.DB, w io.Writer, meta Meta, passphrase, tmpDir string) error {
+	snapDir, err := os.MkdirTemp(tmpDir, "nm-backup-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(snapDir) }()
+	snapPath := filepath.Join(snapDir, dbEntryName)
+
+	// VACUUM INTO takes a quoted string literal, not a bound parameter; the
+	// path is our own temp file, but escape single quotes defensively. It
+	// requires the target file not to already exist, which MkdirTemp guarantees.
+	// #nosec G202 -- VACUUM INTO takes a quoted string literal, not a bind parameter; snapPath is our own MkdirTemp path with single quotes escaped, not user input
+	if _, err := db.ExecContext(ctx, "VACUUM INTO '"+strings.ReplaceAll(snapPath, "'", "''")+"'"); err != nil {
+		return fmt.Errorf("vacuum into snapshot: %w", err)
+	}
+	dbBytes, err := os.ReadFile(snapPath) // #nosec G304 -- snapPath is a temp file we just created
+	if err != nil {
+		return fmt.Errorf("read snapshot: %w", err)
+	}
+
+	manifestBytes, err := json.MarshalIndent(Manifest{
+		FormatVersion: FormatVersion,
+		AppVersion:    meta.AppVersion,
+		SchemaVersion: meta.SchemaVersion,
+		CreatedAt:     meta.Now.UTC(),
+		DBFilename:    dbEntryName,
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	// Assemble the tar.gz in memory so it can be encrypted whole when asked.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := writeTarEntry(tw, manifestName, manifestBytes, meta.Now); err != nil {
+		return err
+	}
+	if err := writeTarEntry(tw, dbEntryName, dbBytes, meta.Now); err != nil {
+		return err
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("close tar: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("close gzip: %w", err)
+	}
+
+	if passphrase == "" {
+		if _, err := w.Write(buf.Bytes()); err != nil {
+			return fmt.Errorf("write archive: %w", err)
+		}
+		return nil
+	}
+	return encrypt(w, buf.Bytes(), passphrase)
+}
+
+// Restore reads an archive from r, decrypting it when it carries the encrypted
+// magic (which requires passphrase), validates the manifest, and writes the
+// embedded database to destDBPath. destDBPath must not already exist — Restore
+// never overwrites a database. It returns the parsed manifest.
+func Restore(r io.Reader, destDBPath, passphrase string) (Manifest, error) {
+	raw, err := io.ReadAll(io.LimitReader(r, maxArchiveBytes))
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read archive: %w", err)
+	}
+	if bytes.HasPrefix(raw, []byte(encMagic)) {
+		if passphrase == "" {
+			return Manifest{}, ErrPassphraseRequired
+		}
+		if raw, err = decrypt(raw, passphrase); err != nil {
+			return Manifest{}, err
+		}
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return Manifest{}, fmt.Errorf("%w: %w", ErrCorruptArchive, err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	var (
+		manifest *Manifest
+		dbBytes  []byte
+	)
+	for {
+		h, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return Manifest{}, fmt.Errorf("%w: %w", ErrCorruptArchive, err)
+		}
+		// Match by exact entry name only; never join h.Name onto a path, so a
+		// hostile archive cannot traverse out of the destination.
+		switch h.Name {
+		case manifestName:
+			b, err := io.ReadAll(io.LimitReader(tr, maxArchiveBytes))
+			if err != nil {
+				return Manifest{}, fmt.Errorf("read manifest: %w", err)
+			}
+			var m Manifest
+			if err := json.Unmarshal(b, &m); err != nil {
+				return Manifest{}, fmt.Errorf("%w: bad manifest: %w", ErrCorruptArchive, err)
+			}
+			manifest = &m
+		case dbEntryName:
+			if dbBytes, err = io.ReadAll(io.LimitReader(tr, maxArchiveBytes)); err != nil {
+				return Manifest{}, fmt.Errorf("read db snapshot: %w", err)
+			}
+		}
+	}
+
+	if manifest == nil {
+		return Manifest{}, fmt.Errorf("%w: no manifest", ErrCorruptArchive)
+	}
+	if manifest.FormatVersion != FormatVersion {
+		return Manifest{}, fmt.Errorf("%w: got %d, want %d", ErrUnsupportedFormat, manifest.FormatVersion, FormatVersion)
+	}
+	if dbBytes == nil {
+		return Manifest{}, ErrMissingDB
+	}
+
+	// O_EXCL: never clobber an existing database. The caller is responsible for
+	// moving any prior DB aside (and removing -wal/-shm) before calling Restore.
+	f, err := os.OpenFile(destDBPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) // #nosec G304 -- destDBPath is the operator-configured db_path, the documented restore target
+	if err != nil {
+		return Manifest{}, fmt.Errorf("open destination: %w", err)
+	}
+	if _, err := f.Write(dbBytes); err != nil {
+		_ = f.Close()
+		return Manifest{}, fmt.Errorf("write database: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return Manifest{}, fmt.Errorf("sync database: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return Manifest{}, fmt.Errorf("close database: %w", err)
+	}
+	return *manifest, nil
+}
+
+func writeTarEntry(tw *tar.Writer, name string, data []byte, mod time.Time) error {
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0o600,
+		Size:     int64(len(data)),
+		ModTime:  mod,
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		return fmt.Errorf("tar header %s: %w", name, err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		return fmt.Errorf("tar write %s: %w", name, err)
+	}
+	return nil
+}
+
+// encrypt seals plaintext under a scrypt-derived key and writes
+// magic | salt | nonce | ciphertext to w.
+func encrypt(w io.Writer, plaintext []byte, passphrase string) error {
+	salt := make([]byte, saltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return fmt.Errorf("generate salt: %w", err)
+	}
+	gcm, err := newGCM(passphrase, salt)
+	if err != nil {
+		return err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("generate nonce: %w", err)
+	}
+	ciphertext := gcm.Seal(nil, nonce, plaintext, []byte(encMagic))
+	for _, chunk := range [][]byte{[]byte(encMagic), salt, nonce, ciphertext} {
+		if _, err := w.Write(chunk); err != nil {
+			return fmt.Errorf("write encrypted archive: %w", err)
+		}
+	}
+	return nil
+}
+
+// decrypt reverses encrypt. A GCM auth failure (wrong passphrase or tampering)
+// surfaces as ErrDecryptFailed.
+func decrypt(raw []byte, passphrase string) ([]byte, error) {
+	body := raw[len(encMagic):]
+	if len(body) < saltLen {
+		return nil, ErrCorruptArchive
+	}
+	salt, body := body[:saltLen], body[saltLen:]
+	gcm, err := newGCM(passphrase, salt)
+	if err != nil {
+		return nil, err
+	}
+	ns := gcm.NonceSize()
+	if len(body) < ns {
+		return nil, ErrCorruptArchive
+	}
+	nonce, ciphertext := body[:ns], body[ns:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, []byte(encMagic))
+	if err != nil {
+		return nil, ErrDecryptFailed
+	}
+	return plaintext, nil
+}
+
+func newGCM(passphrase string, salt []byte) (cipher.AEAD, error) {
+	key, err := scrypt.Key([]byte(passphrase), salt, scryptN, scryptR, scryptP, 32)
+	if err != nil {
+		return nil, fmt.Errorf("derive key: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("new cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("new gcm: %w", err)
+	}
+	return gcm, nil
+}

--- a/internal/backup/archive_test.go
+++ b/internal/backup/archive_test.go
@@ -1,0 +1,125 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// makeDB opens a WAL-mode SQLite database at a temp path, seeds a row, and
+// returns the open handle plus its path. VACUUM INTO must see the seeded row
+// even though it lives in the WAL.
+func makeDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "src.db")
+	db, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO kv VALUES ('hello', 'world')`); err != nil {
+		t.Fatal(err)
+	}
+	return db, path
+}
+
+func readKV(t *testing.T, path string) string {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var v string
+	if err := db.QueryRow(`SELECT v FROM kv WHERE k = 'hello'`).Scan(&v); err != nil {
+		t.Fatalf("read restored row: %v", err)
+	}
+	return v
+}
+
+func testMeta() Meta {
+	return Meta{AppVersion: "v9.9.9", SchemaVersion: "020_x", Now: time.Unix(1_700_000_000, 0)}
+}
+
+func TestCreateRestore_RoundTrip(t *testing.T) {
+	db, _ := makeDB(t)
+	var buf bytes.Buffer
+	if err := Create(context.Background(), db, &buf, testMeta(), "", t.TempDir()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "restored.db")
+	manifest, err := Restore(bytes.NewReader(buf.Bytes()), dest, "")
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if got := readKV(t, dest); got != "world" {
+		t.Errorf("restored value = %q, want world", got)
+	}
+	if manifest.AppVersion != "v9.9.9" || manifest.SchemaVersion != "020_x" || manifest.FormatVersion != FormatVersion {
+		t.Errorf("manifest = %+v, want app v9.9.9 / schema 020_x / format %d", manifest, FormatVersion)
+	}
+}
+
+func TestCreateRestore_Encrypted(t *testing.T) {
+	db, _ := makeDB(t)
+	const pass = "correct horse battery staple"
+	var buf bytes.Buffer
+	if err := Create(context.Background(), db, &buf, testMeta(), pass, t.TempDir()); err != nil {
+		t.Fatalf("Create encrypted: %v", err)
+	}
+	if !bytes.HasPrefix(buf.Bytes(), []byte(encMagic)) {
+		t.Fatal("encrypted archive missing magic header")
+	}
+
+	// Correct passphrase round-trips.
+	dest := filepath.Join(t.TempDir(), "ok.db")
+	if _, err := Restore(bytes.NewReader(buf.Bytes()), dest, pass); err != nil {
+		t.Fatalf("Restore with correct passphrase: %v", err)
+	}
+	if got := readKV(t, dest); got != "world" {
+		t.Errorf("restored value = %q, want world", got)
+	}
+
+	// Wrong passphrase fails closed.
+	if _, err := Restore(bytes.NewReader(buf.Bytes()), filepath.Join(t.TempDir(), "x.db"), "wrong"); !errors.Is(err, ErrDecryptFailed) {
+		t.Errorf("wrong passphrase err = %v, want ErrDecryptFailed", err)
+	}
+
+	// Missing passphrase on an encrypted archive is reported, not a panic.
+	if _, err := Restore(bytes.NewReader(buf.Bytes()), filepath.Join(t.TempDir(), "y.db"), ""); !errors.Is(err, ErrPassphraseRequired) {
+		t.Errorf("missing passphrase err = %v, want ErrPassphraseRequired", err)
+	}
+}
+
+func TestRestore_RefusesExistingDestination(t *testing.T) {
+	db, _ := makeDB(t)
+	var buf bytes.Buffer
+	if err := Create(context.Background(), db, &buf, testMeta(), "", t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(t.TempDir(), "exists.db")
+	if _, err := Restore(bytes.NewReader(buf.Bytes()), dest, ""); err != nil {
+		t.Fatal(err)
+	}
+	// Second restore to the same path must refuse (O_EXCL).
+	if _, err := Restore(bytes.NewReader(buf.Bytes()), dest, ""); err == nil {
+		t.Error("expected error restoring over an existing destination")
+	}
+}
+
+func TestRestore_RejectsCorruptArchive(t *testing.T) {
+	_, err := Restore(bytes.NewReader([]byte("not a valid archive")), filepath.Join(t.TempDir(), "z.db"), "")
+	if !errors.Is(err, ErrCorruptArchive) {
+		t.Errorf("err = %v, want ErrCorruptArchive", err)
+	}
+}

--- a/internal/cli/ops_backup.go
+++ b/internal/cli/ops_backup.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/backup"
+	"github.com/forgekeep/nebula-mesh/internal/config"
+	"github.com/forgekeep/nebula-mesh/internal/keystore"
+	"github.com/forgekeep/nebula-mesh/internal/pki"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// OpsBackup writes a consistent snapshot of the control-plane database
+// referenced by configPath to outputPath. When passphrase is non-empty the
+// archive is encrypted. appVersion is recorded in the manifest. The master key
+// is intentionally not included — restore requires the operator to supply it.
+func OpsBackup(configPath, outputPath, passphrase, appVersion string) error {
+	cfg, err := config.LoadServerConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	s, err := store.NewSQLiteStore(cfg.DBPath)
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+	schemaVer, err := latestMigration(ctx, s.DB())
+	if err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+
+	// O_EXCL: never silently overwrite an existing backup file.
+	out, err := os.OpenFile(outputPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) // #nosec G304 -- outputPath is the operator-supplied --output CLI argument
+	if err != nil {
+		return fmt.Errorf("create %s: %w", outputPath, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	meta := backup.Meta{AppVersion: appVersion, SchemaVersion: schemaVer, Now: time.Now()}
+	if err := backup.Create(ctx, s.DB(), out, meta, passphrase, filepath.Dir(cfg.DBPath)); err != nil {
+		// Remove the half-written archive so a failed backup leaves nothing
+		// that could be mistaken for a usable one.
+		_ = os.Remove(outputPath)
+		return fmt.Errorf("create backup: %w", err)
+	}
+
+	enc := ""
+	if passphrase != "" {
+		enc = " (encrypted)"
+	}
+	_ = s.AddAuditEntry(ctx, "ops", "backup.created", outputPath, "schema="+schemaVer)
+	fmt.Printf("wrote backup%s to %s (schema %s)\n", enc, outputPath, schemaVer)
+	return nil
+}
+
+// OpsRestore restores a backup archive into the data dir referenced by
+// configPath. It refuses to overwrite an existing live database unless force is
+// set (in which case the current DB is moved aside). After restoring it runs
+// migrations forward and verifies the master key can decrypt every restored CA,
+// failing loudly on mismatch rather than at first signing.
+func OpsRestore(configPath, inputPath, passphrase string, force bool) error {
+	cfg, err := config.LoadServerConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	master, err := resolveMaster(cfg, configPath)
+	if err != nil {
+		return err
+	}
+
+	if _, statErr := os.Stat(cfg.DBPath); statErr == nil {
+		if !force {
+			return fmt.Errorf("refusing to overwrite existing database at %s; pass --force to replace it", cfg.DBPath)
+		}
+		if err := moveAside(cfg.DBPath); err != nil {
+			return err
+		}
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", cfg.DBPath, statErr)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cfg.DBPath), 0o750); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+
+	in, err := os.Open(inputPath) // #nosec G304 -- operator-supplied archive path is the documented CLI argument
+	if err != nil {
+		return fmt.Errorf("open %s: %w", inputPath, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	manifest, err := backup.Restore(in, cfg.DBPath, passphrase)
+	if err != nil {
+		return fmt.Errorf("restore archive: %w", err)
+	}
+
+	ctx := context.Background()
+	s, err := store.NewSQLiteStore(cfg.DBPath)
+	if err != nil {
+		return fmt.Errorf("open restored store: %w", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// Roll an older backup forward to the binary's schema.
+	if err := s.Migrate(ctx); err != nil {
+		return fmt.Errorf("migrate restored database: %w", err)
+	}
+
+	// Master-key check: every CA must decrypt under the supplied key, or the
+	// restore is useless. Fail here, loudly, not at first signing.
+	resolver := pki.NewCAResolver(s, master)
+	cas, err := s.ListCAs(ctx)
+	if err != nil {
+		return fmt.Errorf("list restored CAs: %w", err)
+	}
+	for _, ca := range cas {
+		if _, err := resolver.LoadByID(ctx, ca.ID); err != nil {
+			return fmt.Errorf("master key cannot decrypt CA %q (%s): %w — the restored database is in place at %s but NEBULA_MGMT_MASTER_KEY does not match this backup",
+				ca.Name, ca.ID, err, cfg.DBPath)
+		}
+	}
+
+	_ = s.AddAuditEntry(ctx, "ops", "backup.restored", inputPath, "schema="+manifest.SchemaVersion)
+	fmt.Printf("restored %s (app %s, schema %s, taken %s); verified %d CA key(s) decrypt under the master key\n",
+		inputPath, manifest.AppVersion, manifest.SchemaVersion, manifest.CreatedAt.Format(time.RFC3339), len(cas))
+	return nil
+}
+
+// resolveMaster resolves the master key the same way the server does: env wins
+// over the config field. It is required so the post-restore decryption check
+// can run.
+func resolveMaster(cfg *config.ServerConfig, configPath string) (*keystore.Master, error) {
+	masterB64 := cfg.MasterKey
+	if env := os.Getenv("NEBULA_MGMT_MASTER_KEY"); env != "" {
+		masterB64 = env
+	}
+	if masterB64 == "" {
+		return nil, fmt.Errorf("master key required for restore: set NEBULA_MGMT_MASTER_KEY env or master_key in %s", configPath)
+	}
+	master, err := keystore.NewMasterFromBase64(masterB64)
+	if err != nil {
+		return nil, fmt.Errorf("master key: %w", err)
+	}
+	return master, nil
+}
+
+// moveAside renames an existing database (and its WAL/SHM siblings) out of the
+// way so a fresh single-file snapshot can be restored without colliding with
+// stale write-ahead state.
+func moveAside(dbPath string) error {
+	bak := dbPath + ".pre-restore"
+	if err := os.Rename(dbPath, bak); err != nil {
+		return fmt.Errorf("move existing database aside: %w", err)
+	}
+	// WAL/SHM belong to the old DB; a restored consolidated file must not see
+	// them. Best-effort removal — they may not exist.
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Remove(dbPath + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove %s%s: %w", dbPath, suffix, err)
+		}
+	}
+	fmt.Printf("moved existing database to %s\n", bak)
+	return nil
+}
+
+// latestMigration returns the name of the most recently applied migration, used
+// as the manifest's schema version. An empty database (no migrations table or
+// no rows) yields "none".
+func latestMigration(ctx context.Context, db *sql.DB) (string, error) {
+	var name string
+	err := db.QueryRowContext(ctx, "SELECT name FROM schema_migrations ORDER BY name DESC LIMIT 1").Scan(&name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "none", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return name, nil
+}

--- a/internal/cli/ops_backup_test.go
+++ b/internal/cli/ops_backup_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+func masterKeyB64(seed byte) string {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = seed + byte(i)
+	}
+	return base64.StdEncoding.EncodeToString(k)
+}
+
+// writeServerConfig writes a minimal server.yml in dir and returns its path and
+// the db path it references.
+func writeServerConfig(t *testing.T, dir, masterB64 string) (cfgPath, dbPath string) {
+	t.Helper()
+	dbPath = filepath.Join(dir, "nebula.db")
+	cfgPath = filepath.Join(dir, "server.yaml")
+	content := `listen: ":8080"
+data_dir: "` + dir + `"
+db_path: "` + dbPath + `"
+log_level: "info"
+master_key: "` + masterB64 + `"
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return cfgPath, dbPath
+}
+
+// TestOpsBackupRestore_RoundTripWithMasterKeyCheck initializes a control plane
+// (which mints a default CA), backs it up, restores into a fresh data dir under
+// the same master key, and asserts the restored CA decrypts.
+func TestOpsBackupRestore_RoundTripWithMasterKeyCheck(t *testing.T) {
+	t.Setenv("NEBULA_MGMT_MASTER_KEY", "") // force config-file master key
+	master := masterKeyB64(1)
+
+	srcDir := t.TempDir()
+	srcCfg, _ := writeServerConfig(t, srcDir, master)
+	if err := Init(srcCfg); err != nil {
+		t.Fatalf("init source: %v", err)
+	}
+
+	archive := filepath.Join(t.TempDir(), "backup.tar.gz")
+	if err := OpsBackup(srcCfg, archive, "", "vtest"); err != nil {
+		t.Fatalf("OpsBackup: %v", err)
+	}
+	if fi, err := os.Stat(archive); err != nil || fi.Size() == 0 {
+		t.Fatalf("backup archive missing or empty: %v", err)
+	}
+
+	dstDir := t.TempDir()
+	dstCfg, dstDB := writeServerConfig(t, dstDir, master)
+	if err := OpsRestore(dstCfg, archive, "", false); err != nil {
+		t.Fatalf("OpsRestore: %v", err)
+	}
+
+	// Restored DB carries the minted CA.
+	s, err := store.NewSQLiteStore(dstDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	cas, err := s.ListCAs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cas) == 0 {
+		t.Error("restored database has no CAs")
+	}
+}
+
+// TestOpsRestore_RefusesWrongMasterKey proves the master-key guard: restoring
+// under a key that cannot decrypt the CAs fails loudly.
+func TestOpsRestore_RefusesWrongMasterKey(t *testing.T) {
+	t.Setenv("NEBULA_MGMT_MASTER_KEY", "")
+
+	srcDir := t.TempDir()
+	srcCfg, _ := writeServerConfig(t, srcDir, masterKeyB64(2))
+	if err := Init(srcCfg); err != nil {
+		t.Fatalf("init source: %v", err)
+	}
+	archive := filepath.Join(t.TempDir(), "backup.tar.gz")
+	if err := OpsBackup(srcCfg, archive, "", "vtest"); err != nil {
+		t.Fatalf("OpsBackup: %v", err)
+	}
+
+	// Restore under a different master key.
+	dstDir := t.TempDir()
+	dstCfg, _ := writeServerConfig(t, dstDir, masterKeyB64(99))
+	err := OpsRestore(dstCfg, archive, "", false)
+	if err == nil {
+		t.Fatal("expected restore to fail under a mismatched master key")
+	}
+	if !contains(err.Error(), "master key cannot decrypt") {
+		t.Errorf("error = %v, want master-key mismatch", err)
+	}
+}
+
+// TestOpsRestore_RefusesExistingDatabase covers the overwrite guard.
+func TestOpsRestore_RefusesExistingDatabase(t *testing.T) {
+	t.Setenv("NEBULA_MGMT_MASTER_KEY", "")
+	master := masterKeyB64(3)
+
+	srcDir := t.TempDir()
+	srcCfg, _ := writeServerConfig(t, srcDir, master)
+	if err := Init(srcCfg); err != nil {
+		t.Fatalf("init source: %v", err)
+	}
+	archive := filepath.Join(t.TempDir(), "backup.tar.gz")
+	if err := OpsBackup(srcCfg, archive, "", "vtest"); err != nil {
+		t.Fatalf("OpsBackup: %v", err)
+	}
+
+	// Restoring back onto the live source DB without --force must refuse.
+	if err := OpsRestore(srcCfg, archive, "", false); err == nil {
+		t.Fatal("expected restore to refuse overwriting an existing database")
+	}
+	// With force it succeeds and moves the old DB aside.
+	if err := OpsRestore(srcCfg, archive, "", true); err != nil {
+		t.Fatalf("forced restore: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(srcDir, "nebula.db.pre-restore")); err != nil {
+		t.Errorf("expected pre-restore backup of the old database: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Makes control-plane backup/restore a first-class, scriptable operation instead of a hand-rolled `sqlite3 .backup` that nothing validates. The DB holds everything a mesh cannot afford to lose — encrypted CA keys, operators, API keys, enrollment tokens, audit trail, network state.

## Commands

**`nebula-mgmt ops backup --config <c> --output <archive> [--passphrase P]`**
- Consistent snapshot via SQLite `VACUUM INTO` (correct under WAL).
- Bundled with a `manifest.json` (format / app / schema version, timestamp) into a gzipped tar.
- Optional AES-256-GCM encryption (scrypt KDF) so archives can ship to untrusted storage.
- Refuses to overwrite an existing archive file.

**`nebula-mgmt ops restore --config <c> --input <archive> [--passphrase P] [--force]`**
- Refuses to overwrite a live database; `--force` moves it to `<db>.pre-restore` and clears stale `-wal`/`-shm`.
- Verifies the manifest and runs migrations forward when the backup predates the binary.
- **Master-key check**: verifies `NEBULA_MGMT_MASTER_KEY` can decrypt every restored CA and fails loudly at restore time, not at first signing.

The master key is deliberately **not** in the archive — the encrypted CA keys are inert without it, so the operator supplies it out of band. This is what makes encrypted archives safe to ship.

## Layout

- `internal/backup` — `Create`/`Restore`, manifest, encryption (no new external deps; `golang.org/x/crypto/scrypt`).
- `internal/cli/ops_backup.go` — config/store/master-key wiring + the post-restore CA decryption check.
- `cmd/nebula-mgmt` — `ops backup` / `ops restore` subcommands.
- `docs/backup.md` — cadence, restore drill, server migration.

## Tests

- `internal/backup`: round-trip, encrypted round-trip, wrong passphrase (`ErrDecryptFailed`), missing passphrase (`ErrPassphraseRequired`), refuse-existing-destination, corrupt archive.
- `internal/cli`: full backup→restore with master-key verification, **mismatched master key is rejected**, and the existing-DB overwrite guard (+`--force` moves the old DB aside).

`go test -race`, `make gosec`, `make govulncheck`, `make lint` all green.

## Scope note

Covers the issue's core (consistent snapshot, manifest, restore guards, master-key check, optional passphrase encryption, docs). A full disaster-recovery guide (cold standby, master-key rotation) remains a natural follow-up.

Closes #229
