### PR TITLE
fix(config): redeliver WDF config after v1.11 upgrade

### DIFF
--- a/internal/store/migration_026_test.go
+++ b/internal/store/migration_026_test.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+)
+
+var migrations025 = append(append([]string{}, migrations023...),
+	"024_mesh_import_challenge_limits.up.sql",
+	"025_oidc_unique.up.sql",
+)
+
+func TestMigration026RedeliversRenderedConfigExactlyOnce(t *testing.T) {
+	path := t.TempDir() + "/store.db"
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open seed sqlite: %v", err)
+	}
+	applyMigrationFiles(t, db, migrations025)
+	mustExec(t, db, `INSERT INTO networks (id, name, config_version) VALUES (?, ?, ?)`, "net-1", "one", 7)
+	mustExec(t, db, `INSERT INTO networks (id, name, config_version) VALUES (?, ?, ?)`, "net-2", "two", 41)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seed sqlite: %v", err)
+	}
+
+	s, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+	for i := 0; i < 2; i++ {
+		if err := s.Migrate(context.Background()); err != nil {
+			t.Fatalf("migrate pass %d: %v", i+1, err)
+		}
+	}
+
+	for networkID, want := range map[string]int{"net-1": 8, "net-2": 42} {
+		got, err := s.GetNetworkConfigVersion(context.Background(), networkID)
+		if err != nil {
+			t.Fatalf("get network %s config version: %v", networkID, err)
+		}
+		if got != want {
+			t.Errorf("network %s config version = %d, want %d", networkID, got, want)
+		}
+	}
+
+	var applied int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE name = ?`, "026_redeliver_wdf_config.up.sql").Scan(&applied); err != nil {
+		t.Fatalf("query migration record: %v", err)
+	}
+	if applied != 1 {
+		t.Errorf("migration records = %d, want 1", applied)
+	}
+}
+
+func TestMigration026DownDoesNotDiscardLaterConfigVersion(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	applyMigrationFiles(t, db, migrations025)
+	mustExec(t, db, `INSERT INTO networks (id, name, config_version) VALUES (?, ?, ?)`, "net-1", "one", 7)
+	if err := execMigrationFile(db, "026_redeliver_wdf_config.up.sql"); err != nil {
+		t.Fatalf("apply 026: %v", err)
+	}
+	mustExec(t, db, `UPDATE networks SET config_version = config_version + 1 WHERE id = ?`, "net-1")
+	if err := execMigrationFile(db, "026_redeliver_wdf_config.down.sql"); err != nil {
+		t.Fatalf("apply 026 down: %v", err)
+	}
+
+	var got int
+	if err := db.QueryRow(`SELECT config_version FROM networks WHERE id = ?`, "net-1").Scan(&got); err != nil {
+		t.Fatalf("read config version: %v", err)
+	}
+	if got != 9 {
+		t.Errorf("config version after down = %d, want 9", got)
+	}
+}
+
+func TestMigration026ConcurrentMigrateBumpsConfigOnce(t *testing.T) {
+	path := t.TempDir() + "/store.db"
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open seed sqlite: %v", err)
+	}
+	applyMigrationFiles(t, db, migrations025)
+	mustExec(t, db, `INSERT INTO networks (id, name, config_version) VALUES (?, ?, ?)`, "net-1", "one", 7)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seed sqlite: %v", err)
+	}
+
+	stores := make([]*SQLiteStore, 2)
+	for i := range stores {
+		stores[i], err = NewSQLiteStore(path)
+		if err != nil {
+			t.Fatalf("open store %d: %v", i, err)
+		}
+		defer stores[i].Close()
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, len(stores))
+	var wg sync.WaitGroup
+	for _, s := range stores {
+		wg.Go(func() {
+			<-start
+			errs <- s.Migrate(context.Background())
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent migrate: %v", err)
+		}
+	}
+
+	got, err := stores[0].GetNetworkConfigVersion(context.Background(), "net-1")
+	if err != nil {
+		t.Fatalf("get config version: %v", err)
+	}
+	if got != 8 {
+		t.Errorf("config version after concurrent migrate = %d, want 8", got)
+	}
+}

--- a/internal/store/migrations/026_redeliver_wdf_config.down.sql
+++ b/internal/store/migrations/026_redeliver_wdf_config.down.sql
@@ -1,0 +1,3 @@
+-- Intentionally no-op. The previous version cannot be reconstructed safely:
+-- a network may have received legitimate config changes after the release
+-- migration ran, and decrementing would discard that newer revision.

--- a/internal/store/migrations/026_redeliver_wdf_config.up.sql
+++ b/internal/store/migrations/026_redeliver_wdf_config.up.sql
@@ -1,0 +1,4 @@
+-- Force one config delivery after the v1.11 Windows compatibility defaults
+-- changed the server renderer (#320). Existing hosts compare this value to
+-- their last acknowledged config version during the next agent poll.
+UPDATE networks SET config_version = config_version + 1;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -169,6 +169,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		"023_mesh_import.up.sql",
 		"024_mesh_import_challenge_limits.up.sql",
 		"025_oidc_unique.up.sql",
+		"026_redeliver_wdf_config.up.sql",
 	}
 
 	conn, err := s.db.Conn(ctx)
@@ -210,6 +211,12 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		if applied {
 			continue
 		}
+		if f == "026_redeliver_wdf_config.up.sql" {
+			if err := applyMigration026(ctx, conn, f); err != nil {
+				return err
+			}
+			continue
+		}
 		// Migration 018 enforces UNIQUE(network_id, address). Before applying it,
 		// resolve the data conditions that would otherwise make it fail with a raw
 		// SQLite error: a cross-host duplicate (a security defect with no safe
@@ -248,6 +255,47 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 	// next start.
 	if err := repairBlocklistCAID(ctx, conn); err != nil {
 		return fmt.Errorf("repair blocklist ca_id: %w", err)
+	}
+	return nil
+}
+
+// applyMigration026 records the migration and bumps config versions under one
+// SQLite write transaction. Migrate may be called by more than one process
+// during an upgrade; the initial marker check in Migrate is therefore not
+// enough to make this data migration exactly-once.
+func applyMigration026(ctx context.Context, conn *sql.Conn, migration string) (err error) {
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return fmt.Errorf("begin migration %s transaction: %w", migration, err)
+	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		if _, rollbackErr := conn.ExecContext(context.WithoutCancel(ctx), `ROLLBACK`); rollbackErr != nil {
+			slog.Error("rollback migration transaction", "migration", migration, "error", rollbackErr)
+		}
+	}()
+
+	applied, err := migrationApplied(ctx, conn, migration)
+	if err != nil {
+		return fmt.Errorf("check migration %s in transaction: %w", migration, err)
+	}
+	if !applied {
+		sqlBytes, err := migrations.FS.ReadFile(migration)
+		if err != nil {
+			return fmt.Errorf("read migration %s: %w", migration, err)
+		}
+		for _, stmt := range splitSQLStatements(string(sqlBytes)) {
+			if _, err := conn.ExecContext(ctx, stmt); err != nil {
+				return fmt.Errorf("apply migration %s stmt %q: %w", migration, firstLine(stmt), err)
+			}
+		}
+		if _, err := conn.ExecContext(ctx, `INSERT INTO schema_migrations(name) VALUES (?)`, migration); err != nil {
+			return fmt.Errorf("record migration %s: %w", migration, err)
+		}
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return fmt.Errorf("commit migration %s transaction: %w", migration, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Purpose

Ensure already enrolled agents receive the Nebula v1.11 Windows firewall compatibility settings after the server upgrade.

## Changes

- Add migration 026 that increments every Network `config_version` exactly once.
- Perform the migration update and marker write in one SQLite write transaction, so concurrent server starts cannot redeliver the same configuration twice.
- Keep the down migration non-destructive: later legitimate config revisions are never decremented.
- Cover upgrade, repeat migration, rollback, and concurrent startup paths.

## Verification

- `go test ./... -count=1`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`

`golangci-lint run ./...` still reports 36 existing G120 findings in `internal/web`; this change does not touch them.

Closes #320
