### PR TITLE
fix: webhook secret zeroization, bounded response drain, clear() builtin

### DIFF
--- a/internal/alerts/sinks.go
+++ b/internal/alerts/sinks.go
@@ -113,7 +113,7 @@ func (w *WebhookSink) Notify(ctx context.Context, ev Alert) error {
 		// Drain the (small) body before closing so the underlying
 		// connection can return to the keep-alive pool for reuse rather
 		// than being discarded mid-response.
-		_, _ = io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 		if err := resp.Body.Close(); err != nil {
 			_ = err // status already captured; nothing actionable on close failure
 		}

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -167,9 +167,8 @@ func OpenWithDEK(dek []byte, w WrappedBlob, aad []byte) ([]byte, error) {
 }
 
 // Zeroize overwrites b with zeros. Use immediately after the plaintext
-// material is no longer required.
+// material is no longer required. Uses the clear builtin (Go 1.21+)
+// which the spec guarantees will not be optimized away (#297).
 func Zeroize(b []byte) {
-	for i := range b {
-		b[i] = 0
-	}
+	clear(b)
 }

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -122,6 +122,7 @@ type Dispatcher struct {
 	unguarded    *http.Client
 	now          func() time.Time
 	newID        func() string
+	staticSecret []byte // cached HMAC secret for the static config target (#297)
 
 	queue  chan Event
 	wg     sync.WaitGroup
@@ -173,6 +174,9 @@ func New(cfg Config, logger *slog.Logger) *Dispatcher {
 			d.staticEvents[e] = true
 		}
 	}
+	if cfg.HMACSecret != "" {
+		d.staticSecret = []byte(cfg.HMACSecret)
+	}
 	d.wg.Add(1)
 	go d.run()
 	return d
@@ -207,6 +211,7 @@ func (d *Dispatcher) Close() {
 	if d.closed.CompareAndSwap(false, true) {
 		close(d.queue)
 	}
+	clear(d.staticSecret)
 	d.wg.Wait()
 }
 
@@ -234,7 +239,7 @@ func (d *Dispatcher) dispatch(ev Event) {
 func (d *Dispatcher) targets(scope Scope, eventType string) []Target {
 	var out []Target
 	if d.cfg.URL != "" && (d.staticEvents == nil || d.staticEvents[eventType]) {
-		out = append(out, Target{URL: d.cfg.URL, Secret: []byte(d.cfg.HMACSecret), AllowPrivate: d.cfg.AllowPrivate})
+		out = append(out, Target{URL: d.cfg.URL, Secret: d.staticSecret, AllowPrivate: d.cfg.AllowPrivate})
 	}
 	if d.source != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), d.cfg.DeliveryTO)
@@ -253,6 +258,12 @@ func (d *Dispatcher) targets(scope Scope, eventType string) []Target {
 // backoff, aborting early if Close is signaled. The final outcome is recorded
 // against the subscription (managed targets only).
 func (d *Dispatcher) deliverWithRetry(tgt Target, payload []byte, eventType, id string) {
+	// Zeroize the decrypted HMAC secret after all delivery attempts.
+	// The static config secret is shared (cached in d.staticSecret) and
+	// zeroized in Close(); managed secrets are per-delivery copies (#297).
+	if tgt.ID != "" {
+		defer clear(tgt.Secret)
+	}
 	var lastErr error
 	for attempt := 0; attempt <= d.cfg.MaxRetries; attempt++ {
 		if attempt > 0 {
@@ -308,7 +319,7 @@ func (d *Dispatcher) deliver(tgt Target, payload []byte, eventType, id string) e
 		return fmt.Errorf("POST: %w", err)
 	}
 	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode >= 400 {


### PR DESCRIPTION
## Summary

Closes #297.

Four low-severity hygiene improvements for webhook delivery and crypto utilities found during the July 2026 security review.

## Changes

### Static HMAC secret caching (L-2)
`internal/webhook/webhook.go` — the static config HMAC secret is now cached once at `Dispatcher` construction (`d.staticSecret`) instead of re-allocating `[]byte(d.cfg.HMACSecret)` on every `targets()` call. Zeroized in `Close()`.

### Managed secret zeroization (L-1)
`internal/webhook/webhook.go` — managed subscription HMAC secrets (decrypted per-delivery from the store) are zeroized via `defer clear(tgt.Secret)` after all delivery attempts complete.

### Bounded response drain (L-3)
`internal/webhook/webhook.go` + `internal/alerts/sinks.go` — response body drain uses `io.LimitReader(resp.Body, 4096)` instead of unbounded `io.Copy`, preventing a malicious endpoint from holding the single delivery worker for the full timeout.

### clear() builtin (L-4)
`internal/keystore/keystore.go` — `Zeroize` now uses `clear(b)` (Go 1.21+) instead of a manual loop, matching the pattern already used in `internal/importproof`.

## Verification

- `go test -race -count=1 ./internal/webhook/ ./internal/alerts/ ./internal/keystore/` — all pass
- `go vet` — clean
- `golangci-lint run` — 0 issues