### PR TITLE
feat(mobile): align generated profiles with Mobile Nebula

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On a fresh Debian / Ubuntu VM (`amd64`):
 
 ```sh
 # 1. Install the server.
-VERSION=0.7.5
+VERSION=0.8.0
 curl -fsSLO "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSION}/nebula-mgmt_${VERSION}_linux_amd64.deb"
 sudo apt install -y "./nebula-mgmt_${VERSION}_linux_amd64.deb"
 
@@ -122,14 +122,14 @@ nebula-mesh ships **two** static binaries. Install whichever you need on each ma
 | `nebula-mgmt` | one server (the control plane) |
 | `nebula-agent` | every Nebula host, next to `nebula` |
 
-Pick an install method below. The examples assume `VERSION=0.7.5` — always replace with the latest from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest). Each release ships a `checksums.txt` (SHA-256).
+Pick an install method below. The examples assume `VERSION=0.8.0` — always replace with the latest from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest). Each release ships a `checksums.txt` (SHA-256).
 
 > ⚠️ **Install the latest release.** Versions older than the newest tag may be missing published security fixes — see the [security advisories](https://github.com/forgekeep/nebula-mesh/security/advisories). Do not pin to an old version unless you have verified it carries every advisory fix you need.
 
 ### Debian / Ubuntu (`.deb`)
 
 ```sh
-VERSION=0.7.5
+VERSION=0.8.0
 ARCH=$(dpkg --print-architecture)   # amd64 | arm64 | armhf (agent only)
 
 # Server (control plane):
@@ -144,7 +144,7 @@ sudo apt install -y "./nebula-agent_${VERSION}_linux_${ARCH}.deb"
 ### RHEL / Fedora / Rocky / Alma (`.rpm`)
 
 ```sh
-VERSION=0.7.5
+VERSION=0.8.0
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
 sudo rpm -i "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSION}/nebula-mgmt_${VERSION}_linux_${ARCH}.rpm"
@@ -158,7 +158,7 @@ sudo rpm -i "https://github.com/forgekeep/nebula-mesh/releases/download/v${VERSI
 Download a tarball from the [releases page](https://github.com/forgekeep/nebula-mesh/releases/latest) and extract:
 
 ```sh
-VERSION=0.7.5
+VERSION=0.8.0
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -241,6 +241,58 @@ paths:
         "404":
           $ref: "#/components/responses/Error"
 
+  /api/v1/networks/{id}/mobile-config:
+    get:
+      operationId: getNetworkMobileConfig
+      summary: Get the settings used to generate mobile Nebula profiles.
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: Mobile profile settings.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MobileConfig"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        "500":
+          $ref: "#/components/responses/Error"
+    put:
+      operationId: updateNetworkMobileConfig
+      summary: Replace the settings used to generate mobile Nebula profiles.
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MobileConfig"
+      responses:
+        "200":
+          description: Updated mobile profile settings.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MobileConfig"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
+        "500":
+          $ref: "#/components/responses/Error"
+
   /api/v1/hosts:
     get:
       operationId: listHosts
@@ -985,6 +1037,28 @@ components:
         created_at:
           type: string
           format: date-time
+
+    MobileConfig:
+      type: object
+      additionalProperties: false
+      required: [dns_resolvers, match_domains, allow_private_remotes]
+      properties:
+        dns_resolvers:
+          type: array
+          maxItems: 16
+          items:
+            type: string
+            maxLength: 45
+            description: IPv4 or IPv6 address without a zone identifier.
+        match_domains:
+          type: array
+          maxItems: 64
+          items:
+            type: string
+            minLength: 1
+            maxLength: 253
+        allow_private_remotes:
+          type: boolean
 
     CreateHostRequest:
       type: object

--- a/docs/security/invariants.md
+++ b/docs/security/invariants.md
@@ -195,8 +195,8 @@ leave a weaker or partially applied security state.
 - Every certificate-signing path re-checks blocked Host and disabled owning
   Operator state from the store.
 - Mobile bundle generation reads the durable CA blocklist and current enrolled
-  relay inventory. It persists a newly issued certificate only after the full
-  bundle has been generated successfully.
+  relay inventory. After the full bundle has been generated, it atomically
+  re-checks the durable Host and owner status while persisting the certificate.
 - Migration tests exercise upgrade, repeated migrate, rollback, and foreign-key
   enforcement.
 
@@ -209,7 +209,10 @@ leave a weaker or partially applied security state.
   prevent enrollment, renewal, re-enrollment, and mobile bundle issuance.
 - `internal/mobilebundle/mobile_profile_test.go`:
   `TestBuild_SEC_PERSIST_001IncludesCurrentBlocklistAndEnrolledRelays` and
-  `TestBuild_SEC_PERSIST_001InvalidSettingsDoNotEnrollOrRotateCertificate`.
+  `TestBuild_SEC_PERSIST_001InvalidSettingsDoNotEnrollOrRotateCertificate`, and
+  `TestBuild_SEC_PERSIST_001ConcurrentBlockCannotBeUndone`.
+- `internal/store/sqlite_mobile_certificate_test.go`: the certificate write
+  rejects blocked Hosts and disabled owners.
 - `internal/store/sqlite_enroll_token_test.go`:
   `TestConsumeTokenAndEnrollHost_NoBurnOnEnrollFailure`.
 - `internal/store/migration_023_test.go`, `migration_024_test.go`, and

--- a/docs/security/invariants.md
+++ b/docs/security/invariants.md
@@ -37,6 +37,8 @@ broaden it.
   route without a scoping decision fails CI.
 - Managed webhook subscriptions are selected by CA owner; the deployer-owned
   static webhook is intentionally global.
+- Mobile profile settings are read and replaced only after authorization through
+  the owning Network and CA.
 
 ### Test anchors
 
@@ -44,6 +46,8 @@ broaden it.
   `TestProtectedGETRoutesAreClassified` and `TestListEndpointsScopeToOwner`.
 - `internal/api/scoping_boundary_test.go`: foreign filters and response-body
   non-disclosure.
+- `internal/api/mobile_config_authz_test.go`: foreign mobile profile reads do
+  not disclose settings and foreign writes do not mutate them.
 - `internal/web/tenant_scope_test.go`: Web read and mutation isolation.
 - `internal/webhook/fanout_test.go`:
   `TestDispatcher_ManagedTargetsAreCAOwnerScopedAndStaticTargetIsGlobal`.
@@ -190,6 +194,9 @@ leave a weaker or partially applied security state.
   challenge cleanup in one transaction with revision and scope checks.
 - Every certificate-signing path re-checks blocked Host and disabled owning
   Operator state from the store.
+- Mobile bundle generation reads the durable CA blocklist and current enrolled
+  relay inventory. It persists a newly issued certificate only after the full
+  bundle has been generated successfully.
 - Migration tests exercise upgrade, repeated migrate, rollback, and foreign-key
   enforcement.
 
@@ -200,6 +207,9 @@ leave a weaker or partially applied security state.
   `TestFinalizeMeshImportRollsBackChallengeCleanup`.
 - `internal/api/durable_revocation_test.go`: blocked Host and disabled owner
   prevent enrollment, renewal, re-enrollment, and mobile bundle issuance.
+- `internal/mobilebundle/mobile_profile_test.go`:
+  `TestBuild_SEC_PERSIST_001IncludesCurrentBlocklistAndEnrolledRelays` and
+  `TestBuild_SEC_PERSIST_001InvalidSettingsDoNotEnrollOrRotateCertificate`.
 - `internal/store/sqlite_enroll_token_test.go`:
   `TestConsumeTokenAndEnrollHost_NoBurnOnEnrollFailure`.
 - `internal/store/migration_023_test.go`, `migration_024_test.go`, and

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -122,7 +122,7 @@ Trust zones, from least to most trusted:
   multipart parsing for cryptographic secret ingress; body caps and length
   bounds on cert-embedded fields (#186, #195; `SEC-SECRET-001`).
 - **Tenant isolation**: lifecycle events carry a non-serialized CA scope. Managed webhook targets are selected only from subscriptions owned by that CA's operator; empty or unknown scope selects none. The static config target is explicitly deployer-wide.
-- **Mobile bundles**: generation uses the current CA blocklist and enrolled relay inventory, applies the per-Network private-remote policy, and commits a newly issued certificate only after every bundle input and the rendered config succeed.
+- **Mobile bundles**: generation uses the current CA blocklist and enrolled relay inventory, applies the per-Network private-remote policy, and commits a newly issued certificate only after every bundle input and the rendered config succeed. The final certificate write atomically re-checks durable Host and owner status so concurrent revocation wins.
 - **Tooling baseline**: `golangci-lint` (pinned), standalone `gosec`, and `govulncheck` gate every PR, plus ADR-0009 generative fuzzing in CI.
 
 ## 6. Residual risks & accepted trade-offs

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -72,9 +72,9 @@ Trust zones, from least to most trusted:
 
 ### E1 — Management API
 - **Spoofing**: API key required; keys hashed at rest, revocable; disabled operators rejected (re-check on every request, #147).
-- **Tampering**: write actions ownership-checked; input bounded (host name/groups #186, firewall selectors #195).
+- **Tampering**: write actions ownership-checked; input bounded (host name/groups #186, firewall selectors #195). Mobile profile settings reject unknown or missing fields, non-IP DNS resolvers, duplicates, and oversized lists or domains.
 - **Repudiation**: mutating actions write an audit-log entry; audit-log read is admin-gated.
-- **Information disclosure**: list/read scoped to owned CAs in SQL (#154); blocklist scoped per-CA (#203); no cross-tenant IDOR (403 not 404 side-channel documented & accepted).
+- **Information disclosure**: list/read scoped to owned CAs in SQL (#154); blocklist scoped per-CA (#203); mobile profile settings are scoped through their Network and owning CA; no cross-tenant IDOR (403 not 404 side-channel documented & accepted).
 - **DoS**: request body capped + HTTP timeouts (#185); per-IP rate limit (#52). Authenticated legitimate-use DoS is out of scope (SECURITY.md).
 - **Elevation**: no general "update operator" sink → no `role` mass-assignment (Netmaker CVE-2026-29195 class refuted); admin-only operator/settings endpoints.
 
@@ -122,6 +122,7 @@ Trust zones, from least to most trusted:
   multipart parsing for cryptographic secret ingress; body caps and length
   bounds on cert-embedded fields (#186, #195; `SEC-SECRET-001`).
 - **Tenant isolation**: lifecycle events carry a non-serialized CA scope. Managed webhook targets are selected only from subscriptions owned by that CA's operator; empty or unknown scope selects none. The static config target is explicitly deployer-wide.
+- **Mobile bundles**: generation uses the current CA blocklist and enrolled relay inventory, applies the per-Network private-remote policy, and commits a newly issued certificate only after every bundle input and the rendered config succeed.
 - **Tooling baseline**: `golangci-lint` (pinned), standalone `gosec`, and `govulncheck` gate every PR, plus ADR-0009 generative fuzzing in CI.
 
 ## 6. Residual risks & accepted trade-offs

--- a/internal/api/audit_property_test.go
+++ b/internal/api/audit_property_test.go
@@ -46,6 +46,11 @@ func TestAuditRows_AllProductionPathsConform(t *testing.T) {
 		[]byte(`{"inbound":[{"port":"443","proto":"tcp","group":"servers"}],"outbound":[{"port":"any","proto":"any","group":"all"}]}`),
 		http.StatusOK)
 
+	// network.mobile_config.update — update settings used by future mobile bundles.
+	mustDo(t, srv, http.MethodPut, "/api/v1/networks/"+netID+"/mobile-config",
+		[]byte(`{"dns_resolvers":[],"match_domains":[],"allow_private_remotes":true}`),
+		http.StatusOK)
+
 	// host.create — normal create.
 	hostID := mustCreateHost(t, srv, netID, "audit-h1", "192.168.100.50")
 
@@ -167,6 +172,7 @@ var auditActionsExercisedByCoverageSweep = []string{
 	auditCADeleted,
 	auditNetworkCreate,
 	auditNetworkFirewallUpdate,
+	auditNetworkMobileConfigUpdate,
 	auditOperatorCreate,
 	auditOperatorDisable,
 	auditOperatorEnable,

--- a/internal/api/audit_validator_test.go
+++ b/internal/api/audit_validator_test.go
@@ -48,6 +48,7 @@ var knownAuditActions = map[string]struct{}{
 	auditMeshImportFinalized:       {},
 	auditNetworkCreate:             {},
 	auditNetworkFirewallUpdate:     {},
+	auditNetworkMobileConfigUpdate: {},
 	auditOperatorCreate:            {},
 	auditOperatorDisable:           {},
 	auditOperatorEnable:            {},

--- a/internal/api/contract_test.go
+++ b/internal/api/contract_test.go
@@ -105,6 +105,21 @@ func TestContract_AdminEndpoints(t *testing.T) {
 	authRequest(req)
 	assertContract(t, v, req, serve(srv, req))
 
+	// Read and update the mobile profile settings.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/networks/"+net.ID+"/mobile-config", nil)
+	authRequest(req)
+	assertContract(t, v, req, serve(srv, req))
+
+	mobileBody := []byte(`{"dns_resolvers":["1.1.1.1"],"match_domains":[],"allow_private_remotes":false}`)
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/networks/"+net.ID+"/mobile-config", bytes.NewReader(mobileBody))
+	authRequest(req)
+	req.Header.Set("Content-Type", "application/json")
+	rec = serve(srv, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update mobile config: %d / %s", rec.Code, rec.Body.String())
+	}
+	assertContract(t, v, req, rec)
+
 	// Create host.
 	hostBody, _ := json.Marshal(createHostRequest{NetworkID: net.ID, Name: "contract-host", NebulaIPs: []string{"192.168.50.10"}})
 	req = httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewReader(hostBody))

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/netip"
 	"sort"
+	"strconv"
 
 	"github.com/slackhq/nebula/cert"
 
@@ -394,7 +396,7 @@ func (s *Server) getLighthouses(ctx context.Context, networkID string) ([]config
 		}
 		result = append(result, configgen.LighthouseInfo{
 			NebulaIPs:  h.NebulaIPs,
-			PublicAddr: fmt.Sprintf("%s:%d", h.PublicIP, port),
+			PublicAddr: net.JoinHostPort(h.PublicIP, strconv.Itoa(port)),
 		})
 	}
 	return result, nil

--- a/internal/api/lighthouse_test.go
+++ b/internal/api/lighthouse_test.go
@@ -127,6 +127,24 @@ func TestGetLighthouses_MultipleEnrolled(t *testing.T) {
 	}
 }
 
+func TestGetLighthouses_FormatsIPv6PublicAddress(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	enrollLighthouse(t, srv, netID, "lh-v6", "lh-v6", "192.168.100.5", "2001:db8::1", "fp-v6")
+
+	lighthouses, err := srv.getLighthouses(context.Background(), netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lighthouses) != 1 {
+		t.Fatalf("got %d lighthouses, want 1", len(lighthouses))
+	}
+	if got := lighthouses[0].PublicAddr; got != "[2001:db8::1]:4242" {
+		t.Fatalf("public_addr = %q, want bracketed IPv6 endpoint", got)
+	}
+}
+
 func TestRenderHostConfig_EmitsAllEnrolledLighthouses(t *testing.T) {
 	srv, _ := newTestServer(t)
 	netID := createNetwork(t, srv)

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -72,6 +72,7 @@ const (
 	auditMeshImportFinalized       = "mesh_import.finalized"
 	auditNetworkCreate             = "network.create"
 	auditNetworkFirewallUpdate     = "network.firewall.update"
+	auditNetworkMobileConfigUpdate = "network.mobile_config.update"
 	auditOperatorCreate            = "operator.create"
 	auditOperatorDisable           = "operator.disable"
 	auditOperatorEnable            = "operator.enable"
@@ -203,7 +204,7 @@ func newMetrics(s store.Store) *metrics {
 		auditHostCreate, auditHostDelete, auditHostUpdate, auditHostBlock, auditHostUnblock,
 		auditCACreated, auditCAImported, auditCADeleted, auditCARotated,
 		auditMeshImportCreated, auditMeshImportTokenRotated, auditMeshImportCanceled, auditMeshImportHostRegistered, auditMeshImportFinalized,
-		auditNetworkCreate, auditNetworkFirewallUpdate,
+		auditNetworkCreate, auditNetworkFirewallUpdate, auditNetworkMobileConfigUpdate,
 		auditOperatorCreate, auditOperatorDisable, auditOperatorEnable,
 		auditOperatorAPIKeyCreate, auditOperatorAPIKeyRevoke,
 		auditSettingsEnforce2FA,

--- a/internal/api/mobile_config.go
+++ b/internal/api/mobile_config.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/forgekeep/nebula-mesh/internal/mobileconfig"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+func (s *Server) handleGetMobileConfig(w http.ResponseWriter, r *http.Request) {
+	networkID := chi.URLParam(r, "id")
+	if !s.requireMobileConfigAccess(w, r, networkID) {
+		return
+	}
+
+	settings, err := loadNetworkMobileConfig(r.Context(), s.store, networkID)
+	if err != nil {
+		s.logger.Error("get mobile config", "network", networkID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get mobile config")
+		return
+	}
+	writeJSON(w, http.StatusOK, settings)
+}
+
+func (s *Server) handleUpdateMobileConfig(w http.ResponseWriter, r *http.Request) {
+	networkID := chi.URLParam(r, "id")
+	if !s.requireMobileConfigAccess(w, r, networkID) {
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	settings, err := mobileconfig.Decode(string(body))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	settingsJSON, err := json.Marshal(settings)
+	if err != nil {
+		s.logger.Error("marshal mobile config", "network", networkID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to update mobile config")
+		return
+	}
+	if err := s.store.SetNetworkConfig(r.Context(), networkID, mobileconfig.StoreKey, string(settingsJSON)); err != nil {
+		if errors.Is(err, store.ErrMeshImportInProgress) {
+			writeError(w, http.StatusConflict, "mesh import collection is in progress for this network")
+			return
+		}
+		s.logger.Error("set mobile config", "network", networkID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to update mobile config")
+		return
+	}
+
+	s.recordAuditAction(r.Context(), auditNetworkMobileConfigUpdate, networkID, string(settingsJSON))
+	s.logger.Info("mobile config updated", "network", networkID)
+	writeJSON(w, http.StatusOK, settings)
+}
+
+func (s *Server) requireMobileConfigAccess(w http.ResponseWriter, r *http.Request, networkID string) bool {
+	network, err := s.store.GetNetwork(r.Context(), networkID)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "network not found")
+		return false
+	}
+	if err != nil {
+		s.logger.Error("get network for mobile config", "network", networkID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load network")
+		return false
+	}
+	ok, err := s.canAccessNetwork(r.Context(), network)
+	if err != nil {
+		s.logger.Error("mobile config authz check", "network", networkID, "error", err)
+		writeError(w, http.StatusInternalServerError, "authz check failed")
+		return false
+	}
+	if !ok {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return false
+	}
+	return true
+}
+
+func loadNetworkMobileConfig(ctx context.Context, s store.Store, networkID string) (mobileconfig.Settings, error) {
+	raw, err := s.GetNetworkConfig(ctx, networkID, mobileconfig.StoreKey)
+	if errors.Is(err, store.ErrNotFound) {
+		return mobileconfig.Default(), nil
+	}
+	if err != nil {
+		return mobileconfig.Settings{}, err
+	}
+	settings, err := mobileconfig.Decode(raw)
+	if err != nil {
+		return mobileconfig.Settings{}, fmt.Errorf("decode stored mobile config: %w", err)
+	}
+	return settings, nil
+}

--- a/internal/api/mobile_config_authz_test.go
+++ b/internal/api/mobile_config_authz_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/forgekeep/nebula-mesh/internal/mobileconfig"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// SEC-TENANT-001: a non-owner cannot read mobile settings for a foreign network.
+func TestGetMobileConfig_NonOwnerDoesNotLeak(t *testing.T) {
+	srv, st := newTestServer(t)
+	_, _, ownerCA := createOperatorWithCA(t, srv)
+	foreignKey, _, _ := createOperatorWithCA(t, srv)
+	network := mobileConfigNetwork(t, st, ownerCA.ID)
+	require.NoError(t, st.SetNetworkConfig(context.Background(), network.ID, mobileconfig.StoreKey,
+		`{"dns_resolvers":["192.0.2.53"],"match_domains":["secret.example"],"allow_private_remotes":true}`))
+
+	response := mobileConfigRequest(t, srv, http.MethodGet,
+		"/api/v1/networks/"+network.ID+"/mobile-config", nil, foreignKey)
+	assert.Equal(t, http.StatusForbidden, response.Code)
+	assert.NotContains(t, response.Body.String(), "secret.example")
+}
+
+// SEC-TENANT-001: a non-owner cannot mutate mobile settings for a foreign network.
+func TestPutMobileConfig_NonOwnerCannotMutate(t *testing.T) {
+	srv, st := newTestServer(t)
+	_, _, ownerCA := createOperatorWithCA(t, srv)
+	foreignKey, _, _ := createOperatorWithCA(t, srv)
+	network := mobileConfigNetwork(t, st, ownerCA.ID)
+
+	response := mobileConfigRequest(t, srv, http.MethodPut,
+		"/api/v1/networks/"+network.ID+"/mobile-config",
+		[]byte(`{"dns_resolvers":[],"match_domains":[],"allow_private_remotes":false}`), foreignKey)
+	assert.Equal(t, http.StatusForbidden, response.Code)
+	_, err := st.GetNetworkConfig(context.Background(), network.ID, mobileconfig.StoreKey)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMobileConfig_OwnerCanReadAndMutate(t *testing.T) {
+	srv, st := newTestServer(t)
+	ownerKey, _, ownerCA := createOperatorWithCA(t, srv)
+	network := mobileConfigNetwork(t, st, ownerCA.ID)
+	path := "/api/v1/networks/" + network.ID + "/mobile-config"
+
+	put := mobileConfigRequest(t, srv, http.MethodPut, path,
+		[]byte(`{"dns_resolvers":[],"match_domains":[],"allow_private_remotes":false}`), ownerKey)
+	assert.Equal(t, http.StatusOK, put.Code, put.Body.String())
+	get := mobileConfigRequest(t, srv, http.MethodGet, path, nil, ownerKey)
+	assert.Equal(t, http.StatusOK, get.Code, get.Body.String())
+}
+
+func mobileConfigNetwork(t *testing.T, st *store.SQLiteStore, caID string) *models.Network {
+	t.Helper()
+	network := &models.Network{
+		ID: uuid.NewString(), Name: "mobile-config-network", CAID: caID,
+		CIDRs: []string{"10.55.0.0/16"}, CreatedAt: time.Now(),
+	}
+	require.NoError(t, st.CreateNetwork(context.Background(), network))
+	return network
+}

--- a/internal/api/mobile_config_test.go
+++ b/internal/api/mobile_config_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/forgekeep/nebula-mesh/internal/mobileconfig"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+func TestMobileConfig_GetDefaultsAndPutNormalizedSettings(t *testing.T) {
+	srv, st := newTestServer(t)
+	networkID := createNetwork(t, srv)
+	path := "/api/v1/networks/" + networkID + "/mobile-config"
+
+	beforeVersion, err := st.GetNetworkConfigVersion(context.Background(), networkID)
+	require.NoError(t, err)
+
+	response := mobileConfigRequest(t, srv, http.MethodGet, path, nil, testAPIKey)
+	assert.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	assert.JSONEq(t, `{
+		"dns_resolvers": [],
+		"match_domains": [],
+		"allow_private_remotes": true
+	}`, response.Body.String())
+
+	payload := []byte(`{
+		"dns_resolvers": [" 10.0.0.53 ", "2001:0db8::53"],
+		"match_domains": [" corp.example "],
+		"allow_private_remotes": false
+	}`)
+	response = mobileConfigRequest(t, srv, http.MethodPut, path, payload, testAPIKey)
+	assert.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	assert.JSONEq(t, `{
+		"dns_resolvers": ["10.0.0.53", "2001:db8::53"],
+		"match_domains": ["corp.example"],
+		"allow_private_remotes": false
+	}`, response.Body.String())
+
+	stored, err := st.GetNetworkConfig(context.Background(), networkID, mobileconfig.StoreKey)
+	require.NoError(t, err)
+	settings, err := mobileconfig.Decode(stored)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.53", "2001:db8::53"}, settings.DNSResolvers)
+
+	afterVersion, err := st.GetNetworkConfigVersion(context.Background(), networkID)
+	require.NoError(t, err)
+	assert.Equal(t, beforeVersion, afterVersion, "mobile-only settings must not wake desktop agents")
+}
+
+func TestMobileConfig_PutRejectsInvalidJSONAndSettings(t *testing.T) {
+	srv, _ := newTestServer(t)
+	path := "/api/v1/networks/" + createNetwork(t, srv) + "/mobile-config"
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"missing field", `{"dns_resolvers":[],"match_domains":[]}`},
+		{"unknown field", `{"dns_resolvers":[],"match_domains":[],"allow_private_remotes":true,"extra":1}`},
+		{"trailing json", `{"dns_resolvers":[],"match_domains":[],"allow_private_remotes":true}{}`},
+		{"invalid resolver", `{"dns_resolvers":["dns.example"],"match_domains":[],"allow_private_remotes":true}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := mobileConfigRequest(t, srv, http.MethodPut, path, []byte(tt.body), testAPIKey)
+			assert.Equal(t, http.StatusBadRequest, response.Code, response.Body.String())
+		})
+	}
+}
+
+func TestMobileConfig_PutConflictsWithCollectingMeshImport(t *testing.T) {
+	srv, st := newTestServer(t)
+	key, operator, ca := createOperatorWithCA(t, srv)
+	network := &models.Network{
+		ID: uuid.NewString(), Name: "importing-network", CAID: ca.ID,
+		CIDRs: []string{"10.44.0.0/16"}, CreatedAt: time.Now(),
+	}
+	require.NoError(t, st.CreateNetwork(context.Background(), network))
+	require.NoError(t, st.CreateMeshImport(context.Background(), &models.MeshImport{
+		ID: uuid.NewString(), NetworkID: network.ID, CAID: ca.ID,
+		OwnerOperatorID: operator.ID, Status: models.MeshImportStatusCollecting,
+		TokenHash: uuid.NewString(), TokenExpiresAt: time.Now().Add(time.Hour),
+	}))
+
+	response := mobileConfigRequest(t, srv, http.MethodPut,
+		"/api/v1/networks/"+network.ID+"/mobile-config",
+		[]byte(`{"dns_resolvers":[],"match_domains":[],"allow_private_remotes":true}`), key)
+	assert.Equal(t, http.StatusConflict, response.Code, response.Body.String())
+	_, err := st.GetNetworkConfig(context.Background(), network.ID, mobileconfig.StoreKey)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMobileConfig_PutWritesAuditEntry(t *testing.T) {
+	srv, st := newTestServer(t)
+	networkID := createNetwork(t, srv)
+
+	response := mobileConfigRequest(t, srv, http.MethodPut,
+		"/api/v1/networks/"+networkID+"/mobile-config",
+		[]byte(`{"dns_resolvers":["10.0.0.53"],"match_domains":[],"allow_private_remotes":true}`),
+		testAPIKey)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+
+	entries, err := st.ListAuditEntries(context.Background(), store.AuditFilter{Action: auditNetworkMobileConfigUpdate})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, networkID, entries[0].Resource)
+	var details mobileconfig.Settings
+	require.NoError(t, json.Unmarshal([]byte(entries[0].Details), &details))
+	assert.Equal(t, []string{"10.0.0.53"}, details.DNSResolvers)
+}
+
+func mobileConfigRequest(t *testing.T, srv *Server, method, path string, body []byte, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+key)
+	recorder := httptest.NewRecorder()
+	srv.ServeHTTP(recorder, req)
+	return recorder
+}

--- a/internal/api/scoping_boundary_test.go
+++ b/internal/api/scoping_boundary_test.go
@@ -101,6 +101,7 @@ func TestGetByID_NonOwnerDoesNotLeak(t *testing.T) {
 	for _, c := range []struct{ name, path string }{
 		{"network-by-id", "/api/v1/networks/" + netA},
 		{"network-firewall", "/api/v1/networks/" + netA + "/firewall"},
+		{"network-mobile-config", "/api/v1/networks/" + netA + "/mobile-config"},
 		{"ca-by-id", "/api/v1/cas/" + caA.ID},
 	} {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/api/scoping_property_test.go
+++ b/internal/api/scoping_property_test.go
@@ -77,12 +77,13 @@ var protectedGETScoping = map[string]listScoping{
 	"/api/v1/settings":                adminOnly,
 
 	// Single-resource reads — guarded per-row by canAccess*.
-	"/api/v1/networks/{id}":              singleResource,
-	"/api/v1/networks/{id}/firewall":     singleResource,
-	"/api/v1/hosts/{id}":                 singleResource,
-	"/api/v1/cas/{id}":                   singleResource,
-	"/api/v1/mesh-imports/{id}":          singleResource,
-	"/api/v1/webhook-subscriptions/{id}": singleResource,
+	"/api/v1/networks/{id}":               singleResource,
+	"/api/v1/networks/{id}/firewall":      singleResource,
+	"/api/v1/networks/{id}/mobile-config": singleResource,
+	"/api/v1/hosts/{id}":                  singleResource,
+	"/api/v1/cas/{id}":                    singleResource,
+	"/api/v1/mesh-imports/{id}":           singleResource,
+	"/api/v1/webhook-subscriptions/{id}":  singleResource,
 }
 
 // SEC-TENANT-001: TestProtectedGETRoutesAreClassified fails the moment setupRoutes registers

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -266,6 +266,8 @@ func (s *Server) setupRoutes() {
 		r.Get("/api/v1/blocklist", s.handleGetBlocklist)
 		r.Get("/api/v1/networks/{id}/firewall", s.handleGetFirewall)
 		r.Put("/api/v1/networks/{id}/firewall", s.handleUpdateFirewall)
+		r.Get("/api/v1/networks/{id}/mobile-config", s.handleGetMobileConfig)
+		r.Put("/api/v1/networks/{id}/mobile-config", s.handleUpdateMobileConfig)
 		r.Get("/api/v1/audit-log", s.handleGetAuditLog)
 		r.Get("/api/v1/operators", s.handleListOperators)
 		r.Post("/api/v1/operators", s.handleCreateOperator)

--- a/internal/configgen/generator.go
+++ b/internal/configgen/generator.go
@@ -19,6 +19,14 @@ type AdvancedUnsafeRoute struct {
 	Via   string
 }
 
+// MobileProfile enables defaults and settings used by Mobile Nebula clients.
+// A nil profile preserves the agent configuration shape.
+type MobileProfile struct {
+	DNSResolvers        []string
+	MatchDomains        []string
+	AllowPrivateRemotes bool
+}
+
 // GeneratorInput contains all parameters needed to generate a Nebula config.
 type GeneratorInput struct {
 	HostName         string
@@ -33,6 +41,7 @@ type GeneratorInput struct {
 	Relays           []string
 	FirewallInbound  []FirewallRule
 	FirewallOutbound []FirewallRule
+	Mobile           *MobileProfile
 
 	// Optional per-host overrides. Zero values mean "use the default".
 	PunchyOverride *bool

--- a/internal/configgen/marshal.go
+++ b/internal/configgen/marshal.go
@@ -31,9 +31,12 @@ type nebulaConfig struct {
 	Listen        listenSection               `yaml:"listen"`
 	Punchy        punchySection               `yaml:"punchy"`
 	Tun           *tunSection                 `yaml:"tun,omitempty"`
+	Tunnels       *tunnelsSection             `yaml:"tunnels,omitempty"`
 	Relay         *relaySection               `yaml:"relay,omitempty"`
 	Logging       loggingSection              `yaml:"logging"`
 	Firewall      firewallSection             `yaml:"firewall"`
+	Handshakes    *handshakesSection          `yaml:"handshakes,omitempty"`
+	MobileNebula  *mobileNebulaSection        `yaml:"mobile_nebula,omitempty"`
 }
 
 // pkiSection's fields are typed `any` because inline PEMs marshal as
@@ -144,8 +147,15 @@ func (s safeString) MarshalYAML() (any, error) {
 }
 
 type lighthouseSection struct {
-	AmLighthouse bool         `yaml:"am_lighthouse"`
-	Hosts        []safeString `yaml:"hosts,omitempty"`
+	AmLighthouse    bool                   `yaml:"am_lighthouse"`
+	Hosts           []safeString           `yaml:"hosts,omitempty"`
+	Interval        int                    `yaml:"interval,omitempty"`
+	LocalAllowList  *localAllowListSection `yaml:"local_allow_list,omitempty"`
+	RemoteAllowList map[safeString]bool    `yaml:"remote_allow_list,omitempty"`
+}
+
+type localAllowListSection struct {
+	Interfaces map[safeString]bool `yaml:"interfaces"`
 }
 
 type listenSection struct {
@@ -154,13 +164,21 @@ type listenSection struct {
 }
 
 type punchySection struct {
-	Punch bool `yaml:"punch"`
+	Punch   bool  `yaml:"punch"`
+	Respond *bool `yaml:"respond,omitempty"`
 }
 
 type tunSection struct {
-	Dev          safeString    `yaml:"dev,omitempty"`
-	MTU          int           `yaml:"mtu,omitempty"`
-	UnsafeRoutes []unsafeRoute `yaml:"unsafe_routes,omitempty"`
+	Dev                safeString    `yaml:"dev,omitempty"`
+	DropLocalBroadcast *bool         `yaml:"drop_local_broadcast,omitempty"`
+	DropMulticast      *bool         `yaml:"drop_multicast,omitempty"`
+	MTU                int           `yaml:"mtu,omitempty"`
+	UnsafeRoutes       []unsafeRoute `yaml:"unsafe_routes,omitempty"`
+}
+
+type tunnelsSection struct {
+	DropInactive      bool       `yaml:"drop_inactive"`
+	InactivityTimeout safeString `yaml:"inactivity_timeout"`
 }
 
 type unsafeRoute struct {
@@ -169,8 +187,9 @@ type unsafeRoute struct {
 }
 
 type relaySection struct {
-	AmRelay bool         `yaml:"am_relay,omitempty"`
-	Relays  []safeString `yaml:"relays,omitempty"`
+	AmRelay   *bool        `yaml:"am_relay,omitempty"`
+	Relays    []safeString `yaml:"relays,omitempty"`
+	UseRelays *bool        `yaml:"use_relays,omitempty"`
 }
 
 type loggingSection struct {
@@ -179,8 +198,20 @@ type loggingSection struct {
 }
 
 type firewallSection struct {
-	Outbound []firewallRule `yaml:"outbound"`
-	Inbound  []firewallRule `yaml:"inbound"`
+	OutboundAction safeString     `yaml:"outbound_action,omitempty"`
+	InboundAction  safeString     `yaml:"inbound_action,omitempty"`
+	Outbound       []firewallRule `yaml:"outbound"`
+	Inbound        []firewallRule `yaml:"inbound"`
+}
+
+type handshakesSection struct {
+	Retries     int        `yaml:"retries"`
+	TryInterval safeString `yaml:"try_interval"`
+}
+
+type mobileNebulaSection struct {
+	DNSResolvers []safeString `yaml:"dns_resolvers"`
+	MatchDomains []safeString `yaml:"match_domains"`
 }
 
 // firewallRule is constructed with exactly one of {Group, Host} set per rule —
@@ -247,10 +278,14 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 
 	listenHost := input.ListenHost
 	if listenHost == "" {
-		listenHost = "0.0.0.0"
+		if input.Mobile != nil {
+			listenHost = "[::]"
+		} else {
+			listenHost = "0.0.0.0"
+		}
 	}
 	listenPort := input.ListenPort
-	if listenPort == 0 && input.IsLighthouse {
+	if listenPort == 0 && input.IsLighthouse && input.Mobile == nil {
 		listenPort = 4242
 	}
 	cfg.Listen = listenSection{Host: safeString(listenHost), Port: listenPort}
@@ -260,9 +295,26 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 		punch = *input.PunchyOverride
 	}
 	cfg.Punchy = punchySection{Punch: punch}
+	if input.Mobile != nil {
+		cfg.Punchy.Respond = boolPtr(false)
+	}
 
-	if input.MTU != 0 || input.TunDevice != "" || len(input.UnsafeRoutes) > 0 {
-		ts := &tunSection{Dev: safeString(input.TunDevice), MTU: input.MTU}
+	if input.Mobile != nil || input.MTU != 0 || input.TunDevice != "" || len(input.UnsafeRoutes) > 0 {
+		dev := input.TunDevice
+		mtu := input.MTU
+		if input.Mobile != nil {
+			if dev == "" {
+				dev = "nebula1"
+			}
+			if mtu == 0 {
+				mtu = 1300
+			}
+		}
+		ts := &tunSection{Dev: safeString(dev), MTU: mtu}
+		if input.Mobile != nil {
+			ts.DropLocalBroadcast = boolPtr(true)
+			ts.DropMulticast = boolPtr(true)
+		}
 		for _, r := range input.UnsafeRoutes {
 			ts.UnsafeRoutes = append(ts.UnsafeRoutes, unsafeRoute{
 				Route: safeString(r.Route),
@@ -273,19 +325,73 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 	}
 
 	if input.IsRelay {
-		cfg.Relay = &relaySection{AmRelay: true}
-	} else if len(input.Relays) > 0 {
+		cfg.Relay = &relaySection{AmRelay: boolPtr(true)}
+	} else if input.Mobile != nil || len(input.Relays) > 0 {
 		relays := make([]safeString, len(input.Relays))
 		for i, r := range input.Relays {
 			relays[i] = safeString(r)
 		}
 		cfg.Relay = &relaySection{Relays: relays}
+		if input.Mobile != nil {
+			cfg.Relay.AmRelay = boolPtr(false)
+			cfg.Relay.UseRelays = boolPtr(true)
+		}
 	}
 
 	cfg.Firewall.Outbound = mapFirewallRules(input.FirewallOutbound)
 	cfg.Firewall.Inbound = mapFirewallRules(input.FirewallInbound)
+	if input.Mobile != nil {
+		applyMobileProfile(&cfg, *input.Mobile)
+	}
 
 	return cfg
+}
+
+func applyMobileProfile(cfg *nebulaConfig, profile MobileProfile) {
+	cfg.Handshakes = &handshakesSection{Retries: 10, TryInterval: "100ms"}
+	cfg.Lighthouse.Interval = 60
+	cfg.Lighthouse.LocalAllowList = &localAllowListSection{Interfaces: map[safeString]bool{
+		"docker.*":   false,
+		"nebula1":    false,
+		"podman.*":   false,
+		"tailscale0": false,
+		"tun.*":      false,
+		"utun.*":     false,
+		"veth.*":     false,
+	}}
+	cfg.Lighthouse.RemoteAllowList = mobileRemoteAllowList(profile.AllowPrivateRemotes)
+	cfg.Tunnels = &tunnelsSection{DropInactive: true, InactivityTimeout: "10m"}
+	cfg.Firewall.InboundAction = "drop"
+	cfg.Firewall.OutboundAction = "drop"
+	if len(profile.DNSResolvers) > 0 {
+		cfg.MobileNebula = &mobileNebulaSection{
+			DNSResolvers: toSafeStrings(profile.DNSResolvers),
+			MatchDomains: toSafeStringsPreserveEmpty(profile.MatchDomains),
+		}
+	}
+}
+
+func mobileRemoteAllowList(allowPrivate bool) map[safeString]bool {
+	allowList := map[safeString]bool{
+		"0.0.0.0/0":      true,
+		"::/0":           true,
+		"127.0.0.0/8":    false,
+		"::1/128":        false,
+		"169.254.0.0/16": false,
+		"fe80::/10":      false,
+	}
+	if !allowPrivate {
+		allowList["10.0.0.0/8"] = false
+		allowList["100.64.0.0/10"] = false
+		allowList["172.16.0.0/12"] = false
+		allowList["192.168.0.0/16"] = false
+		allowList["fc00::/7"] = false
+	}
+	return allowList
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 func mapFirewallRules(in []FirewallRule) []firewallRule {
@@ -311,4 +417,11 @@ func toSafeStrings(in []string) []safeString {
 		out[i] = safeString(s)
 	}
 	return out
+}
+
+func toSafeStringsPreserveEmpty(in []string) []safeString {
+	if len(in) == 0 {
+		return []safeString{}
+	}
+	return toSafeStrings(in)
 }

--- a/internal/configgen/mobile_test.go
+++ b/internal/configgen/mobile_test.go
@@ -1,0 +1,140 @@
+package configgen
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_MobileProfile(t *testing.T) {
+	t.Parallel()
+
+	in := mobileGeneratorInput()
+	c := loadGenerated(t, in)
+
+	assert.Equal(t, 10, c.GetInt("handshakes.retries", 0))
+	assert.Equal(t, 100*time.Millisecond, c.GetDuration("handshakes.try_interval", 0))
+	assert.Equal(t, 60, c.GetInt("lighthouse.interval", 0))
+	assert.Equal(t, "[::]", c.GetString("listen.host", ""))
+	assert.Equal(t, 0, c.GetInt("listen.port", -1))
+	assert.True(t, c.GetBool("punchy.punch", false))
+	assert.True(t, c.IsSet("punchy.respond"))
+	assert.False(t, c.GetBool("punchy.respond", true))
+	assert.Equal(t, "nebula1", c.GetString("tun.dev", ""))
+	assert.Equal(t, 1300, c.GetInt("tun.mtu", 0))
+	assert.True(t, c.GetBool("tun.drop_local_broadcast", false))
+	assert.True(t, c.GetBool("tun.drop_multicast", false))
+	assert.True(t, c.GetBool("tunnels.drop_inactive", false))
+	assert.Equal(t, 10*time.Minute, c.GetDuration("tunnels.inactivity_timeout", 0))
+	assert.True(t, c.IsSet("relay.am_relay"))
+	assert.False(t, c.GetBool("relay.am_relay", true))
+	assert.True(t, c.GetBool("relay.use_relays", false))
+	assert.Equal(t, "drop", c.GetString("firewall.inbound_action", ""))
+	assert.Equal(t, "drop", c.GetString("firewall.outbound_action", ""))
+
+	assert.Equal(t, map[string]any{
+		"docker.*":   false,
+		"nebula1":    false,
+		"podman.*":   false,
+		"tailscale0": false,
+		"tun.*":      false,
+		"utun.*":     false,
+		"veth.*":     false,
+	}, c.GetMap("lighthouse.local_allow_list.interfaces", nil))
+
+	assert.Equal(t, map[string]any{
+		"0.0.0.0/0":      true,
+		"::/0":           true,
+		"127.0.0.0/8":    false,
+		"::1/128":        false,
+		"169.254.0.0/16": false,
+		"fe80::/10":      false,
+	}, c.GetMap("lighthouse.remote_allow_list", nil))
+
+	require.Equal(t, []string{"10.0.0.53", "2001:db8::53"}, c.GetStringSlice("mobile_nebula.dns_resolvers", nil))
+	require.Equal(t, []string{}, c.GetStringSlice("mobile_nebula.match_domains", nil))
+}
+
+func TestGenerate_MobileProfileRejectsPrivateDiscoveryAddresses(t *testing.T) {
+	t.Parallel()
+
+	in := mobileGeneratorInput()
+	in.Mobile.AllowPrivateRemotes = false
+	c := loadGenerated(t, in)
+
+	remoteAllowList := c.GetMap("lighthouse.remote_allow_list", nil)
+	for _, cidr := range []string{
+		"10.0.0.0/8",
+		"100.64.0.0/10",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"fc00::/7",
+	} {
+		assert.Equal(t, false, remoteAllowList[cidr], cidr)
+	}
+	assert.Len(t, remoteAllowList, 11)
+}
+
+func TestGenerate_MobileProfileOmitsDNSWithoutResolvers(t *testing.T) {
+	t.Parallel()
+
+	in := mobileGeneratorInput()
+	in.Mobile.DNSResolvers = nil
+	in.Mobile.MatchDomains = []string{"corp.example"}
+	c := loadGenerated(t, in)
+
+	assert.False(t, c.IsSet("mobile_nebula"))
+}
+
+func TestGenerate_MobileProfileUsesAdvancedTunOverrides(t *testing.T) {
+	t.Parallel()
+
+	in := mobileGeneratorInput()
+	in.TunDevice = "mobile0"
+	in.MTU = 1280
+	c := loadGenerated(t, in)
+
+	assert.Equal(t, "mobile0", c.GetString("tun.dev", ""))
+	assert.Equal(t, 1280, c.GetInt("tun.mtu", 0))
+}
+
+func TestGenerate_AgentProfileOmitsMobileSections(t *testing.T) {
+	t.Parallel()
+
+	c := loadGenerated(t, GeneratorInput{
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+	})
+
+	assert.Equal(t, "0.0.0.0", c.GetString("listen.host", ""))
+	for _, key := range []string{
+		"handshakes",
+		"tunnels",
+		"mobile_nebula",
+		"lighthouse.interval",
+		"lighthouse.local_allow_list",
+		"lighthouse.remote_allow_list",
+		"punchy.respond",
+		"firewall.inbound_action",
+		"firewall.outbound_action",
+	} {
+		assert.False(t, c.IsSet(key), key)
+	}
+}
+
+func mobileGeneratorInput() GeneratorInput {
+	return GeneratorInput{
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+		Relays:     []string{"10.0.0.2"},
+		Mobile: &MobileProfile{
+			DNSResolvers:        []string{"10.0.0.53", "2001:db8::53"},
+			MatchDomains:        []string{},
+			AllowPrivateRemotes: true,
+		},
+	}
+}

--- a/internal/mobilebundle/builder.go
+++ b/internal/mobilebundle/builder.go
@@ -6,13 +6,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/netip"
+	"sort"
 	"strconv"
 
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
 
 	"github.com/forgekeep/nebula-mesh/internal/configgen"
+	"github.com/forgekeep/nebula-mesh/internal/mobileconfig"
 	"github.com/forgekeep/nebula-mesh/internal/models"
 	"github.com/forgekeep/nebula-mesh/internal/pki"
 	"github.com/forgekeep/nebula-mesh/internal/revocation"
@@ -98,17 +101,6 @@ func Build(ctx context.Context, s store.Store, resolver interface {
 		return nil, fmt.Errorf("cert fingerprint: %w", err)
 	}
 
-	// Persist certificate.
-	if host.Status == models.HostStatusPending {
-		if err := s.SaveCertificateAndEnrollHost(ctx, host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
-			return nil, fmt.Errorf("save certificate: %w", err)
-		}
-	} else {
-		if err := s.SaveCertificateAndUpdateHostCert(ctx, host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
-			return nil, fmt.Errorf("rotate certificate: %w", err)
-		}
-	}
-
 	// Get CA cert PEM.
 	caPEM, err := caMgr.CACertPEM()
 	if err != nil {
@@ -122,6 +114,18 @@ func Build(ctx context.Context, s store.Store, resolver interface {
 	lighthouses, err := listLighthouses(ctx, s, host.NetworkID)
 	if err != nil {
 		return nil, fmt.Errorf("list lighthouses: %w", err)
+	}
+	relays, err := listRelays(ctx, s, host.NetworkID)
+	if err != nil {
+		return nil, fmt.Errorf("list relays: %w", err)
+	}
+	blocklist, err := s.GetBlocklistForCA(ctx, host.CAID)
+	if err != nil {
+		return nil, fmt.Errorf("get blocklist for config: %w", err)
+	}
+	mobileSettings, err := loadMobileSettings(ctx, s, host.NetworkID)
+	if err != nil {
+		return nil, err
 	}
 
 	// Resolve the network's firewall policy. Mirrors the agent enroll path
@@ -141,11 +145,18 @@ func Build(ctx context.Context, s store.Store, resolver interface {
 		IsLighthouse:     host.IsLighthouse,
 		IsRelay:          host.IsRelay,
 		Lighthouses:      lighthouses,
+		Relays:           relays,
 		CACertPEM:        string(caPEM),
 		CertPEM:          string(certPEM),
 		KeyPEM:           string(privPEM),
 		FirewallInbound:  fwInbound,
 		FirewallOutbound: fwOutbound,
+		Blocklist:        blocklist,
+		Mobile: &configgen.MobileProfile{
+			DNSResolvers:        mobileSettings.DNSResolvers,
+			MatchDomains:        mobileSettings.MatchDomains,
+			AllowPrivateRemotes: mobileSettings.AllowPrivateRemotes,
+		},
 	}
 	if adv := host.Advanced; adv != nil {
 		input.PunchyOverride = adv.Punchy
@@ -162,9 +173,37 @@ func Build(ctx context.Context, s store.Store, resolver interface {
 		return nil, fmt.Errorf("generate config: %w", err)
 	}
 
+	// Persist only after every fallible bundle-generation step succeeds. The
+	// private key exists only in configYAML, so an earlier durable write could
+	// leave the host enrolled with a certificate it can never use.
+	if host.Status == models.HostStatusPending {
+		if err := s.SaveCertificateAndEnrollHost(ctx, host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
+			return nil, fmt.Errorf("save certificate: %w", err)
+		}
+	} else {
+		if err := s.SaveCertificateAndUpdateHostCert(ctx, host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
+			return nil, fmt.Errorf("rotate certificate: %w", err)
+		}
+	}
+
 	// TODO: Bundle into QR code or download format
 	// For now, return the YAML
 	return configYAML, nil
+}
+
+func loadMobileSettings(ctx context.Context, s store.Store, networkID string) (mobileconfig.Settings, error) {
+	raw, err := s.GetNetworkConfig(ctx, networkID, mobileconfig.StoreKey)
+	if errors.Is(err, store.ErrNotFound) {
+		return mobileconfig.Default(), nil
+	}
+	if err != nil {
+		return mobileconfig.Settings{}, fmt.Errorf("get mobile config: %w", err)
+	}
+	settings, err := mobileconfig.Decode(raw)
+	if err != nil {
+		return mobileconfig.Settings{}, fmt.Errorf("decode mobile config: %w", err)
+	}
+	return settings, nil
 }
 
 // buildHostPrefixes mirrors the logic from internal/api/helpers.go.
@@ -234,8 +273,35 @@ func listLighthouses(ctx context.Context, s store.Store, networkID string) ([]co
 		}
 		result = append(result, configgen.LighthouseInfo{
 			NebulaIPs:  h.NebulaIPs,
-			PublicAddr: fmt.Sprintf("%s:%d", h.PublicIP, port),
+			PublicAddr: net.JoinHostPort(h.PublicIP, strconv.Itoa(port)),
 		})
 	}
+	return result, nil
+}
+
+// listRelays returns sorted overlay addresses for enrolled relay hosts.
+func listRelays(ctx context.Context, s store.Store, networkID string) ([]string, error) {
+	hosts, err := s.ListHosts(ctx, store.HostFilter{
+		NetworkID: networkID,
+		Status:    models.HostStatusEnrolled,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]struct{})
+	for _, host := range hosts {
+		if host.Role != models.HostRoleRelay && !host.IsRelay {
+			continue
+		}
+		for _, address := range host.NebulaIPs {
+			set[address] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for address := range set {
+		result = append(result, address)
+	}
+	sort.Strings(result)
 	return result, nil
 }

--- a/internal/mobilebundle/builder.go
+++ b/internal/mobilebundle/builder.go
@@ -176,14 +176,10 @@ func Build(ctx context.Context, s store.Store, resolver interface {
 	// Persist only after every fallible bundle-generation step succeeds. The
 	// private key exists only in configYAML, so an earlier durable write could
 	// leave the host enrolled with a certificate it can never use.
-	if host.Status == models.HostStatusPending {
-		if err := s.SaveCertificateAndEnrollHost(ctx, host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
-			return nil, fmt.Errorf("save certificate: %w", err)
-		}
-	} else {
-		if err := s.SaveCertificateAndUpdateHostCert(ctx, host.ID, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter()); err != nil {
-			return nil, fmt.Errorf("rotate certificate: %w", err)
-		}
+	if err := s.SaveCertificateIfIssuanceAllowed(
+		ctx, host.ID, host.Status, certPEM, fp, hostCert.NotBefore(), hostCert.NotAfter(),
+	); err != nil {
+		return nil, fmt.Errorf("persist authorized certificate: %w", err)
 	}
 
 	// TODO: Bundle into QR code or download format

--- a/internal/mobilebundle/mobile_profile_test.go
+++ b/internal/mobilebundle/mobile_profile_test.go
@@ -102,6 +102,43 @@ func TestBuild_SEC_PERSIST_001InvalidSettingsDoNotEnrollOrRotateCertificate(t *t
 	})
 }
 
+// SEC-PERSIST-001: blocking a Host after bundle generation starts must win
+// atomically over the final certificate persistence step.
+func TestBuild_SEC_PERSIST_001ConcurrentBlockCannotBeUndone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, resolver, _, host := newMobileFixture(t, "concurrent-block")
+	paused := &pauseBeforeBlocklistStore{
+		Store:   s,
+		reached: make(chan struct{}),
+		resume:  make(chan struct{}),
+	}
+	type buildResult struct {
+		bundle []byte
+		err    error
+	}
+	resultCh := make(chan buildResult, 1)
+	go func() {
+		bundle, err := Build(ctx, paused, resolver, host)
+		resultCh <- buildResult{bundle: bundle, err: err}
+	}()
+
+	<-paused.reached
+	_, err := s.BlockHostAndAddToBlocklist(ctx, host.ID, "concurrent block")
+	require.NoError(t, err)
+	close(paused.resume)
+
+	result := <-resultCh
+	require.Error(t, result.err)
+	assert.Nil(t, result.bundle)
+	stored, err := s.GetHost(ctx, host.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.HostStatusBlocked, stored.Status)
+	_, err = s.GetCertificateInfo(ctx, host.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
 func TestListLighthousesFormatsIPv6PublicAddress(t *testing.T) {
 	t.Parallel()
 
@@ -154,4 +191,16 @@ func loadBundle(t *testing.T, bundle []byte) *nebcfg.C {
 	var c nebcfg.C
 	require.NoError(t, c.LoadString(string(bundle)))
 	return &c
+}
+
+type pauseBeforeBlocklistStore struct {
+	store.Store
+	reached chan struct{}
+	resume  chan struct{}
+}
+
+func (s *pauseBeforeBlocklistStore) GetBlocklistForCA(ctx context.Context, caID string) ([]string, error) {
+	close(s.reached)
+	<-s.resume
+	return s.Store.GetBlocklistForCA(ctx, caID)
 }

--- a/internal/mobilebundle/mobile_profile_test.go
+++ b/internal/mobilebundle/mobile_profile_test.go
@@ -1,0 +1,157 @@
+package mobilebundle
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	nebcfg "github.com/slackhq/nebula/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/forgekeep/nebula-mesh/internal/mobileconfig"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/pki"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// SEC-PERSIST-001: a mobile bundle must carry the durable CA blocklist so a
+// revoked peer cannot regain access through a newly generated profile.
+func TestBuild_SEC_PERSIST_001IncludesCurrentBlocklistAndEnrolledRelays(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, resolver, network, host := newMobileFixture(t, "state")
+	now := time.Now()
+	for _, peer := range []*models.Host{
+		{
+			ID: "relay-enrolled", Name: "relay-enrolled", NetworkID: network.ID,
+			NebulaIPs: []string{"10.0.0.20", "fd00::20"}, Role: models.HostRoleRelay,
+			IsRelay: true, Status: models.HostStatusEnrolled, CreatedAt: now, UpdatedAt: now,
+		},
+		{
+			ID: "relay-pending", Name: "relay-pending", NetworkID: network.ID,
+			NebulaIPs: []string{"10.0.0.30"}, Role: models.HostRoleRelay,
+			IsRelay: true, Status: models.HostStatusPending, CreatedAt: now, UpdatedAt: now,
+		},
+		{
+			ID: "ordinary-enrolled", Name: "ordinary-enrolled", NetworkID: network.ID,
+			NebulaIPs: []string{"10.0.0.40"}, Role: models.HostRoleHost,
+			Status: models.HostStatusEnrolled, CreatedAt: now, UpdatedAt: now,
+		},
+	} {
+		require.NoError(t, s.CreateHost(ctx, peer))
+	}
+	require.NoError(t, s.AddToBlocklist(ctx, "revoked-fingerprint", "", "test"))
+
+	settingsJSON, err := json.Marshal(mobileconfig.Settings{
+		DNSResolvers:        []string{"10.0.0.53"},
+		MatchDomains:        []string{},
+		AllowPrivateRemotes: false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.SetNetworkConfig(ctx, network.ID, mobileconfig.StoreKey, string(settingsJSON)))
+
+	bundle, err := Build(ctx, s, resolver, host)
+	require.NoError(t, err)
+	c := loadBundle(t, bundle)
+
+	assert.Equal(t, []string{"revoked-fingerprint"}, c.GetStringSlice("pki.blocklist", nil))
+	assert.Equal(t, []string{"10.0.0.20", "fd00::20"}, c.GetStringSlice("relay.relays", nil))
+	assert.Equal(t, []string{"10.0.0.53"}, c.GetStringSlice("mobile_nebula.dns_resolvers", nil))
+	assert.Equal(t, false, c.GetMap("lighthouse.remote_allow_list", nil)["10.0.0.0/8"])
+}
+
+func TestBuild_SEC_PERSIST_001InvalidSettingsDoNotEnrollOrRotateCertificate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pending host", func(t *testing.T) {
+		ctx := context.Background()
+		s, resolver, network, host := newMobileFixture(t, "pending")
+		require.NoError(t, s.SetNetworkConfig(ctx, network.ID, mobileconfig.StoreKey, `{invalid`))
+
+		bundle, err := Build(ctx, s, resolver, host)
+		require.ErrorContains(t, err, "mobile config")
+		assert.Nil(t, bundle)
+
+		stored, getErr := s.GetHost(ctx, host.ID)
+		require.NoError(t, getErr)
+		assert.Equal(t, models.HostStatusPending, stored.Status)
+		assert.Empty(t, stored.CertFingerprint)
+		_, certErr := s.GetCertificateInfo(ctx, host.ID)
+		require.ErrorIs(t, certErr, store.ErrNotFound)
+	})
+
+	t.Run("enrolled host", func(t *testing.T) {
+		ctx := context.Background()
+		s, resolver, network, host := newMobileFixture(t, "rotate")
+		_, err := Build(ctx, s, resolver, host)
+		require.NoError(t, err)
+		before, err := s.GetHost(ctx, host.ID)
+		require.NoError(t, err)
+
+		require.NoError(t, s.SetNetworkConfig(ctx, network.ID, mobileconfig.StoreKey, `{invalid`))
+		bundle, err := Build(ctx, s, resolver, before)
+		require.ErrorContains(t, err, "mobile config")
+		assert.Nil(t, bundle)
+
+		after, getErr := s.GetHost(ctx, host.ID)
+		require.NoError(t, getErr)
+		assert.Equal(t, before.CertFingerprint, after.CertFingerprint)
+	})
+}
+
+func TestListLighthousesFormatsIPv6PublicAddress(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, _, network, _ := newMobileFixture(t, "ipv6")
+	require.NoError(t, s.CreateHost(ctx, &models.Host{
+		ID: "lighthouse-v6", Name: "lighthouse-v6", NetworkID: network.ID,
+		NebulaIPs: []string{"10.0.0.1"}, Role: models.HostRoleLighthouse,
+		IsLighthouse: true, PublicIP: "2001:db8::1", ListenPort: 4244,
+		Status: models.HostStatusEnrolled, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}))
+
+	lighthouses, err := listLighthouses(ctx, s, network.ID)
+	require.NoError(t, err)
+	require.Len(t, lighthouses, 1)
+	assert.Equal(t, "[2001:db8::1]:4244", lighthouses[0].PublicAddr)
+}
+
+func newMobileFixture(t *testing.T, suffix string) (*store.SQLiteStore, *StubCAResolver, *models.Network, *models.Host) {
+	t.Helper()
+
+	ctx := context.Background()
+	s, err := store.NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	require.NoError(t, s.Migrate(ctx))
+
+	ca, err := pki.NewCA("test-ca-"+suffix, 365*24*time.Hour)
+	require.NoError(t, err)
+	resolver := &StubCAResolver{ca: ca}
+	network := &models.Network{
+		ID: "net-" + suffix, Name: "network-" + suffix,
+		CIDRs: []string{"10.0.0.0/8", "fd00::/8"},
+	}
+	require.NoError(t, s.CreateNetwork(ctx, network))
+	host := &models.Host{
+		ID: "mobile-" + suffix, Name: "phone-" + suffix, NetworkID: network.ID,
+		NebulaIPs: []string{"10.0.0.5"}, Kind: models.HostKindMobile,
+		Variant: models.HostVariantAndroid, Role: models.HostRoleHost,
+		Status: models.HostStatusPending, CAID: "ca-" + suffix,
+	}
+	require.NoError(t, s.CreateHost(ctx, host))
+	seedActiveCAOwner(t, s, host.CAID)
+	return s, resolver, network, host
+}
+
+func loadBundle(t *testing.T, bundle []byte) *nebcfg.C {
+	t.Helper()
+
+	var c nebcfg.C
+	require.NoError(t, c.LoadString(string(bundle)))
+	return &c
+}

--- a/internal/mobileconfig/settings.go
+++ b/internal/mobileconfig/settings.go
@@ -1,0 +1,146 @@
+// Package mobileconfig defines network-scoped settings used only when the
+// control plane renders a Mobile Nebula bundle.
+package mobileconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/netip"
+	"strings"
+	"unicode"
+)
+
+const (
+	// StoreKey is the network_config key used for mobile settings.
+	StoreKey = "mobile_config"
+
+	maxDNSResolvers = 16
+	maxMatchDomains = 64
+	maxDomainBytes  = 253
+)
+
+// Settings controls Mobile Nebula-specific DNS and endpoint discovery policy.
+type Settings struct {
+	DNSResolvers        []string `json:"dns_resolvers"`
+	MatchDomains        []string `json:"match_domains"`
+	AllowPrivateRemotes bool     `json:"allow_private_remotes"`
+}
+
+type wireSettings struct {
+	DNSResolvers        *[]string `json:"dns_resolvers"`
+	MatchDomains        *[]string `json:"match_domains"`
+	AllowPrivateRemotes *bool     `json:"allow_private_remotes"`
+}
+
+// Default returns settings that preserve existing private-network discovery.
+func Default() Settings {
+	return Settings{
+		DNSResolvers:        []string{},
+		MatchDomains:        []string{},
+		AllowPrivateRemotes: true,
+	}
+}
+
+// Decode parses and normalizes the persisted JSON representation.
+func Decode(raw string) (Settings, error) {
+	var wire wireSettings
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&wire); err != nil {
+		return Settings{}, fmt.Errorf("decode mobile config: %w", err)
+	}
+	if err := ensureJSONEOF(dec); err != nil {
+		return Settings{}, err
+	}
+	if wire.DNSResolvers == nil {
+		return Settings{}, fmt.Errorf("dns_resolvers is required")
+	}
+	if wire.MatchDomains == nil {
+		return Settings{}, fmt.Errorf("match_domains is required")
+	}
+	if wire.AllowPrivateRemotes == nil {
+		return Settings{}, fmt.Errorf("allow_private_remotes is required")
+	}
+
+	return (Settings{
+		DNSResolvers:        *wire.DNSResolvers,
+		MatchDomains:        *wire.MatchDomains,
+		AllowPrivateRemotes: *wire.AllowPrivateRemotes,
+	}).Normalize()
+}
+
+func ensureJSONEOF(dec *json.Decoder) error {
+	var trailing any
+	err := dec.Decode(&trailing)
+	if err == nil {
+		return fmt.Errorf("trailing JSON value")
+	}
+	if err != io.EOF {
+		return fmt.Errorf("trailing JSON: %w", err)
+	}
+	return nil
+}
+
+// Normalize validates settings and returns their canonical representation.
+func (s Settings) Normalize() (Settings, error) {
+	if len(s.DNSResolvers) > maxDNSResolvers {
+		return Settings{}, fmt.Errorf("dns_resolvers must contain at most %d entries", maxDNSResolvers)
+	}
+	if len(s.MatchDomains) > maxMatchDomains {
+		return Settings{}, fmt.Errorf("match_domains must contain at most %d entries", maxMatchDomains)
+	}
+
+	normalized := Settings{
+		DNSResolvers:        make([]string, 0, len(s.DNSResolvers)),
+		MatchDomains:        make([]string, 0, len(s.MatchDomains)),
+		AllowPrivateRemotes: s.AllowPrivateRemotes,
+	}
+
+	seenResolvers := make(map[string]struct{}, len(s.DNSResolvers))
+	for i, resolver := range s.DNSResolvers {
+		addr, err := netip.ParseAddr(strings.TrimSpace(resolver))
+		if err != nil {
+			return Settings{}, fmt.Errorf("dns_resolvers[%d] must be an IP address: %w", i, err)
+		}
+		if addr.Zone() != "" {
+			return Settings{}, fmt.Errorf("dns_resolvers[%d] must not contain an IPv6 zone", i)
+		}
+		value := addr.String()
+		if _, exists := seenResolvers[value]; exists {
+			return Settings{}, fmt.Errorf("dns_resolvers[%d] duplicates %q", i, value)
+		}
+		seenResolvers[value] = struct{}{}
+		normalized.DNSResolvers = append(normalized.DNSResolvers, value)
+	}
+
+	seenDomains := make(map[string]struct{}, len(s.MatchDomains))
+	for i, domain := range s.MatchDomains {
+		value := strings.TrimSpace(domain)
+		if value == "" {
+			return Settings{}, fmt.Errorf("match_domains[%d] must not be empty", i)
+		}
+		if len(value) > maxDomainBytes {
+			return Settings{}, fmt.Errorf("match_domains[%d] must not exceed %d bytes", i, maxDomainBytes)
+		}
+		if strings.IndexFunc(value, func(r rune) bool {
+			return unicode.IsSpace(r) || unicode.IsControl(r)
+		}) >= 0 {
+			return Settings{}, fmt.Errorf("match_domains[%d] must not contain whitespace or control characters", i)
+		}
+		key := strings.ToLower(value)
+		if _, exists := seenDomains[key]; exists {
+			return Settings{}, fmt.Errorf("match_domains[%d] duplicates %q", i, value)
+		}
+		seenDomains[key] = struct{}{}
+		normalized.MatchDomains = append(normalized.MatchDomains, value)
+	}
+
+	return normalized, nil
+}
+
+// Validate reports whether settings can be stored and rendered.
+func (s Settings) Validate() error {
+	_, err := s.Normalize()
+	return err
+}

--- a/internal/mobileconfig/settings_test.go
+++ b/internal/mobileconfig/settings_test.go
@@ -1,0 +1,156 @@
+package mobileconfig
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefault(t *testing.T) {
+	t.Parallel()
+
+	settings := Default()
+
+	assert.NotNil(t, settings.DNSResolvers)
+	assert.Empty(t, settings.DNSResolvers)
+	assert.NotNil(t, settings.MatchDomains)
+	assert.Empty(t, settings.MatchDomains)
+	assert.True(t, settings.AllowPrivateRemotes)
+	assert.Equal(t, "mobile_config", StoreKey)
+}
+
+func TestDecodeNormalizesSettings(t *testing.T) {
+	t.Parallel()
+
+	settings, err := Decode(`{
+		"dns_resolvers": [" 10.0.0.53 ", "2001:0db8::53"],
+		"match_domains": [" corp.example "],
+		"allow_private_remotes": false
+	}`)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"10.0.0.53", "2001:db8::53"}, settings.DNSResolvers)
+	assert.Equal(t, []string{"corp.example"}, settings.MatchDomains)
+	assert.False(t, settings.AllowPrivateRemotes)
+}
+
+func TestDecodeRejectsInvalidSettings(t *testing.T) {
+	t.Parallel()
+
+	manyResolvers := make([]string, 17)
+	for i := range manyResolvers {
+		manyResolvers[i] = "192.0.2." + string(rune('1'+i))
+	}
+	manyDomains := make([]string, 65)
+	for i := range manyDomains {
+		manyDomains[i] = "domain" + string(rune('a'+i)) + ".example"
+	}
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{
+			name:    "missing dns resolvers",
+			raw:     `{"match_domains":[],"allow_private_remotes":true}`,
+			wantErr: "dns_resolvers is required",
+		},
+		{
+			name:    "missing match domains",
+			raw:     `{"dns_resolvers":[],"allow_private_remotes":true}`,
+			wantErr: "match_domains is required",
+		},
+		{
+			name:    "missing private policy",
+			raw:     `{"dns_resolvers":[],"match_domains":[]}`,
+			wantErr: "allow_private_remotes is required",
+		},
+		{
+			name:    "unknown field",
+			raw:     `{"dns_resolvers":[],"match_domains":[],"allow_private_remotes":true,"extra":1}`,
+			wantErr: "unknown field",
+		},
+		{
+			name:    "trailing json",
+			raw:     `{"dns_resolvers":[],"match_domains":[],"allow_private_remotes":true}{}`,
+			wantErr: "trailing JSON",
+		},
+		{
+			name:    "invalid resolver",
+			raw:     `{"dns_resolvers":["dns.example"],"match_domains":[],"allow_private_remotes":true}`,
+			wantErr: "dns_resolvers[0]",
+		},
+		{
+			name:    "resolver zone",
+			raw:     `{"dns_resolvers":["fe80::1%en0"],"match_domains":[],"allow_private_remotes":true}`,
+			wantErr: "zone",
+		},
+		{
+			name:    "duplicate resolver",
+			raw:     `{"dns_resolvers":["2001:db8::53","2001:0db8::53"],"match_domains":[],"allow_private_remotes":true}`,
+			wantErr: "duplicate",
+		},
+		{
+			name:    "empty domain",
+			raw:     `{"dns_resolvers":[],"match_domains":["  "],"allow_private_remotes":true}`,
+			wantErr: "match_domains[0]",
+		},
+		{
+			name:    "domain whitespace",
+			raw:     `{"dns_resolvers":[],"match_domains":["corp example"],"allow_private_remotes":true}`,
+			wantErr: "whitespace",
+		},
+		{
+			name:    "duplicate domain",
+			raw:     `{"dns_resolvers":[],"match_domains":["Corp.Example","corp.example"],"allow_private_remotes":true}`,
+			wantErr: "duplicate",
+		},
+		{
+			name:    "domain too long",
+			raw:     settingsJSON(t, nil, []string{strings.Repeat("a", 254)}, true),
+			wantErr: "253",
+		},
+		{
+			name:    "too many resolvers",
+			raw:     settingsJSON(t, manyResolvers, nil, true),
+			wantErr: "at most 16",
+		},
+		{
+			name:    "too many domains",
+			raw:     settingsJSON(t, nil, manyDomains, true),
+			wantErr: "at most 64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Decode(tt.raw)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func settingsJSON(t *testing.T, resolvers, domains []string, allowPrivate bool) string {
+	t.Helper()
+
+	if resolvers == nil {
+		resolvers = []string{}
+	}
+	if domains == nil {
+		domains = []string{}
+	}
+	b, err := json.Marshal(Settings{
+		DNSResolvers:        resolvers,
+		MatchDomains:        domains,
+		AllowPrivateRemotes: allowPrivate,
+	})
+	require.NoError(t, err)
+	return string(b)
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -40,6 +40,7 @@ var (
 	ErrConfigAckUnsupported           = errors.New("config acknowledgement is not supported by this host")
 	ErrConfigVersionMismatch          = errors.New("config acknowledgement version does not match pending delivery")
 	ErrHostNotEnrolled                = errors.New("host is not enrolled")
+	ErrIssuanceNotAllowed             = errors.New("certificate issuance is not allowed")
 	ErrMeshImportExpectedHostsReached = errors.New("mesh import expected host count reached")
 	ErrMeshImportScopeInvalid         = errors.New("mesh import scope is invalid")
 	ErrMeshImportConflict             = errors.New("mesh import changed since preview")
@@ -1817,6 +1818,59 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(ctx context.Context, hostID s
 	return nil
 }
 
+// SaveCertificateIfIssuanceAllowed atomically re-checks durable Host and owner
+// state and persists a mobile certificate only when both still authorize the
+// transition. expectedStatus prevents a stale builder from changing a Host
+// whose lifecycle state changed while the bundle was being rendered.
+func (s *SQLiteStore) SaveCertificateIfIssuanceAllowed(
+	ctx context.Context, hostID string, expectedStatus models.HostStatus,
+	certPEM []byte, fp string, notBefore, notAfter time.Time,
+) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Error("rollback", "error", err)
+		}
+	}()
+
+	var hostStatus models.HostStatus
+	var ownerStatus models.OperatorStatus
+	err = tx.QueryRowContext(ctx, `
+		SELECT h.status, o.status
+		FROM hosts h
+		JOIN cas c ON c.id = h.ca_id
+		JOIN operators o ON o.id = c.owner_operator_id
+		WHERE h.id = ?`, hostID,
+	).Scan(&hostStatus, &ownerStatus)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("get issuance state: %w", err)
+	}
+	if hostStatus != expectedStatus ||
+		(expectedStatus != models.HostStatusPending && expectedStatus != models.HostStatusEnrolled) ||
+		ownerStatus != models.OperatorStatusActive {
+		return ErrIssuanceNotAllowed
+	}
+
+	if expectedStatus == models.HostStatusPending {
+		err = s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter)
+	} else {
+		err = s.updateHostCertificateInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter)
+	}
+	if err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit authorized certificate: %w", err)
+	}
+	return nil
+}
+
 // enrollHostInTx saves a freshly-signed certificate and flips the host to
 // enrolled within an existing transaction. If the host has role=lighthouse, the
 // network's config_version is bumped so peer agents pick up the new lighthouse
@@ -1994,6 +2048,20 @@ func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(ctx context.Context, host
 		}
 	}()
 
+	if err := s.updateHostCertificateInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit update host cert: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) updateHostCertificateInTx(
+	ctx context.Context, tx *sql.Tx, hostID string,
+	certPEM []byte, fp string, notBefore, notAfter time.Time,
+) error {
 	if err := s.saveCertificateInTx(ctx, tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
 		return err
 	}
@@ -2028,10 +2096,6 @@ func (s *SQLiteStore) SaveCertificateAndUpdateHostCert(ctx context.Context, host
 	}
 	if rows == 0 {
 		return ErrNotFound
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit update host cert: %w", err)
 	}
 	return nil
 }

--- a/internal/store/sqlite_mobile_certificate_test.go
+++ b/internal/store/sqlite_mobile_certificate_test.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+func TestSaveCertificateIfIssuanceAllowed_SEC_PERSIST_001RejectsBlockedHost(t *testing.T) {
+	s, host, _ := mobileCertificateFixture(t)
+	ctx := context.Background()
+	requireStoreTestNoError(t, s.UpdateHostStatus(ctx, host.ID, models.HostStatusBlocked))
+
+	now := time.Now()
+	err := s.SaveCertificateIfIssuanceAllowed(
+		ctx, host.ID, models.HostStatusPending, []byte("new-cert"), "new-fp", now, now.Add(time.Hour),
+	)
+	if !errors.Is(err, ErrIssuanceNotAllowed) {
+		t.Fatalf("error = %v, want ErrIssuanceNotAllowed", err)
+	}
+	stored, err := s.GetHost(ctx, host.ID)
+	requireStoreTestNoError(t, err)
+	if stored.Status != models.HostStatusBlocked {
+		t.Fatalf("status = %q, want blocked", stored.Status)
+	}
+	if _, err := s.GetCertificateInfo(ctx, host.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("certificate error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSaveCertificateIfIssuanceAllowed_SEC_PERSIST_001RejectsDisabledOwner(t *testing.T) {
+	s, host, owner := mobileCertificateFixture(t)
+	ctx := context.Background()
+	requireStoreTestNoError(t, s.DisableOperator(ctx, owner.ID))
+
+	now := time.Now()
+	err := s.SaveCertificateIfIssuanceAllowed(
+		ctx, host.ID, models.HostStatusPending, []byte("new-cert"), "new-fp", now, now.Add(time.Hour),
+	)
+	if !errors.Is(err, ErrIssuanceNotAllowed) {
+		t.Fatalf("error = %v, want ErrIssuanceNotAllowed", err)
+	}
+	if _, err := s.GetCertificateInfo(ctx, host.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("certificate error = %v, want ErrNotFound", err)
+	}
+}
+
+func mobileCertificateFixture(t *testing.T) (*SQLiteStore, *models.Host, *models.Operator) {
+	t.Helper()
+	s := newTestStore(t)
+	owner := createTestOperator(t, s)
+	ca := createTestCA(t, s, "ca_mobile_certificate", "mobile-certificate", owner.ID, nil)
+	network := &models.Network{
+		ID: "net_mobile_certificate", Name: "mobile-certificate", CAID: ca.ID,
+		CIDRs: []string{"10.80.0.0/16"}, CreatedAt: time.Now(),
+	}
+	requireStoreTestNoError(t, s.CreateNetwork(context.Background(), network))
+	host := &models.Host{
+		ID: "host_mobile_certificate", NetworkID: network.ID, CAID: ca.ID,
+		Name: "mobile-certificate", NebulaIPs: []string{"10.80.0.10"},
+		Role: models.HostRoleHost, Status: models.HostStatusPending,
+		Kind: models.HostKindMobile, Variant: models.HostVariantAndroid,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	requireStoreTestNoError(t, s.CreateHost(context.Background(), host))
+	return s, host, owner
+}
+
+func requireStoreTestNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -133,6 +133,7 @@ type Store interface {
 	// Certificates
 	SaveCertificate(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	SaveCertificateAndEnrollHost(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
+	SaveCertificateIfIssuanceAllowed(ctx context.Context, hostID string, expectedStatus models.HostStatus, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	ConsumeTokenAndEnrollHost(ctx context.Context, hostID, token string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	ConsumeTokenAndEnrollHostWithProfile(ctx context.Context, hostID, token string, certPEM []byte, fp string, notBefore, notAfter time.Time, signingPubPEM string, profile models.AgentProfile) (int, error)
 	SaveCertificateAndUpdateHostCert(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error

--- a/internal/web/mesh_imports_test.go
+++ b/internal/web/mesh_imports_test.go
@@ -316,7 +316,7 @@ func TestMeshImportWebFinalizePreservesRevokedHostAndEmitsBlocked(t *testing.T) 
 	hostCertificate, err := manager.Sign(pki.SignRequest{
 		Name: "blocked-adopted-host", PublicKey: make([]byte, 32),
 		Networks: []netip.Prefix{netip.MustParsePrefix("10.76.0.10/16")}, Groups: []string{"prod"},
-		Duration: 90 * 24 * time.Hour,
+		Duration: 90 * 24 * time.Hour, Now: now,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What

- Generate a dedicated Mobile Nebula profile without changing agent-generated configurations.
- Add validated per-network mobile DNS and remote discovery settings through a network-scoped Management API.
- Include the current CA blocklist and enrolled relays in mobile bundles, and format IPv6 lighthouse endpoints correctly.
- Make final mobile certificate authorization and persistence atomic.

## Why

Mobile bundles reused desktop-oriented defaults and omitted current revocation and relay state. This could produce incomplete profiles and, before the final security fix, allow a concurrent Host block to race certificate persistence.

Closes #285.

## How

- Add an optional `MobileProfile` to the typed config generator.
- Store strict mobile settings under the existing `network_config` model without waking desktop agents.
- Re-check durable Host and CA owner state inside the certificate write transaction.
- Cover tenant isolation, configuration parsing, Nebula compatibility, IPv6 endpoints, bundle state, and concurrent revocation.

### Code pointers

- `internal/configgen`: typed Mobile Nebula profile and YAML rendering.
- `internal/mobileconfig`: persisted settings and validation.
- `internal/mobilebundle`: bundle state and atomic certificate issuance.
- `internal/api`: Management API, authorization, audit, metrics, and OpenAPI contract.
- `docs/security`: SEC-PERSIST-001 and threat-model updates.

## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in API/config documentation
- [x] No breaking API changes
