### PR TITLE
Fix: the host edit form so it displays the host’s associated network name

### DIFF
--- a/internal/web/host_edit_test.go
+++ b/internal/web/host_edit_test.go
@@ -86,6 +86,9 @@ func TestHostEdit_GET_AsAdmin(t *testing.T) {
 	if !strings.Contains(body, `value="web-1"`) {
 		t.Error("form should preserve host name")
 	}
+	if !strings.Contains(body, `value="test-net"`) {
+		t.Error("form should show the host network name")
+	}
 
 	if !strings.Contains(body, `value="192.168.100.10"`) {
 		t.Error("form should preserve nebula_ip")

--- a/internal/web/templates/host_edit.html
+++ b/internal/web/templates/host_edit.html
@@ -15,7 +15,7 @@
         {{ csrfField }}
         <div class="form-group">
             <label>Network</label>
-            <input type="text" class="form-control" value="{{.NetworkName}}" disabled>
+            <input type="text" class="form-control" value="{{.Network.Name}}" disabled>
             <div style="font-size: 12px; color: var(--text-muted); margin-top: 4px;">Network cannot be changed.</div>
         </div>
         <div class="form-group">


### PR DESCRIPTION

## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
