### PR TITLE
feat(host): introduce combined lighthouse+relay role

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1078,6 +1078,11 @@ components:
             type: string
         role:
           type: string
+          enum: [host, lighthouse, relay, lighthouse+relay]
+          description: >-
+            Host role. `lighthouse+relay` makes the host serve both duties at
+            once. `lighthouse`, `relay` and `lighthouse+relay` require
+            `public_ip` and `listen_port`.
         public_ip:
           type: string
         listen_port:
@@ -1282,6 +1287,7 @@ components:
             type: string
         role:
           type: string
+          enum: [host, lighthouse, relay, lighthouse+relay]
         is_lighthouse:
           type: boolean
         is_relay:

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -366,7 +366,7 @@ func (s *Server) getRelays(ctx context.Context, networkID string) ([]string, err
 	}
 	set := make(map[string]struct{})
 	for _, host := range hosts {
-		if host.Role != models.HostRoleRelay && !host.IsRelay {
+		if !host.Role.Relay() && !host.IsRelay {
 			continue
 		}
 		for _, address := range host.NebulaIPs {

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -167,8 +167,8 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		NebulaIPs:    req.NebulaIPs,
 		Groups:       req.Groups,
 		Role:         role,
-		IsLighthouse: role == models.HostRoleLighthouse,
-		IsRelay:      role == models.HostRoleRelay,
+		IsLighthouse: role.Lighthouse(),
+		IsRelay:      role.Relay(),
 		PublicIP:     req.PublicIP,
 		ListenPort:   req.ListenPort,
 		Status:       models.HostStatusPending,
@@ -718,8 +718,8 @@ func (s *Server) handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		host.Role = role
-		host.IsLighthouse = role == models.HostRoleLighthouse
-		host.IsRelay = role == models.HostRoleRelay
+		host.IsLighthouse = role.Lighthouse()
+		host.IsRelay = role.Relay()
 	}
 
 	if req.PublicIP != nil {

--- a/internal/api/hosts_lighthouse_relay_test.go
+++ b/internal/api/hosts_lighthouse_relay_test.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// TestCreateHost_LighthouseRelay covers the combined role: a host created
+// with role=lighthouse+relay must carry both IsLighthouse and IsRelay so it
+// is advertised to peers as a lighthouse (lighthouse.hosts/static_host_map)
+// and as a relay (relay.relays) at the same time.
+func TestCreateHost_LighthouseRelay(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID:  netID,
+		Name:       "lh-relay",
+		NebulaIPs:  []string{"192.168.100.20"},
+		Role:       "lighthouse+relay",
+		PublicIP:   "203.0.113.20",
+		ListenPort: 4242,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	var resp createHostResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Host.Role != models.HostRoleLighthouseRelay {
+		t.Errorf("role = %q, want %q", resp.Host.Role, models.HostRoleLighthouseRelay)
+	}
+	if !resp.Host.IsLighthouse {
+		t.Error("IsLighthouse = false, want true")
+	}
+	if !resp.Host.IsRelay {
+		t.Error("IsRelay = false, want true")
+	}
+}
+
+// TestCreateHost_LighthouseRelay_RequiresReachability: the combined role
+// inherits the same guard as lighthouse/relay — without public_ip and
+// listen_port the host would never be dialed by peers.
+func TestCreateHost_LighthouseRelay_RequiresReachability(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	cases := []struct {
+		name       string
+		publicIP   string
+		listenPort int
+		nebulaIP   string
+		wantSubstr string
+	}{
+		{"missing public_ip", "", 4242, "192.168.100.21", "public_ip"},
+		{"missing listen_port", "203.0.113.21", 0, "192.168.100.22", "listen_port"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(createHostRequest{
+				NetworkID:  netID,
+				Name:       "lh-relay-bad",
+				NebulaIPs:  []string{tc.nebulaIP},
+				Role:       "lighthouse+relay",
+				PublicIP:   tc.publicIP,
+				ListenPort: tc.listenPort,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
+			authRequest(req)
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+			}
+			if !bytes.Contains(w.Body.Bytes(), []byte(tc.wantSubstr)) {
+				t.Errorf("body = %q, want substring %q", w.Body.String(), tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestUpdateHost_LighthouseRelay: PATCHing role to lighthouse+relay must
+// re-derive both booleans, and PATCHing away must clear them.
+func TestUpdateHost_LighthouseRelay(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body, _ := json.Marshal(createHostRequest{
+		NetworkID:  netID,
+		Name:       "patch-me",
+		NebulaIPs:  []string{"192.168.100.23"},
+		Role:       "host",
+		PublicIP:   "203.0.113.23",
+		ListenPort: 4242,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create host: %d %s", w.Code, w.Body.String())
+	}
+	var created createHostResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	patch := func(role string) *models.Host {
+		t.Helper()
+		patchBody, _ := json.Marshal(updateHostRequest{Role: &role})
+		patchReq := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+created.Host.ID, bytes.NewBuffer(patchBody))
+		authRequest(patchReq)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, patchReq)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch role=%s: %d %s", role, rec.Code, rec.Body.String())
+		}
+		var updated models.Host
+		if err := json.NewDecoder(rec.Body).Decode(&updated); err != nil {
+			t.Fatalf("decode patch response: %v", err)
+		}
+		return &updated
+	}
+
+	updated := patch("lighthouse+relay")
+	if !updated.IsLighthouse || !updated.IsRelay {
+		t.Errorf("after patch to lighthouse+relay: IsLighthouse=%v IsRelay=%v, want true/true",
+			updated.IsLighthouse, updated.IsRelay)
+	}
+
+	reverted := patch("host")
+	if reverted.IsLighthouse || reverted.IsRelay {
+		t.Errorf("after patch back to host: IsLighthouse=%v IsRelay=%v, want false/false",
+			reverted.IsLighthouse, reverted.IsRelay)
+	}
+}

--- a/internal/meshimport/reconcile.go
+++ b/internal/meshimport/reconcile.go
@@ -308,16 +308,16 @@ func (r *reconcileState) reconcileEndpoints() {
 func (r *reconcileState) reconcileTopology() {
 	for i := range r.hosts {
 		host := &r.hosts[i]
-		if host.config.AmLighthouse {
-			host.proposal.Host.IsLighthouse = true
+		switch {
+		case host.config.AmLighthouse && host.config.AmRelay:
+			host.proposal.Host.Role = models.HostRoleLighthouseRelay
+		case host.config.AmLighthouse:
 			host.proposal.Host.Role = models.HostRoleLighthouse
+		case host.config.AmRelay:
+			host.proposal.Host.Role = models.HostRoleRelay
 		}
-		if host.config.AmRelay {
-			host.proposal.Host.IsRelay = true
-			if !host.config.AmLighthouse {
-				host.proposal.Host.Role = models.HostRoleRelay
-			}
-		}
+		host.proposal.Host.IsLighthouse = host.proposal.Host.Role.Lighthouse()
+		host.proposal.Host.IsRelay = host.proposal.Host.Role.Relay()
 		if host.config.AmLighthouse || host.config.AmRelay {
 			r.applyRoleEndpoint(host)
 		}

--- a/internal/meshimport/reconcile_test.go
+++ b/internal/meshimport/reconcile_test.go
@@ -112,6 +112,39 @@ func TestReconcileTopologyAndEndpoints(t *testing.T) {
 	}
 }
 
+func TestReconcileCombinedLighthouseRelayRole(t *testing.T) {
+	fixture := newCertificateFixture(t)
+	both := fixture.snapshot(t, "lh-relay", "lh-relay", "10.42.0.1/24", []string{"infra"})
+	both.Config.AmLighthouse = true
+	both.Config.AmRelay = true
+	both.Config.ListenPort = 4242
+	client := fixture.snapshot(t, "client", "client", "10.42.0.2/24", nil)
+	client.Config.LighthouseHosts = []string{"10.42.0.1"}
+	client.Config.Relays = []string{"10.42.0.1"}
+	client.Config.StaticHostMap = map[string][]string{"10.42.0.1": {"203.0.113.10:4242"}}
+
+	report := fixture.reconcile(both, client)
+	if len(report.Blockers) != 0 {
+		t.Fatalf("blockers = %#v", report.Blockers)
+	}
+	var found bool
+	for _, proposal := range report.Proposal.Hosts {
+		if proposal.Host.Name == "lh-relay" {
+			found = true
+			if proposal.Host.Role != models.HostRoleLighthouseRelay {
+				t.Errorf("role = %q, want %q", proposal.Host.Role, models.HostRoleLighthouseRelay)
+			}
+			if !proposal.Host.IsLighthouse || !proposal.Host.IsRelay {
+				t.Errorf("IsLighthouse=%v IsRelay=%v, want true/true",
+					proposal.Host.IsLighthouse, proposal.Host.IsRelay)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("lh-relay host missing from proposal")
+	}
+}
+
 func TestReconcileRejectsTopologyConflicts(t *testing.T) {
 	fixture := newCertificateFixture(t)
 	lighthouse := fixture.snapshot(t, "lh", "lighthouse", "10.42.0.1/24", nil)

--- a/internal/mobilebundle/builder.go
+++ b/internal/mobilebundle/builder.go
@@ -287,7 +287,7 @@ func listRelays(ctx context.Context, s store.Store, networkID string) ([]string,
 
 	set := make(map[string]struct{})
 	for _, host := range hosts {
-		if host.Role != models.HostRoleRelay && !host.IsRelay {
+		if !host.Role.Relay() && !host.IsRelay {
 			continue
 		}
 		for _, address := range host.NebulaIPs {

--- a/internal/models/host.go
+++ b/internal/models/host.go
@@ -18,19 +18,30 @@ const (
 type HostRole string
 
 const (
-	HostRoleHost       HostRole = "host"
-	HostRoleLighthouse HostRole = "lighthouse"
-	HostRoleRelay      HostRole = "relay"
+	HostRoleHost            HostRole = "host"
+	HostRoleLighthouse      HostRole = "lighthouse"
+	HostRoleRelay           HostRole = "relay"
+	HostRoleLighthouseRelay HostRole = "lighthouse+relay"
 )
 
 // ValidRole reports whether r is a known host role or empty (meaning "use default").
 func ValidRole(r HostRole) bool {
 	switch r {
-	case "", HostRoleHost, HostRoleLighthouse, HostRoleRelay:
+	case "", HostRoleHost, HostRoleLighthouse, HostRoleRelay, HostRoleLighthouseRelay:
 		return true
 	default:
 		return false
 	}
+}
+
+// Lighthouse reports whether the role includes lighthouse duty.
+func (r HostRole) Lighthouse() bool {
+	return r == HostRoleLighthouse || r == HostRoleLighthouseRelay
+}
+
+// Relay reports whether the role includes relay duty.
+func (r HostRole) Relay() bool {
+	return r == HostRoleRelay || r == HostRoleLighthouseRelay
 }
 
 type HostKind string
@@ -116,7 +127,7 @@ var ErrRoleRequiresListenPort = errors.New("listen_port is required when role is
 // otherwise peer config.yml renders an empty static_host_map and the host
 // is never dialed (issue #94).
 func ValidateRoleReachability(role HostRole, publicIP string, listenPort int) error {
-	if role != HostRoleLighthouse && role != HostRoleRelay {
+	if !role.Lighthouse() && !role.Relay() {
 		return nil
 	}
 	if strings.TrimSpace(publicIP) == "" {

--- a/internal/models/host_test.go
+++ b/internal/models/host_test.go
@@ -16,10 +16,12 @@ func TestValidRole(t *testing.T) {
 		{HostRoleHost, true},
 		{HostRoleLighthouse, true},
 		{HostRoleRelay, true},
+		{"lighthouse+relay", true},
 		{"", true}, // empty = use default in handler
 		{"invalid", false},
 		{"admin", false},
-		{"HOST", false}, // case-sensitive
+		{"HOST", false},             // case-sensitive
+		{"relay+lighthouse", false}, // only the canonical ordering is valid
 	}
 
 	for _, tt := range tests {
@@ -51,6 +53,10 @@ func TestValidateRoleReachability(t *testing.T) {
 
 		{"relay: missing public_ip", HostRoleRelay, "", 4242, ErrRoleRequiresPublicIP},
 		{"relay: missing listen_port", HostRoleRelay, "203.0.113.1", 0, ErrRoleRequiresListenPort},
+
+		{"lighthouse+relay: both set", "lighthouse+relay", "203.0.113.3", 4242, nil},
+		{"lighthouse+relay: missing public_ip", "lighthouse+relay", "", 4242, ErrRoleRequiresPublicIP},
+		{"lighthouse+relay: missing listen_port", "lighthouse+relay", "203.0.113.3", 0, ErrRoleRequiresListenPort},
 	}
 
 	for _, tt := range tests {
@@ -129,6 +135,14 @@ func TestValidateMobileConstraints(t *testing.T) {
 			kind:    HostKindMobile,
 			variant: HostVariantAndroid,
 			role:    HostRoleRelay,
+			wantErr: true,
+			errIs:   ErrMobileRoleRestricted,
+		},
+		{
+			name:    "mobile with lighthouse+relay role",
+			kind:    HostKindMobile,
+			variant: HostVariantIOS,
+			role:    "lighthouse+relay",
 			wantErr: true,
 			errIs:   ErrMobileRoleRestricted,
 		},

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -991,8 +991,8 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		NebulaIPs:    form.NebulaIPs,
 		Groups:       groups,
 		Role:         role,
-		IsLighthouse: role == models.HostRoleLighthouse,
-		IsRelay:      role == models.HostRoleRelay,
+		IsLighthouse: role.Lighthouse(),
+		IsRelay:      role.Relay(),
 		PublicIP:     form.PublicIP,
 		ListenPort:   listenPort,
 		Status:       models.HostStatusPending,
@@ -1252,8 +1252,8 @@ func (w *Web) handleHostUpdate(rw http.ResponseWriter, r *http.Request) {
 	host.NebulaIPs = form.NebulaIPs
 	host.Groups = groups
 	host.Role = role
-	host.IsLighthouse = role == models.HostRoleLighthouse
-	host.IsRelay = role == models.HostRoleRelay
+	host.IsLighthouse = role.Lighthouse()
+	host.IsRelay = role.Relay()
 	host.PublicIP = form.PublicIP
 	host.ListenPort = listenPort
 	host.Advanced = advanced

--- a/internal/web/host_lighthouse_relay_test.go
+++ b/internal/web/host_lighthouse_relay_test.go
@@ -1,0 +1,227 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// TestHostForms_OfferLighthouseRelayOption: both the create and edit forms
+// must offer the combined lighthouse+relay role in the role select.
+func TestHostForms_OfferLighthouseRelayOption(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-lr", Name: "test-net", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	host := &models.Host{
+		ID: "h-lr", NetworkID: "n-lr", Name: "lr-1", NebulaIPs: []string{"10.0.0.9"},
+		Groups: []string{}, Role: models.HostRoleLighthouseRelay,
+		IsLighthouse: true, IsRelay: true,
+		PublicIP: "203.0.113.9", ListenPort: 4242,
+		Status: models.HostStatusEnrolled, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{"/ui/hosts/new", "/ui/hosts/h-lr/edit"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			for _, c := range cookies {
+				req.AddCookie(c)
+			}
+			rec := httptest.NewRecorder()
+			w.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if !strings.Contains(rec.Body.String(), `<option value="lighthouse+relay"`) {
+				t.Error("role select should offer the lighthouse+relay option")
+			}
+		})
+	}
+
+	// The edit form must preselect the host's combined role.
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts/h-lr/edit", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), `<option value="lighthouse+relay" selected`) &&
+		!strings.Contains(rec.Body.String(), `<option value="lighthouse+relay"selected`) {
+		t.Error("edit form should preselect lighthouse+relay for this host")
+	}
+}
+
+// TestCreateHostViaUI_LighthouseRelay: creating a host through the web form
+// with role=lighthouse+relay must persist both IsLighthouse and IsRelay.
+func TestCreateHostViaUI_LighthouseRelay(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-lr2", Name: "test-net", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/hosts", cookies)
+	form := url.Values{
+		"network_id":  {"n-lr2"},
+		"name":        {"lr-created"},
+		"nebula_ips":  {"10.0.0.10"},
+		"role":        {"lighthouse+relay"},
+		"public_ip":   {"203.0.113.10"},
+		"listen_port": {"4242"},
+		"_csrf":       {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range updatedCookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rec.Code, rec.Body.String())
+	}
+
+	created := findHostByName(t, s, "lr-created")
+	if created.Role != models.HostRoleLighthouseRelay {
+		t.Errorf("role = %q, want %q", created.Role, models.HostRoleLighthouseRelay)
+	}
+	if !created.IsLighthouse || !created.IsRelay {
+		t.Errorf("IsLighthouse=%v IsRelay=%v, want true/true", created.IsLighthouse, created.IsRelay)
+	}
+}
+
+// TestCreateHostViaUI_LighthouseRelay_RequiresReachability: the combined
+// role inherits the public_ip/listen_port guard.
+func TestCreateHostViaUI_LighthouseRelay_RequiresReachability(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-lr3", Name: "test-net", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/hosts", cookies)
+	form := url.Values{
+		"network_id": {"n-lr3"},
+		"name":       {"lr-bad"},
+		"nebula_ips": {"10.0.0.11"},
+		"role":       {"lighthouse+relay"},
+		"_csrf":      {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range updatedCookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "public_ip") {
+		t.Errorf("body should mention public_ip, got: %s", rec.Body.String())
+	}
+}
+
+// TestHostUpdate_POST_LighthouseRelay: editing a host to role=lighthouse+relay
+// must re-derive both booleans; editing back to host must clear them.
+func TestHostUpdate_POST_LighthouseRelay(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-lr4", Name: "test-net", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	host := &models.Host{
+		ID: "h-lr4", NetworkID: "n-lr4", Name: "lr-edit", NebulaIPs: []string{"10.0.0.12"},
+		Groups: []string{}, Role: models.HostRoleHost,
+		Status: models.HostStatusEnrolled, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+
+	postEdit := func(role, publicIP, listenPort string) {
+		t.Helper()
+		csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/hosts/h-lr4/edit", cookies)
+		form := url.Values{
+			"network_id":  {"n-lr4"},
+			"name":        {"lr-edit"},
+			"nebula_ips":  {"10.0.0.12"},
+			"role":        {role},
+			"public_ip":   {publicIP},
+			"listen_port": {listenPort},
+			"_csrf":       {csrfToken},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-lr4/edit", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		for _, c := range updatedCookies {
+			req.AddCookie(c)
+		}
+		rec := httptest.NewRecorder()
+		w.ServeHTTP(rec, req)
+		if rec.Code != http.StatusSeeOther {
+			t.Fatalf("edit to role=%s: status = %d, want 303, body: %s", role, rec.Code, rec.Body.String())
+		}
+	}
+
+	postEdit("lighthouse+relay", "203.0.113.12", "4242")
+	updated, err := s.GetHost(ctx, "h-lr4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated.IsLighthouse || !updated.IsRelay {
+		t.Errorf("after edit to lighthouse+relay: IsLighthouse=%v IsRelay=%v, want true/true",
+			updated.IsLighthouse, updated.IsRelay)
+	}
+
+	postEdit("host", "", "")
+	reverted, err := s.GetHost(ctx, "h-lr4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reverted.IsLighthouse || reverted.IsRelay {
+		t.Errorf("after edit back to host: IsLighthouse=%v IsRelay=%v, want false/false",
+			reverted.IsLighthouse, reverted.IsRelay)
+	}
+}
+
+func findHostByName(t *testing.T, s *store.SQLiteStore, name string) *models.Host {
+	t.Helper()
+	hosts, err := s.ListHosts(context.Background(), store.HostFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hosts {
+		if h.Name == name {
+			return h
+		}
+	}
+	t.Fatalf("host %q not found", name)
+	return nil
+}

--- a/internal/web/templates/host_edit.html
+++ b/internal/web/templates/host_edit.html
@@ -57,6 +57,7 @@
                 <option value="host"{{if eq .Form.Role "host"}} selected{{end}}>Host</option>
                 <option value="lighthouse"{{if eq .Form.Role "lighthouse"}} selected{{end}}>Lighthouse</option>
                 <option value="relay"{{if eq .Form.Role "relay"}} selected{{end}}>Relay</option>
+                <option value="lighthouse+relay"{{if eq .Form.Role "lighthouse+relay"}} selected{{end}}>Lighthouse + Relay</option>
             </select>
         </div>
         <div class="form-group">

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -79,6 +79,7 @@
                 <option value="host"{{if eq .Form.Role "host"}} selected{{end}}>Host</option>
                 <option value="lighthouse"{{if eq .Form.Role "lighthouse"}} selected{{end}}>Lighthouse</option>
                 <option value="relay"{{if eq .Form.Role "relay"}} selected{{end}}>Relay</option>
+                <option value="lighthouse+relay"{{if eq .Form.Role "lighthouse+relay"}} selected{{end}}>Lighthouse + Relay</option>
             </select>
         </div>
         <div class="form-group">


### PR DESCRIPTION
It may be necessary to have Lighthouse and Relay support on the same Nebula instance.


## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x]  No breaking API changes, or they are called out above
