### PR TITLE
fix: Deletion of pending hosts in web UI

### DIFF
--- a/internal/web/host_detail_test.go
+++ b/internal/web/host_detail_test.go
@@ -58,6 +58,61 @@ func TestHostDetail_HasEditButton(t *testing.T) {
 	}
 }
 
+func TestHostDetail_PendingHostCanBeDeleted(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-delete-pending", Name: "test-net", CIDRs: []string{"192.168.100.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	host := &models.Host{
+		ID: "h-delete-pending", NetworkID: "n-delete-pending", Name: "pending-host",
+		NebulaIPs: []string{"192.168.100.11"}, Role: models.HostRoleHost, Status: models.HostStatusPending,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	csrfToken, cookies := getCSRFTokenFromCookies(t, w, "/ui/hosts/"+host.ID, cookies)
+	req := httptest.NewRequest(http.MethodDelete, "/ui/hosts/"+host.ID, nil)
+	req.Header.Set(csrfHeaderName, csrfToken)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if redirect := rec.Header().Get("HX-Redirect"); redirect != "/ui/hosts" {
+		t.Errorf("HX-Redirect = %q, want /ui/hosts", redirect)
+	}
+	if _, err := s.GetHost(ctx, host.ID); err == nil {
+		t.Error("pending host still exists after delete")
+	}
+}
+
+func TestLayout_RegistersHTMXCSRFListenerOnDocument(t *testing.T) {
+	w, _ := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+
+	if !strings.Contains(rec.Body.String(), "document.addEventListener('htmx:configRequest'") {
+		t.Error("layout must register the HTMX CSRF listener on document")
+	}
+}
+
 func TestHostDetail_RendersAdvanced(t *testing.T) {
 	w, s := newTestWeb(t)
 	cookies := loginSession(t, w)

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -10,7 +10,7 @@
     <link rel="manifest" href="/static/manifest.json">
     <script src="/static/htmx.min.js"></script>
     <script>
-    document.body.addEventListener('htmx:configRequest', function(evt) {
+    document.addEventListener('htmx:configRequest', function(evt) {
         var m = document.querySelector('meta[name="csrf-token"]');
         if (m) { evt.detail.headers['X-CSRF-Token'] = m.content; }
     });


### PR DESCRIPTION

## What

Fix pending-host deletion in the web UI.

## Why

HTMX requests could be sent without the CSRF header because the global listener was registered on `document.body` before the body existed. The request was rejected with HTTP 403.


## How

Register the `htmx:configRequest` listener on `document`, which is available while the page head is parsed.
Add regression tests for deleting a pending host with CSRF protection and for the global HTMX listener registration.


## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
