### PR TITLE
fix(api): strict JSON decoding and field length limits

### DIFF
--- a/internal/api/cas.go
+++ b/internal/api/cas.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -94,12 +93,16 @@ func (s *Server) handleCreateCA(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req createCARequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSONStrict(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	if req.Name == "" {
 		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if len(req.Name) > 255 {
+		writeError(w, http.StatusBadRequest, "name must be at most 255 characters")
 		return
 	}
 	duration := 365 * 24 * time.Hour

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -37,7 +36,7 @@ type enrollResponse struct {
 
 func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 	var req enrollRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSONStrict(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/internal/api/firewall.go
+++ b/internal/api/firewall.go
@@ -88,7 +88,7 @@ func (s *Server) handleUpdateFirewall(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req firewallRulesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSONStrict(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/internal/api/networks.go
+++ b/internal/api/networks.go
@@ -33,6 +33,10 @@ func (s *Server) handleCreateNetwork(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name is required")
 		return
 	}
+	if len(req.Name) > 255 {
+		writeError(w, http.StatusBadRequest, "name must be at most 255 characters")
+		return
+	}
 	if err := models.ValidateNetworkCIDRs(req.CIDRs); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/api/operators.go
+++ b/internal/api/operators.go
@@ -30,12 +30,20 @@ func (s *Server) handleCreateOperator(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req createOperatorRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSONStrict(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	if req.Username == "" || req.Password == "" {
 		writeError(w, http.StatusBadRequest, "username and password are required")
+		return
+	}
+	if len(req.Username) > 255 {
+		writeError(w, http.StatusBadRequest, "username must be at most 255 characters")
+		return
+	}
+	if len(req.DisplayName) > 1024 {
+		writeError(w, http.StatusBadRequest, "display_name must be at most 1024 characters")
 		return
 	}
 	// An omitted role means least privilege; anything else must be a known

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 )
 
@@ -38,7 +37,7 @@ func (s *Server) handlePatchSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req settingsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSONStrict(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/internal/api/webhooks.go
+++ b/internal/api/webhooks.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -66,7 +65,7 @@ func (s *Server) handleGetWebhookSubscription(w http.ResponseWriter, r *http.Req
 
 func (s *Server) handleCreateWebhookSubscription(w http.ResponseWriter, r *http.Request) {
 	var req webhookSubRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSONStrict(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -117,7 +116,7 @@ func (s *Server) handleUpdateWebhookSubscription(w http.ResponseWriter, r *http.
 		return
 	}
 	var req webhookSubRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSONStrict(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}


### PR DESCRIPTION
## Summary

Closes #294.

Two API input-validation improvements found during the July 2026 security review.

## Changes

### Strict JSON decoding

Applied `decodeJSONStrict` (with `DisallowUnknownFields`) to seven endpoints that previously used lenient `json.NewDecoder`:

- `handleEnroll` (public, no bearer auth — highest priority)
- `handleCreateOperator`
- `handleCreateCA`
- `handleUpdateFirewall`
- `handleCreateWebhookSubscription`
- `handleUpdateWebhookSubscription`
- `handlePatchSettings`

The PATCH host endpoint (`handleUpdateHost`) stays lenient for forward-compatibility, as documented in its comment.

### Field length limits

Added length caps consistent with the existing host field bounds (`maxHostNameLen = 255`):

- `username`: 255 chars
- `display_name`: 1024 chars
- CA `name`: 255 chars
- Network `name`: 255 chars

### Not included

- `handleListNetworks` SQL scoping (L-1) and disabled-operator gate in agent poll (L-2) are deferred: both require store-layer changes and are lower risk than the input-validation gaps addressed here.

## Verification

- `go test -race -count=1 ./internal/api/` — all pass (100s)
- `go vet ./internal/api/` — clean
- `golangci-lint run ./internal/api/` — 0 issues