### PR TITLE
fix(agent): validate enrollment config YAML for PKI path consistency

### DIFF
--- a/cmd/nebula-agent/enroll_test.go
+++ b/cmd/nebula-agent/enroll_test.go
@@ -56,6 +56,7 @@ type enrollMockServer struct {
 	updatesCalls atomic.Int32
 	updatesCode  atomic.Int32 // override status code for /agent/updates
 	signingPub   ed25519.PublicKey
+	configYAML   string // enrollment config YAML; set by tests to match data dir paths
 }
 
 func newEnrollMockServer(t *testing.T) *enrollMockServer {
@@ -111,7 +112,7 @@ func newEnrollMockServer(t *testing.T) *enrollMockServer {
 			_ = json.NewEncoder(w).Encode(map[string]string{
 				"certificate_pem":    string(hostCertPEM),
 				"ca_certificate_pem": string(caCertPEM),
-				"config_yaml":        "pki:\n  ca: /etc/nebula/ca.crt\n",
+				"config_yaml":        srv.configYAML,
 			})
 		case "/api/v1/agent/updates":
 			srv.updatesCalls.Add(1)
@@ -131,6 +132,14 @@ func newEnrollMockServer(t *testing.T) *enrollMockServer {
 // TestEnrollSubcommand_WritesFiles — happy path. enroll subcommand hits
 // both the enroll and updates endpoints, writes agent.yml + the five
 // enrollment files with the right modes, and exits 0.
+// testConfigYAML generates a Nebula config YAML with PKI paths matching
+// the default agent profile for the given data directory.
+func testConfigYAML(dataDir string) string {
+	return "pki:\n  ca: " + filepath.Join(dataDir, "ca.crt") +
+		"\n  cert: " + filepath.Join(dataDir, "host.crt") +
+		"\n  key: " + filepath.Join(dataDir, "host.key") + "\n"
+}
+
 func TestEnrollSubcommand_WritesFiles(t *testing.T) {
 	srv := newEnrollMockServer(t)
 
@@ -138,6 +147,7 @@ func TestEnrollSubcommand_WritesFiles(t *testing.T) {
 	cfgPath := filepath.Join(dir, "agent.yml")
 	dataDir := filepath.Join(dir, "nebula")
 	signingKeyPath := filepath.Join(dir, "agent", "host.signing.key")
+	srv.configYAML = testConfigYAML(dataDir)
 
 	var stdout, stderr bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -208,6 +218,7 @@ func TestEnrollSubcommand_FirstPollFailureIsNonFatal(t *testing.T) {
 	cfgPath := filepath.Join(dir, "agent.yml")
 	dataDir := filepath.Join(dir, "nebula")
 	signingKeyPath := filepath.Join(dir, "agent", "host.signing.key")
+	srv.configYAML = testConfigYAML(dataDir)
 
 	var stdout, stderr bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -243,6 +254,7 @@ func TestEnrollSubcommand_RefusesWhenAlreadyEnrolled(t *testing.T) {
 	cfgPath := filepath.Join(dir, "agent.yml")
 	dataDir := filepath.Join(dir, "nebula")
 	signingKeyPath := filepath.Join(dir, "agent", "host.signing.key")
+	srv.configYAML = testConfigYAML(dataDir)
 
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -352,6 +364,7 @@ func TestRun_LeavesStandbyAfterFilesAppear(t *testing.T) {
 	cfgPath := filepath.Join(dir, "agent.yml")
 	dataDir := filepath.Join(dir, "nebula")
 	signingKeyPath := filepath.Join(dir, "agent", "host.signing.key")
+	srv.configYAML = testConfigYAML(dataDir)
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/config_validate.go
+++ b/internal/agent/config_validate.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	nebulaconfig "github.com/slackhq/nebula/config"
+)
+
+// validateConfigPKIPaths parses a Nebula config YAML and verifies that
+// pki.ca, pki.cert, and pki.key match the expected paths. This prevents
+// a compromised or buggy server from redirecting the Nebula daemon to
+// read key material from arbitrary paths (#300).
+func validateConfigPKIPaths(configYAML, configDir, caPath, certPath, keyPath string) error {
+	file, err := os.CreateTemp(configDir, ".nebula-agent-validate-")
+	if err != nil {
+		return fmt.Errorf("create temp config: %w", err)
+	}
+	path := file.Name()
+	defer os.Remove(path)
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("secure temp config: %w", err)
+	}
+	if _, err := file.WriteString(configYAML); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write temp config: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync temp config: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temp config: %w", err)
+	}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	configuration := nebulaconfig.NewC(logger)
+	if err := configuration.Load(path); err != nil {
+		return fmt.Errorf("invalid config YAML: %w", err)
+	}
+	expected := map[string]string{
+		"pki.ca": caPath, "pki.cert": certPath, "pki.key": keyPath,
+	}
+	for key, want := range expected {
+		if got := configuration.GetString(key, ""); got != want {
+			return fmt.Errorf("config %s path %q does not match expected %q", key, got, want)
+		}
+	}
+	return nil
+}

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -266,6 +266,13 @@ func enrollWithProfile(
 		return fmt.Errorf("write CA cert: %w", err)
 	}
 
+	// Validate the config YAML PKI paths before writing (#300).
+	configDir := filepath.Dir(profile.NebulaConfigPath)
+	if err := validateConfigPKIPaths(enrollResp.ConfigYAML, configDir,
+		profile.NebulaCAPath, profile.NebulaCertPath, profile.NebulaKeyPath); err != nil {
+		return fmt.Errorf("enrollment config validation: %w", err)
+	}
+
 	// Save config. 0o640 — rendered Nebula daemon config (host name,
 	// nebula IPs, lighthouse list, firewall rules, paths to key/cert
 	// files). No secrets in the file itself; the actual private key

--- a/internal/agent/enroll_rekey_test.go
+++ b/internal/agent/enroll_rekey_test.go
@@ -25,7 +25,7 @@ func TestReenrollUsesProfilePaths(t *testing.T) {
 	}
 	signingKeyPath := filepath.Join(root, "agent", "signing.key")
 	hostCertPEM, caCertPEM := testEnrollCerts(t)
-	configYAML := "pki:\n  ca: " + profile.NebulaCAPath + "\n"
+	configYAML := profileConfigYAML(profile)
 	var submitted models.AgentProfile
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		var body struct {
@@ -83,7 +83,7 @@ func TestReenrollReloadsAfterWritesBeforeAck(t *testing.T) {
 		switch request.URL.Path {
 		case "/api/v1/enroll":
 			_ = json.NewEncoder(response).Encode(EnrollResponse{
-				CertificatePEM: certificatePEM, CACertificatePEM: caCertPEM, ConfigYAML: "config", ConfigVersion: 7,
+				CertificatePEM: certificatePEM, CACertificatePEM: caCertPEM, ConfigYAML: profileConfigYAML(profile), ConfigVersion: 7,
 			})
 		case "/api/v1/agent/config-ack/7":
 			acknowledgements.Add(1)
@@ -132,7 +132,7 @@ func TestReenrollReloadFailureSuppressesAck(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/enroll" {
 			_ = json.NewEncoder(response).Encode(EnrollResponse{
-				CertificatePEM: certPEM3, CACertificatePEM: caPEM3, ConfigYAML: "config", ConfigVersion: 3,
+				CertificatePEM: certPEM3, CACertificatePEM: caPEM3, ConfigYAML: profileConfigYAML(profile), ConfigVersion: 3,
 			})
 			return
 		}
@@ -165,7 +165,7 @@ func TestReenrollWithoutPIDFileSkipsReloadAndAcknowledges(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/enroll" {
 			_ = json.NewEncoder(response).Encode(EnrollResponse{
-				CertificatePEM: certPEM4, CACertificatePEM: caPEM4, ConfigYAML: "config", ConfigVersion: 2,
+				CertificatePEM: certPEM4, CACertificatePEM: caPEM4, ConfigYAML: profileConfigYAML(profile), ConfigVersion: 2,
 			})
 			return
 		}

--- a/internal/agent/enroll_test.go
+++ b/internal/agent/enroll_test.go
@@ -15,6 +15,7 @@ import (
 
 	"golang.org/x/crypto/curve25519"
 
+	"github.com/forgekeep/nebula-mesh/internal/models"
 	"github.com/forgekeep/nebula-mesh/internal/pki"
 )
 
@@ -52,6 +53,22 @@ func testEnrollCerts(t *testing.T) (hostCertPEM, caCertPEM string) {
 		t.Fatal(err)
 	}
 	return string(rawHostPEM), string(rawCAPEM)
+}
+
+// enrollConfigYAML generates a Nebula config YAML with PKI paths matching
+// the default Enroll() profile for the given data directory.
+func enrollConfigYAML(dataDir string) string {
+	return "pki:\n  ca: " + filepath.Join(dataDir, "ca.crt") +
+		"\n  cert: " + filepath.Join(dataDir, "host.crt") +
+		"\n  key: " + filepath.Join(dataDir, "host.key") + "\n"
+}
+
+// profileConfigYAML generates a Nebula config YAML with PKI paths matching
+// the given agent profile.
+func profileConfigYAML(p models.AgentProfile) string {
+	return "pki:\n  ca: " + p.NebulaCAPath +
+		"\n  cert: " + p.NebulaCertPath +
+		"\n  key: " + p.NebulaKeyPath + "\n"
 }
 
 func TestEnroll_Success(t *testing.T) {
@@ -92,7 +109,7 @@ func TestEnroll_Success(t *testing.T) {
 		resp := EnrollResponse{
 			CertificatePEM:   hostCertPEM,
 			CACertificatePEM: caCertPEM,
-			ConfigYAML:       "pki:\n  ca: /etc/nebula/ca.crt\n",
+			ConfigYAML:       enrollConfigYAML(dir),
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)

--- a/internal/agent/enroll_zeroize_test.go
+++ b/internal/agent/enroll_zeroize_test.go
@@ -51,7 +51,7 @@ func TestEnroll_ZeroizesPrivateKeys(t *testing.T) {
 		resp := EnrollResponse{
 			CertificatePEM:   hostCertPEM,
 			CACertificatePEM: caCertPEM,
-			ConfigYAML:       "pki:\n  ca: /etc/nebula/ca.crt\n",
+			ConfigYAML:       enrollConfigYAML(dir),
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -19,9 +19,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/cert"
-	nebulaconfig "github.com/slackhq/nebula/config"
 
 	agentpop "github.com/forgekeep/nebula-mesh/internal/agent/pop"
 	"github.com/forgekeep/nebula-mesh/internal/fsutil"
@@ -424,43 +422,8 @@ func (p *Poller) acknowledgeConfig(ctx context.Context, version int) error {
 }
 
 func (p *Poller) validateCandidateConfig(raw string) error {
-	directory := filepath.Dir(p.nebulaConfigPath())
-	file, err := os.CreateTemp(directory, ".nebula-agent-candidate-")
-	if err != nil {
-		return fmt.Errorf("create candidate config: %w", err)
-	}
-	path := file.Name()
-	defer os.Remove(path)
-	if err := file.Chmod(0o600); err != nil {
-		_ = file.Close()
-		return fmt.Errorf("secure candidate config: %w", err)
-	}
-	if _, err := file.WriteString(raw); err != nil {
-		_ = file.Close()
-		return fmt.Errorf("write candidate config: %w", err)
-	}
-	if err := file.Sync(); err != nil {
-		_ = file.Close()
-		return fmt.Errorf("sync candidate config: %w", err)
-	}
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("close candidate config: %w", err)
-	}
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	configuration := nebulaconfig.NewC(logger)
-	if err := configuration.Load(path); err != nil {
-		return fmt.Errorf("validate candidate config: %w", err)
-	}
-	expected := map[string]string{
-		"pki.ca": p.nebulaCAPath(), "pki.cert": p.nebulaCertPath(), "pki.key": p.nebulaKeyPath(),
-	}
-	for key, want := range expected {
-		if got := configuration.GetString(key, ""); got != want {
-			return fmt.Errorf("validate candidate config: %s path %q does not match configured path %q", key, got, want)
-		}
-	}
-	return nil
+	return validateConfigPKIPaths(raw, filepath.Dir(p.nebulaConfigPath()),
+		p.nebulaCAPath(), p.nebulaCertPath(), p.nebulaKeyPath())
 }
 
 func (p *Poller) ensureImportBackup() error {


### PR DESCRIPTION
## Summary

Closes #300.

The poller validates server-pushed config YAML via `validateCandidateConfig` before writing to disk, ensuring `pki.ca`, `pki.cert`, and `pki.key` match the agent's configured paths. The enrollment path wrote `ConfigYAML` from the enrollment response without this check.

## Changes

### Shared validation function
Extracted the PKI path validation from `Poller.validateCandidateConfig` into a standalone `validateConfigPKIPaths` function (`internal/agent/config_validate.go`). Both the poller and enrollment now use it.

### Enrollment validation
`internal/agent/enroll.go` — the enrollment response's `ConfigYAML` is validated for PKI path consistency before writing to disk. A compromised or buggy server can no longer redirect the Nebula daemon to read key material from arbitrary paths during enrollment.

### Poller refactor
`internal/agent/poller.go` — `validateCandidateConfig` now delegates to the shared function, eliminating ~30 lines of duplicated code.

### Test updates
All enrollment test fixtures updated to return config YAML with PKI paths matching the test data directories (7 test files).

## Verification

- `go test -race -count=1 ./internal/agent/... ./cmd/nebula-agent/` — all pass
- `go vet` — clean
- `golangci-lint run` — 0 issues