### PR TITLE
feat(webhooks): lifecycle-event webhooks (phase 1)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -198,6 +198,90 @@ paths:
                 items:
                   $ref: "#/components/schemas/AuditEntry"
 
+# Outbound webhooks the server POSTs to an operator-configured endpoint (#256).
+# Each delivery carries X-Nebula-Event (type), X-Nebula-Delivery (id), and
+# X-Nebula-Signature (sha256=<hmac> over the raw body). The handler/scanner emit
+# shapes are validated against these schemas by the contract tests.
+webhooks:
+  host.enrolled:
+    post:
+      operationId: webhookHostEnrolled
+      summary: A host completed enrollment and received its first certificate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HostEnrolledEvent"
+      responses:
+        "2XX":
+          description: Acknowledged.
+  host.blocked:
+    post:
+      operationId: webhookHostBlocked
+      summary: A host was blocked and its certificate revoked.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HostEvent"
+      responses:
+        "2XX":
+          description: Acknowledged.
+  host.unblocked:
+    post:
+      operationId: webhookHostUnblocked
+      summary: A previously blocked host was unblocked.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HostEvent"
+      responses:
+        "2XX":
+          description: Acknowledged.
+  host.deleted:
+    post:
+      operationId: webhookHostDeleted
+      summary: A host was deleted and its certificate revoked.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HostEvent"
+      responses:
+        "2XX":
+          description: Acknowledged.
+  cert.rotated:
+    post:
+      operationId: webhookCertRotated
+      summary: A host certificate was re-signed (in-place rotation).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CertRotatedEvent"
+      responses:
+        "2XX":
+          description: Acknowledged.
+  cert.expiring:
+    post:
+      operationId: webhookCertExpiring
+      summary: A host certificate is approaching expiry without renewal.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CertExpiringEvent"
+      responses:
+        "2XX":
+          description: Acknowledged.
+
 components:
   securitySchemes:
     bearerAuth:
@@ -414,3 +498,109 @@ components:
           type: string
         details:
           type: string
+
+    # --- Webhook event envelopes (#256) ---
+
+    HostEventData:
+      type: object
+      required: [host_id, host_name, network_id, ca_id]
+      properties:
+        host_id:
+          type: string
+        host_name:
+          type: string
+        network_id:
+          type: string
+        ca_id:
+          type: string
+
+    HostEnrolledData:
+      type: object
+      required: [host_id, host_name, network_id, ca_id, fingerprint]
+      properties:
+        host_id:
+          type: string
+        host_name:
+          type: string
+        network_id:
+          type: string
+        ca_id:
+          type: string
+        fingerprint:
+          type: string
+
+    CertExpiringData:
+      type: object
+      required: [host_id, host_name, network_id, ca_id, fingerprint, not_after, seconds_until_expiry]
+      properties:
+        host_id:
+          type: string
+        host_name:
+          type: string
+        network_id:
+          type: string
+        ca_id:
+          type: string
+        fingerprint:
+          type: string
+        not_after:
+          type: string
+          format: date-time
+        seconds_until_expiry:
+          type: number
+
+    HostEvent:
+      type: object
+      required: [id, type, created_at, data]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        data:
+          $ref: "#/components/schemas/HostEventData"
+
+    HostEnrolledEvent:
+      type: object
+      required: [id, type, created_at, data]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        data:
+          $ref: "#/components/schemas/HostEnrolledData"
+
+    CertRotatedEvent:
+      type: object
+      required: [id, type, created_at, data]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        data:
+          $ref: "#/components/schemas/HostEnrolledData"
+
+    CertExpiringEvent:
+      type: object
+      required: [id, type, created_at, data]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        data:
+          $ref: "#/components/schemas/CertExpiringData"

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,84 @@
+# Webhooks
+
+The server can POST lifecycle events to an operator-configured HTTP endpoint so
+external systems react to mesh changes without polling — inventory/CMDB sync on
+enrollment, SOC alerting on block/revoke, automation on cert rotation. Delivery
+is asynchronous (off the request path), signed, and SSRF-guarded.
+
+The machine-readable contract for every event lives in
+[`api/openapi.yaml`](../api/openapi.yaml) under `webhooks:`; the contract tests
+validate the real emitted payloads against it.
+
+## Enabling
+
+```yaml
+# server.yml
+webhooks:
+  enabled: true
+  url: https://hooks.example.com/nebula
+  hmac_secret: "<random secret>"        # optional; signs each delivery
+  events: [host.enrolled, host.blocked] # optional; empty = all events
+  allow_private: false                  # set true only for an intentional internal sink
+```
+
+`url` is validated at startup (must be http/https; loopback/private/link-local
+targets are rejected unless `allow_private: true`).
+
+## Events (phase 1)
+
+| Event | Fires when | `data` fields |
+|---|---|---|
+| `host.enrolled` | a host completes enrollment | `host_id`, `host_name`, `network_id`, `ca_id`, `fingerprint` |
+| `host.blocked` | a host is blocked (cert revoked) | `host_id`, `host_name`, `network_id`, `ca_id` |
+| `host.unblocked` | a blocked host is unblocked | same as `host.blocked` |
+| `host.deleted` | a host is deleted (cert revoked) | same as `host.blocked` |
+| `cert.rotated` | a host cert is re-signed in place | host fields + new `fingerprint` |
+| `cert.expiring` | a cert approaches expiry without renewal | host fields + `fingerprint`, `not_after`, `seconds_until_expiry` |
+
+`cert.expiring` is produced by the cert-expiry scanner, so it requires
+`alerts.enabled: true` (the scanner) in addition to `webhooks.enabled`. The
+other events come from the API handlers and need only the webhooks block.
+
+## Delivery format
+
+Every delivery is `POST <url>` with `Content-Type: application/json` and a body:
+
+```json
+{
+  "id": "evt_2f1c…",
+  "type": "host.blocked",
+  "created_at": "2026-06-13T12:00:00Z",
+  "data": { "host_id": "…", "host_name": "…", "network_id": "…", "ca_id": "…" }
+}
+```
+
+Headers:
+
+- `X-Nebula-Event` — the event type (also in the body).
+- `X-Nebula-Delivery` — the unique event id; use it to deduplicate (delivery is at-least-once).
+- `X-Nebula-Signature` — `sha256=<hex>`, the HMAC-SHA256 of the raw body under `hmac_secret` (present only when a secret is set).
+
+## Verifying the signature
+
+Compute `HMAC-SHA256(hmac_secret, raw_request_body)` and compare, in constant
+time, against the hex in `X-Nebula-Signature` (after the `sha256=` prefix).
+Reject deliveries that do not match.
+
+## Reliability
+
+- **Asynchronous**: events are queued and delivered by a background worker; a
+  slow or down receiver never blocks an API request.
+- **Retried**: a failed delivery (connection error or HTTP ≥ 400) is retried a
+  few times with linear backoff. After the retries are exhausted the event is
+  logged and dropped (a durable dead-letter queue is a later phase).
+- **Best-effort under load**: if the in-memory queue is full the event is
+  dropped with a logged warning rather than stalling the server. Treat webhooks
+  as a notification stream, not a system of record — the audit log remains the
+  authoritative history.
+
+## Not in phase 1
+
+- Managed subscriptions (multiple endpoints, CRUD, per-subscription status) —
+  phase 1 is a single config-driven subscription.
+- `ca.expiring` and other CA-lifecycle events.
+- A persistent dead-letter queue and delivery dashboards.

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -236,6 +236,13 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.metrics.recordEnrollment(resultOK)
+	s.emit("host.enrolled", map[string]any{
+		"host_id":     host.ID,
+		"host_name":   host.Name,
+		"network_id":  host.NetworkID,
+		"ca_id":       host.CAID,
+		"fingerprint": fp,
+	})
 	writeJSON(w, http.StatusOK, enrollResponse{
 		CertificatePEM:   string(certPEM),
 		CACertificatePEM: string(caCertPEM),

--- a/internal/api/events_emit_test.go
+++ b/internal/api/events_emit_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+)
+
+type capturedEvent struct {
+	typ  string
+	data map[string]any
+}
+
+// fakeEmitter records events synchronously so handler-emit tests need no waits.
+type fakeEmitter struct {
+	mu     sync.Mutex
+	events []capturedEvent
+}
+
+func (f *fakeEmitter) Emit(eventType string, data map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, capturedEvent{eventType, data})
+}
+
+func (f *fakeEmitter) find(eventType string) (capturedEvent, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, e := range f.events {
+		if e.typ == eventType {
+			return e, true
+		}
+	}
+	return capturedEvent{}, false
+}
+
+func createHostForEvent(t *testing.T, srv *Server, netID string) createHostResponse {
+	t.Helper()
+	body, _ := json.Marshal(createHostRequest{NetworkID: netID, Name: "ev-host", NebulaIPs: []string{"192.168.100.50"}})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewReader(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create host: %d / %s", w.Code, w.Body.String())
+	}
+	var ch createHostResponse
+	_ = json.NewDecoder(w.Body).Decode(&ch)
+	return ch
+}
+
+func TestEmit_HostBlockedAndUnblocked(t *testing.T) {
+	srv, _ := newTestServer(t)
+	fe := &fakeEmitter{}
+	srv.WithEventEmitter(fe)
+
+	netID := createNetwork(t, srv)
+	host := createHostForEvent(t, srv, netID).Host
+
+	for _, step := range []struct{ path, event string }{
+		{"/block", "host.blocked"},
+		{"/unblock", "host.unblocked"},
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+host.ID+step.path, nil)
+		authRequest(req)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("POST %s: %d / %s", step.path, w.Code, w.Body.String())
+		}
+		ev, ok := fe.find(step.event)
+		if !ok {
+			t.Fatalf("expected %s event after %s", step.event, step.path)
+		}
+		if ev.data["host_id"] != host.ID {
+			t.Errorf("%s host_id = %v, want %s", step.event, ev.data["host_id"], host.ID)
+		}
+	}
+}
+
+func TestEmit_HostEnrolled(t *testing.T) {
+	srv, _ := newTestServer(t)
+	fe := &fakeEmitter{}
+	srv.WithEventEmitter(fe)
+
+	netID := createNetwork(t, srv)
+	created := createHostForEvent(t, srv, netID)
+
+	// Minimal enroll handshake.
+	x := make([]byte, 32)
+	if _, err := rand.Read(x); err != nil {
+		t.Fatal(err)
+	}
+	xPub, err := curve25519.X25519(x, curve25519.Basepoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enrollBody, _ := json.Marshal(enrollRequest{
+		Token:         created.EnrollmentToken,
+		PublicKeyPEM:  string(cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, xPub)),
+		SigningPubPEM: string(pem.EncodeToMemory(&pem.Block{Type: SigningPublicKeyPEMType, Bytes: edPub})),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/enroll", bytes.NewReader(enrollBody))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("enroll: %d / %s", w.Code, w.Body.String())
+	}
+
+	ev, ok := fe.find("host.enrolled")
+	if !ok {
+		t.Fatal("expected host.enrolled event after enroll")
+	}
+	if ev.data["host_id"] != created.Host.ID {
+		t.Errorf("host.enrolled host_id = %v, want %s", ev.data["host_id"], created.Host.ID)
+	}
+	if ev.data["fingerprint"] == "" || ev.data["fingerprint"] == nil {
+		t.Error("host.enrolled missing fingerprint")
+	}
+}

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -319,8 +319,19 @@ func (s *Server) handleDeleteHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.recordAuditAction(r.Context(), auditHostDelete, id, "")
+	s.emit("host.deleted", hostEventData(host))
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// hostEventData is the common webhook payload for host lifecycle events.
+func hostEventData(h *models.Host) map[string]any {
+	return map[string]any{
+		"host_id":    h.ID,
+		"host_name":  h.Name,
+		"network_id": h.NetworkID,
+		"ca_id":      h.CAID,
+	}
 }
 
 func (s *Server) handleBlockHost(w http.ResponseWriter, r *http.Request) {
@@ -356,6 +367,7 @@ func (s *Server) handleBlockHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.recordAuditAction(r.Context(), auditHostBlock, id, "")
+	s.emit("host.blocked", hostEventData(host))
 
 	writeJSON(w, http.StatusOK, host)
 }
@@ -393,6 +405,7 @@ func (s *Server) handleUnblockHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.recordAuditAction(r.Context(), auditHostUnblock, id, "")
+	s.emit("host.unblocked", hostEventData(host))
 
 	writeJSON(w, http.StatusOK, host)
 }
@@ -501,6 +514,9 @@ func (s *Server) handleRotateCert(w http.ResponseWriter, r *http.Request) {
 	}
 	s.metrics.recordSignature(host.CAID)
 	s.recordAuditAction(r.Context(), auditHostRotateCertRequested, host.ID, "new_key=false")
+	rotated := hostEventData(host)
+	rotated["fingerprint"] = signed.fp
+	s.emit("cert.rotated", rotated)
 
 	writeJSON(w, http.StatusOK, rotateCertResponse{
 		NewKey:         false,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -36,7 +36,26 @@ type Server struct {
 	limiter            *ratelimit.Limiter
 	passwordPolicy     auth.Policy
 	enrollmentTokenTTL time.Duration
+	events             EventEmitter
 	clock              func() time.Time // nil => time.Now; injectable for tests
+}
+
+// EventEmitter receives lifecycle events the handlers publish (host enrolled,
+// blocked, deleted, cert rotated). The webhook.Dispatcher satisfies it; the
+// interface keeps the api package free of a webhook import. A nil emitter (the
+// default) makes emit a no-op.
+type EventEmitter interface {
+	Emit(eventType string, data map[string]any)
+}
+
+// WithEventEmitter wires the outbound-event sink. Must be set before ServeHTTP.
+func (s *Server) WithEventEmitter(e EventEmitter) { s.events = e }
+
+// emit publishes a lifecycle event, nil-safe so handlers need no guard.
+func (s *Server) emit(eventType string, data map[string]any) {
+	if s.events != nil {
+		s.events.Emit(eventType, data)
+	}
 }
 
 // WithClock overrides the server's wall clock. The default (nil) uses

--- a/internal/api/webhook_contract_test.go
+++ b/internal/api/webhook_contract_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi-validator/schema_validation"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+
+	"github.com/forgekeep/nebula-mesh/internal/webhook"
+)
+
+// webhookSchemas parses the spec and returns the requestBody schema for each
+// documented webhook event, keyed by event type.
+func webhookSchemas(t *testing.T) map[string]*base.Schema {
+	t.Helper()
+	specBytes, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read spec: %v", err)
+	}
+	doc, err := libopenapi.NewDocument(specBytes)
+	if err != nil {
+		t.Fatalf("parse spec: %v", err)
+	}
+	model, err := doc.BuildV3Model()
+	if err != nil {
+		t.Fatalf("build model: %v", err)
+	}
+	if model.Model.Webhooks == nil {
+		t.Fatal("spec has no webhooks block")
+	}
+	out := map[string]*base.Schema{}
+	for pair := model.Model.Webhooks.First(); pair != nil; pair = pair.Next() {
+		op := pair.Value().Post
+		if op == nil || op.RequestBody == nil {
+			continue
+		}
+		mt := op.RequestBody.Content.GetOrZero("application/json")
+		if mt == nil || mt.Schema == nil {
+			t.Fatalf("webhook %q missing application/json schema", pair.Key())
+		}
+		out[pair.Key()] = mt.Schema.Schema()
+	}
+	return out
+}
+
+// TestWebhookContract_EmittedPayloadsMatchSpec drives the real handlers with a
+// live dispatcher, captures every delivered event, and validates each payload
+// against the webhook schema documented for its type. Drift between a handler's
+// emit shape and the spec breaks the build.
+func TestWebhookContract_EmittedPayloadsMatchSpec(t *testing.T) {
+	schemas := webhookSchemas(t)
+	sv := schema_validation.NewSchemaValidator()
+
+	type delivery struct {
+		event string
+		body  []byte
+	}
+	deliveries := make(chan delivery, 16)
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := readAllAndClose(r)
+		deliveries <- delivery{event: r.Header.Get(webhook.EventHeader), body: b}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hookSrv.Close()
+
+	d := webhook.New(webhook.Config{URL: hookSrv.URL, AllowPrivate: true, RetryBackoff: 10 * time.Millisecond}, nil)
+	defer d.Close()
+
+	srv, _ := newTestServer(t)
+	srv.WithEventEmitter(d)
+
+	// One host carries the whole lifecycle: enroll (host.enrolled) -> rotate
+	// (cert.rotated) -> block (host.blocked) -> unblock (host.unblocked) ->
+	// delete (host.deleted). enrolledFixture is the proven enroll helper.
+	host := enrolledFixture(t, srv)
+	id := host.hostID
+
+	// Re-signing the same key within one wall-clock second yields an identical
+	// fingerprint (second-precision certs) that collides on the UNIQUE
+	// constraint; sleep so the rotation mints a distinct cert.
+	time.Sleep(time.Second)
+	rotReq := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+id+"/rotate-cert?new_key=false", nil)
+	authRequest(rotReq)
+	mustOK(t, srv, rotReq)
+
+	for _, p := range []string{"/block", "/unblock"} {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts/"+id+p, nil)
+		authRequest(req)
+		mustOK(t, srv, req)
+	}
+	delReq := httptest.NewRequest(http.MethodDelete, "/api/v1/hosts/"+id, nil)
+	authRequest(delReq)
+	if w := serve(srv, delReq); w.Code != http.StatusNoContent {
+		t.Fatalf("delete: %d / %s", w.Code, w.Body.String())
+	}
+
+	// cert.expiring originates in the scanner adapter; emit a representative
+	// payload (same shape the adapter produces) so its schema is exercised too.
+	d.Emit("cert.expiring", map[string]any{
+		"host_id": "h1", "host_name": "n", "network_id": "net1", "ca_id": "ca1",
+		"fingerprint": "fp", "not_after": time.Now().UTC().Format(time.RFC3339),
+		"seconds_until_expiry": 3600.0,
+	})
+
+	want := map[string]bool{
+		"host.blocked": true, "host.unblocked": true, "host.deleted": true,
+		"host.enrolled": true, "cert.rotated": true, "cert.expiring": true,
+	}
+	seen := map[string]bool{}
+	deadline := time.After(5 * time.Second)
+	for len(seen) < len(want) {
+		select {
+		case dlv := <-deliveries:
+			schema, ok := schemas[dlv.event]
+			if !ok {
+				t.Errorf("delivered undocumented event %q", dlv.event)
+				seen[dlv.event] = true
+				continue
+			}
+			if valid, verrs := sv.ValidateSchemaBytes(schema, dlv.body); !valid {
+				for _, e := range verrs {
+					t.Errorf("%s payload violates schema: %s — %s", dlv.event, e.Message, e.Reason)
+				}
+			}
+			seen[dlv.event] = true
+		case <-deadline:
+			t.Fatalf("timed out; saw %v, want %v", keys(seen), keys(want))
+		}
+	}
+}
+
+func mustOK(t *testing.T, srv *Server, req *http.Request) {
+	t.Helper()
+	if w := serve(srv, req); w.Code != http.StatusOK {
+		t.Fatalf("%s %s: %d / %s", req.Method, req.URL.Path, w.Code, w.Body.String())
+	}
+}
+
+func readAllAndClose(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/forgekeep/nebula-mesh/internal/ratelimit"
 	"github.com/forgekeep/nebula-mesh/internal/store"
 	"github.com/forgekeep/nebula-mesh/internal/web"
+	"github.com/forgekeep/nebula-mesh/internal/webhook"
 )
 
 // buildMux assembles the top-level routing per issue #69.
@@ -137,6 +138,23 @@ func Serve(configPath string, insecureHTTP bool) error {
 	apiSrv.WithMetricsEnabled(cfg.Metrics.PrometheusEnabled())
 	apiSrv.WithMetricsRequireAuth(cfg.Metrics.RequireAuth)
 	apiSrv.WithEnrollmentTokenTTL(cfg.EnrollmentTokenTTLDuration())
+
+	// Outbound lifecycle-event webhooks (#256). When enabled, handlers emit
+	// host.enrolled/blocked/unblocked/deleted and cert.rotated through the
+	// dispatcher; cert.expiring is fanned in below via the alerts scanner. Nil
+	// when disabled — the api emitter and Close are both nil-safe.
+	var webhookDispatcher *webhook.Dispatcher
+	if cfg.Webhooks.Enabled && cfg.Webhooks.URL != "" {
+		webhookDispatcher = webhook.New(webhook.Config{
+			URL:          cfg.Webhooks.URL,
+			HMACSecret:   cfg.Webhooks.HMACSecret,
+			AllowPrivate: cfg.Webhooks.AllowPrivate,
+			Events:       cfg.Webhooks.Events,
+		}, logger)
+		defer webhookDispatcher.Close()
+		apiSrv.WithEventEmitter(webhookDispatcher)
+		logger.Info("webhooks enabled", "url", cfg.Webhooks.URL, "events", cfg.Webhooks.Events)
+	}
 
 	// Build a single rate limiter shared by API and Web. The Web UI runs
 	// auth/ui groups; the API server runs api/enroll/agent_poll groups.
@@ -286,6 +304,12 @@ func Serve(configPath string, insecureHTTP bool) error {
 				HMACSecret:   cfg.Alerts.WebhookHMACSecret,
 				AllowPrivate: cfg.Alerts.AllowPrivateWebhook,
 			})
+		}
+		// Fold cert.expiring into the unified webhook bus when configured, so it
+		// is delivered alongside the handler-driven events under one signing
+		// secret and event-type filter.
+		if webhookDispatcher != nil {
+			sinks = append(sinks, certExpiryWebhookSink{webhookDispatcher})
 		}
 		scanner := &alerts.Scanner{
 			Store:     s,

--- a/internal/cli/webhook_alert_sink.go
+++ b/internal/cli/webhook_alert_sink.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/alerts"
+	"github.com/forgekeep/nebula-mesh/internal/webhook"
+)
+
+// certExpiryWebhookSink adapts the cert-expiry alerter's Sink interface onto the
+// unified webhook bus: each cert-expiry alert is emitted as a `cert.expiring`
+// event (#256), so it flows through the same signing secret, event-type filter,
+// and retry path as the handler-driven lifecycle events.
+type certExpiryWebhookSink struct {
+	dispatcher *webhook.Dispatcher
+}
+
+func (s certExpiryWebhookSink) Notify(_ context.Context, a alerts.Alert) error {
+	s.dispatcher.Emit("cert.expiring", map[string]any{
+		"host_id":              a.HostID,
+		"host_name":            a.HostName,
+		"network_id":           a.NetworkID,
+		"ca_id":                a.CAID,
+		"fingerprint":          a.Fingerprint,
+		"not_after":            a.NotAfter.UTC().Format(time.RFC3339),
+		"seconds_until_expiry": a.SecondsUntilExpiry,
+	})
+	return nil
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -63,6 +63,10 @@ type ServerConfig struct {
 	// by default — operators must opt in by setting Enabled=true.
 	Alerts AlertsConfig `yaml:"alerts,omitempty"`
 
+	// Webhooks configures outbound lifecycle-event delivery (#256). Disabled
+	// by default — operators opt in by setting Enabled=true and a URL.
+	Webhooks WebhooksConfig `yaml:"webhooks,omitempty"`
+
 	// RateLimit configures the per-IP, per-route-group token-bucket
 	// limiter that fronts the Web UI and API (see issue #52). Enabled
 	// by default so login + enrolment endpoints are protected from
@@ -174,24 +178,26 @@ func hostIsPrivate(host string) bool {
 		addr.IsLinkLocalMulticast() || addr.IsUnspecified()
 }
 
-// validateWebhookURL guards the alert webhook against SSRF (#188): the URL must
-// be http/https with a host, and (unless allowPrivate) must not target a
-// private/loopback/link-local address. DNS names are not resolved here — this
-// is the config-load layer; the delivery-time layer (post-resolution dialer
-// guard + per-redirect-hop re-check) lives in the alerts WebhookSink.
-func validateWebhookURL(rawURL string, allowPrivate bool) error {
+// validateWebhookURL guards a webhook URL against SSRF (#188): the URL must be
+// http/https with a host, and (unless allowPrivate) must not target a
+// private/loopback/link-local address. field names the offending config key in
+// errors so both alerts.webhook_url and webhooks.url can reuse it. DNS names are
+// not resolved here — this is the config-load layer; the delivery-time layer
+// (post-resolution dialer guard + per-redirect-hop re-check) lives in the
+// alerts WebhookSink and the webhook.Dispatcher.
+func validateWebhookURL(field, rawURL string, allowPrivate bool) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return fmt.Errorf("alerts.webhook_url: %w", err)
+		return fmt.Errorf("%s: %w", field, err)
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("alerts.webhook_url: scheme must be http or https, got %q", u.Scheme)
+		return fmt.Errorf("%s: scheme must be http or https, got %q", field, u.Scheme)
 	}
 	if u.Hostname() == "" {
-		return fmt.Errorf("alerts.webhook_url: missing host")
+		return fmt.Errorf("%s: missing host", field)
 	}
 	if !allowPrivate && hostIsPrivate(u.Hostname()) {
-		return fmt.Errorf("alerts.webhook_url: %q is a private/loopback/link-local address; set alerts.allow_private_webhook: true for an intentional internal sink", u.Hostname())
+		return fmt.Errorf("%s: %q is a private/loopback/link-local address; allow it explicitly only for an intentional internal sink", field, u.Hostname())
 	}
 	return nil
 }
@@ -276,6 +282,17 @@ type AlertsConfig struct {
 	// SSRF guard (#188); set true for an intentional internal sink (e.g. a
 	// co-located Alertmanager).
 	AllowPrivateWebhook bool `yaml:"allow_private_webhook,omitempty"`
+}
+
+// WebhooksConfig configures the outbound lifecycle-event webhook (#256). The
+// dispatcher signs each delivery (HMACSecret), filters by event type (Events;
+// empty means all), and SSRF-guards the target unless AllowPrivate is set.
+type WebhooksConfig struct {
+	Enabled      bool     `yaml:"enabled,omitempty"`
+	URL          string   `yaml:"url,omitempty"`
+	HMACSecret   string   `yaml:"hmac_secret,omitempty"`
+	AllowPrivate bool     `yaml:"allow_private,omitempty"`
+	Events       []string `yaml:"events,omitempty"`
 }
 
 // IntervalDuration returns Interval as a time.Duration. Falls back to 5m
@@ -461,7 +478,13 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 	}
 
 	if cfg.Alerts.Enabled && cfg.Alerts.WebhookURL != "" {
-		if err := validateWebhookURL(cfg.Alerts.WebhookURL, cfg.Alerts.AllowPrivateWebhook); err != nil {
+		if err := validateWebhookURL("alerts.webhook_url", cfg.Alerts.WebhookURL, cfg.Alerts.AllowPrivateWebhook); err != nil {
+			return nil, err
+		}
+	}
+
+	if cfg.Webhooks.Enabled && cfg.Webhooks.URL != "" {
+		if err := validateWebhookURL("webhooks.url", cfg.Webhooks.URL, cfg.Webhooks.AllowPrivate); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/config/ssrf_validate_test.go
+++ b/internal/config/ssrf_validate_test.go
@@ -29,7 +29,7 @@ func TestValidateWebhookURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateWebhookURL(tt.url, tt.allowPrivate)
+			err := validateWebhookURL("webhooks.url", tt.url, tt.allowPrivate)
 			if tt.wantErr && err == nil {
 				t.Fatalf("validateWebhookURL(%q, %v) = nil, want error", tt.url, tt.allowPrivate)
 			}

--- a/internal/config/webhooks_config_test.go
+++ b/internal/config/webhooks_config_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeAndLoad(t *testing.T, body string) (*ServerConfig, error) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "server.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return LoadServerConfig(path)
+}
+
+func TestWebhooksConfig_Parses(t *testing.T) {
+	cfg, err := writeAndLoad(t, `
+master_key: ""
+webhooks:
+  enabled: true
+  url: https://hooks.example.com/nebula
+  hmac_secret: s3cret
+  events: [host.enrolled, host.blocked]
+`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !cfg.Webhooks.Enabled || cfg.Webhooks.URL != "https://hooks.example.com/nebula" {
+		t.Fatalf("webhooks not parsed: %+v", cfg.Webhooks)
+	}
+	if len(cfg.Webhooks.Events) != 2 || cfg.Webhooks.Events[0] != "host.enrolled" {
+		t.Errorf("events = %v", cfg.Webhooks.Events)
+	}
+}
+
+func TestWebhooksConfig_RejectsPrivateURL(t *testing.T) {
+	_, err := writeAndLoad(t, `
+master_key: ""
+webhooks:
+  enabled: true
+  url: http://127.0.0.1:9000/hook
+`)
+	if err == nil {
+		t.Fatal("expected SSRF rejection of a loopback webhooks.url")
+	}
+}
+
+func TestWebhooksConfig_AllowsPrivateWhenOptedIn(t *testing.T) {
+	cfg, err := writeAndLoad(t, `
+master_key: ""
+webhooks:
+  enabled: true
+  url: http://127.0.0.1:9000/hook
+  allow_private: true
+`)
+	if err != nil {
+		t.Fatalf("load with allow_private: %v", err)
+	}
+	if !cfg.Webhooks.AllowPrivate {
+		t.Error("allow_private not parsed")
+	}
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,291 @@
+// Package webhook delivers lifecycle events (host enrolled/blocked/deleted,
+// cert rotated, cert expiring, …) to an operator-configured HTTP endpoint. It
+// is the unified outbound-event bus: handlers and background scanners publish
+// typed events via Emit; the Dispatcher signs and delivers them asynchronously,
+// off the request path, with bounded retry (#256, phase 1).
+//
+// Deliveries are SSRF-guarded at request time and signed with HMAC-SHA256, the
+// same scheme the cert-expiry alerter already uses. The signing/guard logic
+// mirrors internal/alerts and internal/config.hostIsPrivate and must stay in
+// sync with them.
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// HTTP headers attached to every delivery. Receivers authenticate the body via
+// SignatureHeader and deduplicate on DeliveryHeader.
+const (
+	EventHeader     = "X-Nebula-Event"
+	DeliveryHeader  = "X-Nebula-Delivery"
+	SignatureHeader = "X-Nebula-Signature"
+)
+
+// Event is the envelope POSTed to the subscriber. Data carries the
+// event-type-specific payload.
+type Event struct {
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	CreatedAt time.Time      `json:"created_at"`
+	Data      map[string]any `json:"data"`
+}
+
+// Emitter is the narrow interface handlers depend on so they need not know
+// about delivery. *Dispatcher implements it; a nil *Dispatcher Emit is a no-op,
+// so callers can hold an optional emitter without nil checks at every call site.
+type Emitter interface {
+	Emit(eventType string, data map[string]any)
+}
+
+// Config configures a Dispatcher. Only URL is required.
+type Config struct {
+	URL          string
+	HMACSecret   string
+	AllowPrivate bool     // permit private/loopback targets (disables the SSRF guard)
+	Events       []string // delivered event types; empty means all
+
+	// Tunables — zero values fall back to the defaults below.
+	QueueSize    int
+	MaxRetries   int
+	RetryBackoff time.Duration
+	DeliveryTO   time.Duration
+
+	// Test seams.
+	HTTPClient *http.Client     // nil => an SSRF-guarded client
+	Now        func() time.Time // nil => time.Now
+	NewID      func() string    // nil => "evt_"+uuid
+}
+
+const (
+	defaultQueueSize    = 256
+	defaultMaxRetries   = 4
+	defaultRetryBackoff = 2 * time.Second
+	defaultDeliveryTO   = 10 * time.Second
+)
+
+// Dispatcher signs and delivers events asynchronously. Construct with New,
+// publish with Emit, and Close on shutdown to drain in-flight deliveries.
+type Dispatcher struct {
+	cfg     Config
+	logger  *slog.Logger
+	allowed map[string]bool // nil => all event types
+	queue   chan Event
+	client  *http.Client
+	now     func() time.Time
+	newID   func() string
+
+	wg     sync.WaitGroup
+	closed atomic.Bool
+	done   chan struct{}
+}
+
+// New starts a Dispatcher and its delivery worker. The worker runs until Close.
+func New(cfg Config, logger *slog.Logger) *Dispatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = defaultQueueSize
+	}
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = defaultMaxRetries
+	}
+	if cfg.RetryBackoff <= 0 {
+		cfg.RetryBackoff = defaultRetryBackoff
+	}
+	if cfg.DeliveryTO <= 0 {
+		cfg.DeliveryTO = defaultDeliveryTO
+	}
+	d := &Dispatcher{
+		cfg:    cfg,
+		logger: logger,
+		queue:  make(chan Event, cfg.QueueSize),
+		client: cfg.HTTPClient,
+		now:    cfg.Now,
+		newID:  cfg.NewID,
+		done:   make(chan struct{}),
+	}
+	if d.client == nil {
+		d.client = newGuardedClient(cfg.AllowPrivate, cfg.DeliveryTO)
+	}
+	if d.now == nil {
+		d.now = time.Now
+	}
+	if d.newID == nil {
+		d.newID = func() string { return "evt_" + uuid.NewString() }
+	}
+	if len(cfg.Events) > 0 {
+		d.allowed = make(map[string]bool, len(cfg.Events))
+		for _, e := range cfg.Events {
+			d.allowed[e] = true
+		}
+	}
+	d.wg.Add(1)
+	go d.run()
+	return d
+}
+
+// Emit enqueues an event for delivery. It never blocks the caller: events for
+// unsubscribed types are dropped silently, and a full queue drops the event
+// with a logged warning rather than stalling the request path. A nil Dispatcher
+// (webhooks disabled) is a no-op.
+func (d *Dispatcher) Emit(eventType string, data map[string]any) {
+	if d == nil || d.closed.Load() {
+		return
+	}
+	if d.allowed != nil && !d.allowed[eventType] {
+		return
+	}
+	ev := Event{
+		ID:        d.newID(),
+		Type:      eventType,
+		CreatedAt: d.now().UTC(),
+		Data:      data,
+	}
+	select {
+	case d.queue <- ev:
+	default:
+		d.logger.Warn("webhook queue full, dropping event", "type", eventType, "id", ev.ID)
+	}
+}
+
+// Close stops accepting events and waits for the worker to drain what is
+// already queued. Safe to call once; later calls are no-ops.
+func (d *Dispatcher) Close() {
+	if d == nil {
+		return
+	}
+	if d.closed.CompareAndSwap(false, true) {
+		close(d.queue)
+	}
+	d.wg.Wait()
+}
+
+func (d *Dispatcher) run() {
+	defer d.wg.Done()
+	for ev := range d.queue {
+		d.deliverWithRetry(ev)
+	}
+}
+
+// deliverWithRetry attempts delivery up to MaxRetries+1 times with linear
+// backoff, aborting early if Close is signaled. A permanent failure is logged
+// (a dead-letter store is phase 2).
+func (d *Dispatcher) deliverWithRetry(ev Event) {
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		d.logger.Error("marshal webhook event", "type", ev.Type, "error", err)
+		return
+	}
+	for attempt := 0; attempt <= d.cfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(d.cfg.RetryBackoff * time.Duration(attempt)):
+			case <-d.done:
+				return
+			}
+		}
+		err := d.deliver(payload, ev.Type, ev.ID)
+		if err == nil {
+			return
+		}
+		d.logger.Warn("webhook delivery failed",
+			"type", ev.Type, "id", ev.ID, "attempt", attempt+1, "error", err)
+	}
+	d.logger.Error("webhook delivery exhausted retries", "type", ev.Type, "id", ev.ID)
+}
+
+func (d *Dispatcher) deliver(payload []byte, eventType, id string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), d.cfg.DeliveryTO)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.cfg.URL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(EventHeader, eventType)
+	req.Header.Set(DeliveryHeader, id)
+	if d.cfg.HMACSecret != "" {
+		mac := hmac.New(sha256.New, []byte(d.cfg.HMACSecret))
+		mac.Write(payload)
+		req.Header.Set(SignatureHeader, "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	}
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("endpoint returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// --- SSRF guard (mirrors internal/alerts.isBlockedWebhookAddr / config.hostIsPrivate) ---
+
+var errPrivateWebhookAddr = errors.New("webhook delivery to private/loopback/link-local address blocked (SSRF guard); set webhooks.allow_private: true for an intentional internal sink")
+
+func isBlockedAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return addr.IsLoopback() || addr.IsPrivate() || addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() || addr.IsUnspecified()
+}
+
+// newGuardedClient builds the delivery client. With the guard active the
+// address check runs in the dialer's Control hook — after DNS resolution, on
+// the literal IP — so DNS-rebinding and each redirect hop are both caught.
+func newGuardedClient(allowPrivate bool, timeout time.Duration) *http.Client {
+	if allowPrivate {
+		return &http.Client{Timeout: timeout}
+	}
+	dialer := &net.Dialer{
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("webhook dial %q: %w", address, err)
+			}
+			addr, err := netip.ParseAddr(host)
+			if err != nil {
+				return fmt.Errorf("webhook dial %q: %w", address, err)
+			}
+			if isBlockedAddr(addr) {
+				return errPrivateWebhookAddr
+			}
+			return nil
+		},
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{DialContext: dialer.DialContext},
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("webhook: too many redirects")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,0 +1,173 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type received struct {
+	body     []byte
+	event    string
+	delivery string
+	sig      string
+}
+
+// recvServer returns an httptest server that pushes each received request onto
+// ch and replies with status.
+func recvServer(t *testing.T, ch chan received, status int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		ch <- received{b, r.Header.Get(EventHeader), r.Header.Get(DeliveryHeader), r.Header.Get(SignatureHeader)}
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func waitRecv(t *testing.T, ch chan received) received {
+	t.Helper()
+	select {
+	case r := <-ch:
+		return r
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook delivery")
+		return received{}
+	}
+}
+
+func expectNoRecv(t *testing.T, ch chan received) {
+	t.Helper()
+	select {
+	case r := <-ch:
+		t.Fatalf("unexpected webhook delivery: event=%s body=%s", r.event, r.body)
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+func TestDispatcher_DeliversSignedEnvelope(t *testing.T) {
+	ch := make(chan received, 4)
+	srv := recvServer(t, ch, http.StatusOK)
+
+	d := New(Config{
+		URL:          srv.URL,
+		HMACSecret:   "s3cret",
+		AllowPrivate: true, // httptest listens on loopback
+		Now:          func() time.Time { return time.Unix(1_700_000_000, 0) },
+		NewID:        func() string { return "evt_fixed" },
+	}, testLogger())
+	defer d.Close()
+
+	d.Emit("host.enrolled", map[string]any{"host_id": "h1", "network_id": "n1"})
+	got := waitRecv(t, ch)
+
+	if got.event != "host.enrolled" {
+		t.Errorf("%s header = %q, want host.enrolled", EventHeader, got.event)
+	}
+	if got.delivery != "evt_fixed" {
+		t.Errorf("%s header = %q, want evt_fixed", DeliveryHeader, got.delivery)
+	}
+	mac := hmac.New(sha256.New, []byte("s3cret"))
+	mac.Write(got.body)
+	wantSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if got.sig != wantSig {
+		t.Errorf("signature = %q, want %q", got.sig, wantSig)
+	}
+
+	var ev Event
+	if err := json.Unmarshal(got.body, &ev); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if ev.ID != "evt_fixed" || ev.Type != "host.enrolled" {
+		t.Errorf("envelope id/type = %s/%s", ev.ID, ev.Type)
+	}
+	if !ev.CreatedAt.Equal(time.Unix(1_700_000_000, 0).UTC()) {
+		t.Errorf("created_at = %s", ev.CreatedAt)
+	}
+	if ev.Data["host_id"] != "h1" {
+		t.Errorf("data.host_id = %v, want h1", ev.Data["host_id"])
+	}
+}
+
+func TestDispatcher_FiltersByEventType(t *testing.T) {
+	ch := make(chan received, 4)
+	srv := recvServer(t, ch, http.StatusOK)
+
+	d := New(Config{
+		URL:          srv.URL,
+		AllowPrivate: true,
+		Events:       []string{"host.blocked"},
+	}, testLogger())
+	defer d.Close()
+
+	d.Emit("host.enrolled", map[string]any{"host_id": "h1"}) // not subscribed
+	expectNoRecv(t, ch)
+
+	d.Emit("host.blocked", map[string]any{"host_id": "h1"}) // subscribed
+	if got := waitRecv(t, ch); got.event != "host.blocked" {
+		t.Errorf("delivered %q, want host.blocked", got.event)
+	}
+}
+
+func TestDispatcher_RetriesUntilSuccess(t *testing.T) {
+	ch := make(chan received, 8)
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		n := hits.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		ch <- received{body: b, event: r.Header.Get(EventHeader)}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := New(Config{
+		URL:          srv.URL,
+		AllowPrivate: true,
+		RetryBackoff: 10 * time.Millisecond,
+		MaxRetries:   5,
+	}, testLogger())
+	defer d.Close()
+
+	d.Emit("cert.rotated", map[string]any{"host_id": "h1"})
+	if got := waitRecv(t, ch); got.event != "cert.rotated" {
+		t.Errorf("delivered %q after retries, want cert.rotated", got.event)
+	}
+	if n := hits.Load(); n < 3 {
+		t.Errorf("server saw %d attempts, want >= 3 (two failures then success)", n)
+	}
+}
+
+func TestDispatcher_SSRFGuardBlocksLoopback(t *testing.T) {
+	ch := make(chan received, 4)
+	srv := recvServer(t, ch, http.StatusOK) // listens on 127.0.0.1
+
+	// AllowPrivate false → the guarded dialer must refuse the loopback target,
+	// so no retry ever reaches the server.
+	d := New(Config{
+		URL:          srv.URL,
+		AllowPrivate: false,
+		RetryBackoff: 10 * time.Millisecond,
+		MaxRetries:   2,
+	}, testLogger())
+	defer d.Close()
+
+	d.Emit("host.enrolled", map[string]any{"host_id": "h1"})
+	expectNoRecv(t, ch)
+}


### PR DESCRIPTION
Implements **phase 1** of #256. Generalizes outbound webhook delivery into a unified lifecycle-event bus: handlers publish typed events; a dispatcher signs and delivers them asynchronously, off the request path, with bounded retry and an SSRF guard — the same posture as the existing cert-expiry alerter, now shared.

## What's here

- **`internal/webhook`** — `Event{id,type,created_at,data}` envelope + `Dispatcher`: async queue, linear-backoff retry, HMAC-SHA256 signing, `X-Nebula-Event`/`X-Nebula-Delivery`/`X-Nebula-Signature` headers, request-time SSRF guard, event-type allowlist, graceful `Close`. `Emit` is non-blocking and nil-safe.
- **config** — a `webhooks:` block (`enabled`/`url`/`hmac_secret`/`allow_private`/`events`); `url` SSRF-validated at load. `validateWebhookURL` generalized so alerts and webhooks share it.
- **`api.Server`** — a narrow `EventEmitter` seam (keeps the api package free of a webhook import) + nil-safe `emit`. Handlers emit:
  - `host.enrolled` (enroll), `host.blocked`/`host.unblocked` (block/unblock), `host.deleted` (delete), `cert.rotated` (in-place re-sign).
- **serve.go** — builds the dispatcher when enabled, injects it, drains it on shutdown, and folds `cert.expiring` into the bus via an adapter sink on the cert-expiry scanner.
- **`api/openapi.yaml`** — a 3.1 `webhooks:` block documenting the six events.
- **`docs/webhooks.md`** — config, signature verification, delivery semantics.

## Tests

- `internal/webhook`: signed-envelope delivery, event-type filtering, retry-until-success, SSRF guard blocks loopback.
- `internal/config`: webhooks parse + SSRF rejection + allow-private opt-in.
- `internal/api`: handler-emit assertions (`host.blocked`/`unblocked`/`enrolled`) **and** a webhook contract test that drives the real handlers and validates every emitted payload against the spec's webhook schemas — drift breaks the build.

`go test -race`, `make gosec`, `make govulncheck`, `make lint` all green.

## Deferred (still tracked in #256)

Managed subscriptions (multiple endpoints / CRUD / per-subscription status), `ca.expiring` and other CA-lifecycle events, and a durable dead-letter queue.

Refs #256
