### PR TITLE
docs(readme): bump install version to 0.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On a fresh Debian / Ubuntu VM (`amd64`):
 
 ```sh
 # 1. Install the server.
-VERSION=0.7.3
+VERSION=0.7.4
 curl -fsSLO "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSION}/nebula-mgmt_${VERSION}_linux_amd64.deb"
 sudo apt install -y "./nebula-mgmt_${VERSION}_linux_amd64.deb"
 
@@ -122,14 +122,14 @@ nebula-mesh ships **two** static binaries. Install whichever you need on each ma
 | `nebula-mgmt` | one server (the control plane) |
 | `nebula-agent` | every Nebula host, next to `nebula` |
 
-Pick an install method below. The examples assume `VERSION=0.7.3` — always replace with the latest from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest). Each release ships a `checksums.txt` (SHA-256).
+Pick an install method below. The examples assume `VERSION=0.7.4` — always replace with the latest from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest). Each release ships a `checksums.txt` (SHA-256).
 
 > ⚠️ **Install the latest release.** Versions older than the newest tag may be missing published security fixes — see the [security advisories](https://github.com/forgekeep/nebula-mesh/security/advisories). Do not pin to an old version unless you have verified it carries every advisory fix you need.
 
 ### Debian / Ubuntu (`.deb`)
 
 ```sh
-VERSION=0.7.3
+VERSION=0.7.4
 ARCH=$(dpkg --print-architecture)   # amd64 | arm64 | armhf (agent only)
 
 # Server (control plane):
@@ -144,7 +144,7 @@ sudo apt install -y "./nebula-agent_${VERSION}_linux_${ARCH}.deb"
 ### RHEL / Fedora / Rocky / Alma (`.rpm`)
 
 ```sh
-VERSION=0.7.3
+VERSION=0.7.4
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
 sudo rpm -i "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSION}/nebula-mgmt_${VERSION}_linux_${ARCH}.rpm"
@@ -158,7 +158,7 @@ sudo rpm -i "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSI
 Download a tarball from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest) and extract:
 
 ```sh
-VERSION=0.7.3
+VERSION=0.7.4
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 


### PR DESCRIPTION
## Summary

- update all README install examples from 0.7.3 to the current v0.7.4 release
- restore the README version CI check before merging #277

## Verification

- `bash scripts/check-readme-version.sh`
