### PR TITLE
feat(web): self-service password change for operators

### DIFF
--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -749,6 +749,21 @@ func (s *SQLiteStore) DeleteOperatorSessionsByOperator(ctx context.Context, oper
 	return nil
 }
 
+// DeleteOperatorSessionsByOperatorExcept removes every session of an operator
+// except the one identified by keepToken, used by self-service password change
+// to revoke other (possibly compromised) sessions while keeping the caller's
+// current session alive (#259). keepToken is the raw cookie value; it is hashed
+// here, mirroring DeleteOperatorSession.
+func (s *SQLiteStore) DeleteOperatorSessionsByOperatorExcept(ctx context.Context, operatorID, keepToken string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM operator_sessions WHERE operator_id=? AND token_hash<>?`,
+		operatorID, models.HashSessionToken(keepToken))
+	if err != nil {
+		return fmt.Errorf("delete sessions by operator except current: %w", err)
+	}
+	return nil
+}
+
 func (s *SQLiteStore) DeleteExpiredOperatorSessions(ctx context.Context, before time.Time) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM operator_sessions WHERE expires_at < ?`, before)
 	if err != nil {

--- a/internal/store/sqlite_session_except_test.go
+++ b/internal/store/sqlite_session_except_test.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// TestDeleteOperatorSessionsByOperatorExcept verifies that self-service password
+// change can terminate every other session of an operator while keeping the
+// caller's current session alive (#259). The kept session is identified by its
+// raw token; the method hashes it internally like DeleteOperatorSession.
+func TestDeleteOperatorSessionsByOperatorExcept(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := newTestOperator(t, s, "erin")
+	other := newTestOperator(t, s, "frank")
+
+	mk := func(operatorID, token string) {
+		t.Helper()
+		if err := s.CreateOperatorSession(ctx, &models.OperatorSession{
+			Token:      token,
+			OperatorID: operatorID,
+			State:      models.SessionStateAuthenticated,
+			ExpiresAt:  time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("create session %q: %v", token, err)
+		}
+	}
+	mk(op.ID, "keep-token")
+	mk(op.ID, "drop-token-1")
+	mk(op.ID, "drop-token-2")
+	mk(other.ID, "other-token") // belongs to a different operator, must survive
+
+	if err := s.DeleteOperatorSessionsByOperatorExcept(ctx, op.ID, "keep-token"); err != nil {
+		t.Fatalf("delete except: %v", err)
+	}
+
+	// The kept session is still valid.
+	if _, err := s.GetOperatorBySession(ctx, "keep-token"); err != nil {
+		t.Errorf("kept session should be valid, got %v", err)
+	}
+	// The other two of this operator are gone.
+	for _, tok := range []string{"drop-token-1", "drop-token-2"} {
+		if _, err := s.GetOperatorBySession(ctx, tok); !errors.Is(err, ErrNotFound) {
+			t.Errorf("session %q should be deleted, got err=%v", tok, err)
+		}
+	}
+	// A different operator's session is untouched.
+	if _, err := s.GetOperatorBySession(ctx, "other-token"); err != nil {
+		t.Errorf("other operator's session should survive, got %v", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -184,6 +184,7 @@ type Store interface {
 	PromoteOperatorSession(ctx context.Context, token string, newExpiry time.Time) error
 	DeleteOperatorSession(ctx context.Context, token string) error
 	DeleteOperatorSessionsByOperator(ctx context.Context, operatorID string) error
+	DeleteOperatorSessionsByOperatorExcept(ctx context.Context, operatorID, keepToken string) error
 	DeleteExpiredOperatorSessions(ctx context.Context, before time.Time) error
 
 	// Lifecycle

--- a/internal/web/change_password_test.go
+++ b/internal/web/change_password_test.go
@@ -1,0 +1,214 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+const oldPassword = "Old-Password!1Strong"
+
+// passwordOperator creates a local operator with a real bcrypt hash of
+// oldPassword plus an authenticated session, returning the current-session
+// cookie. Used by the self-service password-change tests (#259).
+func passwordOperator(t *testing.T, s store.Store, username, token string) (*models.Operator, *http.Cookie) {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(oldPassword), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	op := &models.Operator{
+		ID:           "op-" + username,
+		Username:     username,
+		PasswordHash: string(hash),
+		Status:       models.OperatorStatusActive,
+		Role:         "user",
+		AuthProvider: models.OperatorAuthLocal,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(context.Background(), op); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token:      token,
+		OperatorID: op.ID,
+		State:      models.SessionStateAuthenticated,
+		ExpiresAt:  time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return op, &http.Cookie{Name: "nebula_session", Value: token}
+}
+
+func postChangePassword(t *testing.T, w *Web, auth *http.Cookie, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	csrfToken, cookies := getCSRFTokenFromCookies(t, w, "/ui/profile", []*http.Cookie{auth})
+	form.Set("_csrf", csrfToken)
+	req := httptest.NewRequest(http.MethodPost, "/ui/profile/change-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestChangePassword_HappyPath(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	op, auth := passwordOperator(t, s, "erin", "erin-current")
+
+	// A second, "other-device" session that must be revoked by the change.
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token:      "erin-other",
+		OperatorID: op.ID,
+		State:      models.SessionStateAuthenticated,
+		ExpiresAt:  time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	newPass := oldPassword + "-new9"
+	rec := postChangePassword(t, w, auth, url.Values{
+		"old_password":         {oldPassword},
+		"new_password":         {newPass},
+		"new_password_confirm": {newPass},
+	})
+	if rec.Code != http.StatusOK && rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 200/303; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Password actually changed.
+	got, err := s.GetOperator(context.Background(), op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bcrypt.CompareHashAndPassword([]byte(got.PasswordHash), []byte(newPass)) != nil {
+		t.Error("new password does not verify against stored hash")
+	}
+
+	// Current session survives; other session revoked.
+	if _, err := s.GetOperatorBySession(context.Background(), "erin-current"); err != nil {
+		t.Errorf("current session should survive, got %v", err)
+	}
+	if _, err := s.GetOperatorBySession(context.Background(), "erin-other"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("other session should be revoked, got err=%v", err)
+	}
+}
+
+func TestChangePassword_WrongOldPassword(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	op, auth := passwordOperator(t, s, "frank", "frank-current")
+
+	newPass := oldPassword + "-new9"
+	rec := postChangePassword(t, w, auth, url.Values{
+		"old_password":         {"totally-wrong-old"},
+		"new_password":         {newPass},
+		"new_password_confirm": {newPass},
+	})
+	if rec.Code == http.StatusSeeOther {
+		t.Fatalf("wrong old password should not redirect as success; status=%d", rec.Code)
+	}
+
+	// Password unchanged: old still verifies.
+	got, err := s.GetOperator(context.Background(), op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bcrypt.CompareHashAndPassword([]byte(got.PasswordHash), []byte(oldPassword)) != nil {
+		t.Error("password should be unchanged after wrong old password")
+	}
+}
+
+func TestChangePassword_WeakNewPassword(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	op, auth := passwordOperator(t, s, "grace", "grace-current")
+
+	rec := postChangePassword(t, w, auth, url.Values{
+		"old_password":         {oldPassword},
+		"new_password":         {"short"},
+		"new_password_confirm": {"short"},
+	})
+	if rec.Code == http.StatusSeeOther {
+		t.Fatalf("weak new password should not redirect as success; status=%d", rec.Code)
+	}
+	got, _ := s.GetOperator(context.Background(), op.ID)
+	if bcrypt.CompareHashAndPassword([]byte(got.PasswordHash), []byte(oldPassword)) != nil {
+		t.Error("password should be unchanged after weak new password")
+	}
+}
+
+func TestChangePassword_MismatchedConfirm(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	op, auth := passwordOperator(t, s, "heidi", "heidi-current")
+
+	newPass := oldPassword + "-new9"
+	rec := postChangePassword(t, w, auth, url.Values{
+		"old_password":         {oldPassword},
+		"new_password":         {newPass},
+		"new_password_confirm": {newPass + "X"},
+	})
+	if rec.Code == http.StatusSeeOther {
+		t.Fatalf("mismatched confirm should not redirect as success; status=%d", rec.Code)
+	}
+	got, _ := s.GetOperator(context.Background(), op.ID)
+	if bcrypt.CompareHashAndPassword([]byte(got.PasswordHash), []byte(oldPassword)) != nil {
+		t.Error("password should be unchanged after mismatched confirm")
+	}
+}
+
+// TestProfile_ChangePasswordForm_LocalOnly verifies the form renders for a
+// local operator and is hidden for an OIDC operator (#259).
+func TestProfile_ChangePasswordForm_LocalOnly(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	_, localAuth := passwordOperator(t, s, "ivan", "ivan-current")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ui/profile", nil)
+	req.AddCookie(localAuth)
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "change-password") {
+		t.Error("local operator profile should render the change-password form")
+	}
+
+	// OIDC operator: no local password, form hidden.
+	oidc := &models.Operator{
+		ID:           "op-judy",
+		Username:     "judy",
+		PasswordHash: "oidc",
+		Status:       models.OperatorStatusActive,
+		Role:         "user",
+		AuthProvider: models.OperatorAuthOIDC,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(context.Background(), oidc); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateOperatorSession(context.Background(), &models.OperatorSession{
+		Token:      "judy-current",
+		OperatorID: oidc.ID,
+		State:      models.SessionStateAuthenticated,
+		ExpiresAt:  time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/ui/profile", nil)
+	req.AddCookie(&http.Cookie{Name: "nebula_session", Value: "judy-current"})
+	w.ServeHTTP(rec, req)
+	if strings.Contains(rec.Body.String(), "change-password") {
+		t.Error("OIDC operator profile should not render the change-password form")
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -270,6 +270,13 @@ func (w *Web) handleProfilePage(rw http.ResponseWriter, r *http.Request) {
 		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
 		return
 	}
+	w.renderProfile(rw, r, op, nil)
+}
+
+// renderProfile loads the operator's CAs and renders the profile page. extra
+// merges page-specific fields (e.g. password-change messages) into the template
+// data, so callers can re-render the page with an inline result.
+func (w *Web) renderProfile(rw http.ResponseWriter, r *http.Request, op *models.Operator, extra map[string]any) {
 	cas, err := w.store.ListCAsByOwner(r.Context(), op.ID)
 	if err != nil {
 		w.logger.Error("list cas for profile", "error", err)
@@ -284,11 +291,73 @@ func (w *Web) handleProfilePage(rw http.ResponseWriter, r *http.Request) {
 			IsExpiringSoon: pki.ShouldRenew(ca.NotBefore, ca.NotAfter),
 		}
 	}
-	w.renderForRequest(rw, r, "profile.html", map[string]any{
+	data := map[string]any{
 		"Active":   "profile",
 		"Operator": op,
 		"CAs":      caViews,
-	})
+		// IsLocal gates the change-password form: OIDC operators have no local
+		// password to change.
+		"IsLocal": op.AuthProvider == models.OperatorAuthLocal,
+	}
+	for k, v := range extra {
+		data[k] = v
+	}
+	w.renderForRequest(rw, r, "profile.html", data)
+}
+
+// handleChangePassword lets an operator change their own password after proving
+// the current one (#259). On success it revokes every other session of the
+// operator while keeping the caller's current session alive.
+func (w *Web) handleChangePassword(rw http.ResponseWriter, r *http.Request) {
+	op := w.session.CurrentOperator(r)
+	if op == nil {
+		http.Redirect(rw, r, "/ui/login", http.StatusSeeOther)
+		return
+	}
+	// OIDC operators authenticate through the IdP and have no local password.
+	if op.AuthProvider != models.OperatorAuthLocal {
+		http.Error(rw, "password change is not available for federated accounts", http.StatusForbidden)
+		return
+	}
+
+	oldPassword := r.FormValue("old_password")
+	newPassword := r.FormValue("new_password")
+	confirm := r.FormValue("new_password_confirm")
+
+	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(oldPassword)); err != nil {
+		w.renderProfile(rw, r, op, map[string]any{"PasswordError": "Current password is incorrect"})
+		return
+	}
+	if err := w.passwordPolicy.Validate(newPassword, strings.ToLower(op.Username)); err != nil {
+		w.renderProfile(rw, r, op, map[string]any{"PasswordError": err.Error()})
+		return
+	}
+	if newPassword != confirm {
+		w.renderProfile(rw, r, op, map[string]any{"PasswordError": "Password confirmation does not match"})
+		return
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	if err != nil {
+		w.logger.Error("hash password", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := w.store.UpdateOperatorPassword(r.Context(), op.ID, string(hash)); err != nil {
+		w.logger.Error("update password", "error", err)
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+	// Revoke every other session so a self-service change after a suspected
+	// compromise locks out a stolen cookie, while keeping the caller's current
+	// session alive (#259, mirrors the admin-reset cascade in #204, CWE-613).
+	if cookie, err := r.Cookie(sessionCookieName); err == nil {
+		if err := w.store.DeleteOperatorSessionsByOperatorExcept(r.Context(), op.ID, cookie.Value); err != nil {
+			w.logger.Error("invalidate other sessions on password change", "error", err)
+		}
+	}
+	_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.change_password", op.ID, "")
+	w.renderProfile(rw, r, op, map[string]any{"PasswordSuccess": "Password changed. Other sessions have been signed out."})
 }
 
 // --- 2FA management ---

--- a/internal/web/templates/profile.html
+++ b/internal/web/templates/profile.html
@@ -16,6 +16,21 @@
     </table>
 </div>
 
+{{if .IsLocal}}
+<div class="card">
+    <h2>Change password</h2>
+    {{if .PasswordError}}<p class="error" style="color:var(--danger,#c0392b)">{{.PasswordError}}</p>{{end}}
+    {{if .PasswordSuccess}}<p class="success" style="color:var(--success,#27ae60)">{{.PasswordSuccess}}</p>{{end}}
+    <form method="POST" action="/ui/profile/change-password" class="change-password">
+        {{ csrfField }}
+        <p><label>Current password<br><input type="password" name="old_password" autocomplete="current-password" required></label></p>
+        <p><label>New password<br><input type="password" name="new_password" autocomplete="new-password" required></label></p>
+        <p><label>Confirm new password<br><input type="password" name="new_password_confirm" autocomplete="new-password" required></label></p>
+        <button type="submit" class="btn btn-primary">Change password</button>
+    </form>
+</div>
+{{end}}
+
 <div class="card">
     <h2>Account actions</h2>
     <p style="margin-bottom:12px"><a href="/ui/2fa">Manage two-factor authentication →</a></p>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -333,6 +333,7 @@ func (w *Web) setupRoutes() {
 			r.Get("/ui/networks", w.handleNetworks)
 			r.Post("/ui/networks", w.handleNetworkCreate)
 			r.Get("/ui/profile", w.handleProfilePage)
+			r.Post("/ui/profile/change-password", w.handleChangePassword)
 			r.Get("/ui/2fa", w.handleTwoFAPage)
 			r.Get("/ui/2fa/required", w.handleTwoFARequired)
 			r.Get("/ui/settings", w.handleSettingsPage)


### PR DESCRIPTION
## Summary

Operators could not change their own password. The only reset path was admin-only (`handleOperatorResetPassword`) and did not require the old password, so an operator whose credential was compromised could not self-remediate, and an admin reset left no accountability for the original operator. This adds a self-service flow on the profile page (OWASP ASVS V2.1.7).

## Changes

- **`POST /ui/profile/change-password`** (auth-required, CSRF-protected, in the protected route group): verifies `old_password` via `bcrypt.CompareHashAndPassword`, validates `new_password` against the password policy and the confirmation field, then updates the hash.
- **Other-session revocation**: on success, every *other* session of the operator is revoked while the caller's current session stays alive — a change after a suspected compromise locks out a stolen cookie (mirrors the admin-reset cascade, #204, CWE-613). Backed by a new `Store.DeleteOperatorSessionsByOperatorExcept(operatorID, keepToken)` that deletes by `operator_id` excluding the current token's hash.
- **Local-only**: the form renders only for `AuthProvider == local`; OIDC operators have no local password and the handler refuses them with 403.
- **Profile rendering** refactored into a `renderProfile` helper so the page can re-render with an inline error/success message; `handleProfilePage` delegates to it.
- Audit entry `operator.change_password` on success.

## Testing

- `internal/web/change_password_test.go`: happy path (password actually changes, current session survives, other session revoked), wrong old password (unchanged), weak new password (policy rejection), mismatched confirmation, and form local-only/OIDC-hidden rendering.
- `internal/store/sqlite_session_except_test.go`: the new store method keeps the named session, drops the operator's others, leaves other operators' sessions intact.
- `go test -race ./internal/web/ ./internal/store/` — green.
- `make lint` — 0 issues.

Closes #259
