### PR TITLE
fix(agent): harden enrollment and poller against compromised server responses

### DIFF
--- a/cmd/nebula-agent/enroll_test.go
+++ b/cmd/nebula-agent/enroll_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
+	crypto_rand "crypto/rand"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,6 +20,10 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/curve25519"
+
+	"github.com/forgekeep/nebula-mesh/internal/pki"
 )
 
 // syncedBuffer is a tiny mutex-guarded byte buffer used by tests that read
@@ -54,6 +60,39 @@ type enrollMockServer struct {
 
 func newEnrollMockServer(t *testing.T) *enrollMockServer {
 	t.Helper()
+
+	// Generate a real CA and host certificate so the agent's enrollment
+	// validation accepts the response (#293).
+	caMgr, err := pki.NewCA("enroll-mock", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(caMgr.Wipe)
+	xPriv := make([]byte, 32)
+	if _, err := crypto_rand.Read(xPriv); err != nil {
+		t.Fatal(err)
+	}
+	xPub, err := curve25519.X25519(xPriv, curve25519.Basepoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostCert, err := caMgr.Sign(pki.SignRequest{
+		Name: "mock-host", PublicKey: xPub,
+		Networks: []netip.Prefix{netip.MustParsePrefix("10.99.0.1/16")},
+		Duration: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostCertPEM, err := hostCert.MarshalPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCertPEM, err := caMgr.CACertPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	srv := &enrollMockServer{}
 	srv.updatesCode.Store(int32(http.StatusOK))
 	srv.ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -70,8 +109,8 @@ func newEnrollMockServer(t *testing.T) *enrollMockServer {
 				srv.signingPub = ed25519.PublicKey(block.Bytes)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"certificate_pem":    pemBlock("NEBULA CERTIFICATE", "cert-bytes"),
-				"ca_certificate_pem": pemBlock("NEBULA CERTIFICATE", "ca-bytes"),
+				"certificate_pem":    string(hostCertPEM),
+				"ca_certificate_pem": string(caCertPEM),
 				"config_yaml":        "pki:\n  ca: /etc/nebula/ca.crt\n",
 			})
 		case "/api/v1/agent/updates":
@@ -87,10 +126,6 @@ func newEnrollMockServer(t *testing.T) *enrollMockServer {
 	}))
 	t.Cleanup(srv.ts.Close)
 	return srv
-}
-
-func pemBlock(kind, body string) string {
-	return "-----BEGIN " + kind + "-----\n" + body + "\n-----END " + kind + "-----\n"
 }
 
 // TestEnrollSubcommand_WritesFiles — happy path. enroll subcommand hits

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -13,10 +13,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/slackhq/nebula/cert"
 	"golang.org/x/crypto/curve25519"
 
+	"github.com/forgekeep/nebula-mesh/internal/fsutil"
 	"github.com/forgekeep/nebula-mesh/internal/keystore"
 	"github.com/forgekeep/nebula-mesh/internal/models"
 )
@@ -203,15 +206,18 @@ func enrollWithProfile(
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 		if readErr != nil {
 			return fmt.Errorf("enrollment failed (HTTP %d, body unreadable: %w)", resp.StatusCode, readErr)
+		}
+		if len(body) > 512 {
+			body = body[:512]
 		}
 		return fmt.Errorf("enrollment failed (HTTP %d): %s", resp.StatusCode, string(body))
 	}
 
 	var enrollResp EnrollResponse
-	if err := json.NewDecoder(resp.Body).Decode(&enrollResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&enrollResp); err != nil {
 		return fmt.Errorf("decode enrollment response: %w", err)
 	}
 
@@ -224,7 +230,7 @@ func enrollWithProfile(
 	// Save private key. The PEM encoding is a second heap copy of the
 	// secret — tracked in secrets and wiped with the raw bytes.
 	secrets.privKeyPEM = cert.MarshalPrivateKeyToPEM(cert.Curve_CURVE25519, secrets.privKey)
-	if err := os.WriteFile(profile.NebulaKeyPath, secrets.privKeyPEM, 0o600); err != nil {
+	if err := fsutil.AtomicWriteFile(profile.NebulaKeyPath, secrets.privKeyPEM, 0o600); err != nil {
 		return fmt.Errorf("write host key: %w", err)
 	}
 
@@ -234,17 +240,29 @@ func enrollWithProfile(
 		return fmt.Errorf("create signing key dir: %w", err)
 	}
 	secrets.signingPrivPEM = pem.EncodeToMemory(&pem.Block{Type: SigningPrivateKeyPEMType, Bytes: secrets.signingPriv})
-	if err := os.WriteFile(signingKeyPath, secrets.signingPrivPEM, 0o600); err != nil {
+	if err := fsutil.AtomicWriteFile(signingKeyPath, secrets.signingPrivPEM, 0o600); err != nil {
 		return fmt.Errorf("write signing key: %w", err)
 	}
 
-	// Save certificate
-	if err := os.WriteFile(profile.NebulaCertPath, []byte(enrollResp.CertificatePEM), 0o644); err != nil { // #nosec G306 -- host certificate is public PEM material; 0o644 is intentional
+	// Validate the host certificate before writing: must be a valid
+	// non-CA Curve25519 certificate with no trailing PEM blocks.
+	hostCert, remainder, err := cert.UnmarshalCertificateFromPEM([]byte(enrollResp.CertificatePEM))
+	if err != nil || strings.TrimSpace(string(remainder)) != "" || hostCert.IsCA() ||
+		hostCert.Curve() != cert.Curve_CURVE25519 {
+		return fmt.Errorf("enrollment response contains an invalid host certificate")
+	}
+	if err := fsutil.AtomicWriteFile(profile.NebulaCertPath, []byte(enrollResp.CertificatePEM), 0o644); err != nil {
 		return fmt.Errorf("write host cert: %w", err)
 	}
 
-	// Save CA certificate
-	if err := os.WriteFile(profile.NebulaCAPath, []byte(enrollResp.CACertificatePEM), 0o644); err != nil { // #nosec G306 -- CA certificate is public PEM material; 0o644 is intentional
+	// Validate the CA certificate: must be a valid CA with Curve25519
+	// and not expired.
+	caCert, caRemainder, err := cert.UnmarshalCertificateFromPEM([]byte(enrollResp.CACertificatePEM))
+	if err != nil || strings.TrimSpace(string(caRemainder)) != "" || !caCert.IsCA() ||
+		caCert.Curve() != cert.Curve_CURVE25519 || caCert.Expired(time.Now()) {
+		return fmt.Errorf("enrollment response contains an invalid CA certificate")
+	}
+	if err := fsutil.AtomicWriteFile(profile.NebulaCAPath, []byte(enrollResp.CACertificatePEM), 0o644); err != nil {
 		return fmt.Errorf("write CA cert: %w", err)
 	}
 
@@ -252,7 +270,7 @@ func enrollWithProfile(
 	// nebula IPs, lighthouse list, firewall rules, paths to key/cert
 	// files). No secrets in the file itself; the actual private key
 	// lives in host.key, written above at 0o600.
-	if err := os.WriteFile(profile.NebulaConfigPath, []byte(enrollResp.ConfigYAML), 0o640); err != nil { // #nosec G306 -- rendered Nebula config: host name, IPs, lighthouse, firewall rules, paths to key/cert files — no secrets; the actual private key is host.key (0o600)
+	if err := fsutil.AtomicWriteFile(profile.NebulaConfigPath, []byte(enrollResp.ConfigYAML), 0o640); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 	if reload != nil {

--- a/internal/agent/enroll_rekey_test.go
+++ b/internal/agent/enroll_rekey_test.go
@@ -24,6 +24,8 @@ func TestReenrollUsesProfilePaths(t *testing.T) {
 		ConfigAckV1:      true,
 	}
 	signingKeyPath := filepath.Join(root, "agent", "signing.key")
+	hostCertPEM, caCertPEM := testEnrollCerts(t)
+	configYAML := "pki:\n  ca: " + profile.NebulaCAPath + "\n"
 	var submitted models.AgentProfile
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		var body struct {
@@ -36,7 +38,7 @@ func TestReenrollUsesProfilePaths(t *testing.T) {
 		}
 		submitted = body.Profile
 		_ = json.NewEncoder(response).Encode(EnrollResponse{
-			CertificatePEM: "certificate", CACertificatePEM: "ca", ConfigYAML: "config",
+			CertificatePEM: hostCertPEM, CACertificatePEM: caCertPEM, ConfigYAML: configYAML,
 		})
 	}))
 	t.Cleanup(server.Close)
@@ -51,8 +53,8 @@ func TestReenrollUsesProfilePaths(t *testing.T) {
 		t.Fatalf("submitted profile = %#v, want %#v", submitted, profile)
 	}
 	for path, want := range map[string]string{
-		profile.NebulaConfigPath: "config", profile.NebulaCAPath: "ca",
-		profile.NebulaCertPath: "certificate",
+		profile.NebulaConfigPath: configYAML, profile.NebulaCAPath: caCertPEM,
+		profile.NebulaCertPath: hostCertPEM,
 	} {
 		contents, err := os.ReadFile(path)
 		if err != nil || string(contents) != want {
@@ -75,13 +77,13 @@ func TestReenrollReloadsAfterWritesBeforeAck(t *testing.T) {
 		NebulaKeyPath:    filepath.Join(root, "node.key"),
 		ConfigAckV1:      true,
 	}
-	certificatePEM := validPollerHostCertificate(t)
+	certificatePEM, caCertPEM := testEnrollCerts(t)
 	var acknowledgements atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
 		case "/api/v1/enroll":
 			_ = json.NewEncoder(response).Encode(EnrollResponse{
-				CertificatePEM: certificatePEM, CACertificatePEM: "ca", ConfigYAML: "config", ConfigVersion: 7,
+				CertificatePEM: certificatePEM, CACertificatePEM: caCertPEM, ConfigYAML: "config", ConfigVersion: 7,
 			})
 		case "/api/v1/agent/config-ack/7":
 			acknowledgements.Add(1)
@@ -125,11 +127,12 @@ func TestReenrollReloadFailureSuppressesAck(t *testing.T) {
 		NebulaConfigPath: filepath.Join(root, "nebula.yml"), NebulaCAPath: filepath.Join(root, "root.pem"),
 		NebulaCertPath: filepath.Join(root, "node.pem"), NebulaKeyPath: filepath.Join(root, "node.key"), ConfigAckV1: true,
 	}
+	certPEM3, caPEM3 := testEnrollCerts(t)
 	var acknowledgements atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/enroll" {
 			_ = json.NewEncoder(response).Encode(EnrollResponse{
-				CertificatePEM: validPollerHostCertificate(t), CACertificatePEM: "ca", ConfigYAML: "config", ConfigVersion: 3,
+				CertificatePEM: certPEM3, CACertificatePEM: caPEM3, ConfigYAML: "config", ConfigVersion: 3,
 			})
 			return
 		}
@@ -157,11 +160,12 @@ func TestReenrollWithoutPIDFileSkipsReloadAndAcknowledges(t *testing.T) {
 		NebulaConfigPath: filepath.Join(root, "nebula.yml"), NebulaCAPath: filepath.Join(root, "root.pem"),
 		NebulaCertPath: filepath.Join(root, "node.pem"), NebulaKeyPath: filepath.Join(root, "node.key"), ConfigAckV1: true,
 	}
+	certPEM4, caPEM4 := testEnrollCerts(t)
 	var acknowledgements atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/enroll" {
 			_ = json.NewEncoder(response).Encode(EnrollResponse{
-				CertificatePEM: validPollerHostCertificate(t), CACertificatePEM: "ca", ConfigYAML: "config", ConfigVersion: 2,
+				CertificatePEM: certPEM4, CACertificatePEM: caPEM4, ConfigYAML: "config", ConfigVersion: 2,
 			})
 			return
 		}

--- a/internal/agent/enroll_test.go
+++ b/internal/agent/enroll_test.go
@@ -2,19 +2,63 @@ package agent
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"golang.org/x/crypto/curve25519"
+
+	"github.com/forgekeep/nebula-mesh/internal/pki"
 )
+
+// testEnrollCerts generates a real CA and host certificate pair for
+// enrollment test fixtures. Returns (hostCertPEM, caCertPEM).
+func testEnrollCerts(t *testing.T) (hostCertPEM, caCertPEM string) {
+	t.Helper()
+	caMgr, err := pki.NewCA("enroll-test", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(caMgr.Wipe)
+	xPriv := make([]byte, 32)
+	if _, err := rand.Read(xPriv); err != nil {
+		t.Fatal(err)
+	}
+	xPub, err := curve25519.X25519(xPriv, curve25519.Basepoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostCert, err := caMgr.Sign(pki.SignRequest{
+		Name: "enroll-test-host", PublicKey: xPub,
+		Networks: []netip.Prefix{netip.MustParsePrefix("10.99.0.1/16")},
+		Duration: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawHostPEM, err := hostCert.MarshalPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawCAPEM, err := caMgr.CACertPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(rawHostPEM), string(rawCAPEM)
+}
 
 func TestEnroll_Success(t *testing.T) {
 	dir := t.TempDir()
 	agentDir := t.TempDir()
 	signingKeyPath := filepath.Join(agentDir, "host.signing.key")
+	hostCertPEM, caCertPEM := testEnrollCerts(t)
 
 	// Mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -46,8 +90,8 @@ func TestEnroll_Success(t *testing.T) {
 		}
 
 		resp := EnrollResponse{
-			CertificatePEM:   "-----BEGIN NEBULA CERTIFICATE-----\ntest-cert\n-----END NEBULA CERTIFICATE-----",
-			CACertificatePEM: "-----BEGIN NEBULA CERTIFICATE-----\ntest-ca\n-----END NEBULA CERTIFICATE-----",
+			CertificatePEM:   hostCertPEM,
+			CACertificatePEM: caCertPEM,
 			ConfigYAML:       "pki:\n  ca: /etc/nebula/ca.crt\n",
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -98,14 +142,14 @@ func TestEnroll_Success(t *testing.T) {
 func TestEnrollAcknowledgesInitialConfigVersion(t *testing.T) {
 	dataDir := t.TempDir()
 	signingPath := filepath.Join(t.TempDir(), "host.signing.key")
-	certificatePEM := validPollerHostCertificate(t)
+	certificatePEM, caCertPEM := testEnrollCerts(t)
 	rendered := "pki:\n  ca: " + filepath.Join(dataDir, "ca.crt") + "\n  cert: " + filepath.Join(dataDir, "host.crt") + "\n  key: " + filepath.Join(dataDir, "host.key") + "\n"
 	var acknowledgements atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
 		case "/api/v1/enroll":
 			_ = json.NewEncoder(response).Encode(EnrollResponse{
-				CertificatePEM: certificatePEM, CACertificatePEM: "public-ca", ConfigYAML: rendered, ConfigVersion: 4,
+				CertificatePEM: certificatePEM, CACertificatePEM: caCertPEM, ConfigYAML: rendered, ConfigVersion: 4,
 			})
 		case "/api/v1/agent/config-ack/4":
 			if request.Header.Get("X-Nebula-Signature") == "" || request.Header.Get("X-Nebula-Fingerprint") == "" {

--- a/internal/agent/enroll_zeroize_test.go
+++ b/internal/agent/enroll_zeroize_test.go
@@ -45,11 +45,12 @@ func captureEnrollSecrets(t *testing.T) **enrollmentSecrets {
 func TestEnroll_ZeroizesPrivateKeys(t *testing.T) {
 	dir := t.TempDir()
 	signingKeyPath := filepath.Join(t.TempDir(), "host.signing.key")
+	hostCertPEM, caCertPEM := testEnrollCerts(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := EnrollResponse{
-			CertificatePEM:   "-----BEGIN NEBULA CERTIFICATE-----\ntest-cert\n-----END NEBULA CERTIFICATE-----",
-			CACertificatePEM: "-----BEGIN NEBULA CERTIFICATE-----\ntest-ca\n-----END NEBULA CERTIFICATE-----",
+			CertificatePEM:   hostCertPEM,
+			CACertificatePEM: caCertPEM,
 			ConfigYAML:       "pki:\n  ca: /etc/nebula/ca.crt\n",
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -209,8 +209,10 @@ func loadSigningKey(path string) (ed25519.PrivateKey, error) {
 	return ed25519.PrivateKey(block.Bytes), nil
 }
 
-// Run starts the poll loop, blocking until ctx is canceled.
+// Run starts the poll loop, blocking until ctx is canceled. The signing
+// key is zeroized on return so it does not linger in heap memory.
 func (p *Poller) Run(ctx context.Context) error {
+	defer clear(p.signingKey)
 	p.logger.Info("starting poll loop", "interval", p.config.Interval, "server", p.config.ServerURL)
 
 	ticker := time.NewTicker(p.config.Interval)
@@ -292,7 +294,7 @@ func (p *Poller) poll(ctx context.Context) error {
 		return nil
 	}
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusGone {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 		reason := "revoked"
 		if resp.StatusCode == http.StatusGone {
 			reason = "gone"
@@ -306,12 +308,12 @@ func (p *Poller) poll(ctx context.Context) error {
 		return &RevocationError{StatusCode: resp.StatusCode, Reason: reason, Body: string(body)}
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 		return &PollHTTPError{StatusCode: resp.StatusCode, Body: string(body), ReadErr: readErr}
 	}
 
 	var updates UpdatesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&updates); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&updates); err != nil {
 		return fmt.Errorf("decode updates: %w", err)
 	}
 
@@ -360,6 +362,11 @@ func (p *Poller) poll(ctx context.Context) error {
 	}
 
 	if updates.CACertPEM != nil {
+		caCert, remainder, err := cert.UnmarshalCertificateFromPEM([]byte(*updates.CACertPEM))
+		if err != nil || strings.TrimSpace(string(remainder)) != "" || !caCert.IsCA() ||
+			caCert.Curve() != cert.Curve_CURVE25519 || caCert.Expired(time.Now()) {
+			return fmt.Errorf("validate returned CA certificate: invalid or expired CA")
+		}
 		if err := fsutil.AtomicWriteFile(p.nebulaCAPath(), []byte(*updates.CACertPEM), 0o644); err != nil {
 			return fmt.Errorf("write CA cert: %w", err)
 		}
@@ -594,6 +601,9 @@ func signalNebulaFromPID(pidFile string) error {
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
 		return fmt.Errorf("parse PID from %s: %w", pidFile, err)
+	}
+	if pid <= 1 {
+		return fmt.Errorf("invalid PID %d from %s: must be greater than 1", pid, pidFile)
 	}
 
 	proc, err := os.FindProcess(pid)

--- a/internal/agent/poller_test.go
+++ b/internal/agent/poller_test.go
@@ -145,7 +145,16 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 }
 
 func TestPoller_WithCACertUpdate(t *testing.T) {
-	caCertPEM := "-----BEGIN NEBULA CERTIFICATE-----\nca-cert-data\n-----END NEBULA CERTIFICATE-----"
+	caManager, err := pki.NewCA("ca-update-test", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer caManager.Wipe()
+	caPEM, err := caManager.CACertPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCertPEM := string(caPEM)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(UpdatesResponse{
 			HasUpdates: true,
@@ -388,5 +397,94 @@ func TestSignalNebula_NoPIDFile(t *testing.T) {
 func TestNewPoller_MissingSigningKey(t *testing.T) {
 	if _, err := NewPoller(PollerConfig{DataDir: t.TempDir()}, slog.Default()); err == nil {
 		t.Fatal("expected error when host.signing.key missing")
+	}
+}
+
+// TestPoller_RejectsInvalidCACert verifies that a poll response carrying a
+// non-CA or malformed certificate is rejected and the on-disk CA file is
+// not overwritten (#293 M-1).
+func TestPoller_RejectsInvalidCACert(t *testing.T) {
+	// A valid host certificate (not a CA) must be rejected.
+	hostCertPEM := validPollerHostCertificate(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
+			HasUpdates: true,
+			CACertPEM:  &hostCertPEM,
+			Blocklist:  []string{},
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	// Seed an existing CA file so we can verify it is not overwritten.
+	originalCA := []byte("original-ca")
+	if err := os.WriteFile(filepath.Join(dir, "ca.crt"), originalCA, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newTestPoller(t, PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    50 * time.Millisecond,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	data, err := os.ReadFile(filepath.Join(dir, "ca.crt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(originalCA) {
+		t.Errorf("CA file was overwritten with invalid cert; got %q", string(data))
+	}
+}
+
+// TestSignalNebula_InvalidPID verifies that PID values 0 and -1 are
+// rejected before sending SIGHUP (#293 M-5).
+func TestSignalNebula_InvalidPID(t *testing.T) {
+	for _, pidContent := range []string{"0", "-1", " 0 ", " -1 "} {
+		dir := t.TempDir()
+		pidFile := filepath.Join(dir, "nebula.pid")
+		if err := os.WriteFile(pidFile, []byte(pidContent), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := signalNebulaFromPID(pidFile); err == nil {
+			t.Errorf("expected error for PID content %q, got nil", pidContent)
+		}
+	}
+}
+
+// TestPoller_ZeroizesSigningKeyOnShutdown verifies that the signing key
+// is zeroed after Run returns (#293 L-2).
+func TestPoller_ZeroizesSigningKeyOnShutdown(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{HasUpdates: false, Blocklist: []string{}})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	p := newTestPoller(t, PollerConfig{
+		ServerURL:   server.URL,
+		Fingerprint: "test-fp",
+		DataDir:     dir,
+		Interval:    50 * time.Millisecond,
+	})
+
+	// Capture a reference to the key bytes before Run.
+	keyBytes := p.signingKey
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	for i, b := range keyBytes {
+		if b != 0 {
+			t.Fatalf("signing key byte %d = %d after Run, want 0", i, b)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #293.

Seven defense-in-depth fixes for `internal/agent/` found during the July 2026 security review. None are exploitable under normal operation; each strengthens resilience against a compromised server, crash, or malformed input.

## Changes

### Poller (`internal/agent/poller.go`)

- **CA cert validation** — poll updates carrying a CA certificate are now parsed and validated (IsCA, Curve25519, not expired, no trailing PEM) before writing to disk, mirroring the existing host cert validation and the `discovery.go` pattern.
- **Bounded response reads** — all three `resp.Body` reads wrapped with `io.LimitReader` (64 KiB errors, 1 MiB JSON), matching `import_client.go`.
- **PID sanity check** — `signalNebulaFromPID` rejects `pid <= 1` before sending SIGHUP, preventing broadcast to the process group.
- **Signing key zeroization** — `defer clear(p.signingKey)` in `Run()` so the Ed25519 key does not linger in heap after shutdown.

### Enrollment (`internal/agent/enroll.go`)

- **Certificate validation** — both host cert and CA cert from the enrollment response are parsed and validated before writing to disk.
- **Bounded response reads** — `io.LimitReader` on both error and success paths.
- **Error truncation** — server response body truncated to 512 bytes in error messages.
- **Atomic writes** — all five `os.WriteFile` calls replaced with `fsutil.AtomicWriteFile`.

### Tests

- 3 new tests: `TestPoller_RejectsInvalidCACert`, `TestSignalNebula_InvalidPID`, `TestPoller_ZeroizesSigningKeyOnShutdown`.
- All test fixtures updated from synthetic PEM blocks to real Nebula certificates via `pki.NewCA` (7 test files).

## Verification

- `go test -race -count=1 ./internal/agent/... ./cmd/nebula-agent/` — all pass
- `go vet ./internal/agent/... ./cmd/nebula-agent/` — clean