### PR TITLE
feat(agent): add nebula_reload_command for service reload customization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,32 @@ jobs:
           go-version: '1.26.5'
           cache: true
 
+      # nebula_reload_command's Windows half — the cmd.exe command line and the
+      # taskkill /T timeout path — is code the build alone never executes.
+      # Run the reload hook for real on a Windows host.
+      # -run is scoped because the rest of internal/agent still assumes a Unix
+      # host; widen it as those tests are ported.
+      - name: Test reload command (cmd /C path)
+        shell: pwsh
+        run: |
+          $output = go test -count=1 -v -run 'TestNebulaReloader|TestCappedBuffer' ./internal/agent | Out-String
+          Write-Host $output
+          if ($LASTEXITCODE -ne 0) { throw "reload command tests failed" }
+          # A -run pattern that matches nothing still exits 0, so require the
+          # individual tests to have reported a pass.
+          $expected = @(
+            'TestNebulaReloader_CommandRuns',
+            'TestNebulaReloader_CommandFailureIncludesOutput',
+            'TestNebulaReloader_CommandTimesOut',
+            'TestNebulaReloader_CapsCommandOutput',
+            'TestNebulaReloader_CommandTakesPrecedenceOverPIDFile'
+          )
+          foreach ($name in $expected) {
+            if ($output -notmatch "--- PASS: $name") {
+              throw "$name did not run — the cmd /C reload path is unverified"
+            }
+          }
+
       - name: Test and build agent
         shell: pwsh
         run: |

--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -351,6 +351,7 @@ func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logg
 			SigningKeyPath:   cfg.SigningKeyPath,
 			Interval:         cfg.PollInterval,
 			PIDFile:          cfg.NebulaPIDFile,
+			ReloadCommand:    cfg.NebulaReloadCommand,
 			NebulaConfigPath: cfg.NebulaConfigPath,
 			NebulaCAPath:     cfg.ResolvedNebulaCAPath(),
 			NebulaCertPath:   cfg.ResolvedNebulaCertPath(),
@@ -379,6 +380,7 @@ func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logg
 			logger.Info("performing server-requested rekey")
 			if err := agent.Reenroll(ctx, cfg.ServerURL, re.Token, agent.ReenrollOptions{
 				DataDir: cfg.DataDir, SigningKeyPath: cfg.SigningKeyPath, PIDFile: cfg.NebulaPIDFile,
+				ReloadCommand: cfg.NebulaReloadCommand,
 				Profile: models.AgentProfile{
 					NebulaConfigPath: cfg.NebulaConfigPath, NebulaCAPath: cfg.ResolvedNebulaCAPath(),
 					NebulaCertPath: cfg.ResolvedNebulaCertPath(), NebulaKeyPath: cfg.ResolvedNebulaKeyPath(),

--- a/configs/agent.example.yml
+++ b/configs/agent.example.yml
@@ -9,4 +9,5 @@ nebula_config_path: "/etc/nebula/config.yml"
 # nebula_key_path: "/etc/nebula/host.key"
 # import_session_id: ""  # managed by nebula-agent during mesh import
 nebula_pid_file: "/run/nebula.pid"
+# nebula_reload_command: "systemctl reload nebula"  # optional — run via shell instead of the SIGHUP; takes precedence over nebula_pid_file
 # signing_key_path: "/etc/nebula-agent/host.signing.key"  # default; override for non-root setups (parent dir must be writable by the agent user)

--- a/deploy/ansible/roles/nebula_agent/README.md
+++ b/deploy/ansible/roles/nebula_agent/README.md
@@ -23,5 +23,6 @@ manager).
 | `nebula_agent_data_dir` | `/etc/nebula` | Where host.crt/host.key/ca.crt/config.yml/.fingerprint live. |
 | `nebula_agent_poll_interval` | `30s` | How often to ask the server for updates. |
 | `nebula_agent_nebula_pid_file` | `/run/nebula.pid` | SIGHUP'd on changes (empty disables reload signal). |
+| `nebula_agent_nebula_reload_command` | (empty) | Shell command run on changes instead of the SIGHUP, e.g. `systemctl reload nebula`. Takes precedence over the PID file. Must not restart `nebula-agent` itself — see [Reload command contract](../../../../docs/agent.md#reload-command-contract). |
 
 See [`defaults/main.yml`](defaults/main.yml).

--- a/deploy/ansible/roles/nebula_agent/defaults/main.yml
+++ b/deploy/ansible/roles/nebula_agent/defaults/main.yml
@@ -7,6 +7,9 @@ nebula_agent_data_dir: /etc/nebula
 nebula_agent_poll_interval: "30s"
 nebula_agent_nebula_config_path: /etc/nebula/config.yml
 nebula_agent_nebula_pid_file: /run/nebula.pid
+# Set to run a command instead of the SIGHUP, e.g. "systemctl reload nebula".
+# Takes precedence over nebula_agent_nebula_pid_file when non-empty.
+nebula_agent_nebula_reload_command: ""
 
 # Where to fetch release artifacts. Override to mirror in restricted networks.
 nebula_agent_release_base_url: "https://github.com/forgekeep/nebula-mesh/releases/download"

--- a/deploy/ansible/roles/nebula_agent/templates/agent.yml.j2
+++ b/deploy/ansible/roles/nebula_agent/templates/agent.yml.j2
@@ -5,3 +5,8 @@ nebula_config_path: "{{ nebula_agent_nebula_config_path }}"
 {% if nebula_agent_nebula_pid_file %}
 nebula_pid_file: "{{ nebula_agent_nebula_pid_file }}"
 {% endif %}
+{% if nebula_agent_nebula_reload_command %}
+{# to_json, not bare quotes: reload commands routinely contain quotes and
+   backslashes that would break a naively quoted YAML scalar. #}
+nebula_reload_command: {{ nebula_agent_nebula_reload_command | to_json }}
+{% endif %}

--- a/deploy/cloud-init/nebula-agent.example.yaml
+++ b/deploy/cloud-init/nebula-agent.example.yaml
@@ -13,6 +13,8 @@ write_files:
       poll_interval: "30s"
       nebula_config_path: "/etc/nebula/config.yml"
       nebula_pid_file: "/run/nebula.pid"
+      # Replace the SIGHUP with a service-manager call instead:
+      # nebula_reload_command: "systemctl reload nebula"
 
 runcmd:
   - |

--- a/deploy/systemd/nebula-agent.service
+++ b/deploy/systemd/nebula-agent.service
@@ -3,12 +3,22 @@ Description=Nebula Management Agent
 Documentation=https://github.com/forgekeep/nebula-mesh
 After=network-online.target nebula.service
 Wants=network-online.target
-PartOf=nebula.service
+# Deliberately no PartOf=/BindsTo=/Requires=nebula.service. Stop/restart
+# propagation from nebula.service would land on the agent mid-poll, and with
+# nebula_reload_command set that is a restart loop: the hook restarts
+# nebula.service, systemd tears down this unit's control group, the hook dies
+# with it before the config ack is sent, and the agent re-applies the same
+# update on its next start — forever. Keeping the units independent also lets
+# the agent keep fetching a corrected config while Nebula is down, which is
+# exactly when you need it to. See docs/agent.md "Reload command contract".
 
 [Service]
 Type=simple
 # Agent needs to write to /etc/nebula and send SIGHUP to nebula.service —
 # either run as root, or grant CAP_KILL + write access to the nebula data dir.
+# A nebula_reload_command runs as this user too, in this control group, and
+# under every restriction below — ProtectSystem=strict and RestrictAddressFamilies
+# in particular. Test your hook as the service, not from a login shell.
 User=root
 Group=root
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -22,7 +22,7 @@ and troubleshooting. The 30-second walkthrough lives in the project [README](../
         ▼
    /etc/nebula/{config.yml, host.crt, host.key, ca.crt}
         │
-        │ SIGHUP (if pid file present)
+        │ nebula_reload_command, else SIGHUP to nebula_pid_file
         ▼
    nebula.service
 ```
@@ -39,6 +39,9 @@ running and continue to update certificates as they approach expiry.
 - Permission to read & write the agent's `data_dir` (`/etc/nebula` by default).
 - If signalling Nebula via PID file, permission to send `SIGHUP` to that PID
   (typically root, or `CAP_KILL`).
+- If reloading via `nebula_reload_command`, a `sh` (or `cmd.exe`) on the host and
+  whatever privileges the command itself needs — talking to the service manager
+  usually means root. See [Reload command contract](#reload-command-contract).
 - Write access to the parent directory of `signing_key_path` (`/etc/nebula-agent/` by default). For non-root deployments override this path to a directory the agent user owns.
 - ~10 MB of disk for the binary; runtime memory < 20 MB.
 
@@ -141,9 +144,12 @@ sudo systemctl enable --now nebula-agent.service
 journalctl -u nebula-agent.service -f
 ```
 
-The unit declares `PartOf=nebula.service`, so `systemctl stop nebula` stops the agent
-too, and `systemctl restart nebula-agent` does **not** restart Nebula (only the agent
-itself).
+The two units are independent: `systemctl restart nebula-agent` does **not** restart
+Nebula, and `systemctl stop nebula` leaves the agent polling — so it keeps collecting
+config updates while Nebula is down, and a `nebula_reload_command` that restarts
+Nebula does not take the agent down with it. The unit therefore declares no
+`PartOf=nebula.service`; see [Reload command contract](#reload-command-contract) before
+adding one in a drop-in.
 
 The supplied unit grants writes only below `/etc/nebula`. If an imported or
 fresh installation keeps its config or PKI in another directory, add that
@@ -370,9 +376,75 @@ signing_key_path: "/etc/nebula-agent/host.signing.key"  # Ed25519 PoP signing ke
 | `poll_interval` | `30s` | Lower values reduce convergence time but increase server load. 5s–5m is the practical range. |
 | `nebula_config_path` | `/etc/nebula/config.yml` | The agent overwrites this file atomically. |
 | `nebula_pid_file` | (empty) | When set and the file holds a numeric PID, the agent sends `SIGHUP` after every successful write. |
-| `nebula_reload_command` | (empty) | When set, run through the system shell (`sh -c`, `cmd /C` on Windows) after every successful write **instead of** the SIGHUP — takes precedence over `nebula_pid_file`. 30s timeout; a failing command blocks the config ack so the reload is retried on the next poll. Use it to hook a service manager, e.g. `systemctl reload nebula`. |
+| `nebula_reload_command` | (empty) | When set, run through the system shell (`sh -c`, `cmd /C` on Windows) after every successful write **instead of** the SIGHUP — takes precedence over `nebula_pid_file`. Use it to hook a service manager, e.g. `systemctl reload nebula`. See [Reload command contract](#reload-command-contract). |
 | `signing_key_path` | `/etc/nebula-agent/host.signing.key` | Ed25519 PoP signing key (ADR 0004). Override for non-root setups so the parent directory is writable by the agent user. |
 | `allow_insecure_http` | `false` | Opts out of the `https`-required guard on `server_url` (or pass `--insecure-http`). Only for isolated lab networks; credentials transit in the clear. |
+
+### Reload command contract
+
+`nebula_reload_command` replaces the SIGHUP for hosts where Nebula exposes no
+usable PID file, where a service manager owns the process, or on Windows where
+`SIGHUP` does not exist. It runs after every successful write and before the
+config acknowledgement, as the agent's own user and under whatever hardening
+its service unit applies.
+
+What the agent guarantees:
+
+- **Bounded.** The command gets 30 seconds. On expiry the agent terminates the
+  whole process group — `taskkill /T` on Windows — not just the shell, then
+  stops draining output 2s later. A single stuck grandchild cannot wedge the
+  poll loop. Stopping the agent applies the same termination immediately
+  rather than waiting the timeout out.
+- **Load-bearing.** A non-zero exit *or* a timeout suppresses the config ack.
+  The server keeps the version pending and redelivers it on the next poll, so
+  a failed reload is retried instead of being silently recorded as applied.
+- **Bounded output.** Up to 8 KiB of combined stdout/stderr is quoted in the
+  `failed to reload nebula` log line. Beyond that the agent counts and drops
+  rather than buffers, so a chatty or runaway hook cannot grow its memory.
+- **Verbatim.** The string reaches the interpreter exactly as written in
+  `agent.yml`, quotes and redirections included.
+
+What the command must not do:
+
+> **The command must not stop or restart `nebula-agent`, directly or
+> indirectly.** The hook runs inside the agent's own process tree — under
+> systemd, its control group. Anything that takes the agent down kills the hook
+> mid-flight, before the ack: the restarted agent is handed the same config
+> version again and runs the same command again. That is a restart loop, and it
+> presents as a flapping tunnel rather than as a configuration mistake.
+
+This is why the shipped
+[`nebula-agent.service`](../deploy/systemd/nebula-agent.service) deliberately
+declares no `PartOf=`, `BindsTo=` or `Requires=nebula.service`: with any of
+those, `systemctl restart nebula` inside the hook tears down the agent as
+collateral. If you replaced the unit or added a drop-in that couples them, pick
+one of:
+
+| Situation | Safe command |
+|---|---|
+| Nebula supports reload (preferred) | `systemctl reload nebula` — `reload` is propagated by no dependency type, so it stays safe even under a unit that couples the two. |
+| Restart needed, shipped unit | `systemctl restart nebula` — the units are independent, so the agent survives to send the ack. |
+| Restart needed, units coupled | None. Drop the coupling; there is no command that makes this safe. |
+
+That last row is not a hedge. Moving the restart out of the agent's control
+group — `systemd-run --collect --wait …`, the obvious workaround — does not
+help: it keeps the *restart* alive, but the propagation still tears the agent
+down before it acks, so the loop is unchanged. Measured on a coupled pair, both
+the plain and the `systemd-run` form produced three restarts in three seconds
+and zero acks.
+
+Smaller sharp edges, in rough order of how often they bite:
+
+- **Exit status is the only signal.** A command that returns 0 without having
+  reloaded anything is acknowledged as delivered.
+- **Polling is serialized.** A slow hook delays the next poll by however long
+  it runs. Shutdown is not delayed: stopping the agent cancels an in-flight
+  hook, terminates its process group, and suppresses the ack, so the next
+  start re-applies and retries.
+- **Do not leave background processes on the hook's stdout/stderr.** The agent
+  stops reading shortly after the command exits, so anything still holding
+  that pipe gets `EPIPE`/`SIGPIPE` on its next write. Hand long-lived
+  processes to a service manager, or redirect them (`>/dev/null 2>&1 &`).
 
 ## Enrollment
 
@@ -827,8 +899,22 @@ to enroll, or check that `data_dir/host.crt` exists (the path in `agent.yml`).
 
 ### Nebula keeps using the old config
 
-`nebula_pid_file` is empty or points at a non-existent PID. Either set it
-correctly, or restart `nebula.service` manually after the agent updates the config.
+No reload is configured, or the one that is configured is failing.
+
+- Neither `nebula_reload_command` nor `nebula_pid_file` is set, or the PID file
+  is empty / points at a dead PID. Set one correctly, or restart
+  `nebula.service` manually after each update.
+- `journalctl -u nebula-agent` shows `failed to reload nebula`. The `via=`
+  field names the mechanism that failed (`nebula_reload_command` or
+  `sighup`). The quoted
+  command output (up to 8 KiB) says why. Until it succeeds the agent does not
+  acknowledge the config version, so it retries every poll — a steady stream of
+  identical warnings means the hook itself is broken, not the config.
+- The warning is `timed out after 30s`. The hook did not finish in its budget;
+  the agent killed its whole process group and will retry. Reach for
+  `systemctl reload nebula` over anything that blocks on a full restart.
+- The agent keeps restarting alongside Nebula. The reload command is taking the
+  agent down with it — see [Reload command contract](#reload-command-contract).
 
 ### `permission denied: /etc/nebula/host.key`
 
@@ -900,11 +986,12 @@ Useful after the host's keys are believed compromised. Two flavours:
    `data_dir`. The agent checks every destination directory before consuming
    the single-use token, then writes the files individually.
 
-   When `nebula_pid_file` is configured, the agent sends `SIGHUP` after all
-   writes and before acknowledging the config version. A signal error leaves
+   When a reload is configured, the agent triggers it after all writes and
+   before acknowledging the config version: `nebula_reload_command` if set,
+   otherwise `SIGHUP` to `nebula_pid_file`. A failing command or signal leaves
    the version pending; the next signed poll returns the current config again.
-   With no PID file, management re-enrollment and acknowledgement complete, and
-   you must restart Nebula to load the new identity.
+   With neither configured, management re-enrollment and acknowledgement
+   complete, and you must restart Nebula to load the new identity.
 
 3. **Hard reset** (last resort, churns the host row). `host delete` the
    old record on the server and create a new one; agent steps as in

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -61,7 +61,7 @@ you need them.
 | darwin | arm64 | `darwin_arm64.tar.gz` | Apple Silicon. |
 | freebsd | amd64 | `freebsd_amd64.tar.gz` | Built. Use with the FreeBSD Nebula port. |
 | freebsd | arm64 | `freebsd_arm64.tar.gz` | Built, not regularly tested. |
-| windows | amd64 | `windows_amd64.zip` | Built. SIGHUP-based reload is unavailable on Windows — leave `nebula_pid_file` empty and restart Nebula manually. |
+| windows | amd64 | `windows_amd64.zip` | Built. SIGHUP-based reload is unavailable on Windows — leave `nebula_pid_file` empty and set `nebula_reload_command` (e.g. a service restart), or restart Nebula manually. |
 
 Unsupported targets and reasoning:
 
@@ -235,8 +235,9 @@ Control or remove the service with:
 
 Uninstalling the service does not delete `agent.yml`, certificates, or private
 keys. Windows cannot use the Unix `SIGHUP` mechanism, so leave
-`nebula_pid_file` empty and restart the separate Nebula service after managed
-config updates when required.
+`nebula_pid_file` empty and either set `nebula_reload_command` to restart the
+Nebula service (e.g. `sc stop nebula & sc start nebula`) or restart it
+manually after managed config updates when required.
 
 ### 4. Docker / sidecar
 
@@ -358,6 +359,7 @@ data_dir: "/etc/nebula"                       # where host.crt/host.key/ca.crt/c
 poll_interval: "30s"                          # how often to ask for updates
 nebula_config_path: "/etc/nebula/config.yml"  # full path to the rendered nebula config
 nebula_pid_file: "/run/nebula.pid"            # optional — if set, SIGHUP'd on changes
+# nebula_reload_command: "systemctl reload nebula"  # optional — replaces the SIGHUP when set
 signing_key_path: "/etc/nebula-agent/host.signing.key"  # Ed25519 PoP signing key — parent dir must be writable by the agent user
 ```
 
@@ -368,6 +370,7 @@ signing_key_path: "/etc/nebula-agent/host.signing.key"  # Ed25519 PoP signing ke
 | `poll_interval` | `30s` | Lower values reduce convergence time but increase server load. 5s–5m is the practical range. |
 | `nebula_config_path` | `/etc/nebula/config.yml` | The agent overwrites this file atomically. |
 | `nebula_pid_file` | (empty) | When set and the file holds a numeric PID, the agent sends `SIGHUP` after every successful write. |
+| `nebula_reload_command` | (empty) | When set, run through the system shell (`sh -c`, `cmd /C` on Windows) after every successful write **instead of** the SIGHUP — takes precedence over `nebula_pid_file`. 30s timeout; a failing command blocks the config ack so the reload is retried on the next poll. Use it to hook a service manager, e.g. `systemctl reload nebula`. |
 | `signing_key_path` | `/etc/nebula-agent/host.signing.key` | Ed25519 PoP signing key (ADR 0004). Override for non-root setups so the parent directory is writable by the agent user. |
 | `allow_insecure_http` | `false` | Opts out of the `https`-required guard on `server_url` (or pass `--insecure-http`). Only for isolated lab networks; credentials transit in the clear. |
 
@@ -754,12 +757,14 @@ Each `poll_interval` the agent:
    sibling temp file with the same permissions, calls `fsync(2)`, then `rename(2)`s
    into place. A crash mid-write leaves either the old or the new file — never a
    half-written one.
-4. If any file changed and `nebula_pid_file` is set, the agent reads the PID and
-   sends `SIGHUP`, prompting Nebula to reload without dropping tunnels.
+4. If any file changed, the agent triggers a reload: with
+   `nebula_reload_command` set it runs that command through the system shell;
+   otherwise, with `nebula_pid_file` set, it reads the PID and sends `SIGHUP`,
+   prompting Nebula to reload without dropping tunnels.
 5. For agents advertising `config_ack_v1`, the server keeps the delivered
    `config_version` pending. After validation, atomic write, and successful
-   `SIGHUP` delivery, the agent sends a signed
-   `POST /api/v1/agent/config-ack/<version>`. Without `nebula_pid_file`, the ack
+   reload delivery (command or `SIGHUP`), the agent sends a signed
+   `POST /api/v1/agent/config-ack/<version>`. Without a configured reload, the ack
    means only that the config was validated and written. It does not prove that
    Nebula accepted the reload or that the tunnel is healthy. Until the ack is
    committed, later polls receive the newest config again; duplicate ack

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -66,16 +66,19 @@ func reenrollWithSignal(
 	signal func(string) error,
 ) error {
 	return enrollWithProfile(ctx, serverURL, token, options.DataDir, options.SigningKeyPath, options.Profile,
-		reenrollReload(options, signal))
+		reenrollReload(ctx, options, signal))
 }
 
 // reenrollReload picks the reload hook for a re-enrollment: the shell
 // command when configured (taking precedence over the PID file), the
-// SIGHUP seam when only a PID file is set, nil when neither is.
-func reenrollReload(options ReenrollOptions, signal func(string) error) func() error {
+// SIGHUP seam when only a PID file is set, nil when neither is. The command
+// hook is bound to the re-enrollment's context so an abandoned rekey does
+// not leave a hook running.
+func reenrollReload(ctx context.Context, options ReenrollOptions, signal func(string) error) func() error {
 	switch {
 	case options.ReloadCommand != "":
-		return nebulaReloader(options.ReloadCommand, "")
+		reload := nebulaReloader(options.ReloadCommand, "")
+		return func() error { return reload(ctx) }
 	case options.PIDFile != "":
 		return func() error { return signal(options.PIDFile) }
 	default:

--- a/internal/agent/enroll.go
+++ b/internal/agent/enroll.go
@@ -48,7 +48,10 @@ type ReenrollOptions struct {
 	DataDir        string
 	SigningKeyPath string
 	PIDFile        string
-	Profile        models.AgentProfile
+	// ReloadCommand, when set, replaces the SIGHUP-to-PIDFile reload with a
+	// shell command (see nebulaReloader).
+	ReloadCommand string
+	Profile       models.AgentProfile
 }
 
 // Reenroll replaces an existing agent identity using its current profile.
@@ -62,11 +65,22 @@ func reenrollWithSignal(
 	options ReenrollOptions,
 	signal func(string) error,
 ) error {
-	var reload func() error
-	if options.PIDFile != "" {
-		reload = func() error { return signal(options.PIDFile) }
+	return enrollWithProfile(ctx, serverURL, token, options.DataDir, options.SigningKeyPath, options.Profile,
+		reenrollReload(options, signal))
+}
+
+// reenrollReload picks the reload hook for a re-enrollment: the shell
+// command when configured (taking precedence over the PID file), the
+// SIGHUP seam when only a PID file is set, nil when neither is.
+func reenrollReload(options ReenrollOptions, signal func(string) error) func() error {
+	switch {
+	case options.ReloadCommand != "":
+		return nebulaReloader(options.ReloadCommand, "")
+	case options.PIDFile != "":
+		return func() error { return signal(options.PIDFile) }
+	default:
+		return nil
 	}
-	return enrollWithProfile(ctx, serverURL, token, options.DataDir, options.SigningKeyPath, options.Profile, reload)
 }
 
 // enrollmentSecrets collects every heap copy of private key material made

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -141,6 +141,9 @@ type PollerConfig struct {
 	SigningKeyPath string
 	Interval       time.Duration
 	PIDFile        string
+	// ReloadCommand, when set, replaces the SIGHUP-to-PIDFile reload with a
+	// shell command (see nebulaReloader).
+	ReloadCommand string
 	// NebulaConfigPath is where the rendered Nebula config.yml is written.
 	// Empty falls back to DataDir/config.yml. Honors agent.yml's
 	// nebula_config_path so the daemon writes the config to the file Nebula
@@ -186,9 +189,7 @@ func NewPoller(cfg PollerConfig, logger *slog.Logger) (*Poller, error) {
 		signingKey: priv,
 		httpClient: &http.Client{Timeout: timeout},
 	}
-	p.signalFunc = func() error {
-		return signalNebulaFromPID(cfg.PIDFile)
-	}
+	p.signalFunc = nebulaReloader(cfg.ReloadCommand, cfg.PIDFile)
 	return p, nil
 }
 
@@ -384,7 +385,7 @@ func (p *Poller) poll(ctx context.Context) error {
 	if needsReload {
 		if err := p.signalFunc(); err != nil {
 			p.logger.Warn("failed to signal nebula", "error", err)
-			if p.config.PIDFile != "" {
+			if p.config.ReloadCommand != "" || p.config.PIDFile != "" {
 				reloadDelivered = false
 			}
 		} else {

--- a/internal/agent/poller.go
+++ b/internal/agent/poller.go
@@ -162,7 +162,7 @@ type PollerConfig struct {
 type Poller struct {
 	config     PollerConfig
 	logger     *slog.Logger
-	signalFunc func() error // for testing: override SIGHUP sending
+	signalFunc func(context.Context) error // for testing: override reload delivery
 	signingKey ed25519.PrivateKey
 	httpClient *http.Client
 }
@@ -191,6 +191,20 @@ func NewPoller(cfg PollerConfig, logger *slog.Logger) (*Poller, error) {
 	}
 	p.signalFunc = nebulaReloader(cfg.ReloadCommand, cfg.PIDFile)
 	return p, nil
+}
+
+// reloadMechanism names the configured reload path for logs. "SIGHUP" in a
+// log line is actively misleading when the operator configured a shell
+// command, and vice versa.
+func (p *Poller) reloadMechanism() string {
+	switch {
+	case p.config.ReloadCommand != "":
+		return "nebula_reload_command"
+	case p.config.PIDFile != "":
+		return "sighup"
+	default:
+		return "none"
+	}
 }
 
 func loadSigningKey(path string) (ed25519.PrivateKey, error) {
@@ -383,13 +397,13 @@ func (p *Poller) poll(ctx context.Context) error {
 
 	reloadDelivered := true
 	if needsReload {
-		if err := p.signalFunc(); err != nil {
-			p.logger.Warn("failed to signal nebula", "error", err)
+		if err := p.signalFunc(ctx); err != nil {
+			p.logger.Warn("failed to reload nebula", "via", p.reloadMechanism(), "error", err)
 			if p.config.ReloadCommand != "" || p.config.PIDFile != "" {
 				reloadDelivered = false
 			}
 		} else {
-			p.logger.Info("nebula reloaded")
+			p.logger.Info("nebula reloaded", "via", p.reloadMechanism())
 		}
 	}
 	if updates.ConfigYAML != nil && updates.ConfigVersion > 0 && reloadDelivered {

--- a/internal/agent/poller_nebula_config_path_test.go
+++ b/internal/agent/poller_nebula_config_path_test.go
@@ -39,7 +39,7 @@ func TestPoller_WritesConfigToNebulaConfigPath(t *testing.T) {
 		NebulaConfigPath: customPath,
 		Interval:         time.Hour, // immediate poll on Run is enough
 	})
-	p.signalFunc = func() error { return nil } // no real Nebula to SIGHUP
+	p.signalFunc = func(context.Context) error { return nil } // no real Nebula to SIGHUP
 
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
@@ -82,7 +82,7 @@ func TestPoller_NebulaConfigPathFallback(t *testing.T) {
 		DataDir:     dir,
 		Interval:    time.Hour,
 	})
-	p.signalFunc = func() error { return nil }
+	p.signalFunc = func(context.Context) error { return nil }
 
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()

--- a/internal/agent/poller_rekey_test.go
+++ b/internal/agent/poller_rekey_test.go
@@ -35,7 +35,7 @@ func TestPoll_ReturnsRekeyError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.signalFunc = func() error { return nil }
+	p.signalFunc = func(context.Context) error { return nil }
 
 	pollErr := p.poll(context.Background())
 	if pollErr == nil {
@@ -75,7 +75,7 @@ func TestPoll_RejectsRekeyWithoutToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.signalFunc = func() error { return nil }
+	p.signalFunc = func(context.Context) error { return nil }
 
 	err = p.poll(context.Background())
 	if err == nil {

--- a/internal/agent/poller_revocation_test.go
+++ b/internal/agent/poller_revocation_test.go
@@ -30,7 +30,7 @@ func TestPoll_ReturnsRevocationErrorOn403(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.signalFunc = func() error { return nil }
+	p.signalFunc = func(context.Context) error { return nil }
 
 	pollErr := p.poll(context.Background())
 	if pollErr == nil {
@@ -67,7 +67,7 @@ func TestPoll_ReturnsRevocationErrorOn410(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.signalFunc = func() error { return nil }
+	p.signalFunc = func(context.Context) error { return nil }
 
 	pollErr := p.poll(context.Background())
 	if !IsRevoked(pollErr) {

--- a/internal/agent/poller_safe_apply_test.go
+++ b/internal/agent/poller_safe_apply_test.go
@@ -101,7 +101,7 @@ func TestPollerRejectsUnsafeCandidateBeforeWriteOrSignal(t *testing.T) {
 				ImportSessionID: "session", Interval: time.Hour,
 			})
 			var signals atomic.Int32
-			p.signalFunc = func() error { signals.Add(1); return nil }
+			p.signalFunc = func(context.Context) error { signals.Add(1); return nil }
 			if err := p.PollOnce(context.Background()); err == nil {
 				t.Fatal("unsafe candidate accepted")
 			}
@@ -221,7 +221,7 @@ func TestPollerDoesNotAckWhenConfiguredReloadSignalFails(t *testing.T) {
 		SigningKeyPath: filepath.Join(dir, "host.signing.key"), NebulaCAPath: caPath,
 		NebulaCertPath: certPath, NebulaKeyPath: keyPath, Interval: time.Hour,
 	})
-	p.signalFunc = func() error { return errors.New("signal delivery failed") }
+	p.signalFunc = func(context.Context) error { return errors.New("signal delivery failed") }
 	if err := p.PollOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/poller_test.go
+++ b/internal/agent/poller_test.go
@@ -53,7 +53,7 @@ func newTestPoller(t *testing.T, cfg PollerConfig) *Poller {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.signalFunc = func() error { return nil }
+	p.signalFunc = func(context.Context) error { return nil }
 	return p
 }
 
@@ -87,7 +87,7 @@ func TestPoller_NoUpdates(t *testing.T) {
 	})
 
 	var signaled atomic.Bool
-	p.signalFunc = func() error {
+	p.signalFunc = func(context.Context) error {
 		signaled.Store(true)
 		return nil
 	}
@@ -122,7 +122,7 @@ func TestPoller_WithCertUpdate(t *testing.T) {
 	})
 
 	var signaled atomic.Bool
-	p.signalFunc = func() error {
+	p.signalFunc = func(context.Context) error {
 		signaled.Store(true)
 		return nil
 	}
@@ -174,7 +174,7 @@ func TestPoller_WithCACertUpdate(t *testing.T) {
 	})
 
 	var signaled atomic.Bool
-	p.signalFunc = func() error {
+	p.signalFunc = func(context.Context) error {
 		signaled.Store(true)
 		return nil
 	}

--- a/internal/agent/reload.go
+++ b/internal/agent/reload.go
@@ -2,9 +2,10 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
-	"runtime"
+	"sync"
 	"time"
 )
 
@@ -13,33 +14,117 @@ import (
 // tests can shrink it.
 var reloadCommandTimeout = 30 * time.Second
 
+// reloadCommandWaitDelay is how long we keep draining output after the
+// command's process group has been terminated. Terminating the group is
+// best-effort — a descendant can be stopped, uninterruptible, or in another
+// group entirely — and any survivor still holds the inherited output pipe.
+// Without this bound cmd.Wait blocks on that pipe for as long as the
+// survivor lives, defeating the timeout it was meant to enforce. var (not
+// const) so tests can shrink it.
+var reloadCommandWaitDelay = 2 * time.Second
+
+// reloadCommandOutputLimit caps the combined output retained for the error
+// message. A chatty (or runaway) hook writes for as long as it likes, so an
+// unbounded buffer is unbounded agent memory. 8 KiB is far more than a
+// service manager prints on failure and still fits a log line's worth of
+// context.
+const reloadCommandOutputLimit = 8 << 10
+
 // nebulaReloader returns the reload hook for the given agent settings:
 // when reloadCommand is set it is run through the system shell (taking
 // precedence over the PID file), otherwise the classic SIGHUP to the PID
 // named in pidFile. A failing or timed-out command surfaces its combined
 // output in the error so the poller's no-ack retry loop logs something
 // actionable.
-func nebulaReloader(reloadCommand, pidFile string) func() error {
+// The returned hook takes the caller's context so that shutting the agent
+// down does not have to wait out a hook that is wedged: canceling it
+// terminates the command's process group the same way the timeout does.
+// SIGHUP delivery ignores the context — it is a single syscall.
+func nebulaReloader(reloadCommand, pidFile string) func(context.Context) error {
 	if reloadCommand == "" {
-		return func() error { return signalNebulaFromPID(pidFile) }
+		return func(context.Context) error { return signalNebulaFromPID(pidFile) }
 	}
-	return func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), reloadCommandTimeout)
-		defer cancel()
+	return func(ctx context.Context) error { return runReloadCommand(ctx, reloadCommand) }
+}
 
-		var cmd *exec.Cmd
-		if runtime.GOOS == "windows" {
-			cmd = exec.CommandContext(ctx, "cmd", "/C", reloadCommand) // #nosec G204 -- operator-controlled reload hook from agent config, documented API contract
-		} else {
-			cmd = exec.CommandContext(ctx, "sh", "-c", reloadCommand) // #nosec G204 -- operator-controlled reload hook from agent config, documented API contract
-		}
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				return fmt.Errorf("nebula_reload_command timed out after %s: %s", reloadCommandTimeout, out)
-			}
-			return fmt.Errorf("nebula_reload_command failed: %w: %s", err, out)
-		}
+// runReloadCommand executes one reload hook, bounded by both the caller's
+// context and the reload timeout. The command runs in its own process group
+// so either bound can take down everything it spawned rather than just the
+// shell (see terminateReloadCommand).
+func runReloadCommand(parent context.Context, reloadCommand string) error {
+	ctx, cancel := context.WithTimeout(parent, reloadCommandTimeout)
+	defer cancel()
+
+	cmd := reloadShellCommand(ctx, reloadCommand)
+	out := &cappedBuffer{limit: reloadCommandOutputLimit}
+	// Same writer for both streams: os/exec then shares a single pipe and
+	// copier, so stdout and stderr stay interleaved as CombinedOutput had them.
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.Cancel = func() error { return terminateReloadCommand(cmd) }
+	cmd.WaitDelay = reloadCommandWaitDelay
+
+	err := cmd.Run()
+	switch {
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return fmt.Errorf("nebula_reload_command timed out after %s (process group terminated): %s",
+			reloadCommandTimeout, out.String())
+	case errors.Is(ctx.Err(), context.Canceled):
+		// The agent is shutting down. Whether the reload landed is
+		// unknowable, so this stays an error and the config ack is
+		// suppressed — the next start re-applies and retries.
+		return fmt.Errorf("nebula_reload_command interrupted by shutdown (process group terminated): %s",
+			out.String())
+	case err == nil:
 		return nil
+	case errors.Is(err, exec.ErrWaitDelay):
+		// The hook itself exited 0; only its output pipe outlived it,
+		// because something it spawned still holds the write end. The
+		// reload was delivered, so let the config ack through — we have
+		// already stopped reading, so nothing leaks on our side.
+		return nil
+	default:
+		return fmt.Errorf("nebula_reload_command failed: %w: %s", err, out.String())
 	}
+}
+
+// cappedBuffer accumulates at most limit bytes and counts the rest. Writes
+// past the cap are discarded rather than rejected: returning an error would
+// make os/exec close the pipe and hand the hook an EPIPE/SIGPIPE it never
+// asked for.
+//
+// The mutex guards against os/exec's copier goroutine still running when
+// Wait returns early on WaitDelay.
+type cappedBuffer struct {
+	limit int
+
+	mu      sync.Mutex
+	buf     []byte
+	dropped int
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	total := len(p)
+	if room := b.limit - len(b.buf); room > 0 {
+		kept := min(room, len(p))
+		b.buf = append(b.buf, p[:kept]...)
+		p = p[kept:]
+	}
+	b.dropped += len(p)
+	return total, nil
+}
+
+// String renders the captured output, noting how much was dropped so an
+// operator reading the log knows the message is not the whole story.
+func (b *cappedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.dropped == 0 {
+		return string(b.buf)
+	}
+	return fmt.Sprintf("%s… [%d more bytes truncated]", b.buf, b.dropped)
 }

--- a/internal/agent/reload.go
+++ b/internal/agent/reload.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// reloadCommandTimeout bounds a nebula_reload_command run. A hook that
+// hangs would otherwise stall the poll loop forever; var (not const) so
+// tests can shrink it.
+var reloadCommandTimeout = 30 * time.Second
+
+// nebulaReloader returns the reload hook for the given agent settings:
+// when reloadCommand is set it is run through the system shell (taking
+// precedence over the PID file), otherwise the classic SIGHUP to the PID
+// named in pidFile. A failing or timed-out command surfaces its combined
+// output in the error so the poller's no-ack retry loop logs something
+// actionable.
+func nebulaReloader(reloadCommand, pidFile string) func() error {
+	if reloadCommand == "" {
+		return func() error { return signalNebulaFromPID(pidFile) }
+	}
+	return func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), reloadCommandTimeout)
+		defer cancel()
+
+		var cmd *exec.Cmd
+		if runtime.GOOS == "windows" {
+			cmd = exec.CommandContext(ctx, "cmd", "/C", reloadCommand) // #nosec G204 -- operator-controlled reload hook from agent config, documented API contract
+		} else {
+			cmd = exec.CommandContext(ctx, "sh", "-c", reloadCommand) // #nosec G204 -- operator-controlled reload hook from agent config, documented API contract
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("nebula_reload_command timed out after %s: %s", reloadCommandTimeout, out)
+			}
+			return fmt.Errorf("nebula_reload_command failed: %w: %s", err, out)
+		}
+		return nil
+	}
+}

--- a/internal/agent/reload_cancel_test.go
+++ b/internal/agent/reload_cancel_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// waitForFile blocks until path exists, so a test can be sure the reload
+// hook is genuinely running before it interferes with it.
+func waitForFile(t *testing.T, path string, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("reload hook never created %s within %v", path, within)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestNebulaReloader_ContextCancelInterrupts: canceling the caller's context
+// terminates the hook instead of letting it run out the full timeout.
+//
+// Deliberately does NOT shrink reloadCommandTimeout — the whole point is that
+// cancellation does not have to wait for it. With the hook bound to
+// context.Background() this test hangs for the full 30s and trips the guard.
+func TestNebulaReloader_ContextCancelInterrupts(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "started")
+	reload := nebulaReloader(scriptTouchThenSleep(marker), "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errc := make(chan error, 1)
+	go func() { errc <- reload(ctx) }()
+
+	waitForFile(t, marker, 10*time.Second)
+	start := time.Now()
+	cancel()
+
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("an interrupted reload must report an error so the config ack stays suppressed")
+		}
+		if !strings.Contains(err.Error(), "interrupted by shutdown") {
+			t.Errorf("err = %v, want the shutdown-interrupted error", err)
+		}
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Errorf("reload took %v to unwind after cancel", elapsed)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatalf("reload ignored its canceled context (timeout is %v)", reloadCommandTimeout)
+	}
+}
+
+// TestPoller_ReloadCommandShutdown_DoesNotWaitOutTimeout: stopping the agent
+// while a hook is wedged must not block for the reload timeout.
+//
+// This is the operator-visible half: with the hook on context.Background(),
+// `systemctl stop nebula-agent` sits there for 30 seconds — long enough for a
+// supervisor to escalate to SIGKILL on a stricter TimeoutStopSec.
+func TestPoller_ReloadCommandShutdown_DoesNotWaitOutTimeout(t *testing.T) {
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	var acked atomic.Bool
+	server := reloadTestServer(t, dir, &acked)
+	defer server.Close()
+
+	marker := filepath.Join(dir, "hook-started")
+	p := newReloadCommandPoller(t, server.URL, dir, scriptTouchThenSleep(marker))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { defer close(done); _ = p.Run(ctx) }()
+
+	waitForFile(t, marker, 10*time.Second)
+	start := time.Now()
+	cancel()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Errorf("shutdown took %v with a %v reload timeout", elapsed, reloadCommandTimeout)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatalf("Run did not return; shutdown is waiting out the %v reload timeout", reloadCommandTimeout)
+	}
+	if acked.Load() {
+		t.Error("an interrupted reload must not be acked — delivery is unknown")
+	}
+}

--- a/internal/agent/reload_pgroup_unix_test.go
+++ b/internal/agent/reload_pgroup_unix_test.go
@@ -1,0 +1,68 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNebulaReloader_TimeoutKillsProcessTree is the regression test for a
+// reload hook that outlives its shell.
+//
+// `sh -c` forks for a background job, a pipeline, or any service manager
+// that spawns a helper, and those children inherit the command's
+// stdout/stderr. Killing only the shell left them running, which broke the
+// timeout twice over: the write end of the output pipe stayed open so the
+// agent blocked in Wait for the child's whole lifetime, and the work the
+// operator asked to abort carried on regardless.
+//
+// The two assertions below cover the two halves separately — WaitDelay
+// bounds how long the agent waits, terminating the process group is what
+// actually stops the child — so neither fix can silently regress behind the
+// other.
+func TestNebulaReloader_TimeoutKillsProcessTree(t *testing.T) {
+	const (
+		childWork  = 2 * time.Second
+		reapMargin = 500 * time.Millisecond
+	)
+	shrinkReloadTimeout(t, 200*time.Millisecond, 500*time.Millisecond)
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "child-finished")
+	// A backgrounded grandchild that inherits the pipe and outlives `sh`.
+	// It only touches the marker once its work completes, so the marker is
+	// the proof that killing the group really stopped it.
+	script := fmt.Sprintf("(sleep %d; touch %s) & wait",
+		int(childWork.Seconds()), strconv.Quote(marker))
+
+	start := time.Now()
+	err := nebulaReloader(script, "")(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("err = %v, want a timeout error", err)
+	}
+	// Half the child's runtime: comfortably above timeout+WaitDelay, and
+	// unambiguously below "blocked until the child exited".
+	if budget := childWork / 2; elapsed > budget {
+		t.Errorf("reload returned after %v, want under %v — a surviving child still blocks the poll loop",
+			elapsed, budget)
+	}
+
+	time.Sleep(time.Until(start.Add(childWork + reapMargin)))
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("the backgrounded child ran to completion — the process group was not terminated")
+	} else if !os.IsNotExist(err) {
+		t.Errorf("stat marker: %v", err)
+	}
+}

--- a/internal/agent/reload_script_unix_test.go
+++ b/internal/agent/reload_script_unix_test.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package agent
+
+import "strconv"
+
+// Shell snippets for the reload tests, in the dialect of the interpreter
+// reloadShellCommand picks on this platform. The Windows file defines the
+// same names in cmd.exe syntax so the tests themselves stay OS-agnostic.
+const (
+	scriptSucceed     = "true"
+	scriptFailNoisily = "echo boom-detail >&2; exit 3"
+	scriptSleepLong   = "sleep 60"
+
+	// scriptFlood prints 64 KiB and fails, to exercise the output cap.
+	// Pure POSIX shell doubling — no coreutils dependency.
+	scriptFlood = "s=xxxxxxxxxxxxxxxx; i=0; " +
+		"while [ $i -lt 12 ]; do s=\"$s$s\"; i=$((i+1)); done; " +
+		"echo \"$s\"; exit 3"
+)
+
+func scriptTouch(path string) string { return "touch " + strconv.Quote(path) }
+
+// scriptTouchThenSleep signals that the hook has really started, then hangs.
+func scriptTouchThenSleep(path string) string { return scriptTouch(path) + "; " + scriptSleepLong }

--- a/internal/agent/reload_script_windows_test.go
+++ b/internal/agent/reload_script_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package agent
+
+// Shell snippets for the reload tests, in cmd.exe syntax. The Unix file
+// defines the same names for `sh -c`.
+const (
+	scriptSucceed     = "exit 0"
+	scriptFailNoisily = "echo boom-detail 1>&2 & exit 3"
+	// ping is the reliable cmd.exe sleep: `timeout /t` refuses to run when
+	// stdin is redirected, which it always is under os/exec.
+	scriptSleepLong = "ping -n 61 127.0.0.1 >nul"
+
+	// scriptFlood prints ~60 KB and fails, to exercise the output cap.
+	scriptFlood = "(for /L %i in (1,1,600) do @echo " +
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx) & exit 3"
+)
+
+// scriptTouch relies on the raw command line reaching cmd.exe unmangled:
+// the temp path is quoted here and must survive as typed.
+func scriptTouch(path string) string { return `type nul > "` + path + `"` }
+
+// scriptTouchThenSleep signals that the hook has really started, then hangs.
+func scriptTouchThenSleep(path string) string { return scriptTouch(path) + " & " + scriptSleepLong }

--- a/internal/agent/reload_systemd_test.go
+++ b/internal/agent/reload_systemd_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// stopPropagatingDirectives are the systemd dependency types that make
+// systemd stop or restart this unit when the named unit stops or restarts.
+// After= and Wants= are ordering/weak-dependency only and stay allowed.
+var stopPropagatingDirectives = []string{"PartOf", "BindsTo", "Requires", "Requisite"}
+
+// TestSystemdUnitDoesNotCoupleAgentToNebula pins the unit half of the
+// nebula_reload_command contract.
+//
+// The hook runs synchronously inside nebula-agent.service's control group.
+// If the unit declares stop/restart propagation from nebula.service, then a
+// hook that restarts Nebula — the documented `systemctl restart nebula`
+// case, and the only option where `reload` is not supported — makes systemd
+// tear down the agent while that very command is still running. The hook is
+// killed with the cgroup, the config ack never goes out, and the restarted
+// agent is handed the same update again: a restart loop that looks like a
+// flapping tunnel rather than a unit-file bug.
+//
+// Reload delivery is only as safe as the unit shipped alongside it, so guard
+// the unit from the package that implements the hook.
+func TestSystemdUnitDoesNotCoupleAgentToNebula(t *testing.T) {
+	path := filepath.Join("..", "..", "deploy", "systemd", "nebula-agent.service")
+	unit, err := os.ReadFile(path) // #nosec G304 -- fixed in-repo path
+	if err != nil {
+		t.Fatalf("read unit: %v", err)
+	}
+
+	for i, line := range strings.Split(string(unit), "\n") {
+		directive := strings.TrimSpace(line)
+		if directive == "" || strings.HasPrefix(directive, "#") || strings.HasPrefix(directive, ";") {
+			continue
+		}
+		key, value, ok := strings.Cut(directive, "=")
+		if !ok {
+			continue
+		}
+		for _, forbidden := range stopPropagatingDirectives {
+			if !strings.EqualFold(strings.TrimSpace(key), forbidden) {
+				continue
+			}
+			// Field-wise, not substring: these directives take a space
+			// separated list, and "my-nebula.service" is a different unit.
+			if slices.Contains(strings.Fields(value), "nebula.service") {
+				t.Errorf("%s:%d: %s — %s=nebula.service propagates stops to the agent, "+
+					"so a nebula_reload_command that restarts Nebula kills the hook "+
+					"before it can ack (use After=/Wants= for ordering instead)",
+					path, i+1, directive, forbidden)
+			}
+		}
+	}
+}

--- a/internal/agent/reload_test.go
+++ b/internal/agent/reload_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -16,12 +15,9 @@ import (
 )
 
 func TestNebulaReloader_CommandRuns(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix shell test")
-	}
 	marker := filepath.Join(t.TempDir(), "ran")
-	reload := nebulaReloader("touch "+marker, "")
-	if err := reload(); err != nil {
+	reload := nebulaReloader(scriptTouch(marker), "")
+	if err := reload(context.Background()); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
 	if _, err := os.Stat(marker); err != nil {
@@ -30,11 +26,8 @@ func TestNebulaReloader_CommandRuns(t *testing.T) {
 }
 
 func TestNebulaReloader_CommandFailureIncludesOutput(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix shell test")
-	}
-	reload := nebulaReloader("echo boom-detail >&2; exit 3", "")
-	err := reload()
+	reload := nebulaReloader(scriptFailNoisily, "")
+	err := reload(context.Background())
 	if err == nil {
 		t.Fatal("expected error from failing command")
 	}
@@ -44,21 +37,37 @@ func TestNebulaReloader_CommandFailureIncludesOutput(t *testing.T) {
 }
 
 func TestNebulaReloader_CommandTimesOut(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix shell test")
-	}
-	orig := reloadCommandTimeout
-	reloadCommandTimeout = 200 * time.Millisecond
-	defer func() { reloadCommandTimeout = orig }()
+	shrinkReloadTimeout(t, 200*time.Millisecond, 500*time.Millisecond)
 
-	reload := nebulaReloader("sleep 5", "")
+	reload := nebulaReloader(scriptSleepLong, "")
 	start := time.Now()
-	err := reload()
+	err := reload(context.Background())
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
-	if elapsed := time.Since(start); elapsed > 2*time.Second {
+	// scriptSleepLong runs for a minute. The budget is loose enough to
+	// absorb a slow terminator (Windows shells out to taskkill) and still
+	// an order of magnitude short of "waited for the command".
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Errorf("reload took %v, should have been killed by the %v timeout", elapsed, reloadCommandTimeout)
+	}
+}
+
+// TestNebulaReloader_CapsCommandOutput: a hook that floods its output must
+// not grow the agent's heap without bound. The error keeps the head of the
+// output and says how much it dropped.
+func TestNebulaReloader_CapsCommandOutput(t *testing.T) {
+	err := nebulaReloader(scriptFlood, "")(context.Background())
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	// Generous slack over the cap for the error's own prose; the point is
+	// that the message is bounded rather than proportional to the flood.
+	if got, limit := len(err.Error()), reloadCommandOutputLimit+1024; got > limit {
+		t.Errorf("error message is %d bytes, want at most %d — output is not capped", got, limit)
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("error %q should say that output was truncated", err)
 	}
 }
 
@@ -66,11 +75,8 @@ func TestNebulaReloader_CommandTimesOut(t *testing.T) {
 // present the command wins — the PID file must not even be read (a bogus
 // path would otherwise error).
 func TestNebulaReloader_CommandTakesPrecedenceOverPIDFile(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix shell test")
-	}
-	reload := nebulaReloader("true", "/nonexistent/nebula.pid")
-	if err := reload(); err != nil {
+	reload := nebulaReloader(scriptSucceed, "/nonexistent/nebula.pid")
+	if err := reload(context.Background()); err != nil {
 		t.Errorf("command should take precedence over pid file: %v", err)
 	}
 }
@@ -80,13 +86,55 @@ func TestNebulaReloader_CommandTakesPrecedenceOverPIDFile(t *testing.T) {
 // pid file.
 func TestNebulaReloader_FallsBackToPIDFile(t *testing.T) {
 	reload := nebulaReloader("", "")
-	err := reload()
+	err := reload(context.Background())
 	if err == nil {
 		t.Fatal("expected 'not configured' error with no command and no pid file")
 	}
 	if !strings.Contains(err.Error(), "not configured") {
 		t.Errorf("err = %v, want the signalNebulaFromPID 'not configured' error", err)
 	}
+}
+
+func TestCappedBuffer(t *testing.T) {
+	b := &cappedBuffer{limit: 8}
+
+	// Short of the cap: verbatim, no note.
+	if n, err := b.Write([]byte("abc")); n != 3 || err != nil {
+		t.Fatalf("Write = (%d, %v), want (3, nil)", n, err)
+	}
+	if got := b.String(); got != "abc" {
+		t.Errorf("String() = %q, want %q", got, "abc")
+	}
+
+	// Straddling the cap: the head is kept, the overflow only counted.
+	// Write must still report every byte consumed, or os/exec's copier
+	// treats the short write as an error and tears down the pipe.
+	if n, err := b.Write([]byte("defghijkl")); n != 9 || err != nil {
+		t.Fatalf("Write = (%d, %v), want (9, nil)", n, err)
+	}
+	// Past the cap entirely: still accepted, still only counted.
+	if n, err := b.Write([]byte("mno")); n != 3 || err != nil {
+		t.Fatalf("Write = (%d, %v), want (3, nil)", n, err)
+	}
+
+	got := b.String()
+	if !strings.HasPrefix(got, "abcdefgh") {
+		t.Errorf("String() = %q, want it to start with the first 8 bytes", got)
+	}
+	if !strings.Contains(got, "7 more bytes truncated") {
+		t.Errorf("String() = %q, want it to report the 7 dropped bytes", got)
+	}
+}
+
+// shrinkReloadTimeout rescales the reload budget for tests and restores it
+// afterwards.
+func shrinkReloadTimeout(t *testing.T, timeout, waitDelay time.Duration) {
+	t.Helper()
+	origTimeout, origDelay := reloadCommandTimeout, reloadCommandWaitDelay
+	reloadCommandTimeout, reloadCommandWaitDelay = timeout, waitDelay
+	t.Cleanup(func() {
+		reloadCommandTimeout, reloadCommandWaitDelay = origTimeout, origDelay
+	})
 }
 
 func reloadTestServer(t *testing.T, dir string, acked *atomic.Bool) *httptest.Server {
@@ -128,9 +176,6 @@ func newReloadCommandPoller(t *testing.T, serverURL, dir, command string) *Polle
 // configured pid file — the config version is NOT acknowledged so the
 // agent retries the reload on the next poll.
 func TestPoller_ReloadCommandFailure_BlocksAck(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix shell test")
-	}
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
 	var acked atomic.Bool
@@ -139,7 +184,7 @@ func TestPoller_ReloadCommandFailure_BlocksAck(t *testing.T) {
 
 	// NewPoller directly: newTestPoller would replace signalFunc with a
 	// no-op, and this test needs the real command-backed reloader.
-	p := newReloadCommandPoller(t, server.URL, dir, "exit 1")
+	p := newReloadCommandPoller(t, server.URL, dir, scriptFailNoisily)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -150,19 +195,38 @@ func TestPoller_ReloadCommandFailure_BlocksAck(t *testing.T) {
 	}
 }
 
-// TestPoller_ReloadCommandSuccess_Acks: the happy path — the command runs,
-// the config is acknowledged.
-func TestPoller_ReloadCommandSuccess_Acks(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix shell test")
-	}
+// TestPoller_ReloadCommandTimeout_BlocksAck: a hook that hangs (and leaves a
+// child behind) must not be mistaken for a delivered reload either.
+func TestPoller_ReloadCommandTimeout_BlocksAck(t *testing.T) {
+	shrinkReloadTimeout(t, 100*time.Millisecond, 200*time.Millisecond)
+
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
 	var acked atomic.Bool
 	server := reloadTestServer(t, dir, &acked)
 	defer server.Close()
 
-	p := newReloadCommandPoller(t, server.URL, dir, "true")
+	p := newReloadCommandPoller(t, server.URL, dir, scriptSleepLong)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	if acked.Load() {
+		t.Error("config must NOT be acked when nebula_reload_command times out")
+	}
+}
+
+// TestPoller_ReloadCommandSuccess_Acks: the happy path — the command runs,
+// the config is acknowledged.
+func TestPoller_ReloadCommandSuccess_Acks(t *testing.T) {
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	var acked atomic.Bool
+	server := reloadTestServer(t, dir, &acked)
+	defer server.Close()
+
+	p := newReloadCommandPoller(t, server.URL, dir, scriptSucceed)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -177,14 +241,11 @@ func TestPoller_ReloadCommandSuccess_Acks(t *testing.T) {
 // command (when set) wins over the pid-file SIGHUP seam; with neither, no
 // reload hook is installed.
 func TestReenrollReload_Selection(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix shell test")
-	}
 	marker := filepath.Join(t.TempDir(), "ran")
 	var signaledPID string
 	seam := func(pidFile string) error { signaledPID = pidFile; return nil }
 
-	reload := reenrollReload(ReenrollOptions{ReloadCommand: "touch " + marker, PIDFile: "/run/nebula.pid"}, seam)
+	reload := reenrollReload(context.Background(), ReenrollOptions{ReloadCommand: scriptTouch(marker), PIDFile: "/run/nebula.pid"}, seam)
 	if reload == nil {
 		t.Fatal("reload hook should be set when command is configured")
 	}
@@ -198,7 +259,7 @@ func TestReenrollReload_Selection(t *testing.T) {
 		t.Error("SIGHUP seam must not be called when command is set")
 	}
 
-	reload = reenrollReload(ReenrollOptions{PIDFile: "/run/nebula.pid"}, seam)
+	reload = reenrollReload(context.Background(), ReenrollOptions{PIDFile: "/run/nebula.pid"}, seam)
 	if err := reload(); err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +267,7 @@ func TestReenrollReload_Selection(t *testing.T) {
 		t.Errorf("signaled pid file = %q, want /run/nebula.pid", signaledPID)
 	}
 
-	if reload = reenrollReload(ReenrollOptions{}, seam); reload != nil {
+	if reload = reenrollReload(context.Background(), ReenrollOptions{}, seam); reload != nil {
 		t.Error("no command and no pid file should install no reload hook")
 	}
 }

--- a/internal/agent/reload_test.go
+++ b/internal/agent/reload_test.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNebulaReloader_CommandRuns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell test")
+	}
+	marker := filepath.Join(t.TempDir(), "ran")
+	reload := nebulaReloader("touch "+marker, "")
+	if err := reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("command did not run: %v", err)
+	}
+}
+
+func TestNebulaReloader_CommandFailureIncludesOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell test")
+	}
+	reload := nebulaReloader("echo boom-detail >&2; exit 3", "")
+	err := reload()
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if !strings.Contains(err.Error(), "boom-detail") {
+		t.Errorf("error %q should include command output", err)
+	}
+}
+
+func TestNebulaReloader_CommandTimesOut(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell test")
+	}
+	orig := reloadCommandTimeout
+	reloadCommandTimeout = 200 * time.Millisecond
+	defer func() { reloadCommandTimeout = orig }()
+
+	reload := nebulaReloader("sleep 5", "")
+	start := time.Now()
+	err := reload()
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("reload took %v, should have been killed by the %v timeout", elapsed, reloadCommandTimeout)
+	}
+}
+
+// TestNebulaReloader_CommandTakesPrecedenceOverPIDFile: with both settings
+// present the command wins — the PID file must not even be read (a bogus
+// path would otherwise error).
+func TestNebulaReloader_CommandTakesPrecedenceOverPIDFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell test")
+	}
+	reload := nebulaReloader("true", "/nonexistent/nebula.pid")
+	if err := reload(); err != nil {
+		t.Errorf("command should take precedence over pid file: %v", err)
+	}
+}
+
+// TestNebulaReloader_FallsBackToPIDFile: without a command the existing
+// SIGHUP path is used, including its "not configured" error for an empty
+// pid file.
+func TestNebulaReloader_FallsBackToPIDFile(t *testing.T) {
+	reload := nebulaReloader("", "")
+	err := reload()
+	if err == nil {
+		t.Fatal("expected 'not configured' error with no command and no pid file")
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("err = %v, want the signalNebulaFromPID 'not configured' error", err)
+	}
+}
+
+func reloadTestServer(t *testing.T, dir string, acked *atomic.Bool) *httptest.Server {
+	t.Helper()
+	configYAML := "pki:\n  ca: " + filepath.Join(dir, "ca.crt") + "\n  cert: " + filepath.Join(dir, "host.crt") + "\n  key: " + filepath.Join(dir, "host.key") + "\n"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/agent/config-ack/") {
+			acked.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(UpdatesResponse{
+			HasUpdates:    true,
+			ConfigYAML:    &configYAML,
+			ConfigVersion: 7,
+			Blocklist:     []string{},
+		})
+	}))
+}
+
+func newReloadCommandPoller(t *testing.T, serverURL, dir, command string) *Poller {
+	t.Helper()
+	p, err := NewPoller(PollerConfig{
+		ServerURL:      serverURL,
+		Fingerprint:    "test-fp",
+		DataDir:        dir,
+		SigningKeyPath: filepath.Join(dir, "host.signing.key"),
+		Interval:       50 * time.Millisecond,
+		ReloadCommand:  command,
+	}, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestPoller_ReloadCommandFailure_BlocksAck: with nebula_reload_command
+// configured, a failing command must behave like a failed SIGHUP with a
+// configured pid file — the config version is NOT acknowledged so the
+// agent retries the reload on the next poll.
+func TestPoller_ReloadCommandFailure_BlocksAck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell test")
+	}
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	var acked atomic.Bool
+	server := reloadTestServer(t, dir, &acked)
+	defer server.Close()
+
+	// NewPoller directly: newTestPoller would replace signalFunc with a
+	// no-op, and this test needs the real command-backed reloader.
+	p := newReloadCommandPoller(t, server.URL, dir, "exit 1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	if acked.Load() {
+		t.Error("config must NOT be acked when nebula_reload_command fails")
+	}
+}
+
+// TestPoller_ReloadCommandSuccess_Acks: the happy path — the command runs,
+// the config is acknowledged.
+func TestPoller_ReloadCommandSuccess_Acks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell test")
+	}
+	dir := t.TempDir()
+	seedSigningKeyAt(t, dir)
+	var acked atomic.Bool
+	server := reloadTestServer(t, dir, &acked)
+	defer server.Close()
+
+	p := newReloadCommandPoller(t, server.URL, dir, "true")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = p.Run(ctx)
+
+	if !acked.Load() {
+		t.Error("config should be acked when nebula_reload_command succeeds")
+	}
+}
+
+// TestReenrollReload_Selection: re-enroll uses the same precedence — the
+// command (when set) wins over the pid-file SIGHUP seam; with neither, no
+// reload hook is installed.
+func TestReenrollReload_Selection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell test")
+	}
+	marker := filepath.Join(t.TempDir(), "ran")
+	var signaledPID string
+	seam := func(pidFile string) error { signaledPID = pidFile; return nil }
+
+	reload := reenrollReload(ReenrollOptions{ReloadCommand: "touch " + marker, PIDFile: "/run/nebula.pid"}, seam)
+	if reload == nil {
+		t.Fatal("reload hook should be set when command is configured")
+	}
+	if err := reload(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Error("command did not run")
+	}
+	if signaledPID != "" {
+		t.Error("SIGHUP seam must not be called when command is set")
+	}
+
+	reload = reenrollReload(ReenrollOptions{PIDFile: "/run/nebula.pid"}, seam)
+	if err := reload(); err != nil {
+		t.Fatal(err)
+	}
+	if signaledPID != "/run/nebula.pid" {
+		t.Errorf("signaled pid file = %q, want /run/nebula.pid", signaledPID)
+	}
+
+	if reload = reenrollReload(ReenrollOptions{}, seam); reload != nil {
+		t.Error("no command and no pid file should install no reload hook")
+	}
+}

--- a/internal/agent/reload_unix.go
+++ b/internal/agent/reload_unix.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// reloadShellCommand builds the shell invocation for a reload hook and puts
+// it in a fresh process group. Setpgid is what makes the timeout mean
+// anything: `sh -c` frequently forks (background jobs, pipelines, a service
+// manager that spawns helpers), and those children inherit the output pipe.
+// Without a group to kill, terminating the shell leaves them running and
+// holding that pipe open.
+func reloadShellCommand(ctx context.Context, command string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "sh", "-c", command) // #nosec G204 -- operator-controlled reload hook from agent config, documented API contract
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd
+}
+
+// terminateReloadCommand SIGKILLs the whole process group created above.
+// The hook already had the full timeout to finish, so there is nothing left
+// to be graceful about; a SIGTERM-then-wait dance would only extend the
+// stall the timeout exists to prevent.
+func terminateReloadCommand(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	// Negative PID addresses the group. The group id equals the shell's pid
+	// because Setpgid made it a group leader.
+	switch err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); {
+	case err == nil:
+		return nil
+	case errors.Is(err, syscall.ESRCH):
+		// Already gone. Reporting it as ErrProcessDone keeps os/exec from
+		// turning a benign race into a spurious Wait error.
+		return os.ErrProcessDone
+	default:
+		// No such group (Setpgid refused, or the shell was reaped between
+		// the two calls) — at least take down the process itself.
+		return cmd.Process.Kill()
+	}
+}

--- a/internal/agent/reload_windows.go
+++ b/internal/agent/reload_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// reloadShellCommand builds the cmd.exe invocation for a reload hook.
+//
+// The command line is handed over verbatim through SysProcAttr.CmdLine
+// rather than assembled from Args. os/exec would quote the hook with
+// syscall.EscapeArg, whose backslash-escaped quotes cmd.exe does not
+// understand — an operator command containing quotes or redirections would
+// arrive mangled. Passing the raw line gives `cmd /C <command>` the exact
+// text from agent.yml, which is what the documented contract promises. The
+// leading token is cmd.exe's own argv[0]; the interpreter it actually runs
+// is the resolved path below.
+//
+// CREATE_NEW_PROCESS_GROUP mirrors the Unix Setpgid: it keeps console
+// signals aimed at an interactively-run agent from reaching the hook.
+func reloadShellCommand(ctx context.Context, command string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, commandInterpreter()) // #nosec G204 -- resolved from COMSPEC/System32, never a bare PATH lookup
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine:       "cmd /C " + command,
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	return cmd
+}
+
+// terminateReloadCommand kills the reload command and everything it spawned.
+// Windows has no killpg: TerminateProcess on cmd.exe leaves the process it
+// launched — the actual service-manager call — running and holding the
+// inherited output pipe, so walk the tree with taskkill /T instead.
+func terminateReloadCommand(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	kill := exec.Command(system32("taskkill.exe"), // #nosec G204 -- fixed system binary; the only variable is our own child's pid
+		"/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid))
+	if err := kill.Run(); err != nil {
+		// taskkill missing or the tree already gone — still make sure the
+		// interpreter itself is not left behind.
+		return cmd.Process.Kill()
+	}
+	return nil
+}
+
+// commandInterpreter resolves cmd.exe from System32.
+//
+// Deliberately not a PATH lookup and deliberately not COMSPEC: the agent
+// runs as LocalSystem, so an environment or PATH entry writable by a lesser
+// user would be a privilege-escalation path. COMSPEC is also a correctness
+// hazard here — the command line we build is cmd.exe syntax (`/C`), so
+// honouring a COMSPEC that points at some other interpreter would hand it
+// flags it does not understand.
+func commandInterpreter() string {
+	return system32("cmd.exe")
+}
+
+func system32(name string) string {
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = `C:\Windows`
+	}
+	return filepath.Join(root, "System32", name)
+}

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -26,6 +26,13 @@ type AgentConfig struct {
 	ImportSessionID  string        `yaml:"import_session_id,omitempty"`
 	NebulaPIDFile    string        `yaml:"nebula_pid_file"`
 
+	// NebulaReloadCommand, when set, is run through the system shell after
+	// config/cert changes instead of sending SIGHUP to nebula_pid_file
+	// (which it takes precedence over). Lets operators hook their service
+	// manager (e.g. "systemctl reload nebula") and gives Windows — where
+	// SIGHUP does not exist — a working reload path.
+	NebulaReloadCommand string `yaml:"nebula_reload_command,omitempty"`
+
 	// AllowInsecureHTTP opts out of the https-required guard on server_url.
 	// Without it a plaintext http:// URL is only accepted for loopback
 	// hosts — over any other network the enrollment token, certificates,

--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -279,3 +279,29 @@ func TestLoadAgentConfig_PlaintextHTTPRefused(t *testing.T) {
 		t.Error("AllowInsecureHTTP not loaded from YAML")
 	}
 }
+
+func TestLoadAgentConfig_NebulaReloadCommand(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yml")
+
+	data := []byte(`server_url: "https://mgmt.example.com:8080"
+nebula_reload_command: "systemctl reload nebula"
+`)
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadAgentConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.NebulaReloadCommand != "systemctl reload nebula" {
+		t.Errorf("NebulaReloadCommand = %q, want %q", cfg.NebulaReloadCommand, "systemctl reload nebula")
+	}
+}
+
+func TestLoadAgentConfig_NebulaReloadCommand_DefaultEmpty(t *testing.T) {
+	if got := DefaultAgentConfig().NebulaReloadCommand; got != "" {
+		t.Errorf("default NebulaReloadCommand = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
I am setting up nebula-mesh, and I’ve encountered an issue on my Gentoo installations—using both OpenRC and systemd—where Nebula fails to restart because it cannot locate the PID file. The simplest solution is to run a command that triggers a restart directly from the init system itself.


## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
