### PR TITLE
fix(security): generic error on duplicate registration username

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -229,7 +229,11 @@ func (w *Web) handleRegister(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := w.store.GetOperatorByUsername(r.Context(), username); err == nil {
-		w.renderForRequest(rw, r, "register.html", map[string]any{"Error": "Username already taken"})
+		// Generic message so an unauthenticated caller cannot enumerate
+		// existing operator usernames via a distinct error (#260). The real
+		// reason is logged server-side.
+		w.renderForRequest(rw, r, "register.html", map[string]any{"Error": "Registration failed"})
+		w.logger.Info("register: username taken", "username", username)
 		return
 	} else if !errors.Is(err, store.ErrNotFound) {
 		w.logger.Error("register: lookup", "error", err)

--- a/internal/web/register_test.go
+++ b/internal/web/register_test.go
@@ -91,8 +91,14 @@ func TestRegister_RejectsDuplicateUsername(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
-	if !strings.Contains(rec.Body.String(), "Username already taken") {
-		t.Errorf("expected duplicate-username error; body=%s", rec.Body.String())
+	body := rec.Body.String()
+	if !strings.Contains(body, "Registration failed") {
+		t.Errorf("expected generic registration error; body=%s", body)
+	}
+	// The response must not reveal that the username specifically is taken,
+	// otherwise it becomes a username-enumeration oracle (#260).
+	if strings.Contains(body, "already taken") {
+		t.Errorf("response leaks that username exists; body=%s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

The self-registration handler (`internal/web/handlers.go`) returned a distinct `"Username already taken"` error when the chosen username already existed, letting an unauthenticated caller enumerate valid operator usernames via `/ui/register`. The login page is already protected against this via the dummy-hash timing equalizer (#180); registration had no equivalent.

Self-registration is disabled by default (`allow_self_registration: false`), so only deployments that enable it are exposed — but defence-in-depth still applies.

## Changes

- Registration now returns a generic `"Registration failed"` message and logs the real reason (`register: username taken`) server-side.
- The admin operator-creation path (`internal/web/operators.go`) is intentionally **unchanged**: that caller is authenticated and can already list operators, so its specific message is not an enumeration oracle.
- `TestRegister_RejectsDuplicateUsername` updated to assert the generic message and that the response does not leak `already taken`.

## Testing

- `go test -race ./internal/web/ -run TestRegister` — green.

Closes #260
