### PR TITLE
fix(security): add object-src 'none' to CSP

### DIFF
--- a/internal/cli/security_headers.go
+++ b/internal/cli/security_headers.go
@@ -15,6 +15,7 @@ func securityHeaders(next http.Handler) http.Handler {
 		"script-src 'self' 'unsafe-inline'; " +
 		"style-src 'self' 'unsafe-inline'; " +
 		"img-src 'self' data:; " +
+		"object-src 'none'; " +
 		"frame-ancestors 'none'; " +
 		"base-uri 'none'; " +
 		"form-action 'self'"

--- a/internal/cli/security_headers_test.go
+++ b/internal/cli/security_headers_test.go
@@ -81,6 +81,7 @@ func TestSecurityHeaders_CSPDirectives(t *testing.T) {
 	csp := rec.Result().Header.Get("Content-Security-Policy")
 	want := []string{
 		"default-src 'self'",
+		"object-src 'none'",
 		"frame-ancestors 'none'",
 		"base-uri 'none'",
 		"form-action 'self'",


### PR DESCRIPTION
## Summary

Adds the `object-src 'none'` directive to the Content-Security-Policy header (`internal/cli/security_headers.go`).

Without it, the CSP has no explicit `object-src`, so the browser falls back to `default-src 'self'` for `<object>`, `<embed>`, and `<applet>` — permitting plugin-based content (Flash, Java, ActiveX). Modern browsers no longer load these plugins, but security scanners (Mozilla Observatory, CSP Evaluator) flag the missing directive as a gap. Setting it to `'none'` blocks the vector explicitly.

## Changes

- `object-src 'none'` added to the CSP const.
- `TestSecurityHeaders_CSPDirectives` asserts the new directive is present.

## Testing

- `go test -race ./internal/cli/ -run TestSecurityHeaders` — green.

Closes #261
