### PR TITLE
feat(auth): per-account lockout after repeated failed logins

### DIFF
--- a/internal/models/operator.go
+++ b/internal/models/operator.go
@@ -46,6 +46,13 @@ type Operator struct {
 	CreatedAt    time.Time            `json:"created_at"`
 	UpdatedAt    time.Time            `json:"updated_at"`
 	LastLoginAt  *time.Time           `json:"last_login_at,omitempty"`
+
+	// FailedLoginAttempts counts consecutive failed password logins; it
+	// resets to 0 on a successful login or when an expired lock is cleared
+	// (#263). LockedUntil, when non-nil and in the future, blocks login
+	// regardless of credentials.
+	FailedLoginAttempts int        `json:"-"`
+	LockedUntil         *time.Time `json:"-"`
 }
 
 // OperatorAPIKey is a per-operator API key. Only the hash is stored.

--- a/internal/store/migrations/022_operator_lockout.down.sql
+++ b/internal/store/migrations/022_operator_lockout.down.sql
@@ -1,0 +1,5 @@
+-- Reverse 022_operator_lockout (#263). DROP COLUMN requires SQLite >= 3.35.
+-- The migration loader is up-only, so this file documents the rollback and is
+-- not executed at runtime.
+ALTER TABLE operators DROP COLUMN locked_until;
+ALTER TABLE operators DROP COLUMN failed_login_attempts;

--- a/internal/store/migrations/022_operator_lockout.up.sql
+++ b/internal/store/migrations/022_operator_lockout.up.sql
@@ -1,0 +1,6 @@
+-- Per-account login lockout (#263). failed_login_attempts counts consecutive
+-- failed password logins; locked_until, when in the future, blocks login
+-- regardless of credentials. Both reset on a successful login and when an
+-- expired lock is observed. NULL locked_until means "not locked".
+ALTER TABLE operators ADD COLUMN failed_login_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE operators ADD COLUMN locked_until DATETIME;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -149,6 +149,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		"019_session_token_hash.up.sql",
 		"020_operator_totp_timestep.up.sql",
 		"021_webhook_subscriptions.up.sql",
+		"022_operator_lockout.up.sql",
 	}
 
 	conn, err := s.db.Conn(ctx)

--- a/internal/store/sqlite_lockout_test.go
+++ b/internal/store/sqlite_lockout_test.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestOperatorLockout_DefaultsAndMethods covers the per-account lockout store
+// surface (#263): fresh operators start unlocked; RecordFailedLoginAttempt
+// increments and locks at the threshold; ResetFailedLoginAttempts clears both.
+func TestOperatorLockout_DefaultsAndMethods(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	op := newTestOperator(t, s, "mallory")
+
+	// Fresh operator: zero attempts, no lock.
+	got, err := s.GetOperator(ctx, op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FailedLoginAttempts != 0 {
+		t.Errorf("fresh FailedLoginAttempts = %d, want 0", got.FailedLoginAttempts)
+	}
+	if got.LockedUntil != nil {
+		t.Errorf("fresh LockedUntil = %v, want nil", got.LockedUntil)
+	}
+
+	const maxAttempts = 5
+	lockUntil := time.Now().Add(15 * time.Minute)
+
+	// The first maxAttempts-1 failures must not lock.
+	for i := 1; i < maxAttempts; i++ {
+		locked, err := s.RecordFailedLoginAttempt(ctx, op.ID, maxAttempts, lockUntil)
+		if err != nil {
+			t.Fatalf("record attempt %d: %v", i, err)
+		}
+		if locked {
+			t.Fatalf("locked after %d attempts, want lock only at %d", i, maxAttempts)
+		}
+	}
+	got, _ = s.GetOperator(ctx, op.ID)
+	if got.FailedLoginAttempts != maxAttempts-1 {
+		t.Errorf("FailedLoginAttempts = %d, want %d", got.FailedLoginAttempts, maxAttempts-1)
+	}
+	if got.LockedUntil != nil {
+		t.Errorf("LockedUntil set before threshold: %v", got.LockedUntil)
+	}
+
+	// The maxAttempts-th failure locks the account.
+	locked, err := s.RecordFailedLoginAttempt(ctx, op.ID, maxAttempts, lockUntil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !locked {
+		t.Fatal("expected account locked at threshold")
+	}
+	got, _ = s.GetOperator(ctx, op.ID)
+	if got.LockedUntil == nil {
+		t.Fatal("LockedUntil should be set after threshold")
+	}
+
+	// Reset clears both counter and lock.
+	if err := s.ResetFailedLoginAttempts(ctx, op.ID); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.GetOperator(ctx, op.ID)
+	if got.FailedLoginAttempts != 0 || got.LockedUntil != nil {
+		t.Errorf("after reset: attempts=%d locked=%v, want 0/nil", got.FailedLoginAttempts, got.LockedUntil)
+	}
+}

--- a/internal/store/sqlite_operators.go
+++ b/internal/store/sqlite_operators.go
@@ -11,7 +11,7 @@ import (
 	"github.com/forgekeep/nebula-mesh/internal/models"
 )
 
-const operatorColumns = `id, username, display_name, password_hash, auth_provider, status, role, totp_secret, totp_enabled, oidc_issuer, oidc_subject, created_at, updated_at, last_login_at`
+const operatorColumns = `id, username, display_name, password_hash, auth_provider, status, role, totp_secret, totp_enabled, oidc_issuer, oidc_subject, created_at, updated_at, last_login_at, failed_login_attempts, locked_until`
 
 func scanOperator(scanner interface {
 	Scan(dest ...any) error
@@ -19,6 +19,7 @@ func scanOperator(scanner interface {
 	var op models.Operator
 	var (
 		lastLogin   sql.NullTime
+		lockedUntil sql.NullTime
 		totpEnabled int
 	)
 	if err := scanner.Scan(
@@ -27,6 +28,7 @@ func scanOperator(scanner interface {
 		&op.TOTPSecret, &totpEnabled,
 		&op.OIDCIssuer, &op.OIDCSubject,
 		&op.CreatedAt, &op.UpdatedAt, &lastLogin,
+		&op.FailedLoginAttempts, &lockedUntil,
 	); err != nil {
 		return nil, err
 	}
@@ -34,6 +36,10 @@ func scanOperator(scanner interface {
 	if lastLogin.Valid {
 		t := lastLogin.Time
 		op.LastLoginAt = &t
+	}
+	if lockedUntil.Valid {
+		t := lockedUntil.Time
+		op.LockedUntil = &t
 	}
 	return &op, nil
 }
@@ -260,6 +266,41 @@ func (s *SQLiteStore) UpdateOperatorLastLogin(ctx context.Context, id string, t 
 	_, err := s.db.ExecContext(ctx, `UPDATE operators SET last_login_at=?, updated_at=? WHERE id=?`, t, t, id)
 	if err != nil {
 		return fmt.Errorf("update last_login_at: %w", err)
+	}
+	return nil
+}
+
+// RecordFailedLoginAttempt increments the operator's consecutive failed-login
+// counter and, when the count reaches maxAttempts, sets locked_until to
+// lockUntil — atomically in one UPDATE so concurrent failures can't race past
+// the threshold (#263). It reports whether the account is now locked.
+func (s *SQLiteStore) RecordFailedLoginAttempt(ctx context.Context, id string, maxAttempts int, lockUntil time.Time) (bool, error) {
+	now := time.Now()
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE operators
+		    SET failed_login_attempts = failed_login_attempts + 1,
+		        locked_until = CASE WHEN failed_login_attempts + 1 >= ? THEN ? ELSE locked_until END,
+		        updated_at = ?
+		  WHERE id = ?`,
+		maxAttempts, lockUntil, now, id); err != nil {
+		return false, fmt.Errorf("record failed login: %w", err)
+	}
+	var locked sql.NullTime
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT locked_until FROM operators WHERE id = ?`, id).Scan(&locked); err != nil {
+		return false, fmt.Errorf("read lock state: %w", err)
+	}
+	return locked.Valid && locked.Time.After(now), nil
+}
+
+// ResetFailedLoginAttempts clears the failed-login counter and any active lock,
+// called on a successful login and when an expired lock is observed (#263).
+func (s *SQLiteStore) ResetFailedLoginAttempts(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE operators SET failed_login_attempts = 0, locked_until = NULL, updated_at = ? WHERE id = ?`,
+		time.Now(), id)
+	if err != nil {
+		return fmt.Errorf("reset failed login attempts: %w", err)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -155,6 +155,8 @@ type Store interface {
 	ListOperators(ctx context.Context) ([]*models.Operator, error)
 	UpdateOperatorPassword(ctx context.Context, id, passwordHash string) error
 	UpdateOperatorLastLogin(ctx context.Context, id string, t time.Time) error
+	RecordFailedLoginAttempt(ctx context.Context, id string, maxAttempts int, lockUntil time.Time) (bool, error)
+	ResetFailedLoginAttempts(ctx context.Context, id string) error
 	DisableOperator(ctx context.Context, id string) error
 	EnableOperator(ctx context.Context, id string) error
 

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -21,6 +21,13 @@ const (
 	sessionCookieName  = "nebula_session"
 	sessionDuration    = 24 * time.Hour
 	pendingTOTPMaxLife = 5 * time.Minute
+
+	// maxFailedLoginAttempts is the number of consecutive failed password
+	// logins that lock a local account; lockoutDuration is how long the lock
+	// lasts (#263, OWASP ASVS V2.1.5). Defense-in-depth over the IP rate
+	// limiter against distributed brute-force from many source IPs.
+	maxFailedLoginAttempts = 10
+	lockoutDuration        = 15 * time.Minute
 )
 
 // dummyPasswordHash is compared against the submitted password on the
@@ -99,6 +106,22 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 		_ = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password))
 		return LoginResult{}, false, nil
 	}
+	// Per-account lockout (#263). An active lock denies login regardless of the
+	// password, with the same dummy-bcrypt timing and (false, nil) result as a
+	// wrong password so an attacker can't tell a locked account apart (#180).
+	// An expired lock is cleared first so the operator gets a fresh attempt
+	// budget instead of re-locking on the next single mistake.
+	if op.LockedUntil != nil {
+		if time.Now().Before(*op.LockedUntil) {
+			_ = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password))
+			return LoginResult{}, false, nil
+		}
+		if err := sm.store.ResetFailedLoginAttempts(r.Context(), op.ID); err != nil {
+			slog.Debug("reset expired lockout", "error", err)
+		}
+		op.FailedLoginAttempts = 0
+		op.LockedUntil = nil
+	}
 	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {
 		if !errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
 			// The stored value is not a usable bcrypt hash — e.g. the "oidc"
@@ -107,10 +130,28 @@ func (sm *SessionManager) Login(w http.ResponseWriter, r *http.Request, username
 			// an active OIDC username is indistinguishable from a wrong
 			// password (#180).
 			_ = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password))
+		} else {
+			// Genuine wrong password on a local account: count it toward the
+			// lockout threshold and lock when reached. OIDC accounts (no usable
+			// hash, handled above) are not counted — they never log in here.
+			locked, rerr := sm.store.RecordFailedLoginAttempt(r.Context(), op.ID, maxFailedLoginAttempts, time.Now().Add(lockoutDuration))
+			if rerr != nil {
+				slog.Debug("record failed login", "error", rerr)
+			} else if locked {
+				_ = sm.store.AddAuditEntry(r.Context(), op.Username, "operator.account_locked", op.ID, "")
+			}
 		}
 		// Wrong password is a normal auth failure (bool=false), not a system
 		// error to surface to the caller.
 		return LoginResult{}, false, nil //nolint:nilerr
+	}
+
+	// Correct password: clear any prior failure streak so good logins never
+	// accumulate toward a lock (#263). Cheap no-op when already zero.
+	if op.FailedLoginAttempts > 0 {
+		if err := sm.store.ResetFailedLoginAttempts(r.Context(), op.ID); err != nil {
+			slog.Debug("reset failed login counter", "error", err)
+		}
 	}
 
 	// Generate both tokens BEFORE any DB write or response mutation.

--- a/internal/web/session_lockout_test.go
+++ b/internal/web/session_lockout_test.go
@@ -1,0 +1,141 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// attemptLogin drives SessionManager.Login once and returns whether it
+// succeeded. The ResponseRecorder absorbs any Set-Cookie writes.
+func attemptLogin(t *testing.T, sm *SessionManager, username, password string) bool {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/ui/login", nil)
+	_, ok, err := sm.Login(rec, req, username, password)
+	if err != nil {
+		t.Fatalf("Login returned error: %v", err)
+	}
+	return ok
+}
+
+// TestLogin_LockoutAfterRepeatedFailures verifies the per-account lockout (#263):
+// after maxFailedLoginAttempts wrong passwords the account is locked, and while
+// locked even the correct password is rejected without creating a session.
+func TestLogin_LockoutAfterRepeatedFailures(t *testing.T) {
+	_, s := newOperatorsWeb(t)
+	op, _ := passwordOperator(t, s, "lockme", "tok-lockme")
+	sm := NewSessionManager(s)
+
+	for i := 0; i < maxFailedLoginAttempts; i++ {
+		if attemptLogin(t, sm, "lockme", "wrong-password") {
+			t.Fatalf("attempt %d: wrong password should not succeed", i+1)
+		}
+	}
+
+	got, err := s.GetOperator(context.Background(), op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LockedUntil == nil || !got.LockedUntil.After(time.Now()) {
+		t.Fatalf("account should be locked after %d failures; LockedUntil=%v", maxFailedLoginAttempts, got.LockedUntil)
+	}
+
+	// While locked, the correct password is also rejected and no session row
+	// is created (the lock takes precedence over a valid credential).
+	if attemptLogin(t, sm, "lockme", oldPassword) {
+		t.Fatal("correct password should be rejected while account is locked")
+	}
+}
+
+// TestLogin_SucceedsAfterLockExpires verifies an expired lock is cleared so the
+// correct password works again (and the counter is reset).
+func TestLogin_SucceedsAfterLockExpires(t *testing.T) {
+	_, s := newOperatorsWeb(t)
+	op, _ := passwordOperator(t, s, "expireme", "tok-expireme")
+	sm := NewSessionManager(s)
+	ctx := context.Background()
+
+	// Simulate an already-expired lock by recording a failure with a lock time
+	// in the past (threshold 1 → locks immediately, but at a past instant).
+	if _, err := s.RecordFailedLoginAttempt(ctx, op.ID, 1, time.Now().Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	if !attemptLogin(t, sm, "expireme", oldPassword) {
+		t.Fatal("correct password should succeed once the lock has expired")
+	}
+
+	got, err := s.GetOperator(ctx, op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FailedLoginAttempts != 0 || got.LockedUntil != nil {
+		t.Errorf("after successful login: attempts=%d locked=%v, want 0/nil", got.FailedLoginAttempts, got.LockedUntil)
+	}
+}
+
+// TestLogin_SuccessResetsCounter verifies a successful login clears a partial
+// failure streak so it never accumulates toward a lock across good logins.
+func TestLogin_SuccessResetsCounter(t *testing.T) {
+	_, s := newOperatorsWeb(t)
+	op, _ := passwordOperator(t, s, "resetme", "tok-resetme")
+	sm := NewSessionManager(s)
+	ctx := context.Background()
+
+	// A couple of failures below the threshold.
+	for i := 0; i < 3; i++ {
+		if attemptLogin(t, sm, "resetme", "wrong-password") {
+			t.Fatalf("attempt %d should fail", i+1)
+		}
+	}
+	if !attemptLogin(t, sm, "resetme", oldPassword) {
+		t.Fatal("correct password should succeed below the lock threshold")
+	}
+	got, err := s.GetOperator(ctx, op.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FailedLoginAttempts != 0 {
+		t.Errorf("FailedLoginAttempts = %d after success, want 0", got.FailedLoginAttempts)
+	}
+}
+
+// TestLogin_OIDCAccountNotLocked verifies password-login failures against an
+// OIDC operator do not accumulate a lock (they have no local password; OIDC
+// login goes through HandleCallback, not Login).
+func TestLogin_OIDCAccountNotLocked(t *testing.T) {
+	_, s := newOperatorsWeb(t)
+	ctx := context.Background()
+	oidc := &models.Operator{
+		ID:           "op-oidcuser",
+		Username:     "oidcuser",
+		PasswordHash: "oidc",
+		Status:       models.OperatorStatusActive,
+		Role:         "user",
+		AuthProvider: models.OperatorAuthOIDC,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := s.CreateOperator(ctx, oidc); err != nil {
+		t.Fatal(err)
+	}
+	sm := NewSessionManager(s)
+
+	for i := 0; i < maxFailedLoginAttempts+2; i++ {
+		if attemptLogin(t, sm, "oidcuser", "any-password") {
+			t.Fatalf("attempt %d: OIDC account should never authenticate via password", i+1)
+		}
+	}
+	got, err := s.GetOperator(ctx, oidc.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FailedLoginAttempts != 0 || got.LockedUntil != nil {
+		t.Errorf("OIDC account should not be locked: attempts=%d locked=%v", got.FailedLoginAttempts, got.LockedUntil)
+	}
+}


### PR DESCRIPTION
## Summary

Brute-force protection relied entirely on IP rate limiting (`internal/ratelimit`, 5 req/s on auth routes), so a distributed attack from many source IPs could each send ~5 login attempts/second against the same account with no per-account ceiling. This adds per-account lockout (OWASP ASVS V2.1.5) as defence-in-depth.

## Behavior

- After **10** consecutive failed password logins (`maxFailedLoginAttempts`), a local account is locked for **15 minutes** (`lockoutDuration`).
- While locked, `Login` denies access **regardless of credentials**, using the same dummy-bcrypt timing and `(false, nil)` result as a wrong password — an attacker cannot tell a locked account apart from a wrong password (anti-enumeration, #180).
- An **expired** lock is cleared before the password check, so the operator regains a full attempt budget rather than re-locking on a single mistake.
- A **successful** login resets the counter.
- **OIDC accounts** (no local password; login goes through `HandleCallback`, not `Login`) are never counted toward a lock.
- An audit entry `operator.account_locked` is written when a lock triggers.

## Changes

- Migration `022_operator_lockout`: adds `failed_login_attempts INTEGER NOT NULL DEFAULT 0` and `locked_until DATETIME` to `operators`.
- `models.Operator`: `FailedLoginAttempts`, `LockedUntil`; read in `scanOperator`.
- Store: `RecordFailedLoginAttempt` (increments and locks at the threshold in one atomic UPDATE; reports whether now locked) and `ResetFailedLoginAttempts`.
- `SessionManager.Login`: lock check, increment on wrong password (local only), reset on success and on expired lock, audit on lock.
- Threshold/duration are package constants (the session manager takes no config today); making them configurable is a possible follow-up.

## Testing

- `internal/web/session_lockout_test.go`: lock after N failures; locked account rejects even the correct password; success after lock expiry (counter reset); success resets a partial streak; OIDC account never locked.
- `internal/store/sqlite_lockout_test.go`: defaults, threshold behavior, reset.
- `go test -race ./internal/web/ ./internal/store/ ./internal/models/` — green.
- `make lint` — 0 issues.

Closes #263
