### PR TITLE
docs(agent): document combined role compatibility

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1288,6 +1288,10 @@ components:
         role:
           type: string
           enum: [host, lighthouse, relay, lighthouse+relay]
+          description: >-
+            Host role. `lighthouse+relay` was added in v0.10.0. Clients that
+            model this enum as closed must add the new value before decoding
+            hosts with the combined role.
         is_lighthouse:
           type: boolean
         is_relay:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1289,9 +1289,8 @@ components:
           type: string
           enum: [host, lighthouse, relay, lighthouse+relay]
           description: >-
-            Host role. `lighthouse+relay` was added in v0.10.0. Clients that
-            model this enum as closed must add the new value before decoding
-            hosts with the combined role.
+            Host role. Clients that model this enum as closed must include
+            `lighthouse+relay` before decoding hosts with the combined role.
         is_lighthouse:
           type: boolean
         is_relay:

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -513,7 +513,7 @@ Compatibility is intentionally narrow for the first adoption flow:
 | Existing installation | Import behavior |
 |---|---|
 | One Curve25519 CA certificate and one X25519 host certificate/key in regular files | Supported |
-| `static_host_map`, lighthouse/relay roles, `listen`, `punchy`, `tun`, `unsafe_routes`, firewall and CA blocklist | Imported and reconciled |
+| `static_host_map`, `lighthouse`, `relay`, and `lighthouse+relay` roles, `listen`, `punchy`, `tun`, `unsafe_routes`, firewall and CA blocklist | Imported and reconciled |
 | Logging, stats and SSH daemon settings | Reported as warnings; server does not manage them |
 | Other unsupported connectivity settings | Blocking preview issue |
 | P256 CA, host certificate or private key | Rejected before registration |
@@ -762,6 +762,18 @@ the same response — no manual reconfiguration required.
 
 The server resolves enrolled `role: relay` hosts and writes their overlay
 addresses to `relay.relays`. It excludes pending, importing and blocked relays.
+
+Use `role: lighthouse+relay` when one Nebula instance should perform both
+duties. The server enables `lighthouse.am_lighthouse` and `relay.am_relay` in
+that host's config, and advertises the host to peers as both a lighthouse and a
+relay. Like the individual infrastructure roles, the combined role requires
+`public_ip` and `listen_port`.
+
+Starting with v0.10.0, the OpenAPI `Host.role` and `CreateHostRequest.role`
+enums include `lighthouse+relay`. JSON clients that treat `role` as an arbitrary
+string remain compatible. Clients generated with a closed enum, or clients
+with exhaustive switches over the previous values, must add the new value
+before creating or decoding combined-role hosts.
 
 ## Troubleshooting
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -769,11 +769,11 @@ that host's config, and advertises the host to peers as both a lighthouse and a
 relay. Like the individual infrastructure roles, the combined role requires
 `public_ip` and `listen_port`.
 
-Starting with v0.10.0, the OpenAPI `Host.role` and `CreateHostRequest.role`
-enums include `lighthouse+relay`. JSON clients that treat `role` as an arbitrary
-string remain compatible. Clients generated with a closed enum, or clients
-with exhaustive switches over the previous values, must add the new value
-before creating or decoding combined-role hosts.
+The OpenAPI `Host.role` and `CreateHostRequest.role` enums now include
+`lighthouse+relay`. JSON clients that treat `role` as an arbitrary string
+remain compatible. Clients generated with a closed enum, or clients with
+exhaustive switches over the previous values, must add the new value before
+creating or decoding combined-role hosts.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Purpose

Document the combined `lighthouse+relay` host role added by #306 and explain the compatibility impact of expanding the OpenAPI role enums.

## Changes

- Describe combined-role import, routing, and reachability requirements.
- Warn clients with closed enums or exhaustive switches about the new value.
- Add the compatibility note to the OpenAPI `Host.role` schema.

## Verification

- `go test ./internal/api -run '^TestContract_SpecIsValid$' -count=1`
- `git diff --check`

## Code pointers

- `docs/agent.md`
- `api/openapi.yaml`
