### PR TITLE
fix(web): harden OIDC error handling, 2FA disable flow, and registration timing

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -233,7 +233,9 @@ func (w *Web) handleRegister(rw http.ResponseWriter, r *http.Request) {
 	if _, err := w.store.GetOperatorByUsername(r.Context(), username); err == nil {
 		// Generic message so an unauthenticated caller cannot enumerate
 		// existing operator usernames via a distinct error (#260). The real
-		// reason is logged server-side.
+		// reason is logged server-side. Run a dummy bcrypt to equalize
+		// response time with the username-free path (#296).
+		_ = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password))
 		w.renderForRequest(rw, r, "register.html", map[string]any{"Error": "Registration failed"})
 		w.logger.Info("register: username taken", "username", username)
 		return
@@ -533,12 +535,40 @@ func (w *Web) handleTwoFADisable(rw http.ResponseWriter, r *http.Request) {
 	}
 	password := r.FormValue("password")
 	if err := bcrypt.CompareHashAndPassword([]byte(op.PasswordHash), []byte(password)); err != nil {
-		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.disable_failed", op.ID, "")
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.disable_failed", op.ID, "bad_password")
 		w.renderForRequest(rw, r, "twofa.html", map[string]any{
 			"Active":      "2fa",
 			"Operator":    op,
 			"TOTPEnabled": op.TOTPEnabled,
 			"Error":       "Password does not match",
+		})
+		return
+	}
+	// OWASP ASVS V2.1.7: require the current second factor when
+	// disabling MFA so a password-only compromise (phishing, credential
+	// stuffing) cannot silently remove 2FA (#296).
+	totpCode := r.FormValue("totp_code")
+	recoveryCode := r.FormValue("recovery_code")
+	secondFactorOK := false
+	if totpCode != "" {
+		timestep, valid := verifyTOTPWithTimestep(op.TOTPSecret, totpCode)
+		if valid {
+			if err := w.store.ConsumeOperatorTOTPTimestep(r.Context(), op.ID, timestep); err == nil {
+				secondFactorOK = true
+			}
+		}
+	} else if recoveryCode != "" {
+		if err := w.store.ConsumeOperatorRecoveryCode(r.Context(), op.ID, hashRecoveryCode(recoveryCode)); err == nil {
+			secondFactorOK = true
+		}
+	}
+	if !secondFactorOK {
+		_ = w.store.AddAuditEntry(r.Context(), op.Username, "operator.2fa.disable_failed", op.ID, "bad_second_factor")
+		w.renderForRequest(rw, r, "twofa.html", map[string]any{
+			"Active":      "2fa",
+			"Operator":    op,
+			"TOTPEnabled": op.TOTPEnabled,
+			"Error":       "Enter a valid TOTP or recovery code to confirm",
 		})
 		return
 	}

--- a/internal/web/oidc.go
+++ b/internal/web/oidc.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
@@ -201,13 +202,13 @@ func (o *OIDC) HandleCallback(rw http.ResponseWriter, r *http.Request) {
 		}
 		desc := r.URL.Query().Get("error_description")
 		o.logger.Warn("oidc provider error", "error", errParam, "description", desc)
-		http.Error(rw, "oidc provider error: "+errParam, http.StatusBadRequest)
+		http.Error(rw, "oidc login failed", http.StatusBadRequest)
 		return
 	}
 
 	state := r.URL.Query().Get("state")
 	cookie, err := r.Cookie(oidcStateCookieName)
-	if err != nil || cookie.Value == "" || cookie.Value != state || !o.consumeState(state) {
+	if err != nil || cookie.Value == "" || subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(state)) != 1 || !o.consumeState(state) {
 		http.Error(rw, "invalid oidc state", http.StatusBadRequest)
 		return
 	}
@@ -250,12 +251,14 @@ func (o *OIDC) HandleCallback(rw http.ResponseWriter, r *http.Request) {
 	}
 	idToken, err := o.verifier.Verify(ctx, rawID)
 	if err != nil {
-		http.Error(rw, "oidc id_token verification failed: "+err.Error(), http.StatusBadGateway)
+		o.logger.Error("oidc id_token verification failed", "error", err)
+		http.Error(rw, "oidc verification failed", http.StatusBadGateway)
 		return
 	}
 	var claims map[string]any
 	if err := idToken.Claims(&claims); err != nil {
-		http.Error(rw, "oidc claims parse: "+err.Error(), http.StatusBadGateway)
+		o.logger.Error("oidc claims parse failed", "error", err)
+		http.Error(rw, "oidc verification failed", http.StatusBadGateway)
 		return
 	}
 

--- a/internal/web/totp_test.go
+++ b/internal/web/totp_test.go
@@ -351,7 +351,7 @@ func TestTwoFADisable_RequiresPassword(t *testing.T) {
 	cookies := loginSession(t, w)
 
 	// Pre-enable TOTP
-	_, _ = enableTOTPForAdmin(t, w)
+	secret, _ := enableTOTPForAdmin(t, w)
 
 	// Wrong password — should fail
 	// Get CSRF token for 2FA disable form
@@ -376,8 +376,7 @@ func TestTwoFADisable_RequiresPassword(t *testing.T) {
 		t.Error("TOTP should still be enabled after failed disable")
 	}
 
-	// Correct password — should succeed
-	// Get CSRF token for 2FA disable form
+	// Correct password but no TOTP code — should fail (#296)
 	csrfToken, updatedCookies = getCSRFTokenFromCookies(t, w, "/ui/2fa", cookies)
 
 	form = url.Values{
@@ -391,8 +390,31 @@ func TestTwoFADisable_RequiresPassword(t *testing.T) {
 	}
 	rec = httptest.NewRecorder()
 	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "Enter a valid TOTP or recovery code") {
+		t.Error("expected second factor required error")
+	}
+
+	// Correct password + valid TOTP code — should succeed
+	disableCode, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	csrfToken, updatedCookies = getCSRFTokenFromCookies(t, w, "/ui/2fa", cookies)
+
+	form = url.Values{
+		"password":  {testPassword},
+		"totp_code": {disableCode},
+		"_csrf":     {csrfToken},
+	}
+	req = httptest.NewRequest(http.MethodPost, "/ui/2fa/disable", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range updatedCookies {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
 	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("disable status = %d", rec.Code)
+		t.Fatalf("disable status = %d, body = %s", rec.Code, rec.Body.String())
 	}
 
 	op, _ = s.GetOperator(context.Background(), "admin-test-id")


### PR DESCRIPTION
## Summary

Closes #296.

Five web authentication hardening fixes found during the July 2026 security review.

## Changes

### OIDC error leakage (M-1)
`internal/web/oidc.go` — `verifier.Verify()` and `idToken.Claims()` errors no longer leak `err.Error()` details (issuer/audience mismatch, token expiry, JWKS key IDs) to the client. Generic `"oidc verification failed"` returned; full error logged server-side.

### OIDC error reflection (L-2)
`internal/web/oidc.go` — the IdP's `error` query parameter is no longer reflected in the response body. Fixed string `"oidc login failed"` returned instead.

### OIDC state comparison (L-1)
`internal/web/oidc.go` — state parameter compared with `subtle.ConstantTimeCompare` instead of `!=`.

### 2FA disable requires second factor (M-2)
`internal/web/handlers.go` — disabling 2FA now requires a valid TOTP code or recovery code alongside the password (OWASP ASVS V2.1.7). A password-only compromise can no longer silently remove the second factor.

### Registration timing equalization (L-3)
`internal/web/handlers.go` — the username-taken branch runs a dummy bcrypt comparison to equalize response time with the username-free path.

## Verification

- `go test -race -count=1 ./internal/web/` — all pass (121s)
- `go vet ./internal/web/` — clean
- `golangci-lint run ./internal/web/` — 0 issues