### PR TITLE
fix: remove unused hidden input for network CIDR in host edit form

### DIFF
--- a/internal/web/templates/host_edit.html
+++ b/internal/web/templates/host_edit.html
@@ -93,8 +93,6 @@
     </form>
 </div>
 
-<input type="hidden" id="network-cidr-data" value="{{.NetworkCIDR}}">
-
 <script>
 (function() {
     // Setup add/remove row handlers (same as host_new.html)


### PR DESCRIPTION
The form now relies on Network.CIDRs for multi-CIDR display and selection, so the legacy single-CIDR field is no longer needed.


## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
