### PR TITLE
feat(webhooks): managed webhook subscriptions (phase 2)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -198,6 +198,86 @@ paths:
                 items:
                   $ref: "#/components/schemas/AuditEntry"
 
+  /api/v1/webhook-subscriptions:
+    get:
+      operationId: listWebhookSubscriptions
+      summary: List webhook subscriptions visible to the operator.
+      responses:
+        "200":
+          description: Subscriptions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WebhookSubscription"
+    post:
+      operationId: createWebhookSubscription
+      summary: Create a webhook subscription.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookSubscriptionRequest"
+      responses:
+        "201":
+          description: Created subscription.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookSubscription"
+        "400":
+          $ref: "#/components/responses/Error"
+
+  /api/v1/webhook-subscriptions/{id}:
+    get:
+      operationId: getWebhookSubscription
+      summary: Get a webhook subscription by id.
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: Subscription.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookSubscription"
+        "404":
+          $ref: "#/components/responses/Error"
+    patch:
+      operationId: updateWebhookSubscription
+      summary: Update a webhook subscription.
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookSubscriptionRequest"
+      responses:
+        "200":
+          description: Updated subscription.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookSubscription"
+        "400":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+    delete:
+      operationId: deleteWebhookSubscription
+      summary: Delete a webhook subscription.
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      responses:
+        "204":
+          description: Deleted.
+        "404":
+          $ref: "#/components/responses/Error"
+
 # Outbound webhooks the server POSTs to an operator-configured endpoint (#256).
 # Each delivery carries X-Nebula-Event (type), X-Nebula-Delivery (id), and
 # X-Nebula-Signature (sha256=<hmac> over the raw body). The handler/scanner emit
@@ -604,3 +684,59 @@ components:
           format: date-time
         data:
           $ref: "#/components/schemas/CertExpiringData"
+
+    # --- Managed webhook subscriptions (#256 phase 2) ---
+
+    WebhookSubscriptionRequest:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+        events:
+          type: ["array", "null"]
+          items:
+            type: string
+        active:
+          type: boolean
+        allow_private:
+          type: boolean
+        secret:
+          type: string
+          description: Write-only HMAC secret. Omit to keep, "" to clear, value to set.
+
+    WebhookSubscription:
+      type: object
+      required: [id, owner_operator_id, url, active, allow_private, has_secret, consecutive_failures, created_at, updated_at]
+      properties:
+        id:
+          type: string
+        owner_operator_id:
+          type: string
+        url:
+          type: string
+        events:
+          type: ["array", "null"]
+          items:
+            type: string
+        active:
+          type: boolean
+        allow_private:
+          type: boolean
+        has_secret:
+          type: boolean
+        last_delivery_at:
+          type: string
+          format: date-time
+        last_status:
+          type: string
+        last_error:
+          type: string
+        consecutive_failures:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -24,7 +24,52 @@ webhooks:
 `url` is validated at startup (must be http/https; loopback/private/link-local
 targets are rejected unless `allow_private: true`).
 
-## Events (phase 1)
+The config webhook is a single static target. For multiple endpoints, runtime
+management, and per-endpoint delivery status, use **managed subscriptions**
+below — both are delivered through the same bus.
+
+## Managed subscriptions
+
+Subscriptions are operator-owned rows managed through the REST API; they need no
+config and take effect immediately (no restart). Each is one delivery target
+with its own URL, event filter, signing secret, and delivery status.
+
+```
+GET    /api/v1/webhook-subscriptions          # list (admin: all; operator: own)
+POST   /api/v1/webhook-subscriptions          # create
+GET    /api/v1/webhook-subscriptions/{id}     # get
+PATCH  /api/v1/webhook-subscriptions/{id}     # update
+DELETE /api/v1/webhook-subscriptions/{id}     # delete
+```
+
+Create body (all but `url` optional):
+
+```json
+{
+  "url": "https://hooks.example.com/team-a",
+  "events": ["host.enrolled", "cert.expiring"],
+  "active": true,
+  "allow_private": false,
+  "secret": "<hmac secret>"
+}
+```
+
+- `events` empty/omitted means all events.
+- `secret` is **write-only**: it is stored envelope-encrypted under
+  `NEBULA_MGMT_MASTER_KEY` (the same scheme as CA keys) and never returned.
+  Responses expose only `has_secret`. On update, omit `secret` to keep it, send
+  `""` to clear it, or a new value to replace it. A non-empty secret requires
+  the master key to be configured.
+- `url` is SSRF-validated like the config webhook; `allow_private: true` opts a
+  private/loopback target in.
+
+Each subscription tracks `last_delivery_at`, `last_status` (`ok`/`failed`),
+`last_error`, and `consecutive_failures` for observability.
+
+## Events
+
+| Event | Fires when | `data` fields |
+|---|---|---|
 
 | Event | Fires when | `data` fields |
 |---|---|---|
@@ -76,9 +121,8 @@ Reject deliveries that do not match.
   as a notification stream, not a system of record — the audit log remains the
   authoritative history.
 
-## Not in phase 1
+## Not yet
 
-- Managed subscriptions (multiple endpoints, CRUD, per-subscription status) —
-  phase 1 is a single config-driven subscription.
+- A Web UI for managing subscriptions (the REST API exists today).
 - `ca.expiring` and other CA-lifecycle events.
 - A persistent dead-letter queue and delivery dashboards.

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -72,6 +72,9 @@ const (
 	auditOperatorAPIKeyCreate      = "operator.api_key.create"
 	auditOperatorAPIKeyRevoke      = "operator.api_key.revoke"
 	auditSettingsEnforce2FA        = "settings.enforce_2fa"
+	auditWebhookSubCreate          = "webhook_subscription.create"
+	auditWebhookSubUpdate          = "webhook_subscription.update"
+	auditWebhookSubDelete          = "webhook_subscription.delete"
 )
 
 // Audit reason codes used in the `details` field of host.auth.failed audit
@@ -197,6 +200,7 @@ func newMetrics(s store.Store) *metrics {
 		auditOperatorCreate, auditOperatorDisable, auditOperatorEnable,
 		auditOperatorAPIKeyCreate, auditOperatorAPIKeyRevoke,
 		auditSettingsEnforce2FA,
+		auditWebhookSubCreate, auditWebhookSubUpdate, auditWebhookSubDelete,
 	} {
 		m.auditEntries.WithLabelValues(action).Add(0)
 	}

--- a/internal/api/scoping_property_test.go
+++ b/internal/api/scoping_property_test.go
@@ -63,9 +63,10 @@ var protectedGETScoping = map[string]listScoping{
 	"/api/v1/agent/updates": publicRoute, // agent poll, signed-poll auth — not operator bearer
 
 	// Collection reads — must scope non-admins to owned CAs.
-	"/api/v1/networks": scopedToOwner,
-	"/api/v1/hosts":    scopedToOwner,
-	"/api/v1/cas":      scopedToOwner,
+	"/api/v1/networks":              scopedToOwner,
+	"/api/v1/hosts":                 scopedToOwner,
+	"/api/v1/cas":                   scopedToOwner,
+	"/api/v1/webhook-subscriptions": scopedToOwner,
 
 	// Admin-only reads — non-admin gets 403, no tenant data in the body.
 	"/api/v1/operators":               adminOnly,
@@ -75,10 +76,11 @@ var protectedGETScoping = map[string]listScoping{
 	"/api/v1/settings":                adminOnly,
 
 	// Single-resource reads — guarded per-row by canAccess*.
-	"/api/v1/networks/{id}":          singleResource,
-	"/api/v1/networks/{id}/firewall": singleResource,
-	"/api/v1/hosts/{id}":             singleResource,
-	"/api/v1/cas/{id}":               singleResource,
+	"/api/v1/networks/{id}":              singleResource,
+	"/api/v1/networks/{id}/firewall":     singleResource,
+	"/api/v1/hosts/{id}":                 singleResource,
+	"/api/v1/cas/{id}":                   singleResource,
+	"/api/v1/webhook-subscriptions/{id}": singleResource,
 }
 
 // TestProtectedGETRoutesAreClassified fails the moment setupRoutes registers
@@ -116,12 +118,16 @@ func TestProtectedGETRoutesAreClassified(t *testing.T) {
 func TestListEndpointsScopeToOwner(t *testing.T) {
 	srv, st := newTestServer(t)
 
-	keyA, _, caA := createOperatorWithCA(t, srv)
-	keyB, _, caB := createOperatorWithCA(t, srv)
+	keyA, opA, caA := createOperatorWithCA(t, srv)
+	keyB, opB, caB := createOperatorWithCA(t, srv)
 	// Distinct CIDRs/IPs so the seed is robust to any nebula_ip uniqueness
 	// scheme; ownership is what the test cares about, not addressing.
 	seedNetworkAndHost(t, st, caA.ID, "a", "10.10.0.0/24", "10.10.0.10")
 	seedNetworkAndHost(t, st, caB.ID, "b", "10.20.0.0/24", "10.20.0.10")
+	// Webhook subscriptions carry no ca_id, so embed the owner's CA id in the
+	// URL to satisfy the generic owner-leak assertions below.
+	seedWebhookSub(t, st, opA.ID, "https://example.com/"+caA.ID)
+	seedWebhookSub(t, st, opB.ID, "https://example.com/"+caB.ID)
 
 	for route, scoping := range protectedGETScoping {
 		switch scoping {
@@ -176,6 +182,20 @@ func authedGET(srv *Server, route, key string) (int, string) {
 // {kid} sub-key param, so {id} is the only substitution needed.
 func concretePath(route string) string {
 	return strings.ReplaceAll(route, "{id}", "test-admin")
+}
+
+// seedWebhookSub inserts a webhook subscription owned by ownerID directly via
+// the store, bypassing the create handler's owner derivation so cross-operator
+// fixtures can be set up.
+func seedWebhookSub(t *testing.T, st *store.SQLiteStore, ownerID, url string) {
+	t.Helper()
+	require.NoError(t, st.CreateWebhookSubscription(context.Background(), &models.WebhookSubscription{
+		ID:              uuid.New().String(),
+		OwnerOperatorID: ownerID,
+		URL:             url,
+		Active:          true,
+		CreatedAt:       time.Now(),
+	}))
 }
 
 // seedNetworkAndHost inserts a network and a host bound to caID directly via

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -239,6 +239,12 @@ func (s *Server) setupRoutes() {
 		r.Post("/api/v1/cas/{id}/rotate", s.handleRotateCA)
 		r.Get("/api/v1/settings", s.handleGetSettings)
 		r.Patch("/api/v1/settings", s.handlePatchSettings)
+
+		r.Get("/api/v1/webhook-subscriptions", s.handleListWebhookSubscriptions)
+		r.Post("/api/v1/webhook-subscriptions", s.handleCreateWebhookSubscription)
+		r.Get("/api/v1/webhook-subscriptions/{id}", s.handleGetWebhookSubscription)
+		r.Patch("/api/v1/webhook-subscriptions/{id}", s.handleUpdateWebhookSubscription)
+		r.Delete("/api/v1/webhook-subscriptions/{id}", s.handleDeleteWebhookSubscription)
 	})
 
 	s.router = r

--- a/internal/api/webhook_subs_contract_test.go
+++ b/internal/api/webhook_subs_contract_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestContract_WebhookSubscriptions validates the CRUD responses against the
+// OpenAPI spec, so the managed-subscription API cannot drift from its contract.
+func TestContract_WebhookSubscriptions(t *testing.T) {
+	v := loadContract(t)
+	srv, _ := newTestServer(t)
+
+	// Create.
+	body := `{"url":"https://hooks.example.com/c","events":["host.enrolled","cert.rotated"],"secret":"s3cret"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhook-subscriptions", bytes.NewBufferString(body))
+	authRequest(req)
+	rec := serve(srv, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: %d / %s", rec.Code, rec.Body.String())
+	}
+	assertContract(t, v, req, rec)
+	var sub struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &sub)
+
+	// List.
+	lreq := httptest.NewRequest(http.MethodGet, "/api/v1/webhook-subscriptions", nil)
+	authRequest(lreq)
+	assertContract(t, v, lreq, serve(srv, lreq))
+
+	// Get.
+	greq := httptest.NewRequest(http.MethodGet, "/api/v1/webhook-subscriptions/"+sub.ID, nil)
+	authRequest(greq)
+	assertContract(t, v, greq, serve(srv, greq))
+
+	// Update.
+	ureq := httptest.NewRequest(http.MethodPatch, "/api/v1/webhook-subscriptions/"+sub.ID,
+		bytes.NewBufferString(`{"url":"https://hooks.example.com/d","active":false}`))
+	authRequest(ureq)
+	urec := serve(srv, ureq)
+	if urec.Code != http.StatusOK {
+		t.Fatalf("update: %d / %s", urec.Code, urec.Body.String())
+	}
+	assertContract(t, v, ureq, urec)
+}

--- a/internal/api/webhooks.go
+++ b/internal/api/webhooks.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/forgekeep/nebula-mesh/internal/config"
+	"github.com/forgekeep/nebula-mesh/internal/keystore"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// webhookSubRequest is the create/update body. Secret is write-only: on create
+// a non-empty value enables signing; on update nil keeps the existing secret,
+// "" clears it, and a value replaces it. Active is a pointer so update can omit
+// it to keep the current state (create defaults to true).
+type webhookSubRequest struct {
+	URL          string   `json:"url"`
+	Events       []string `json:"events,omitempty"`
+	Active       *bool    `json:"active,omitempty"`
+	AllowPrivate bool     `json:"allow_private,omitempty"`
+	Secret       *string  `json:"secret,omitempty"`
+}
+
+func (s *Server) canAccessWebhookSub(r *http.Request, sub *models.WebhookSubscription) bool {
+	if s.isActiveAdmin(r.Context()) {
+		return true
+	}
+	return ActorOf(r.Context()).ID == sub.OwnerOperatorID
+}
+
+// handleListWebhookSubscriptions lists subscriptions visible to the actor.
+func (s *Server) handleListWebhookSubscriptions(w http.ResponseWriter, r *http.Request) {
+	var (
+		subs []*models.WebhookSubscription
+		err  error
+	)
+	if s.isActiveAdmin(r.Context()) {
+		subs, err = s.store.ListWebhookSubscriptions(r.Context())
+	} else {
+		subs, err = s.store.ListWebhookSubscriptionsByOwner(r.Context(), ActorOf(r.Context()).ID)
+	}
+	if err != nil {
+		s.logger.Error("list webhook subscriptions", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list webhook subscriptions")
+		return
+	}
+	if subs == nil {
+		subs = []*models.WebhookSubscription{}
+	}
+	writeJSON(w, http.StatusOK, subs)
+}
+
+func (s *Server) handleGetWebhookSubscription(w http.ResponseWriter, r *http.Request) {
+	sub, ok := s.loadOwnedWebhookSub(w, r)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, sub)
+}
+
+func (s *Server) handleCreateWebhookSubscription(w http.ResponseWriter, r *http.Request) {
+	var req webhookSubRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := config.ValidateWebhookURL("url", req.URL, req.AllowPrivate); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Secret != nil && *req.Secret != "" && s.master == nil {
+		writeError(w, http.StatusServiceUnavailable, "signing a webhook requires NEBULA_MGMT_MASTER_KEY to be configured")
+		return
+	}
+
+	now := time.Now()
+	sub := &models.WebhookSubscription{
+		ID:              uuid.New().String(),
+		OwnerOperatorID: ActorOf(r.Context()).ID,
+		URL:             req.URL,
+		Events:          req.Events,
+		Active:          req.Active == nil || *req.Active,
+		AllowPrivate:    req.AllowPrivate,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if req.Secret != nil && *req.Secret != "" {
+		if err := s.sealWebhookSecret(sub, *req.Secret); err != nil {
+			s.logger.Error("seal webhook secret", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to encrypt webhook secret")
+			return
+		}
+	}
+	if err := s.store.CreateWebhookSubscription(r.Context(), sub); err != nil {
+		s.logger.Error("create webhook subscription", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create webhook subscription")
+		return
+	}
+	sub.HasSecret = len(sub.EncryptedSecret) > 0
+	s.recordAuditAction(r.Context(), auditWebhookSubCreate, sub.ID, sub.URL)
+	writeJSON(w, http.StatusCreated, sub)
+}
+
+func (s *Server) handleUpdateWebhookSubscription(w http.ResponseWriter, r *http.Request) {
+	sub, ok := s.loadOwnedWebhookSub(w, r)
+	if !ok {
+		return
+	}
+	var req webhookSubRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.URL == "" {
+		req.URL = sub.URL
+	}
+	if err := config.ValidateWebhookURL("url", req.URL, req.AllowPrivate); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	sub.URL = req.URL
+	sub.Events = req.Events
+	sub.AllowPrivate = req.AllowPrivate
+	if req.Active != nil {
+		sub.Active = *req.Active
+	}
+	switch {
+	case req.Secret == nil: // keep existing secret
+	case *req.Secret == "": // clear secret
+		sub.EncryptedSecretDEK, sub.NonceDEK, sub.EncryptedSecret, sub.NonceSecret = nil, nil, nil, nil
+	default: // replace secret
+		if s.master == nil {
+			writeError(w, http.StatusServiceUnavailable, "signing a webhook requires NEBULA_MGMT_MASTER_KEY to be configured")
+			return
+		}
+		if err := s.sealWebhookSecret(sub, *req.Secret); err != nil {
+			s.logger.Error("seal webhook secret", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to encrypt webhook secret")
+			return
+		}
+	}
+	if err := s.store.UpdateWebhookSubscription(r.Context(), sub); err != nil {
+		s.logger.Error("update webhook subscription", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to update webhook subscription")
+		return
+	}
+	sub.HasSecret = len(sub.EncryptedSecret) > 0
+	s.recordAuditAction(r.Context(), auditWebhookSubUpdate, sub.ID, sub.URL)
+	writeJSON(w, http.StatusOK, sub)
+}
+
+func (s *Server) handleDeleteWebhookSubscription(w http.ResponseWriter, r *http.Request) {
+	sub, ok := s.loadOwnedWebhookSub(w, r)
+	if !ok {
+		return
+	}
+	if err := s.store.DeleteWebhookSubscription(r.Context(), sub.ID); err != nil {
+		s.logger.Error("delete webhook subscription", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete webhook subscription")
+		return
+	}
+	s.recordAuditAction(r.Context(), auditWebhookSubDelete, sub.ID, "")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// loadOwnedWebhookSub loads the {id} subscription and enforces ownership,
+// writing the error response and returning ok=false on any failure.
+func (s *Server) loadOwnedWebhookSub(w http.ResponseWriter, r *http.Request) (*models.WebhookSubscription, bool) {
+	id := chi.URLParam(r, "id")
+	sub, err := s.store.GetWebhookSubscription(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "webhook subscription not found")
+		return nil, false
+	}
+	if err != nil {
+		s.logger.Error("get webhook subscription", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load webhook subscription")
+		return nil, false
+	}
+	if !s.canAccessWebhookSub(r, sub) {
+		writeError(w, http.StatusForbidden, "you do not own this webhook subscription")
+		return nil, false
+	}
+	return sub, true
+}
+
+// sealWebhookSecret envelope-encrypts the secret under the master key, binding
+// the subscription id as AAD (mirrors the CA key envelope).
+func (s *Server) sealWebhookSecret(sub *models.WebhookSubscription, secret string) error {
+	plaintext := []byte(secret)
+	defer keystore.Zeroize(plaintext)
+	dek, wrappedDEK, err := s.master.GenerateDEK([]byte(sub.ID))
+	if err != nil {
+		return err
+	}
+	defer keystore.Zeroize(dek)
+	blob, err := keystore.SealWithDEK(dek, plaintext, []byte(sub.ID))
+	if err != nil {
+		return err
+	}
+	sub.EncryptedSecretDEK = wrappedDEK.Ciphertext
+	sub.NonceDEK = wrappedDEK.Nonce
+	sub.EncryptedSecret = blob.Ciphertext
+	sub.NonceSecret = blob.Nonce
+	return nil
+}

--- a/internal/api/webhooks_test.go
+++ b/internal/api/webhooks_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+func createWebhookSub(t *testing.T, srv *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhook-subscriptions", bytes.NewBufferString(body))
+	authRequest(req)
+	return serve(srv, req)
+}
+
+func TestWebhookSubscriptions_CRUD(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	// Create with a signing secret.
+	rec := createWebhookSub(t, srv, `{"url":"https://hooks.example.com/a","events":["host.enrolled"],"secret":"s3cret"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: %d / %s", rec.Code, rec.Body.String())
+	}
+	// The secret must never echo back, but HasSecret must be true.
+	var raw map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &raw)
+	if _, leaked := raw["secret"]; leaked {
+		t.Error("response leaked the secret")
+	}
+	if hs, _ := raw["has_secret"].(bool); !hs {
+		t.Errorf("has_secret = %v, want true", raw["has_secret"])
+	}
+	var sub models.WebhookSubscription
+	_ = json.Unmarshal(rec.Body.Bytes(), &sub)
+	if sub.ID == "" || !sub.Active {
+		t.Fatalf("unexpected created sub: %+v", sub)
+	}
+
+	// List includes it.
+	lreq := httptest.NewRequest(http.MethodGet, "/api/v1/webhook-subscriptions", nil)
+	authRequest(lreq)
+	lrec := serve(srv, lreq)
+	var list []models.WebhookSubscription
+	_ = json.Unmarshal(lrec.Body.Bytes(), &list)
+	if len(list) != 1 || list[0].ID != sub.ID {
+		t.Fatalf("list = %+v", list)
+	}
+
+	// Get.
+	greq := httptest.NewRequest(http.MethodGet, "/api/v1/webhook-subscriptions/"+sub.ID, nil)
+	authRequest(greq)
+	if grec := serve(srv, greq); grec.Code != http.StatusOK {
+		t.Fatalf("get: %d", grec.Code)
+	}
+
+	// Update: clear the secret and deactivate.
+	ureq := httptest.NewRequest(http.MethodPatch, "/api/v1/webhook-subscriptions/"+sub.ID,
+		bytes.NewBufferString(`{"url":"https://hooks.example.com/b","active":false,"secret":""}`))
+	authRequest(ureq)
+	urec := serve(srv, ureq)
+	if urec.Code != http.StatusOK {
+		t.Fatalf("update: %d / %s", urec.Code, urec.Body.String())
+	}
+	var updated models.WebhookSubscription
+	_ = json.Unmarshal(urec.Body.Bytes(), &updated)
+	if updated.URL != "https://hooks.example.com/b" || updated.Active || updated.HasSecret {
+		t.Errorf("update not applied: %+v", updated)
+	}
+
+	// Delete.
+	dreq := httptest.NewRequest(http.MethodDelete, "/api/v1/webhook-subscriptions/"+sub.ID, nil)
+	authRequest(dreq)
+	if drec := serve(srv, dreq); drec.Code != http.StatusNoContent {
+		t.Fatalf("delete: %d", drec.Code)
+	}
+	greq2 := httptest.NewRequest(http.MethodGet, "/api/v1/webhook-subscriptions/"+sub.ID, nil)
+	authRequest(greq2)
+	if grec2 := serve(srv, greq2); grec2.Code != http.StatusNotFound {
+		t.Errorf("get after delete: %d, want 404", grec2.Code)
+	}
+}
+
+func TestWebhookSubscriptions_RejectsPrivateURL(t *testing.T) {
+	srv, _ := newTestServer(t)
+	rec := createWebhookSub(t, srv, `{"url":"http://127.0.0.1:9000/hook"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("create with loopback url: %d, want 400", rec.Code)
+	}
+	// allow_private opts in.
+	rec2 := createWebhookSub(t, srv, `{"url":"http://127.0.0.1:9000/hook","allow_private":true}`)
+	if rec2.Code != http.StatusCreated {
+		t.Fatalf("create with allow_private: %d / %s", rec2.Code, rec2.Body.String())
+	}
+}
+
+func TestWebhookSubscriptions_GetNotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/webhook-subscriptions/missing", nil)
+	authRequest(req)
+	if rec := serve(srv, req); rec.Code != http.StatusNotFound {
+		t.Errorf("get missing: %d, want 404", rec.Code)
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -143,18 +143,21 @@ func Serve(configPath string, insecureHTTP bool) error {
 	// host.enrolled/blocked/unblocked/deleted and cert.rotated through the
 	// dispatcher; cert.expiring is fanned in below via the alerts scanner. Nil
 	// when disabled — the api emitter and Close are both nil-safe.
-	var webhookDispatcher *webhook.Dispatcher
-	if cfg.Webhooks.Enabled && cfg.Webhooks.URL != "" {
-		webhookDispatcher = webhook.New(webhook.Config{
-			URL:          cfg.Webhooks.URL,
-			HMACSecret:   cfg.Webhooks.HMACSecret,
-			AllowPrivate: cfg.Webhooks.AllowPrivate,
-			Events:       cfg.Webhooks.Events,
-		}, logger)
-		defer webhookDispatcher.Close()
-		apiSrv.WithEventEmitter(webhookDispatcher)
-		logger.Info("webhooks enabled", "url", cfg.Webhooks.URL, "events", cfg.Webhooks.Events)
-	}
+	// The webhook dispatcher always runs: managed subscriptions (#256 phase 2)
+	// are created at runtime via the API, so the bus must be live to pick them
+	// up even when the static config webhook (phase 1) is unset. It fans each
+	// event out to DB-backed subscriptions plus the optional static config
+	// target.
+	webhookDispatcher := webhook.New(webhook.Config{
+		URL:          cfg.Webhooks.URL,
+		HMACSecret:   cfg.Webhooks.HMACSecret,
+		AllowPrivate: cfg.Webhooks.AllowPrivate,
+		Events:       cfg.Webhooks.Events,
+		Source:       webhook.NewStoreSource(s, master, logger),
+	}, logger)
+	defer webhookDispatcher.Close()
+	apiSrv.WithEventEmitter(webhookDispatcher)
+	logger.Info("webhook dispatcher started", "static_url", cfg.Webhooks.URL != "")
 
 	// Build a single rate limiter shared by API and Web. The Web UI runs
 	// auth/ui groups; the API server runs api/enroll/agent_poll groups.

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -178,14 +178,14 @@ func hostIsPrivate(host string) bool {
 		addr.IsLinkLocalMulticast() || addr.IsUnspecified()
 }
 
-// validateWebhookURL guards a webhook URL against SSRF (#188): the URL must be
+// ValidateWebhookURL guards a webhook URL against SSRF (#188): the URL must be
 // http/https with a host, and (unless allowPrivate) must not target a
 // private/loopback/link-local address. field names the offending config key in
 // errors so both alerts.webhook_url and webhooks.url can reuse it. DNS names are
 // not resolved here — this is the config-load layer; the delivery-time layer
 // (post-resolution dialer guard + per-redirect-hop re-check) lives in the
 // alerts WebhookSink and the webhook.Dispatcher.
-func validateWebhookURL(field, rawURL string, allowPrivate bool) error {
+func ValidateWebhookURL(field, rawURL string, allowPrivate bool) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("%s: %w", field, err)
@@ -478,13 +478,13 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 	}
 
 	if cfg.Alerts.Enabled && cfg.Alerts.WebhookURL != "" {
-		if err := validateWebhookURL("alerts.webhook_url", cfg.Alerts.WebhookURL, cfg.Alerts.AllowPrivateWebhook); err != nil {
+		if err := ValidateWebhookURL("alerts.webhook_url", cfg.Alerts.WebhookURL, cfg.Alerts.AllowPrivateWebhook); err != nil {
 			return nil, err
 		}
 	}
 
 	if cfg.Webhooks.Enabled && cfg.Webhooks.URL != "" {
-		if err := validateWebhookURL("webhooks.url", cfg.Webhooks.URL, cfg.Webhooks.AllowPrivate); err != nil {
+		if err := ValidateWebhookURL("webhooks.url", cfg.Webhooks.URL, cfg.Webhooks.AllowPrivate); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/config/ssrf_validate_test.go
+++ b/internal/config/ssrf_validate_test.go
@@ -29,12 +29,12 @@ func TestValidateWebhookURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateWebhookURL("webhooks.url", tt.url, tt.allowPrivate)
+			err := ValidateWebhookURL("webhooks.url", tt.url, tt.allowPrivate)
 			if tt.wantErr && err == nil {
-				t.Fatalf("validateWebhookURL(%q, %v) = nil, want error", tt.url, tt.allowPrivate)
+				t.Fatalf("ValidateWebhookURL(%q, %v) = nil, want error", tt.url, tt.allowPrivate)
 			}
 			if !tt.wantErr && err != nil {
-				t.Fatalf("validateWebhookURL(%q, %v) = %v, want nil", tt.url, tt.allowPrivate, err)
+				t.Fatalf("ValidateWebhookURL(%q, %v) = %v, want nil", tt.url, tt.allowPrivate, err)
 			}
 		})
 	}

--- a/internal/models/webhook_subscription.go
+++ b/internal/models/webhook_subscription.go
@@ -1,0 +1,35 @@
+package models
+
+import "time"
+
+// WebhookSubscription is an operator-owned outbound webhook target (#256
+// phase 2). The HMAC secret is stored envelope-encrypted (a per-row DEK wrapped
+// under the master key, the secret sealed under the DEK), so the encrypted
+// fields never serialize to JSON; API responses expose only HasSecret.
+type WebhookSubscription struct {
+	ID              string   `json:"id"`
+	OwnerOperatorID string   `json:"owner_operator_id"`
+	URL             string   `json:"url"`
+	Events          []string `json:"events"` // empty = all events
+	Active          bool     `json:"active"`
+	AllowPrivate    bool     `json:"allow_private"`
+
+	// Envelope-encrypted HMAC secret. All nil => unsigned deliveries.
+	EncryptedSecretDEK []byte `json:"-"`
+	NonceDEK           []byte `json:"-"`
+	EncryptedSecret    []byte `json:"-"`
+	NonceSecret        []byte `json:"-"`
+
+	// HasSecret is a computed, response-only flag (the secret itself is never
+	// returned). It is not persisted as a column.
+	HasSecret bool `json:"has_secret"`
+
+	// Per-subscription delivery observability.
+	LastDeliveryAt      *time.Time `json:"last_delivery_at,omitempty"`
+	LastStatus          string     `json:"last_status,omitempty"`
+	LastError           string     `json:"last_error,omitempty"`
+	ConsecutiveFailures int        `json:"consecutive_failures"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/internal/store/migrations/021_webhook_subscriptions.up.sql
+++ b/internal/store/migrations/021_webhook_subscriptions.up.sql
@@ -1,0 +1,33 @@
+-- Managed webhook subscriptions (#256 phase 2). Each row is one operator-owned
+-- delivery target: a URL, an event-type filter (comma-separated; empty = all),
+-- and an optional HMAC secret stored envelope-encrypted under the master key
+-- (same two-layer scheme as cas: a per-row DEK wrapped under the master, the
+-- secret sealed under the DEK). Delivery-status columns give per-subscription
+-- observability.
+
+CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+    id                   TEXT PRIMARY KEY,
+    owner_operator_id    TEXT NOT NULL REFERENCES operators(id) ON DELETE RESTRICT,
+    url                  TEXT NOT NULL,
+    events               TEXT NOT NULL DEFAULT '',   -- comma-separated; empty = all events
+    active               INTEGER NOT NULL DEFAULT 1,
+    allow_private        INTEGER NOT NULL DEFAULT 0,
+
+    -- Optional HMAC secret, envelope-encrypted. NULL columns => unsigned deliveries.
+    encrypted_secret_dek BLOB,
+    nonce_dek            BLOB,
+    encrypted_secret     BLOB,
+    nonce_secret         BLOB,
+
+    -- Per-subscription delivery observability.
+    last_delivery_at     DATETIME,
+    last_status          TEXT NOT NULL DEFAULT '',   -- '' | 'ok' | 'failed'
+    last_error           TEXT NOT NULL DEFAULT '',
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+
+    created_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_subs_owner  ON webhook_subscriptions(owner_operator_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_subs_active ON webhook_subscriptions(active) WHERE active = 1;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -148,6 +148,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		"018_host_address_network_uniqueness.up.sql",
 		"019_session_token_hash.up.sql",
 		"020_operator_totp_timestep.up.sql",
+		"021_webhook_subscriptions.up.sql",
 	}
 
 	conn, err := s.db.Conn(ctx)

--- a/internal/store/sqlite_webhooks.go
+++ b/internal/store/sqlite_webhooks.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+const webhookSubColumns = `id, owner_operator_id, url, events, active, allow_private, ` +
+	`encrypted_secret_dek, nonce_dek, encrypted_secret, nonce_secret, ` +
+	`last_delivery_at, last_status, last_error, consecutive_failures, created_at, updated_at`
+
+func joinEvents(events []string) string { return strings.Join(events, ",") }
+
+func splitEvents(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func scanWebhookSubscription(scanner interface{ Scan(dest ...any) error }) (*models.WebhookSubscription, error) {
+	var (
+		sub          models.WebhookSubscription
+		eventsCSV    string
+		lastDelivery sql.NullTime
+	)
+	if err := scanner.Scan(
+		&sub.ID, &sub.OwnerOperatorID, &sub.URL, &eventsCSV, &sub.Active, &sub.AllowPrivate,
+		&sub.EncryptedSecretDEK, &sub.NonceDEK, &sub.EncryptedSecret, &sub.NonceSecret,
+		&lastDelivery, &sub.LastStatus, &sub.LastError, &sub.ConsecutiveFailures,
+		&sub.CreatedAt, &sub.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	sub.Events = splitEvents(eventsCSV)
+	sub.HasSecret = len(sub.EncryptedSecret) > 0
+	if lastDelivery.Valid {
+		sub.LastDeliveryAt = &lastDelivery.Time
+	}
+	return &sub, nil
+}
+
+// CreateWebhookSubscription inserts a new subscription.
+func (s *SQLiteStore) CreateWebhookSubscription(ctx context.Context, sub *models.WebhookSubscription) error {
+	if sub.ID == "" || sub.OwnerOperatorID == "" || sub.URL == "" {
+		return fmt.Errorf("webhook subscription id, owner_operator_id, url are required")
+	}
+	now := time.Now()
+	if sub.CreatedAt.IsZero() {
+		sub.CreatedAt = now
+	}
+	if sub.UpdatedAt.IsZero() {
+		sub.UpdatedAt = now
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO webhook_subscriptions (`+webhookSubColumns+`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sub.ID, sub.OwnerOperatorID, sub.URL, joinEvents(sub.Events), sub.Active, sub.AllowPrivate,
+		sub.EncryptedSecretDEK, sub.NonceDEK, sub.EncryptedSecret, sub.NonceSecret,
+		nil, "", "", 0, sub.CreatedAt, sub.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert webhook subscription: %w", err)
+	}
+	return nil
+}
+
+// GetWebhookSubscription returns one subscription by id.
+func (s *SQLiteStore) GetWebhookSubscription(ctx context.Context, id string) (*models.WebhookSubscription, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+webhookSubColumns+` FROM webhook_subscriptions WHERE id = ?`, id)
+	sub, err := scanWebhookSubscription(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get webhook subscription: %w", err)
+	}
+	return sub, nil
+}
+
+func (s *SQLiteStore) queryWebhookSubscriptions(ctx context.Context, query string, args ...any) ([]*models.WebhookSubscription, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query webhook subscriptions: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("close rows", "error", err)
+		}
+	}()
+	var out []*models.WebhookSubscription
+	for rows.Next() {
+		sub, err := scanWebhookSubscription(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan webhook subscription: %w", err)
+		}
+		out = append(out, sub)
+	}
+	return out, rows.Err()
+}
+
+// ListWebhookSubscriptions returns every subscription (admin view).
+func (s *SQLiteStore) ListWebhookSubscriptions(ctx context.Context) ([]*models.WebhookSubscription, error) {
+	return s.queryWebhookSubscriptions(ctx, `SELECT `+webhookSubColumns+` FROM webhook_subscriptions ORDER BY created_at`)
+}
+
+// ListWebhookSubscriptionsByOwner returns subscriptions owned by ownerID.
+func (s *SQLiteStore) ListWebhookSubscriptionsByOwner(ctx context.Context, ownerID string) ([]*models.WebhookSubscription, error) {
+	return s.queryWebhookSubscriptions(ctx, `SELECT `+webhookSubColumns+` FROM webhook_subscriptions WHERE owner_operator_id = ? ORDER BY created_at`, ownerID)
+}
+
+// ListActiveWebhookSubscriptions returns active subscriptions for delivery.
+func (s *SQLiteStore) ListActiveWebhookSubscriptions(ctx context.Context) ([]*models.WebhookSubscription, error) {
+	return s.queryWebhookSubscriptions(ctx, `SELECT `+webhookSubColumns+` FROM webhook_subscriptions WHERE active = 1`)
+}
+
+// UpdateWebhookSubscription writes the mutable fields (url, events, active,
+// allow_private, secret envelope) and bumps updated_at. Delivery-status columns
+// are left to RecordWebhookDelivery.
+func (s *SQLiteStore) UpdateWebhookSubscription(ctx context.Context, sub *models.WebhookSubscription) error {
+	sub.UpdatedAt = time.Now()
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE webhook_subscriptions SET url = ?, events = ?, active = ?, allow_private = ?,
+		 encrypted_secret_dek = ?, nonce_dek = ?, encrypted_secret = ?, nonce_secret = ?, updated_at = ?
+		 WHERE id = ?`,
+		sub.URL, joinEvents(sub.Events), sub.Active, sub.AllowPrivate,
+		sub.EncryptedSecretDEK, sub.NonceDEK, sub.EncryptedSecret, sub.NonceSecret, sub.UpdatedAt,
+		sub.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update webhook subscription: %w", err)
+	}
+	return rowsAffectedOrNotFound(res)
+}
+
+// DeleteWebhookSubscription removes a subscription.
+func (s *SQLiteStore) DeleteWebhookSubscription(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM webhook_subscriptions WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete webhook subscription: %w", err)
+	}
+	return rowsAffectedOrNotFound(res)
+}
+
+// RecordWebhookDelivery updates a subscription's delivery-status columns after
+// an attempt. On success it clears the failure counter and error; on failure it
+// increments the counter and stores the (truncated) error.
+func (s *SQLiteStore) RecordWebhookDelivery(ctx context.Context, id string, ok bool, errMsg string, at time.Time) error {
+	var query string
+	var args []any
+	if ok {
+		query = `UPDATE webhook_subscriptions SET last_delivery_at = ?, last_status = 'ok', last_error = '', consecutive_failures = 0 WHERE id = ?`
+		args = []any{at, id}
+	} else {
+		if len(errMsg) > 500 {
+			errMsg = errMsg[:500]
+		}
+		query = `UPDATE webhook_subscriptions SET last_delivery_at = ?, last_status = 'failed', last_error = ?, consecutive_failures = consecutive_failures + 1 WHERE id = ?`
+		args = []any{at, errMsg, id}
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("record webhook delivery: %w", err)
+	}
+	return nil
+}
+
+func rowsAffectedOrNotFound(res sql.Result) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/store/sqlite_webhooks_test.go
+++ b/internal/store/sqlite_webhooks_test.go
@@ -1,0 +1,124 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+func seedWebhookOwner(t *testing.T, s *SQLiteStore, id string) {
+	t.Helper()
+	op := &models.Operator{ID: id, Username: id, DisplayName: id, PasswordHash: "x", Role: "admin"}
+	if err := s.CreateOperator(context.Background(), op); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWebhookSubscription_CRUD(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedWebhookOwner(t, s, "op1")
+
+	sub := &models.WebhookSubscription{
+		ID:                 "wh1",
+		OwnerOperatorID:    "op1",
+		URL:                "https://hooks.example.com/a",
+		Events:             []string{"host.enrolled", "host.blocked"},
+		Active:             true,
+		AllowPrivate:       false,
+		EncryptedSecretDEK: []byte("dek"),
+		NonceDEK:           []byte("nd"),
+		EncryptedSecret:    []byte("sec"),
+		NonceSecret:        []byte("ns"),
+	}
+	if err := s.CreateWebhookSubscription(ctx, sub); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := s.GetWebhookSubscription(ctx, "wh1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.URL != sub.URL || len(got.Events) != 2 || got.Events[0] != "host.enrolled" {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+	if !got.HasSecret {
+		t.Error("HasSecret should be true when secret present")
+	}
+	if string(got.EncryptedSecret) != "sec" {
+		t.Errorf("secret blob = %q", got.EncryptedSecret)
+	}
+
+	// Update: change url, deactivate, drop secret.
+	got.URL = "https://hooks.example.com/b"
+	got.Active = false
+	got.Events = nil // all events
+	got.EncryptedSecretDEK, got.NonceDEK, got.EncryptedSecret, got.NonceSecret = nil, nil, nil, nil
+	if err := s.UpdateWebhookSubscription(ctx, got); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got2, _ := s.GetWebhookSubscription(ctx, "wh1")
+	if got2.URL != "https://hooks.example.com/b" || got2.Active || got2.HasSecret || len(got2.Events) != 0 {
+		t.Errorf("update not applied: %+v", got2)
+	}
+
+	// ListActive excludes the now-inactive sub.
+	active, _ := s.ListActiveWebhookSubscriptions(ctx)
+	if len(active) != 0 {
+		t.Errorf("active list = %d, want 0", len(active))
+	}
+
+	// Owner scoping.
+	owned, _ := s.ListWebhookSubscriptionsByOwner(ctx, "op1")
+	if len(owned) != 1 {
+		t.Errorf("owned = %d, want 1", len(owned))
+	}
+	none, _ := s.ListWebhookSubscriptionsByOwner(ctx, "op-other")
+	if len(none) != 0 {
+		t.Errorf("other-owner = %d, want 0", len(none))
+	}
+
+	// Delete.
+	if err := s.DeleteWebhookSubscription(ctx, "wh1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetWebhookSubscription(ctx, "wh1"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("get after delete = %v, want ErrNotFound", err)
+	}
+	if err := s.DeleteWebhookSubscription(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("delete missing = %v, want ErrNotFound", err)
+	}
+}
+
+func TestWebhookSubscription_RecordDelivery(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedWebhookOwner(t, s, "op1")
+	sub := &models.WebhookSubscription{ID: "wh1", OwnerOperatorID: "op1", URL: "https://x/y", Active: true}
+	if err := s.CreateWebhookSubscription(ctx, sub); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	if err := s.RecordWebhookDelivery(ctx, "wh1", false, "boom", now); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.GetWebhookSubscription(ctx, "wh1")
+	if got.LastStatus != "failed" || got.ConsecutiveFailures != 1 || got.LastError != "boom" {
+		t.Errorf("after failure: %+v", got)
+	}
+	if got.LastDeliveryAt == nil {
+		t.Error("last_delivery_at not set")
+	}
+
+	if err := s.RecordWebhookDelivery(ctx, "wh1", true, "", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := s.GetWebhookSubscription(ctx, "wh1")
+	if got2.LastStatus != "ok" || got2.ConsecutiveFailures != 0 || got2.LastError != "" {
+		t.Errorf("after success: %+v", got2)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -38,6 +38,16 @@ type Store interface {
 	UpdateCAStatus(ctx context.Context, id string, status models.CAStatus) error
 	DeleteCA(ctx context.Context, id string) error
 
+	// Webhook subscriptions
+	CreateWebhookSubscription(ctx context.Context, sub *models.WebhookSubscription) error
+	GetWebhookSubscription(ctx context.Context, id string) (*models.WebhookSubscription, error)
+	ListWebhookSubscriptions(ctx context.Context) ([]*models.WebhookSubscription, error)
+	ListWebhookSubscriptionsByOwner(ctx context.Context, ownerID string) ([]*models.WebhookSubscription, error)
+	ListActiveWebhookSubscriptions(ctx context.Context) ([]*models.WebhookSubscription, error)
+	UpdateWebhookSubscription(ctx context.Context, sub *models.WebhookSubscription) error
+	DeleteWebhookSubscription(ctx context.Context, id string) error
+	RecordWebhookDelivery(ctx context.Context, id string, ok bool, errMsg string, at time.Time) error
+
 	// Networks
 	CreateNetwork(ctx context.Context, n *models.Network) error
 	GetNetwork(ctx context.Context, id string) (*models.Network, error)

--- a/internal/webhook/fanout_test.go
+++ b/internal/webhook/fanout_test.go
@@ -1,0 +1,147 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/keystore"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+type recordedDelivery struct {
+	id string
+	ok bool
+}
+
+type fakeSource struct {
+	targets  []Target
+	mu       sync.Mutex
+	recorded []recordedDelivery
+}
+
+func (f *fakeSource) TargetsFor(_ context.Context, _ string) ([]Target, error) {
+	return f.targets, nil
+}
+
+func (f *fakeSource) RecordDelivery(_ context.Context, id string, ok bool, _ string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recorded = append(f.recorded, recordedDelivery{id, ok})
+}
+
+func (f *fakeSource) outcomes() []recordedDelivery {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]recordedDelivery(nil), f.recorded...)
+}
+
+func TestDispatcher_FanOutToSourceTargets(t *testing.T) {
+	var hitsA, hitsB sync.WaitGroup
+	hitsA.Add(1)
+	hitsB.Add(1)
+	srvA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { hitsA.Done() }))
+	defer srvA.Close()
+	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { hitsB.Done() }))
+	defer srvB.Close()
+
+	src := &fakeSource{targets: []Target{
+		{ID: "sub-a", URL: srvA.URL, AllowPrivate: true},
+		{ID: "sub-b", URL: srvB.URL, AllowPrivate: true},
+	}}
+	d := New(Config{Source: src}, testLogger())
+	defer d.Close()
+
+	d.Emit("host.enrolled", map[string]any{"host_id": "h1"})
+
+	doneA := make(chan struct{})
+	go func() { hitsA.Wait(); close(doneA) }()
+	doneB := make(chan struct{})
+	go func() { hitsB.Wait(); close(doneB) }()
+	for _, ch := range []chan struct{}{doneA, doneB} {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatal("a fan-out target did not receive the event")
+		}
+	}
+
+	// Delivery status recorded ok for both subscriptions.
+	d.Close()
+	got := src.outcomes()
+	if len(got) != 2 {
+		t.Fatalf("recorded %d outcomes, want 2: %+v", len(got), got)
+	}
+	for _, o := range got {
+		if !o.ok {
+			t.Errorf("subscription %s recorded failure, want ok", o.id)
+		}
+	}
+}
+
+func TestStoreSource_DecryptsAndFilters(t *testing.T) {
+	s, err := store.NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	ctx := context.Background()
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateOperator(ctx, &models.Operator{ID: "op1", Username: "op1", DisplayName: "op1", PasswordHash: "x", Role: "admin"}); err != nil {
+		t.Fatal(err)
+	}
+
+	master, err := keystore.NewMaster(make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seal a secret for sub "wh1" the way the API handler will.
+	const subID, secret = "wh1", "topsecret"
+	dek, wrappedDEK, err := master.GenerateDEK([]byte(subID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := keystore.SealWithDEK(dek, []byte(secret), []byte(subID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keystore.Zeroize(dek)
+
+	sub := &models.WebhookSubscription{
+		ID: subID, OwnerOperatorID: "op1", URL: "https://x/y", Active: true,
+		Events:             []string{"host.blocked"},
+		EncryptedSecretDEK: wrappedDEK.Ciphertext, NonceDEK: wrappedDEK.Nonce,
+		EncryptedSecret: blob.Ciphertext, NonceSecret: blob.Nonce,
+	}
+	if err := s.CreateWebhookSubscription(ctx, sub); err != nil {
+		t.Fatal(err)
+	}
+
+	src := NewStoreSource(s, master, testLogger())
+
+	// Event filter: not subscribed -> no targets.
+	if tgts, _ := src.TargetsFor(ctx, "host.enrolled"); len(tgts) != 0 {
+		t.Errorf("host.enrolled targets = %d, want 0", len(tgts))
+	}
+	// Subscribed -> one target with the decrypted secret.
+	tgts, err := src.TargetsFor(ctx, "host.blocked")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tgts) != 1 {
+		t.Fatalf("host.blocked targets = %d, want 1", len(tgts))
+	}
+	if string(tgts[0].Secret) != secret {
+		t.Errorf("decrypted secret = %q, want %q", tgts[0].Secret, secret)
+	}
+	if tgts[0].ID != subID || tgts[0].URL != "https://x/y" {
+		t.Errorf("target = %+v", tgts[0])
+	}
+}

--- a/internal/webhook/store_source.go
+++ b/internal/webhook/store_source.go
@@ -1,0 +1,104 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/keystore"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// errMasterRequired is returned when a subscription has an encrypted secret but
+// no master key is configured to decrypt it.
+var errMasterRequired = errors.New("webhook secret is encrypted but master key is not configured")
+
+// SubStore is the store surface a StoreSource needs.
+type SubStore interface {
+	ListActiveWebhookSubscriptions(ctx context.Context) ([]*models.WebhookSubscription, error)
+	RecordWebhookDelivery(ctx context.Context, id string, ok bool, errMsg string, at time.Time) error
+}
+
+// StoreSource resolves managed subscriptions from the store, decrypting each
+// subscription's HMAC secret under the master key at delivery time. It
+// satisfies SubscriptionSource.
+type StoreSource struct {
+	store  SubStore
+	master *keystore.Master
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewStoreSource builds a store-backed subscription source. master may be nil
+// (subscriptions with secrets are then skipped with a logged error).
+func NewStoreSource(s SubStore, master *keystore.Master, logger *slog.Logger) *StoreSource {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &StoreSource{store: s, master: master, logger: logger, now: time.Now}
+}
+
+// TargetsFor returns active subscriptions wanting eventType, secrets decrypted.
+func (s *StoreSource) TargetsFor(ctx context.Context, eventType string) ([]Target, error) {
+	subs, err := s.store.ListActiveWebhookSubscriptions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []Target
+	for _, sub := range subs {
+		if !wantsEvent(sub.Events, eventType) {
+			continue
+		}
+		secret, err := s.decryptSecret(sub)
+		if err != nil {
+			// A configured-but-undecryptable secret is a misconfiguration;
+			// skip rather than deliver unsigned when the operator expects a
+			// signature. RecordDelivery on the next live attempt would surface
+			// it, but here we just log and move on.
+			s.logger.Error("decrypt webhook secret", "subscription", sub.ID, "error", err)
+			continue
+		}
+		out = append(out, Target{ID: sub.ID, URL: sub.URL, Secret: secret, AllowPrivate: sub.AllowPrivate})
+	}
+	return out, nil
+}
+
+// RecordDelivery persists a delivery outcome against the subscription.
+func (s *StoreSource) RecordDelivery(ctx context.Context, id string, ok bool, errMsg string) {
+	if err := s.store.RecordWebhookDelivery(ctx, id, ok, errMsg, s.now()); err != nil {
+		s.logger.Error("record webhook delivery", "subscription", id, "error", err)
+	}
+}
+
+func wantsEvent(events []string, eventType string) bool {
+	if len(events) == 0 {
+		return true
+	}
+	for _, e := range events {
+		if e == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *StoreSource) decryptSecret(sub *models.WebhookSubscription) ([]byte, error) {
+	if len(sub.EncryptedSecret) == 0 {
+		return nil, nil // unsigned subscription
+	}
+	if s.master == nil {
+		return nil, errMasterRequired
+	}
+	aad := []byte(sub.ID)
+	dek, err := s.master.UnwrapDEK(keystore.WrappedKey{Ciphertext: sub.EncryptedSecretDEK, Nonce: sub.NonceDEK}, aad)
+	if err != nil {
+		return nil, err
+	}
+	defer keystore.Zeroize(dek)
+	secret, err := keystore.OpenWithDEK(dek, keystore.WrappedBlob{Ciphertext: sub.EncryptedSecret, Nonce: sub.NonceSecret}, aad)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,13 +1,14 @@
 // Package webhook delivers lifecycle events (host enrolled/blocked/deleted,
-// cert rotated, cert expiring, …) to an operator-configured HTTP endpoint. It
-// is the unified outbound-event bus: handlers and background scanners publish
-// typed events via Emit; the Dispatcher signs and delivers them asynchronously,
-// off the request path, with bounded retry (#256, phase 1).
+// cert rotated, cert expiring, …) to operator-configured HTTP endpoints. It is
+// the unified outbound-event bus: handlers and background scanners publish typed
+// events via Emit; the Dispatcher signs and delivers them asynchronously, off
+// the request path, with bounded retry (#256).
 //
-// Deliveries are SSRF-guarded at request time and signed with HMAC-SHA256, the
-// same scheme the cert-expiry alerter already uses. The signing/guard logic
-// mirrors internal/alerts and internal/config.hostIsPrivate and must stay in
-// sync with them.
+// Targets come from two places: an optional static target from server config
+// (phase 1) and managed subscriptions loaded from a SubscriptionSource
+// (phase 2). Deliveries are SSRF-guarded at request time and signed with
+// HMAC-SHA256. The signing/guard logic mirrors internal/alerts and
+// internal/config.hostIsPrivate and must stay in sync with them.
 package webhook
 
 import (
@@ -40,7 +41,7 @@ const (
 	SignatureHeader = "X-Nebula-Signature"
 )
 
-// Event is the envelope POSTed to the subscriber. Data carries the
+// Event is the envelope POSTed to a subscriber. Data carries the
 // event-type-specific payload.
 type Event struct {
 	ID        string         `json:"id"`
@@ -49,19 +50,40 @@ type Event struct {
 	Data      map[string]any `json:"data"`
 }
 
-// Emitter is the narrow interface handlers depend on so they need not know
-// about delivery. *Dispatcher implements it; a nil *Dispatcher Emit is a no-op,
-// so callers can hold an optional emitter without nil checks at every call site.
+// Emitter is the narrow interface handlers depend on. *Dispatcher implements
+// it; a nil *Dispatcher Emit is a no-op.
 type Emitter interface {
 	Emit(eventType string, data map[string]any)
 }
 
-// Config configures a Dispatcher. Only URL is required.
+// Target is one resolved delivery endpoint. ID is the subscription id for
+// managed targets (delivery status is recorded against it) and empty for the
+// static config target.
+type Target struct {
+	ID           string
+	URL          string
+	Secret       []byte // HMAC secret; empty => unsigned
+	AllowPrivate bool
+}
+
+// SubscriptionSource yields managed subscriptions for an event and records the
+// outcome of each delivery.
+type SubscriptionSource interface {
+	TargetsFor(ctx context.Context, eventType string) ([]Target, error)
+	RecordDelivery(ctx context.Context, targetID string, ok bool, errMsg string)
+}
+
+// Config configures a Dispatcher. A static target is delivered when URL is set
+// (phase-1 config webhook); managed targets come from Source.
 type Config struct {
+	// Static config target (optional).
 	URL          string
 	HMACSecret   string
-	AllowPrivate bool     // permit private/loopback targets (disables the SSRF guard)
-	Events       []string // delivered event types; empty means all
+	AllowPrivate bool
+	Events       []string // static target's event filter; empty = all
+
+	// Managed subscriptions (optional).
+	Source SubscriptionSource
 
 	// Tunables — zero values fall back to the defaults below.
 	QueueSize    int
@@ -70,7 +92,7 @@ type Config struct {
 	DeliveryTO   time.Duration
 
 	// Test seams.
-	HTTPClient *http.Client     // nil => an SSRF-guarded client
+	HTTPClient *http.Client     // overrides both guarded/unguarded clients
 	Now        func() time.Time // nil => time.Now
 	NewID      func() string    // nil => "evt_"+uuid
 }
@@ -85,14 +107,16 @@ const (
 // Dispatcher signs and delivers events asynchronously. Construct with New,
 // publish with Emit, and Close on shutdown to drain in-flight deliveries.
 type Dispatcher struct {
-	cfg     Config
-	logger  *slog.Logger
-	allowed map[string]bool // nil => all event types
-	queue   chan Event
-	client  *http.Client
-	now     func() time.Time
-	newID   func() string
+	cfg          Config
+	logger       *slog.Logger
+	source       SubscriptionSource
+	staticEvents map[string]bool // nil => all; only consulted when cfg.URL != ""
+	guarded      *http.Client
+	unguarded    *http.Client
+	now          func() time.Time
+	newID        func() string
 
+	queue  chan Event
 	wg     sync.WaitGroup
 	closed atomic.Bool
 	done   chan struct{}
@@ -118,14 +142,17 @@ func New(cfg Config, logger *slog.Logger) *Dispatcher {
 	d := &Dispatcher{
 		cfg:    cfg,
 		logger: logger,
-		queue:  make(chan Event, cfg.QueueSize),
-		client: cfg.HTTPClient,
+		source: cfg.Source,
 		now:    cfg.Now,
 		newID:  cfg.NewID,
+		queue:  make(chan Event, cfg.QueueSize),
 		done:   make(chan struct{}),
 	}
-	if d.client == nil {
-		d.client = newGuardedClient(cfg.AllowPrivate, cfg.DeliveryTO)
+	if cfg.HTTPClient != nil {
+		d.guarded, d.unguarded = cfg.HTTPClient, cfg.HTTPClient
+	} else {
+		d.guarded = newGuardedClient(false, cfg.DeliveryTO)
+		d.unguarded = newGuardedClient(true, cfg.DeliveryTO)
 	}
 	if d.now == nil {
 		d.now = time.Now
@@ -134,9 +161,9 @@ func New(cfg Config, logger *slog.Logger) *Dispatcher {
 		d.newID = func() string { return "evt_" + uuid.NewString() }
 	}
 	if len(cfg.Events) > 0 {
-		d.allowed = make(map[string]bool, len(cfg.Events))
+		d.staticEvents = make(map[string]bool, len(cfg.Events))
 		for _, e := range cfg.Events {
-			d.allowed[e] = true
+			d.staticEvents[e] = true
 		}
 	}
 	d.wg.Add(1)
@@ -144,15 +171,11 @@ func New(cfg Config, logger *slog.Logger) *Dispatcher {
 	return d
 }
 
-// Emit enqueues an event for delivery. It never blocks the caller: events for
-// unsubscribed types are dropped silently, and a full queue drops the event
-// with a logged warning rather than stalling the request path. A nil Dispatcher
-// (webhooks disabled) is a no-op.
+// Emit enqueues an event. It never blocks the caller: a full queue drops the
+// event with a logged warning rather than stalling the request path. Per-target
+// filtering happens at delivery. A nil Dispatcher (webhooks disabled) is a no-op.
 func (d *Dispatcher) Emit(eventType string, data map[string]any) {
 	if d == nil || d.closed.Load() {
-		return
-	}
-	if d.allowed != nil && !d.allowed[eventType] {
 		return
 	}
 	ev := Event{
@@ -168,8 +191,7 @@ func (d *Dispatcher) Emit(eventType string, data map[string]any) {
 	}
 }
 
-// Close stops accepting events and waits for the worker to drain what is
-// already queued. Safe to call once; later calls are no-ops.
+// Close stops accepting events and drains what is already queued. Idempotent.
 func (d *Dispatcher) Close() {
 	if d == nil {
 		return
@@ -183,19 +205,47 @@ func (d *Dispatcher) Close() {
 func (d *Dispatcher) run() {
 	defer d.wg.Done()
 	for ev := range d.queue {
-		d.deliverWithRetry(ev)
+		d.dispatch(ev)
 	}
 }
 
-// deliverWithRetry attempts delivery up to MaxRetries+1 times with linear
-// backoff, aborting early if Close is signaled. A permanent failure is logged
-// (a dead-letter store is phase 2).
-func (d *Dispatcher) deliverWithRetry(ev Event) {
+// dispatch resolves every target for the event and delivers to each.
+func (d *Dispatcher) dispatch(ev Event) {
 	payload, err := json.Marshal(ev)
 	if err != nil {
 		d.logger.Error("marshal webhook event", "type", ev.Type, "error", err)
 		return
 	}
+	for _, tgt := range d.targets(ev.Type) {
+		d.deliverWithRetry(tgt, payload, ev.Type, ev.ID)
+	}
+}
+
+// targets gathers the static config target (when it wants the event) and any
+// managed subscriptions from the source.
+func (d *Dispatcher) targets(eventType string) []Target {
+	var out []Target
+	if d.cfg.URL != "" && (d.staticEvents == nil || d.staticEvents[eventType]) {
+		out = append(out, Target{URL: d.cfg.URL, Secret: []byte(d.cfg.HMACSecret), AllowPrivate: d.cfg.AllowPrivate})
+	}
+	if d.source != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), d.cfg.DeliveryTO)
+		subs, err := d.source.TargetsFor(ctx, eventType)
+		cancel()
+		if err != nil {
+			d.logger.Error("load webhook subscriptions", "type", eventType, "error", err)
+		} else {
+			out = append(out, subs...)
+		}
+	}
+	return out
+}
+
+// deliverWithRetry attempts delivery up to MaxRetries+1 times with linear
+// backoff, aborting early if Close is signaled. The final outcome is recorded
+// against the subscription (managed targets only).
+func (d *Dispatcher) deliverWithRetry(tgt Target, payload []byte, eventType, id string) {
+	var lastErr error
 	for attempt := 0; attempt <= d.cfg.MaxRetries; attempt++ {
 		if attempt > 0 {
 			select {
@@ -204,34 +254,48 @@ func (d *Dispatcher) deliverWithRetry(ev Event) {
 				return
 			}
 		}
-		err := d.deliver(payload, ev.Type, ev.ID)
-		if err == nil {
+		if lastErr = d.deliver(tgt, payload, eventType, id); lastErr == nil {
+			d.record(tgt, true, "")
 			return
 		}
 		d.logger.Warn("webhook delivery failed",
-			"type", ev.Type, "id", ev.ID, "attempt", attempt+1, "error", err)
+			"target", tgt.URL, "type", eventType, "id", id, "attempt", attempt+1, "error", lastErr)
 	}
-	d.logger.Error("webhook delivery exhausted retries", "type", ev.Type, "id", ev.ID)
+	d.logger.Error("webhook delivery exhausted retries", "target", tgt.URL, "type", eventType, "id", id)
+	d.record(tgt, false, lastErr.Error())
 }
 
-func (d *Dispatcher) deliver(payload []byte, eventType, id string) error {
+func (d *Dispatcher) record(tgt Target, ok bool, errMsg string) {
+	if tgt.ID == "" || d.source == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), d.cfg.DeliveryTO)
+	defer cancel()
+	d.source.RecordDelivery(ctx, tgt.ID, ok, errMsg)
+}
+
+func (d *Dispatcher) deliver(tgt Target, payload []byte, eventType, id string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), d.cfg.DeliveryTO)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.cfg.URL, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tgt.URL, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(EventHeader, eventType)
 	req.Header.Set(DeliveryHeader, id)
-	if d.cfg.HMACSecret != "" {
-		mac := hmac.New(sha256.New, []byte(d.cfg.HMACSecret))
+	if len(tgt.Secret) > 0 {
+		mac := hmac.New(sha256.New, tgt.Secret)
 		mac.Write(payload)
 		req.Header.Set(SignatureHeader, "sha256="+hex.EncodeToString(mac.Sum(nil)))
 	}
 
-	resp, err := d.client.Do(req)
+	client := d.guarded
+	if tgt.AllowPrivate {
+		client = d.unguarded
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("POST: %w", err)
 	}
@@ -247,7 +311,7 @@ func (d *Dispatcher) deliver(payload []byte, eventType, id string) error {
 
 // --- SSRF guard (mirrors internal/alerts.isBlockedWebhookAddr / config.hostIsPrivate) ---
 
-var errPrivateWebhookAddr = errors.New("webhook delivery to private/loopback/link-local address blocked (SSRF guard); set webhooks.allow_private: true for an intentional internal sink")
+var errPrivateWebhookAddr = errors.New("webhook delivery to private/loopback/link-local address blocked (SSRF guard); set allow_private: true for an intentional internal sink")
 
 func isBlockedAddr(addr netip.Addr) bool {
 	addr = addr.Unmap()


### PR DESCRIPTION
Phase 2 of #256: DB-backed, operator-managed webhook subscriptions delivered through the same bus as the phase-1 config webhook. Multiple endpoints, runtime management via REST (no restart), per-endpoint event filter, signing secret, and per-endpoint delivery-status observability.

## What's here

- **Store** — `webhook_subscriptions` table (migration 021) + CRUD + `RecordWebhookDelivery`. The HMAC secret is **envelope-encrypted under the master key** (per-row DEK wrapped under the master, secret sealed under the DEK — the `cas` table's scheme), so it never leaves the server in cleartext and is never returned by the API.
- **Dispatcher** — refactored from a single static target to **fan-out**: each event is delivered to the optional static config target plus all matching managed subscriptions from a `SubscriptionSource`, with per-target retry and status recording. `StoreSource` resolves active subscriptions and decrypts their secrets at delivery time. Phase-1 config behavior is preserved (its tests pass unchanged).
- **REST** — owner-scoped CRUD at `/api/v1/webhook-subscriptions` (admin sees all; operators see their own). Secret is **write-only** (omit to keep, `""` to clear, value to set); responses expose only `has_secret`. `config.ValidateWebhookURL` is exported and reused for URL/SSRF validation.
- **serve.go** — the dispatcher now always runs (managed subs are created at runtime) with a store-backed source; `cert.expiring` still folds into the bus.
- **OpenAPI + docs** — CRUD endpoints + schemas; contract tests validate the responses; `docs/webhooks.md` documents managed subscriptions.

## Tests

- store: subscription CRUD round-trip (incl. secret blobs, owner scoping, active filter) + delivery-status recording.
- webhook: fan-out to multiple source targets with status recording; `StoreSource` decrypt + event filter.
- api: CRUD happy path (secret never echoed, `has_secret` exposed), SSRF rejection + `allow_private` opt-in, 404s. The route-scoping registry and cross-operator leak test are extended to cover the new routes.

`go test -race`, `make gosec`, `make govulncheck`, `make lint` all green.

## Deferred (still tracked in #256)

Web UI for subscriptions (the REST API exists now), `ca.expiring`/CA-lifecycle events, and a durable dead-letter queue.

Refs #256
