### PR TITLE
ci: automate dependency updates (Dependabot + nightly govulncheck)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot version updates.
+# Security updates (CVE-driven) are enabled separately via repo Settings ->
+# Code security -> "Dependabot security updates".
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Batch all non-major updates into one PR to reduce noise;
+      # major bumps still open individually since they may break API.
+      go-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions pinned in .github/workflows/*.yml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Etc/UTC"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -70,3 +70,25 @@ jobs:
           name: fuzz-crashers-${{ matrix.target }}
           path: '**/testdata/fuzz/**'
           if-no-files-found: ignore
+
+  # Go-native vulnerability scan against the Go vuln DB (golang.org/x/vuln).
+  # Off the PR path deliberately: the Go DB imports advisories faster than the
+  # GitHub Advisory Database that drives Dependabot alerts, so this nightly run
+  # is the timely tripwire for Go-specific CVEs. It is reachability-aware — a
+  # failure means a vulnerable code path is actually called, not merely present
+  # in go.mod.
+  govulncheck:
+    name: govulncheck (Go vuln DB)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...


### PR DESCRIPTION
## Summary

Set up automated dependency maintenance so outdated deps and Go CVEs surface without manual scanning (follow-up to #272 / #273).

## What this adds

**1. `.github/dependabot.yml` — version updates**
- `gomod` and `github-actions` ecosystems, weekly (Monday 07:00 UTC).
- Non-major (minor/patch) updates grouped into a single PR to cut noise; major bumps still open individually since they may break the API.

**2. Nightly `govulncheck` job in `scheduled.yml` — CVE tripwire**
- Runs in the existing slow lane (ADR 0009 — off the PR path), reachability-aware.
- The Go vuln DB imports Go-specific advisories ahead of the GitHub Advisory Database that drives Dependabot alerts, so this is the timely signal for Go CVEs.

## Why govulncheck in addition to Dependabot

Dependabot alerts and security updates are already enabled on the repo, but they showed **0 open alerts** while `govulncheck` found 14 real Go advisories against `x/crypto@v0.48.0` (the #272 finding). The gap is import lag: GHSA hadn't picked up the July 2026 Go advisories yet. The nightly `govulncheck` closes that gap.

## Coverage after merge

| Layer | Source | Catches |
|---|---|---|
| Dependabot alerts + security updates | GitHub Advisory DB | CVEs once in GHSA |
| Dependabot version updates (this PR) | version registry | routine freshness, weekly |
| Nightly govulncheck (this PR) | Go vuln DB | Go CVEs, timely + reachability-aware |

## Note

No manual repo-settings change required — Dependabot alerts and automated security fixes are already on (verified via API). This PR is purely the config/workflow layer.
