### PR TITLE
feat(metrics)!: default metrics.require_auth to true

### DIFF
--- a/configs/server.example.yml
+++ b/configs/server.example.yml
@@ -36,11 +36,12 @@ allow_self_registration: false
 # /debug/vars regardless.
 # metrics:
 #   prometheus: true
-#   # Gate /metrics behind the same bearer auth as the API (#187). Default
-#   # false keeps unauthenticated scraping; set true when the server is
-#   # reachable beyond a trusted network — metric labels expose host/network/CA
-#   # IDs. /debug/vars is always bearer-gated.
-#   require_auth: false
+#   # Gate /metrics behind the same bearer auth as the API (#187). Defaults
+#   # to true (#262): metric labels expose host/network/CA IDs, so scraping is
+#   # authenticated unless you opt out. Set false only on a trusted network
+#   # where the scraper cannot pass a bearer token. /debug/vars is always
+#   # bearer-gated.
+#   require_auth: true
 
 # Cert-expiry alerter (issue #41). Disabled by default. When enabled, a
 # periodic scanner fans out alerts for hosts whose current certificate

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -179,7 +179,8 @@ func (s *Server) setupRoutes() {
 	r.Get("/health", s.handleHealth) // legacy alias
 	r.Get("/healthz", s.handleHealth)
 	r.Get("/readyz", s.handleReady)
-	// /metrics is public by default; when metrics.require_auth is set it moves
+	// /metrics is bearer-gated by default (#262); set metrics.require_auth:
+	// false to expose it publicly on a trusted network. When gated it moves
 	// into the bearer-protected group below (#187) — the labels expose
 	// host/network/CA IDs and operational counters.
 	if s.metricsEnabled && !s.metricsRequireAuth {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -136,7 +136,7 @@ func Serve(configPath string, insecureHTTP bool) error {
 	// Create API server
 	apiSrv := api.NewServer(s, logger)
 	apiSrv.WithMetricsEnabled(cfg.Metrics.PrometheusEnabled())
-	apiSrv.WithMetricsRequireAuth(cfg.Metrics.RequireAuth)
+	apiSrv.WithMetricsRequireAuth(cfg.Metrics.RequireAuthEnabled())
 	apiSrv.WithEnrollmentTokenTTL(cfg.EnrollmentTokenTTLDuration())
 
 	// Outbound lifecycle-event webhooks (#256). When enabled, handlers emit

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -329,10 +329,11 @@ type MetricsConfig struct {
 	Prometheus *bool `yaml:"prometheus,omitempty"`
 
 	// RequireAuth gates the /metrics endpoint behind the same bearer auth as
-	// the API (#187). Default false keeps unauthenticated scraping working;
-	// set true when the server is reachable beyond a trusted network, since
-	// the metric labels expose host/network/CA IDs and operational counters.
-	RequireAuth bool `yaml:"require_auth,omitempty"`
+	// the API (#187). It is a pointer so an unset value (yaml omitted) takes
+	// the default (true, #262): the metric labels expose host/network/CA IDs
+	// and operational counters, so unauthenticated scraping is opt-in. Set
+	// `require_auth: false` to allow it on a trusted network.
+	RequireAuth *bool `yaml:"require_auth,omitempty"`
 }
 
 // PrometheusEnabled returns whether the Prometheus exporter should be served.
@@ -342,6 +343,16 @@ func (m MetricsConfig) PrometheusEnabled() bool {
 		return true
 	}
 	return *m.Prometheus
+}
+
+// RequireAuthEnabled returns whether /metrics must be bearer-authenticated.
+// Defaults to true when unset (#262); set `require_auth: false` to opt into
+// unauthenticated scraping on a trusted network.
+func (m MetricsConfig) RequireAuthEnabled() bool {
+	if m.RequireAuth == nil {
+		return true
+	}
+	return *m.RequireAuth
 }
 
 // OIDCConfig configures an OpenID Connect identity provider for operator

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -67,6 +67,44 @@ func TestLoadServerConfig_Defaults(t *testing.T) {
 	}
 }
 
+func TestMetricsConfig_RequireAuthEnabled(t *testing.T) {
+	// Default (omitted) gates /metrics behind bearer auth (#262): the metric
+	// labels expose host/network/CA IDs, so unauthenticated scraping is now
+	// opt-in.
+	var m MetricsConfig
+	if !m.RequireAuthEnabled() {
+		t.Error("RequireAuthEnabled() = false for unset config, want true (auth-gated by default)")
+	}
+
+	// Operators on a trusted network opt out explicitly.
+	f := false
+	m.RequireAuth = &f
+	if m.RequireAuthEnabled() {
+		t.Error("RequireAuthEnabled() = true with require_auth: false, want false")
+	}
+
+	tr := true
+	m.RequireAuth = &tr
+	if !m.RequireAuthEnabled() {
+		t.Error("RequireAuthEnabled() = false with require_auth: true, want true")
+	}
+}
+
+func TestLoadServerConfig_MetricsRequireAuthDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "server.yml")
+	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadServerConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Metrics.RequireAuthEnabled() {
+		t.Error("metrics.require_auth default = false, want true (#262)")
+	}
+}
+
 func TestLoadServerConfig_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "server.yml")


### PR DESCRIPTION
## Summary

Flips the default of `metrics.require_auth` from `false` to `true`, so the `/metrics` endpoint is bearer-gated by default. The gate itself already existed (#187); this is the behavioral default decision tracked in #262.

The metric labels expose internal identifiers to any scraper:

| Metric | Leaked label |
|--------|--------------|
| `nebula_mgmt_hosts` | `network={network_id}` |
| `nebula_mgmt_cert_expiring_seconds` | `host={host_id}`, `network={network_id}` |
| `nebula_mgmt_ca_signatures_total` | `ca_id={ca_id}` |

Defaulting to authenticated scraping is the safer posture; operators on a trusted network opt back into unauthenticated scraping with `require_auth: false`.

## Changes

- `MetricsConfig.RequireAuth` is now `*bool` (mirrors `Prometheus`), so an omitted value takes the secure default while `require_auth: false` still disables the gate. New `RequireAuthEnabled()` accessor.
- `internal/cli/serve.go` wires `RequireAuthEnabled()`.
- `configs/server.example.yml` and the route comment in `internal/api/server.go` updated to document the new default.
- Tests: `TestMetricsConfig_RequireAuthEnabled` (accessor default + opt-out) and `TestLoadServerConfig_MetricsRequireAuthDefault` (loaded default is gated).

## ⚠️ Breaking change

`/metrics` now requires bearer auth unless `metrics.require_auth: false` is set. Trusted-network scrapers relying on unauthenticated `/metrics` must either pass the API bearer token or set `require_auth: false`.

## Testing

- `go test -race ./internal/config/ ./internal/api/ ./internal/cli/` — green.
- `make lint` — 0 issues.

Closes #262
