### PR TITLE
fix(config): preserve Windows firewall behavior with Nebula v1.11

### DIFF
--- a/internal/configgen/advanced_test.go
+++ b/internal/configgen/advanced_test.go
@@ -25,11 +25,49 @@ func TestGenerate_DefaultsWhenNoAdvanced(t *testing.T) {
 	if !strings.Contains(s, "punch: true") {
 		t.Error("expected default punch: true")
 	}
-	if strings.Contains(s, "tun:") {
-		t.Error("tun block should not appear without advanced overrides")
+	if strings.Contains(s, "dev:") {
+		t.Error("tun.dev should not appear without advanced overrides")
 	}
 	if strings.Contains(s, "unsafe_routes") {
 		t.Error("unsafe_routes should not appear without advanced overrides")
+	}
+}
+
+func TestGenerate_WindowsV111CompatibilityDefaults(t *testing.T) {
+	out, err := Generate(GeneratorInput{
+		HostName:   "h",
+		NebulaIPs:  []string{"10.0.0.1"},
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := string(out)
+	if strings.Count(s, "windows_bypass_wdf: false") != 2 {
+		t.Errorf("expected listen and tun Windows WDF compatibility settings, got:\n%s", out)
+	}
+	if !strings.Contains(s, "network_category: unset") {
+		t.Errorf("expected legacy Windows network category setting, got:\n%s", out)
+	}
+
+	parsed := loadGenerated(t, GeneratorInput{
+		HostName:   "h",
+		NebulaIPs:  []string{"10.0.0.1"},
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+	})
+	if parsed.GetBool("listen.windows_bypass_wdf", true) {
+		t.Error("v1.11 parser read listen.windows_bypass_wdf as true")
+	}
+	if parsed.GetBool("tun.windows_bypass_wdf", true) {
+		t.Error("v1.11 parser read tun.windows_bypass_wdf as true")
+	}
+	if got := parsed.GetString("tun.network_category", ""); got != "unset" {
+		t.Errorf("v1.11 parser read tun.network_category = %q, want unset", got)
 	}
 }
 

--- a/internal/configgen/marshal.go
+++ b/internal/configgen/marshal.go
@@ -159,8 +159,9 @@ type localAllowListSection struct {
 }
 
 type listenSection struct {
-	Host safeString `yaml:"host"`
-	Port int        `yaml:"port"`
+	Host             safeString `yaml:"host"`
+	Port             int        `yaml:"port"`
+	WindowsBypassWDF bool       `yaml:"windows_bypass_wdf"`
 }
 
 type punchySection struct {
@@ -174,6 +175,8 @@ type tunSection struct {
 	DropMulticast      *bool         `yaml:"drop_multicast,omitempty"`
 	MTU                int           `yaml:"mtu,omitempty"`
 	UnsafeRoutes       []unsafeRoute `yaml:"unsafe_routes,omitempty"`
+	WindowsBypassWDF   bool          `yaml:"windows_bypass_wdf"`
+	NetworkCategory    safeString    `yaml:"network_category"`
 }
 
 type tunnelsSection struct {
@@ -288,7 +291,11 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 	if listenPort == 0 && input.IsLighthouse && input.Mobile == nil {
 		listenPort = 4242
 	}
-	cfg.Listen = listenSection{Host: safeString(listenHost), Port: listenPort}
+	cfg.Listen = listenSection{
+		Host:             safeString(listenHost),
+		Port:             listenPort,
+		WindowsBypassWDF: false,
+	}
 
 	punch := true
 	if input.PunchyOverride != nil {
@@ -299,30 +306,33 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 		cfg.Punchy.Respond = boolPtr(false)
 	}
 
-	if input.Mobile != nil || input.MTU != 0 || input.TunDevice != "" || len(input.UnsafeRoutes) > 0 {
-		dev := input.TunDevice
-		mtu := input.MTU
-		if input.Mobile != nil {
-			if dev == "" {
-				dev = "nebula1"
-			}
-			if mtu == 0 {
-				mtu = 1300
-			}
+	dev := input.TunDevice
+	mtu := input.MTU
+	if input.Mobile != nil {
+		if dev == "" {
+			dev = "nebula1"
 		}
-		ts := &tunSection{Dev: safeString(dev), MTU: mtu}
-		if input.Mobile != nil {
-			ts.DropLocalBroadcast = boolPtr(true)
-			ts.DropMulticast = boolPtr(true)
+		if mtu == 0 {
+			mtu = 1300
 		}
-		for _, r := range input.UnsafeRoutes {
-			ts.UnsafeRoutes = append(ts.UnsafeRoutes, unsafeRoute{
-				Route: safeString(r.Route),
-				Via:   safeString(r.Via),
-			})
-		}
-		cfg.Tun = ts
 	}
+	ts := &tunSection{
+		Dev:              safeString(dev),
+		MTU:              mtu,
+		WindowsBypassWDF: false,
+		NetworkCategory:  "unset",
+	}
+	if input.Mobile != nil {
+		ts.DropLocalBroadcast = boolPtr(true)
+		ts.DropMulticast = boolPtr(true)
+	}
+	for _, r := range input.UnsafeRoutes {
+		ts.UnsafeRoutes = append(ts.UnsafeRoutes, unsafeRoute{
+			Route: safeString(r.Route),
+			Via:   safeString(r.Via),
+		})
+	}
+	cfg.Tun = ts
 
 	if input.IsRelay {
 		cfg.Relay = &relaySection{AmRelay: boolPtr(true)}


### PR DESCRIPTION
## Purpose

Keep pre-v1.11 Windows Defender Firewall behavior during agent upgrades.

## Changes

- Emit explicit WDF and network-category compatibility defaults.
- Cover generated config with regression tests.

## Verification

- `go test ./... -count=1`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `make gosec`
- `make govulncheck`

`golangci-lint run ./...` still reports 36 existing G120 findings in `internal/web/*`; this PR does not modify those files.

## Code pointers

- `internal/configgen/marshal.go`
- `internal/configgen/advanced_test.go`

Closes #318
