### PR TITLE
fix(hosts): re-issue certificates when a host's groups change

### DIFF
--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -82,6 +82,45 @@ func printUsage(w io.Writer) {
 // not mutate it at runtime.
 var standbyTick = 10 * time.Second
 
+const (
+	rekeyRetryInitialDelay = time.Second
+	rekeyRetryMaxDelay     = time.Minute
+)
+
+// rekeyRetryDelay returns an exponentially increasing, bounded delay for
+// consecutive re-enrollment failures. A new Poller performs its first poll
+// immediately, so this delay is the only throttle between failed rekey
+// attempts.
+func rekeyRetryDelay(consecutiveFailures int) time.Duration {
+	if consecutiveFailures <= 1 {
+		return rekeyRetryInitialDelay
+	}
+
+	delay := rekeyRetryInitialDelay
+	for attempt := 1; attempt < consecutiveFailures && delay < rekeyRetryMaxDelay; attempt++ {
+		if delay > rekeyRetryMaxDelay/2 {
+			return rekeyRetryMaxDelay
+		}
+		delay *= 2
+	}
+	return delay
+}
+
+// waitForRekeyRetry makes the retry delay interruptible by SIGTERM/SIGINT.
+// It deliberately uses a timer instead of Sleep so stopping the agent never
+// waits for a backoff window to elapse.
+func waitForRekeyRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 // runUnified is the daemon entrypoint. After #88 it never fails fast on a
 // missing config or missing enrollment; instead it parks in standby and
 // re-checks every standbyTick until the operator runs `nebula-agent enroll`
@@ -339,6 +378,7 @@ func applyOverrides(cfg *config.AgentConfig, serverURL, dataDir string, pollInte
 func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logger) error {
 	logger.Info("nebula-agent starting", "server", cfg.ServerURL, "poll_interval", cfg.PollInterval)
 
+	consecutiveRekeyFailures := 0
 	for {
 		fingerprint, err := agent.ReadCertFingerprintAt(cfg.ResolvedNebulaCertPath())
 		if err != nil {
@@ -389,12 +429,20 @@ func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logg
 				// reasons the next attempt may not hit (an unwritable
 				// directory an operator is about to fix, a server blip), and
 				// the server re-offers it until the enrollment completes.
-				// Exiting instead handed the retry to the service manager,
-				// which restarts on a fixed delay and eventually hits its
-				// start limit — turning a recoverable rekey failure into an
-				// agent that is stopped for good and silently stops applying
-				// config and certificate updates.
-				logger.Error("rekey enrollment failed; continuing to poll and will retry", "error", err)
+				// A new Poller polls immediately, so wait here rather than
+				// relying on PollInterval or the service manager to throttle
+				// persistent local failures.
+				consecutiveRekeyFailures++
+				delay := rekeyRetryDelay(consecutiveRekeyFailures)
+				logger.Error("rekey enrollment failed; retrying after backoff", "error", err, "retry_in", delay)
+				if waitErr := waitForRekeyRetry(ctx, delay); waitErr != nil {
+					if errors.Is(waitErr, context.Canceled) {
+						return nil
+					}
+					return waitErr
+				}
+			} else {
+				consecutiveRekeyFailures = 0
 			}
 			continue
 		}

--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -385,7 +385,16 @@ func startPoller(ctx context.Context, cfg *config.AgentConfig, logger *slog.Logg
 					ConfigAckV1: true,
 				},
 			}); err != nil {
-				return fmt.Errorf("rekey enrollment: %w", err)
+				// Keep polling rather than exiting. A rekey can fail for
+				// reasons the next attempt may not hit (an unwritable
+				// directory an operator is about to fix, a server blip), and
+				// the server re-offers it until the enrollment completes.
+				// Exiting instead handed the retry to the service manager,
+				// which restarts on a fixed delay and eventually hits its
+				// start limit — turning a recoverable rekey failure into an
+				// agent that is stopped for good and silently stops applying
+				// config and certificate updates.
+				logger.Error("rekey enrollment failed; continuing to poll and will retry", "error", err)
 			}
 			continue
 		}

--- a/cmd/nebula-agent/main_rekey_test.go
+++ b/cmd/nebula-agent/main_rekey_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -23,22 +24,27 @@ import (
 	"github.com/forgekeep/nebula-mesh/internal/pki"
 )
 
-func TestRekeyPreservesImportedNebulaPaths(t *testing.T) {
-	fixture := newCommandImportFixture(t)
-	dataDir := filepath.Join(fixture.dir, "managed-defaults")
-	if err := os.MkdirAll(filepath.Dir(fixture.signingKeyPath), 0o750); err != nil {
+func writeRekeySigningKey(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatal(err)
 	}
 	_, signingPrivate, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(fixture.signingKeyPath, pem.EncodeToMemory(&pem.Block{
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{
 		Type: meshagent.SigningPrivateKeyPEMType, Bytes: signingPrivate,
 	}), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	clear(signingPrivate)
+}
+
+func TestRekeyPreservesImportedNebulaPaths(t *testing.T) {
+	fixture := newCommandImportFixture(t)
+	dataDir := filepath.Join(fixture.dir, "managed-defaults")
+	writeRekeySigningKey(t, fixture.signingKeyPath)
 
 	oldFingerprint, err := meshagent.ReadCertFingerprintAt(fixture.certPath)
 	if err != nil {
@@ -147,6 +153,79 @@ func TestRekeyPreservesImportedNebulaPaths(t *testing.T) {
 	for _, name := range []string{"ca.crt", "host.crt", "host.key"} {
 		if _, err := os.Stat(filepath.Join(dataDir, name)); !os.IsNotExist(err) {
 			t.Fatalf("unexpected default PKI file %s: %v", name, err)
+		}
+	}
+}
+
+// TestRekeyRetryBacksOffAfterLocalFailure guards the loop formed by Poller's
+// immediate first poll and a re-enrollment preflight error. DataDir is a
+// regular file, so Reenroll fails locally before it can make an enrollment
+// request; the next poll must still wait for the bounded retry backoff.
+func TestRekeyRetryBacksOffAfterLocalFailure(t *testing.T) {
+	fixture := newCommandImportFixture(t)
+	writeRekeySigningKey(t, fixture.signingKeyPath)
+
+	blockedDataDir := filepath.Join(fixture.dir, "not-a-directory")
+	if err := os.WriteFile(blockedDataDir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pollTimes := make(chan time.Time, 2)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	var polls int
+	var enrollCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/agent/updates":
+			polls++
+			pollTimes <- time.Now()
+			_ = json.NewEncoder(response).Encode(map[string]any{
+				"has_updates": true, "rekey_required": true,
+				"enrollment_token": "nme_rekey-token", "blocklist": []string{},
+			})
+			if polls == 2 {
+				cancel()
+			}
+		case "/api/v1/enroll":
+			enrollCalls++
+			response.WriteHeader(http.StatusInternalServerError)
+		default:
+			response.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := &config.AgentConfig{
+		ServerURL: server.URL, DataDir: blockedDataDir, SigningKeyPath: fixture.signingKeyPath,
+		PollInterval: time.Hour, NebulaConfigPath: fixture.nebulaConfigPath,
+		NebulaCAPath: fixture.caPath, NebulaCertPath: fixture.certPath, NebulaKeyPath: fixture.keyPath,
+	}
+	if err := startPoller(ctx, cfg, slog.New(slog.NewTextHandler(io.Discard, nil))); err != nil {
+		t.Fatalf("startPoller: %v", err)
+	}
+
+	first := <-pollTimes
+	second := <-pollTimes
+	if elapsed := second.Sub(first); elapsed < rekeyRetryInitialDelay-100*time.Millisecond {
+		t.Fatalf("second poll arrived after %v, want at least roughly the initial backoff %v", elapsed, rekeyRetryInitialDelay)
+	}
+	if enrollCalls != 0 {
+		t.Fatalf("enrollment requests = %d, want 0 after local preflight failures", enrollCalls)
+	}
+}
+
+func TestRekeyRetryDelayIsBounded(t *testing.T) {
+	for failures, want := range map[int]time.Duration{
+		0:    rekeyRetryInitialDelay,
+		1:    rekeyRetryInitialDelay,
+		2:    2 * rekeyRetryInitialDelay,
+		3:    4 * rekeyRetryInitialDelay,
+		7:    rekeyRetryMaxDelay,
+		1000: rekeyRetryMaxDelay,
+	} {
+		if got := rekeyRetryDelay(failures); got != want {
+			t.Errorf("rekeyRetryDelay(%d) = %v, want %v", failures, got, want)
 		}
 	}
 }

--- a/deploy/systemd/nebula-agent.service
+++ b/deploy/systemd/nebula-agent.service
@@ -5,6 +5,13 @@ After=network-online.target nebula.service
 Wants=network-online.target
 PartOf=nebula.service
 
+# Never give up restarting. The default start limit stops a unit for good
+# after a few rapid failures, and a stopped agent is silent: it goes on
+# neither applying config nor rotating certificates while the host keeps
+# serving the ones it already has. RestartSec below already bounds the retry
+# rate, so there is nothing to protect against by capping the count.
+StartLimitIntervalSec=0
+
 [Service]
 Type=simple
 # Agent needs to write to /etc/nebula and send SIGHUP to nebula.service —
@@ -34,7 +41,12 @@ SystemCallFilter=@system-service
 SystemCallFilter=~@privileged @resources
 SystemCallFilter=kill
 
-ReadWritePaths=/etc/nebula
+# Both directories the agent writes to. /etc/nebula-agent holds the PoP
+# signing key (the default signing_key_path) and agent.yml; leaving it out
+# made ProtectSystem=strict fail every re-enrollment at the preflight write
+# test, while ordinary polling — which only reads the existing key — kept
+# working and hid the problem.
+ReadWritePaths=/etc/nebula /etc/nebula-agent
 
 LimitNOFILE=65536
 

--- a/docs/security/invariants.md
+++ b/docs/security/invariants.md
@@ -190,6 +190,10 @@ leave a weaker or partially applied security state.
 
 - Enrollment, revocation, token rotation, and mesh import lifecycle changes use
   transactional SQLite store methods.
+- Enrollment compares the certificate-bound Host identity read for signing with
+  the durable row inside its consume transaction. If a concurrent edit changed
+  `Name`, `NebulaIPs`, or `Groups`, the transaction retains `pending_rekey` so
+  the signed stale certificate cannot settle the newer identity.
 - Mesh import finalize applies Host state, firewall, blocklist, version, and
   challenge cleanup in one transaction with revision and scope checks.
 - Host updates persist Host fields and reset `config_version` in the same
@@ -217,7 +221,8 @@ leave a weaker or partially applied security state.
 - `internal/store/sqlite_mobile_certificate_test.go`: the certificate write
   rejects blocked Hosts and disabled owners.
 - `internal/store/sqlite_enroll_token_test.go`:
-  `TestConsumeTokenAndEnrollHost_NoBurnOnEnrollFailure`.
+  `TestConsumeTokenAndEnrollHost_NoBurnOnEnrollFailure` and
+  `TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterIdentityChange`.
 - `internal/store/sqlite_update_host_atomic_test.go`:
   `TestUpdateHost_ResetsConfigVersion` and
   `TestUpdateHost_SECPERSIST001_RollbackIsAtomic`.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -87,11 +87,13 @@ Trust zones, from least to most trusted:
 ### E3 — Agent enroll
 - **Spoofing / Replay**: token is single-use (atomic consume, #197), TTL-bounded, and bound to a `host_id` server-side — a token cannot enroll a different host.
 - **Elevation**: certificate fields (`Name`, `NebulaIPs`, `Groups`) come from the DB host row, not the request body.
+- **Concurrent identity edits**: enrollment re-checks those certificate-bound fields inside the token-consume transaction. A change after signing preserves `pending_rekey`, so the agent must re-enroll for the newer durable identity.
 - **Issuance abuse**: blocked host / disabled operator refused before signing (GHSA-339v-266x-79xr).
 
 ### E4 — Agent poll
 - **Spoofing**: identity is the certificate fingerprint; the Ed25519 PoP signature is verified against *that host's* `signing_pub_pem`. Host A cannot poll as host B without B's signing key.
 - **Replay**: per-host nonce + ±5 min timestamp window.
+- **Retry containment**: a failed local re-enrollment waits with a context-aware exponential backoff (1 second through 1 minute) before creating the next immediately-polling Poller, preventing persistent local failures from producing an unbounded authenticated request loop.
 - **Information disclosure**: peer config and blocklist scoped to the polling host's own CA/network (#203).
 - **Revocation**: blocked → `403`; deleted → `410`; rotation overlap bounded by `prev_cert_fingerprint` / `cert_rotated_at`.
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -225,9 +225,25 @@ Response (201):
 - `nebula_ips` (hosts): array of IP address strings. Each address must fall within one of the parent network's CIDRs. At least one is required. Order is preserved in the issued certificate.
 - Legacy singular fields (`cidr` and `nebula_ip`) were removed in v0.3.0. Requests using the old field names receive a 400 Bad Request error.
 
-### Updating host addresses
+### Updating certificate-bound fields
 
-To change a host's addresses (trigger a new certificate issuance), use PATCH:
+`name`, `nebula_ips` and `groups` are all carried inside the host's Nebula
+certificate, so editing any of them schedules a re-issuance: the host row is
+flagged `pending_rekey`, the next poll answers `rekey_required: true` with a
+single-use enrollment token, and the agent re-enrolls with a certificate that
+reflects the change. Other fields (`role`, `public_ip`, `listen_port`,
+`advanced`) only affect the rendered config and are picked up on the next poll
+without a new certificate.
+
+This matters most for `groups`. Peers authorize each other on the certificate,
+and firewall rules select their counterparties by group, so a group edit does
+nothing on the mesh until the new certificate lands. Note that the previous
+certificate stays valid until it expires — removing a host from a group closes
+its new sessions' access once the host re-enrolls, but it does not retroactively
+invalidate the old certificate. Block the host (which adds its fingerprint to
+the blocklist) when you need immediate, enforced revocation.
+
+To change a host's addresses, use PATCH:
 
 ```bash
 curl -X PATCH "https://mgmt.example.com:8080/api/v1/hosts/host_def456" \
@@ -239,6 +255,17 @@ curl -X PATCH "https://mgmt.example.com:8080/api/v1/hosts/host_def456" \
 ```
 
 The new certificate will reflect the reordered addresses on the agent's next poll.
+
+Changing group membership works the same way:
+
+```bash
+curl -X PATCH "https://mgmt.example.com:8080/api/v1/hosts/host_def456" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "groups": ["web", "prod"]
+  }'
+```
 
 ## Hosts
 

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -102,6 +102,11 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "enrollment failed")
 		return
 	}
+	// Keep an application-owned snapshot of every certificate-bound field. The
+	// store compares it with the durable row in the consume transaction after
+	// signing, so a concurrent PATCH cannot make this certificate settle a
+	// newer host identity.
+	signedIdentity := models.CertificateIdentityFromHost(host)
 
 	// Durable revocation (GHSA-339v-266x-79xr): refuse to (re-)issue a cert for
 	// a blocked host or one whose owning operator is disabled. This closes the
@@ -212,7 +217,7 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 	// transient failure during signing leaves the token usable for retry; a
 	// concurrent enrollment that already consumed it loses the CAS and gets 409.
 	configVersion, err := s.store.ConsumeTokenAndEnrollHostWithProfile(r.Context(), host.ID, req.Token, certPEM, fp,
-		hostCert.NotBefore(), hostCert.NotAfter(), req.SigningPubPEM, profile)
+		hostCert.NotBefore(), hostCert.NotAfter(), req.SigningPubPEM, profile, &signedIdentity)
 	if err != nil {
 		if errors.Is(err, store.ErrTokenUsed) {
 			s.metrics.recordEnrollment(resultDenied)
@@ -225,6 +230,17 @@ func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reload after the transaction so the enrollment response never renders
+	// configuration from the pre-sign snapshot when a concurrent host edit won.
+	// The transaction retains pending_rekey in that case, so the certificate is
+	// retried with this durable identity on the next poll.
+	host, err = s.store.GetHost(r.Context(), host.ID)
+	if err != nil {
+		s.metrics.recordEnrollment(resultError)
+		s.logger.Error("reload host after enrollment", "error", err, "host", tok.HostID)
+		writeError(w, http.StatusInternalServerError, "enrollment failed")
+		return
+	}
 	configYAML, err := s.renderHostConfig(r.Context(), host)
 	if err != nil {
 		s.metrics.recordEnrollment(resultError)

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -769,11 +769,15 @@ func (s *Server) handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.store.UpdateHost(r.Context(), host); err != nil {
-		// Reachable only via a TOCTOU race between concurrent host writes: the
-		// validateHostIPs fast-path above returns 400 for any collision visible
-		// at request time, so reaching the store's UNIQUE(network_id, address)
-		// guard means another writer claimed the IP in between.
+	// Persist, schedule a cert re-issuance if a cert-bound field moved, and
+	// bump the network config version on a role change. config_version reset
+	// and the pending-rekey flag commit inside UpdateHost (SEC-PERSIST-001).
+	if err := store.ApplyHostEdit(r.Context(), s.store, s.logger, &before, host); err != nil {
+		// ErrIPTaken is reachable only via a TOCTOU race between concurrent
+		// host writes: the validateHostIPs fast-path above returns 400 for any
+		// collision visible at request time, so reaching the store's
+		// UNIQUE(network_id, address) guard means another writer claimed the
+		// IP in between.
 		if errors.Is(err, store.ErrIPTaken) {
 			writeError(w, http.StatusConflict, "one or more nebula_ips are already assigned to another host in this network")
 			return
@@ -781,39 +785,6 @@ func (s *Server) handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("update host", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update host")
 		return
-	}
-
-	// config_version reset now happens atomically inside UpdateHost (SEC-PERSIST-001).
-
-	// If role changed, bump network config version for peer updates
-	if before.Role != host.Role {
-		if err := s.store.BumpNetworkConfigVersion(r.Context(), host.NetworkID); err != nil {
-			s.logger.Error("bump network config version", "network", host.NetworkID, "error", err)
-		}
-	}
-
-	// If name or any IP changed, set pending rekey for cert re-enrollment
-	ipsEqual := len(before.NebulaIPs) == len(host.NebulaIPs)
-	if ipsEqual {
-		for i := range before.NebulaIPs {
-			if before.NebulaIPs[i] != host.NebulaIPs[i] {
-				ipsEqual = false
-				break
-			}
-		}
-	}
-	if before.Name != host.Name || !ipsEqual {
-		if err := s.store.SetPendingRekey(r.Context(), host.ID); err != nil {
-			if !errors.Is(err, store.ErrRekeyAlreadyPending) {
-				s.logger.Error("set pending rekey", "host", host.ID, "error", err)
-			}
-			// Idempotent: ErrRekeyAlreadyPending is success (rekey already scheduled)
-		}
-		// Reload host to get PendingRekey flag in response
-		freshHost, err := s.store.GetHost(r.Context(), host.ID)
-		if err == nil {
-			host = freshHost
-		}
 	}
 
 	// Record audit entry with diff

--- a/internal/api/hosts_rotate_cert_test.go
+++ b/internal/api/hosts_rotate_cert_test.go
@@ -139,10 +139,11 @@ func TestPoll_EmitsRekeyToken_WhenPending(t *testing.T) {
 		t.Errorf("EnrollmentToken = %q, want nme_ prefix", resp.EnrollmentToken)
 	}
 
-	// Pending flag must be cleared so a follow-up poll does not mint a
-	// second token.
+	// The flag deliberately survives minting: only a completed enrollment
+	// clears it, so a rekey the agent fails to finish is re-offered instead
+	// of being lost. See TestRekey_ReofferedUntilEnrollmentCompletes.
 	got, _ := st.GetHost(context.Background(), host.ID)
-	if got.PendingRekey {
-		t.Errorf("PendingRekey still true after rekey token was minted")
+	if !got.PendingRekey {
+		t.Errorf("PendingRekey cleared at token mint; the rekey would be lost if the agent never enrolls")
 	}
 }

--- a/internal/api/hosts_update_groups_test.go
+++ b/internal/api/hosts_update_groups_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/slackhq/nebula/cert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// patchHostGroups PATCHes a host's groups and returns the decoded response.
+func patchHostGroups(t *testing.T, srv *Server, hostID string, groups []string) *models.Host {
+	t.Helper()
+	body, err := json.Marshal(updateHostRequest{Groups: &groups})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+hostID, bytes.NewBuffer(body))
+	authRequest(req)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "PATCH groups: %s", rec.Body.String())
+
+	var updated models.Host
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&updated))
+	return &updated
+}
+
+// certGroups parses a stored certificate PEM and returns its embedded groups.
+func certGroups(t *testing.T, pemBytes []byte) []string {
+	t.Helper()
+	parsed, _, err := cert.UnmarshalCertificateFromPEM(pemBytes)
+	require.NoError(t, err)
+	return parsed.Groups()
+}
+
+// TestUpdateHost_GroupChangeSetsPendingRekey: a host's groups are baked into
+// its Nebula certificate, and firewall rules select peers by group. Changing
+// the groups on the host row therefore has no effect on the mesh until a new
+// certificate is issued — so the change has to schedule one, exactly as a
+// rename or an IP change does.
+func TestUpdateHost_GroupChangeSetsPendingRekey(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	host := createHostHelper(t, srv, netID, "web-1", "192.168.100.1", nil)
+
+	fresh, err := srv.store.GetHost(context.Background(), host.ID)
+	require.NoError(t, err)
+	require.False(t, fresh.PendingRekey, "setup: PendingRekey should start false")
+
+	updated := patchHostGroups(t, srv, host.ID, []string{"web", "prod"})
+	require.Equal(t, []string{"web", "prod"}, updated.Groups)
+	require.True(t, updated.PendingRekey, "changing groups must schedule a new certificate")
+
+	fresh, err = srv.store.GetHost(context.Background(), host.ID)
+	require.NoError(t, err)
+	require.True(t, fresh.PendingRekey, "the scheduled rekey must be persisted")
+}
+
+// TestUpdateHost_GroupRemovalSetsPendingRekey is the security-relevant
+// direction: dropping a host from a privileged group must not leave it holding
+// a certificate that still claims membership. Peers authorize on the cert, not
+// on the server's host row.
+func TestUpdateHost_GroupRemovalSetsPendingRekey(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	host := createHostHelper(t, srv, netID, "web-1", "192.168.100.1", nil)
+
+	_ = patchHostGroups(t, srv, host.ID, []string{"admin", "web"})
+	require.NoError(t, srv.store.ClearPendingRekey(context.Background(), host.ID))
+
+	updated := patchHostGroups(t, srv, host.ID, []string{"web"})
+	require.Equal(t, []string{"web"}, updated.Groups)
+	require.True(t, updated.PendingRekey, "removing a group must schedule a new certificate")
+}
+
+// TestUpdateHost_SameGroupsDoesNotRekey: a PATCH that does not actually change
+// the groups must stay a no-op. Re-issuing on every write would churn
+// certificates across the fleet for idempotent config pushes.
+func TestUpdateHost_SameGroupsDoesNotRekey(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	host := createHostHelper(t, srv, netID, "web-1", "192.168.100.1", nil)
+
+	_ = patchHostGroups(t, srv, host.ID, []string{"web"})
+	require.NoError(t, srv.store.ClearPendingRekey(context.Background(), host.ID))
+
+	updated := patchHostGroups(t, srv, host.ID, []string{"web"})
+	require.False(t, updated.PendingRekey, "re-sending identical groups must not rekey")
+
+	fresh, err := srv.store.GetHost(context.Background(), host.ID)
+	require.NoError(t, err)
+	require.False(t, fresh.PendingRekey, "re-sending identical groups must not rekey")
+}
+
+// TestUpdateHost_GroupChangeReachesTheAgent walks the whole chain the bug
+// report was about: an operator edits the groups, and the host's very next
+// signed poll is told to re-key. Everything else here asserts one link;
+// without this one, all the links could pass while the chain stays broken.
+func TestUpdateHost_GroupChangeReachesTheAgent(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	host, err := st.GetHostByFingerprint(context.Background(), agent.fingerprint)
+	require.NoError(t, err)
+	require.False(t, host.PendingRekey, "setup: nothing pending before the edit")
+
+	_ = patchHostGroups(t, srv, host.ID, []string{"admin"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "poll: %s", rec.Body.String())
+
+	var resp agentUpdatesResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.True(t, resp.RekeyRequired, "the agent was never told to re-key after the group change")
+	require.NotEmpty(t, resp.EnrollmentToken, "a re-key needs a token for the agent to re-enroll with")
+}
+
+// TestUpdateHost_GroupChangeReissuedCertCarriesNewGroups closes the loop on
+// why the rekey matters: once the scheduled re-issuance happens, the new
+// certificate must carry the new groups and drop the old ones.
+func TestUpdateHost_GroupChangeReissuedCertCarriesNewGroups(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	host, err := st.GetHostByFingerprint(context.Background(), agent.fingerprint)
+	require.NoError(t, err)
+
+	_ = patchHostGroups(t, srv, host.ID, []string{"admin"})
+	certInfo, err := st.GetCertificateInfo(context.Background(), host.ID)
+	require.NoError(t, err)
+	require.NotContains(t, certGroups(t, []byte(certInfo.PEM)), "admin",
+		"setup: the cert on record predates the group change")
+
+	// Re-issue the way the rekey path eventually does: same key, current
+	// host attributes.
+	host, err = st.GetHost(context.Background(), host.ID)
+	require.NoError(t, err)
+	signed, err := srv.signHostCert(context.Background(), host, certInfo, srv.now())
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"admin"}, certGroups(t, signed.certPEM),
+		"the re-issued certificate must carry the host's current groups")
+}

--- a/internal/api/hosts_update_test.go
+++ b/internal/api/hosts_update_test.go
@@ -921,5 +921,9 @@ func TestUpdateHost_OmittedNebulaIPs_Untouched(t *testing.T) {
 	require.NoError(t, json.NewDecoder(patchRec.Body).Decode(&updatedHost))
 
 	require.Equal(t, originalIPs, updatedHost.NebulaIPs, "addresses should be unchanged")
-	require.False(t, updatedHost.PendingRekey, "groups-only change should not set PendingRekey")
+	// The groups themselves do schedule a re-issuance — they are carried in
+	// the certificate that peers authorize against. See
+	// TestUpdateHost_GroupChangeSetsPendingRekey; asserted here only to keep
+	// this test honest about what a groups-only PATCH does.
+	require.True(t, updatedHost.PendingRekey, "groups-only change still re-issues the cert")
 }

--- a/internal/api/rekey_lifecycle_test.go
+++ b/internal/api/rekey_lifecycle_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/slackhq/nebula/cert"
+	"golang.org/x/crypto/curve25519"
+)
+
+// pollForRekey performs one signed poll and returns the decoded response.
+func pollForRekey(t *testing.T, srv *Server, agent enrolledAgent) agentUpdatesResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/updates", nil)
+	signPoll(t, req, agent)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("poll: status %d, body %s", rec.Code, rec.Body.String())
+	}
+	var resp agentUpdatesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// enrollWithToken runs a full enrollment handshake with the given token,
+// standing in for the agent's re-enrollment after a rekey.
+func enrollWithToken(t *testing.T, srv *Server, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	x25519Priv := make([]byte, 32)
+	if _, err := rand.Read(x25519Priv); err != nil {
+		t.Fatal(err)
+	}
+	x25519Pub, err := curve25519.X25519(x25519Priv, curve25519.Basepoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(enrollRequest{
+		Token:         token,
+		PublicKeyPEM:  string(cert.MarshalPublicKeyToPEM(cert.Curve_CURVE25519, x25519Pub)),
+		SigningPubPEM: string(pem.EncodeToMemory(&pem.Block{Type: SigningPublicKeyPEMType, Bytes: edPub})),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/enroll", bytes.NewBuffer(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestRekey_ReofferedUntilEnrollmentCompletes is the regression test for a
+// silently dropped rekey.
+//
+// The flag used to clear the moment the token was minted, so an agent that
+// could not complete the re-enrollment — an unwritable directory, a crash, a
+// host that never came back — lost the request outright: the server reported
+// nothing pending while the host went on serving the certificate the rekey
+// was meant to replace, and re-requesting it just repeated the cycle.
+func TestRekey_ReofferedUntilEnrollmentCompletes(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	ctx := context.Background()
+
+	host, err := st.GetHostByFingerprint(ctx, agent.fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetPendingRekey(ctx, host.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// First poll: the agent is told to re-key but (as far as the server can
+	// tell) never follows through.
+	first := pollForRekey(t, srv, agent)
+	if !first.RekeyRequired || first.EnrollmentToken == "" {
+		t.Fatal("first poll did not carry the rekey signal")
+	}
+
+	// Second poll: the rekey must still be on offer.
+	second := pollForRekey(t, srv, agent)
+	if !second.RekeyRequired || second.EnrollmentToken == "" {
+		t.Fatal("rekey was dropped after one unanswered poll — the host would keep its old certificate forever")
+	}
+	if second.EnrollmentToken == first.EnrollmentToken {
+		t.Error("a re-offer must mint a fresh token; only the hash is stored, so the old one cannot be re-sent")
+	}
+
+	// The superseded token must be dead, so re-offering cannot leave a trail
+	// of usable credentials behind it. (That only one row survives is pinned
+	// in the store's TestCreateTokenForHost_SupersedesPreviousUnused.)
+	if rec := enrollWithToken(t, srv, first.EnrollmentToken); rec.Code == http.StatusOK {
+		t.Error("the superseded token still enrolled; re-offering must invalidate the one it replaces")
+	}
+}
+
+// TestRekey_ClearedByCompletedEnrollment: the flag's one exit path. It clears
+// in the same transaction as the certificate it asked for, so the host cannot
+// end up enrolled-but-still-pending or pending-but-already-enrolled.
+func TestRekey_ClearedByCompletedEnrollment(t *testing.T) {
+	srv, st := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+	ctx := context.Background()
+
+	host, err := st.GetHostByFingerprint(ctx, agent.fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetPendingRekey(ctx, host.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := pollForRekey(t, srv, agent)
+	if !resp.RekeyRequired {
+		t.Fatal("poll did not carry the rekey signal")
+	}
+
+	if rec := enrollWithToken(t, srv, resp.EnrollmentToken); rec.Code != http.StatusOK {
+		t.Fatalf("re-enroll: status %d, body %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := st.GetHost(ctx, host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PendingRekey {
+		t.Error("PendingRekey survived a completed enrollment; the agent would be told to re-key forever")
+	}
+}
+
+// TestRekey_NotOfferedOnceCleared: with nothing pending, an ordinary poll must
+// not hand out enrollment tokens.
+func TestRekey_NotOfferedOnceCleared(t *testing.T) {
+	srv, _ := newTestServer(t)
+	agent := enrolledFixture(t, srv)
+
+	resp := pollForRekey(t, srv, agent)
+	if resp.RekeyRequired {
+		t.Error("RekeyRequired set without a pending rekey")
+	}
+	if resp.EnrollmentToken != "" {
+		t.Error("an enrollment token was minted for a host with no pending rekey")
+	}
+}

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -258,11 +258,23 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Rekey signal: force-rotate?new_key=true sets pending_rekey on the
-	// host row; the very next poll under the existing fingerprint carries
-	// a single-use enrollment token so the agent can re-enroll a fresh
-	// keypair. The pending_rekey flag is cleared once the token is minted
-	// so a follow-up poll doesn't re-issue another token.
+	// Rekey signal: pending_rekey on the host row (force-rotate?new_key=true,
+	// or an edit to a certificate-bound field) makes the next poll under the
+	// existing fingerprint carry a single-use enrollment token so the agent
+	// can re-enroll a fresh keypair.
+	//
+	// The flag stays set until the agent actually completes the enrollment,
+	// which clears it inside that transaction. A rekey the agent cannot
+	// finish — an unwritable directory, a crash, a host that never comes
+	// back — is therefore re-offered on the following poll instead of being
+	// silently lost, which used to strand the host on its old certificate
+	// with the server reporting nothing pending.
+	//
+	// Re-offering means minting a fresh token each poll while the rekey is
+	// outstanding; only the token hash is stored, so the previous one cannot
+	// be re-sent. CreateTokenForHost deletes the host's other unused tokens,
+	// so at most one is ever live. The agent stops polling while it
+	// re-enrolls, so it cannot invalidate the token it is currently using.
 	if host.PendingRekey {
 		tokenStr, tokenErr := bootstraptoken.Generate(bootstraptoken.PurposeEnrollment)
 		if tokenErr != nil {
@@ -271,8 +283,6 @@ func (s *Server) handleAgentUpdates(w http.ResponseWriter, r *http.Request) {
 			expiresAt := now.Add(s.tokenTTLFor(r.Context(), host.NetworkID))
 			if err := s.store.CreateTokenForHost(r.Context(), host.ID, tokenStr, expiresAt); err != nil {
 				s.logger.Error("mint rekey token", "host", host.ID, "error", err)
-			} else if err := s.store.ClearPendingRekey(r.Context(), host.ID); err != nil {
-				s.logger.Error("clear pending_rekey", "host", host.ID, "error", err)
 			} else {
 				resp.RekeyRequired = true
 				resp.EnrollmentToken = tokenStr

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -167,6 +167,7 @@ func HostList(serverURL, apiKey, networkID string) error {
 		ID        string   `json:"id"`
 		Name      string   `json:"name"`
 		NebulaIPs []string `json:"nebula_ips"`
+		Groups    []string `json:"groups"`
 		Role      string   `json:"role"`
 		Status    string   `json:"status"`
 	}
@@ -179,10 +180,14 @@ func HostList(serverURL, apiKey, networkID string) error {
 		return nil
 	}
 
-	fmt.Printf("%-36s  %-20s  %-40s  %-12s  %s\n", "ID", "NAME", "NEBULA IPS", "ROLE", "STATUS")
+	fmt.Printf("%-36s  %-20s  %-40s  %-24s  %-12s  %s\n", "ID", "NAME", "NEBULA IPS", "GROUPS", "ROLE", "STATUS")
 	for _, h := range hosts {
 		ipsStr := strings.Join(h.NebulaIPs, ", ")
-		fmt.Printf("%-36s  %-20s  %-40s  %-12s  %s\n", h.ID, h.Name, ipsStr, h.Role, h.Status)
+		groupsStr := strings.Join(h.Groups, ", ")
+		if groupsStr == "" {
+			groupsStr = "-"
+		}
+		fmt.Printf("%-36s  %-20s  %-40s  %-24s  %-12s  %s\n", h.ID, h.Name, ipsStr, groupsStr, h.Role, h.Status)
 	}
 	return nil
 }

--- a/internal/models/hostcert_identity_test.go
+++ b/internal/models/hostcert_identity_test.go
@@ -1,0 +1,84 @@
+package models
+
+import "testing"
+
+// TestCertIdentityChanged covers each certificate-bound field on its own, and
+// pins the fields that must NOT trigger a re-issuance — a false positive there
+// churns certificates across the fleet on every routine config edit.
+func TestCertIdentityChanged(t *testing.T) {
+	base := func() *Host {
+		return &Host{
+			Name:       "web-1",
+			NebulaIPs:  []string{"10.0.0.1", "fd00::1"},
+			Groups:     []string{"web", "prod"},
+			Role:       HostRoleHost,
+			PublicIP:   "203.0.113.1",
+			ListenPort: 4242,
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Host)
+		want   bool
+	}{
+		{"no change", func(*Host) {}, false},
+
+		{"name changed", func(h *Host) { h.Name = "web-2" }, true},
+		{"ip changed", func(h *Host) { h.NebulaIPs = []string{"10.0.0.9", "fd00::1"} }, true},
+		{"ip added", func(h *Host) { h.NebulaIPs = append(h.NebulaIPs, "10.0.0.2") }, true},
+		{"ip removed", func(h *Host) { h.NebulaIPs = h.NebulaIPs[:1] }, true},
+		// Order is preserved into the certificate, so a reorder is a change.
+		{"ips reordered", func(h *Host) { h.NebulaIPs = []string{"fd00::1", "10.0.0.1"} }, true},
+
+		{"group added", func(h *Host) { h.Groups = append(h.Groups, "admin") }, true},
+		{"group removed", func(h *Host) { h.Groups = h.Groups[:1] }, true},
+		{"group renamed", func(h *Host) { h.Groups = []string{"web", "staging"} }, true},
+		{"groups reordered", func(h *Host) { h.Groups = []string{"prod", "web"} }, true},
+		{"all groups cleared", func(h *Host) { h.Groups = nil }, true},
+
+		// Config-only fields: delivered on the next poll, no new cert.
+		{"role changed", func(h *Host) { h.Role = HostRoleLighthouse }, false},
+		{"public ip changed", func(h *Host) { h.PublicIP = "203.0.113.9" }, false},
+		{"listen port changed", func(h *Host) { h.ListenPort = 4243 }, false},
+		{"advanced changed", func(h *Host) { h.Advanced = &HostAdvanced{MTU: 1300} }, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before, after := base(), base()
+			tt.mutate(after)
+			if got := CertIdentityChanged(before, after); got != tt.want {
+				t.Errorf("CertIdentityChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCertIdentityChanged_NilSides mirrors HostDiff's contract: a nil side
+// reads as the zero Host rather than panicking.
+func TestCertIdentityChanged_NilSides(t *testing.T) {
+	populated := &Host{Name: "web-1", Groups: []string{"web"}}
+
+	if !CertIdentityChanged(nil, populated) {
+		t.Error("nil before vs a populated host should count as changed")
+	}
+	if !CertIdentityChanged(populated, nil) {
+		t.Error("a populated host vs nil after should count as changed")
+	}
+	if CertIdentityChanged(nil, nil) {
+		t.Error("two zero hosts should not count as changed")
+	}
+}
+
+// TestCertIdentityChanged_EmptyVersusNilSlices: a host round-tripped through
+// JSON or the store can come back with []string{} where it went in as nil.
+// Treating that as a change would rekey hosts on every no-op write.
+func TestCertIdentityChanged_EmptyVersusNilSlices(t *testing.T) {
+	nilSlices := &Host{Name: "web-1"}
+	emptySlices := &Host{Name: "web-1", NebulaIPs: []string{}, Groups: []string{}}
+
+	if CertIdentityChanged(nilSlices, emptySlices) {
+		t.Error("nil and empty slices describe the same certificate; want no change")
+	}
+}

--- a/internal/models/hostcert_identity_test.go
+++ b/internal/models/hostcert_identity_test.go
@@ -2,6 +2,28 @@ package models
 
 import "testing"
 
+func TestCertificateIdentityFromHost_SnapshotIsIndependent(t *testing.T) {
+	host := &Host{
+		Name:      "web-1",
+		NebulaIPs: []string{"10.0.0.1"},
+		Groups:    []string{"web"},
+	}
+
+	snapshot := CertificateIdentityFromHost(host)
+	host.Name = "web-2"
+	host.NebulaIPs[0] = "10.0.0.2"
+	host.Groups[0] = "admin"
+
+	want := CertificateIdentity{
+		Name:      "web-1",
+		NebulaIPs: []string{"10.0.0.1"},
+		Groups:    []string{"web"},
+	}
+	if !snapshot.Equal(want) {
+		t.Fatalf("snapshot = %#v, want %#v", snapshot, want)
+	}
+}
+
 // TestCertIdentityChanged covers each certificate-bound field on its own, and
 // pins the fields that must NOT trigger a re-issuance — a false positive there
 // churns certificates across the fleet on every routine config edit.

--- a/internal/models/hostdiff.go
+++ b/internal/models/hostdiff.go
@@ -157,6 +157,48 @@ func HostDiff(before, after *Host) ([]byte, bool, error) {
 	return jsonBytes, true, nil
 }
 
+// CertificateIdentity is the subset of a Host that is carried inside its
+// Nebula certificate.
+//
+// It is intentionally separate from Host so callers that sign a certificate
+// can retain precisely the identity they signed without also retaining mutable
+// lifecycle or configuration state.
+type CertificateIdentity struct {
+	Name      string
+	NebulaIPs []string
+	Groups    []string
+}
+
+// CertificateIdentityFromHost returns an independent snapshot of the fields
+// that are carried in a Host's Nebula certificate. A nil Host is the zero
+// identity, matching HostDiff's nil-host convention.
+func CertificateIdentityFromHost(host *Host) CertificateIdentity {
+	identity := certificateIdentityFields(host)
+	identity.NebulaIPs = append([]string(nil), identity.NebulaIPs...)
+	identity.Groups = append([]string(nil), identity.Groups...)
+	return identity
+}
+
+// Equal reports whether two certificate identities describe the same Nebula
+// certificate subject. Empty and nil slices are equivalent, as they are when a
+// Host is diffed after a store or JSON round trip.
+func (identity CertificateIdentity) Equal(other CertificateIdentity) bool {
+	return identity.Name == other.Name &&
+		nebulaIPsEqual(identity.NebulaIPs, other.NebulaIPs) &&
+		groupsEqual(identity.Groups, other.Groups)
+}
+
+func certificateIdentityFields(host *Host) CertificateIdentity {
+	if host == nil {
+		return CertificateIdentity{}
+	}
+	return CertificateIdentity{
+		Name:      host.Name,
+		NebulaIPs: host.NebulaIPs,
+		Groups:    host.Groups,
+	}
+}
+
 // CertIdentityChanged reports whether an edit touched a field that is carried
 // inside the host's Nebula certificate: Name, NebulaIPs or Groups.
 //
@@ -175,15 +217,7 @@ func HostDiff(before, after *Host) ([]byte, bool, error) {
 //
 // A nil side is treated as the zero Host, matching HostDiff.
 func CertIdentityChanged(before, after *Host) bool {
-	if before == nil {
-		before = &Host{}
-	}
-	if after == nil {
-		after = &Host{}
-	}
-	return before.Name != after.Name ||
-		!nebulaIPsEqual(before.NebulaIPs, after.NebulaIPs) ||
-		!groupsEqual(before.Groups, after.Groups)
+	return !certificateIdentityFields(before).Equal(certificateIdentityFields(after))
 }
 
 // nebulaIPsEqual compares two IP slices for equality (order matters).

--- a/internal/models/hostdiff.go
+++ b/internal/models/hostdiff.go
@@ -157,6 +157,35 @@ func HostDiff(before, after *Host) ([]byte, bool, error) {
 	return jsonBytes, true, nil
 }
 
+// CertIdentityChanged reports whether an edit touched a field that is carried
+// inside the host's Nebula certificate: Name, NebulaIPs or Groups.
+//
+// Those three are the host's identity as far as the mesh is concerned. Peers
+// authorize each other on the certificate rather than on the management
+// server's host row, and firewall rules select their counterparties by group,
+// so editing any of them is inert until a new certificate is issued. Callers
+// use this to schedule that re-issuance. Every other field (Role, PublicIP,
+// ListenPort, Advanced) only shapes the rendered config, which the agent picks
+// up on its next poll without a new certificate.
+//
+// Both host-edit paths — the API's PATCH handler and the web UI's form — must
+// agree on this, hence one definition rather than a copy each. It deliberately
+// reuses the same comparators as HostDiff above, so what the audit trail
+// records as a change and what triggers a re-issuance cannot drift apart.
+//
+// A nil side is treated as the zero Host, matching HostDiff.
+func CertIdentityChanged(before, after *Host) bool {
+	if before == nil {
+		before = &Host{}
+	}
+	if after == nil {
+		after = &Host{}
+	}
+	return before.Name != after.Name ||
+		!nebulaIPsEqual(before.NebulaIPs, after.NebulaIPs) ||
+		!groupsEqual(before.Groups, after.Groups)
+}
+
 // nebulaIPsEqual compares two IP slices for equality (order matters).
 func nebulaIPsEqual(a, b []string) bool {
 	if len(a) != len(b) {

--- a/internal/store/enrollment_token_supersede_test.go
+++ b/internal/store/enrollment_token_supersede_test.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// TestCreateTokenForHost_SupersedesPreviousUnused pins the property the rekey
+// re-offer depends on.
+//
+// While a rekey is outstanding the poll handler mints a fresh token on every
+// poll — only the hash is stored, so the previous one cannot be re-sent. That
+// is only safe because minting deletes the host's other unused tokens: the
+// rows cannot pile up once per poll, and no superseded credential stays
+// usable.
+func TestCreateTokenForHost_SupersedesPreviousUnused(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-1", Name: "net", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateHost(ctx, &models.Host{
+		ID: "h-1", NetworkID: "n-1", Name: "web-1",
+		NebulaIPs: []string{"10.0.0.1"}, Role: models.HostRoleHost,
+		Status: models.HostStatusPending, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	expires := time.Now().Add(time.Hour)
+	for i, tok := range []string{"tok-a", "tok-b", "tok-c"} {
+		if err := s.CreateTokenForHost(ctx, "h-1", tok, expires); err != nil {
+			t.Fatalf("mint %d: %v", i, err)
+		}
+	}
+
+	var live int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM enrollment_tokens WHERE host_id = ? AND used = 0`, "h-1").Scan(&live); err != nil {
+		t.Fatal(err)
+	}
+	if live != 1 {
+		t.Errorf("live unused tokens = %d, want 1 — repeated rekey offers would accumulate rows", live)
+	}
+
+	// Only the newest is redeemable.
+	for _, superseded := range []string{"tok-a", "tok-b"} {
+		if _, err := s.ConsumeToken(ctx, superseded); err == nil {
+			t.Errorf("superseded token %q is still redeemable", superseded)
+		}
+	}
+	if _, err := s.ConsumeToken(ctx, "tok-c"); err != nil {
+		t.Errorf("newest token should be redeemable: %v", err)
+	}
+}

--- a/internal/store/host_edit.go
+++ b/internal/store/host_edit.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// ApplyHostEdit persists an edited host together with the follow-up writes a
+// host edit implies. Both edit paths — the API's PATCH handler and the web
+// UI's edit form — go through here so they cannot drift apart on what an edit
+// means; they previously kept separate copies of these rules, and the copies
+// disagreed about whether a group change needs a new certificate.
+//
+// Callers are expected to have snapshotted `before`, merged their input into
+// `after`, validated it, and established that something actually changed.
+//
+// The pending-rekey flag is set on the host struct rather than through a
+// separate SetPendingRekey write. UpdateHost commits it in the same
+// transaction as the config_version reset (SEC-PERSIST-001), so a crash
+// between the two cannot leave a host whose certificate-bound fields moved but
+// whose re-issuance was never scheduled — which would strand an agent on a
+// stale, possibly more permissive, certificate. Setting the flag when it is
+// already set is a no-op, so retries stay idempotent.
+//
+// The returned error is the one from persisting the host; callers map it to
+// their own transport (ErrIPTaken → 409, ErrNotFound → 404). The network
+// config-version bump is best-effort and only logged: it is a propagation hint
+// for peers, and failing an otherwise-applied edit over it would be worse than
+// a late peer update.
+func ApplyHostEdit(ctx context.Context, s Store, logger *slog.Logger, before, after *models.Host) error {
+	if models.CertIdentityChanged(before, after) {
+		after.PendingRekey = true
+	}
+
+	if err := s.UpdateHost(ctx, after); err != nil {
+		return err
+	}
+
+	// A role change alters the topology every peer renders (lighthouse and
+	// relay entries), not just this host's own config.
+	if before.Role != after.Role {
+		if err := s.BumpNetworkConfigVersion(ctx, after.NetworkID); err != nil {
+			logger.Error("bump network config version", "network", after.NetworkID, "error", err)
+		}
+	}
+	return nil
+}

--- a/internal/store/host_edit_test.go
+++ b/internal/store/host_edit_test.go
@@ -1,0 +1,226 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// seedEditableHost creates a network and one host ready to be edited.
+func seedEditableHost(t *testing.T, s *SQLiteStore) *models.Host {
+	t.Helper()
+	ctx := context.Background()
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-1", Name: "net", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	host := &models.Host{
+		ID: "h-1", NetworkID: "n-1", Name: "web-1",
+		NebulaIPs: []string{"10.0.0.1"},
+		Groups:    []string{"web"},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := s.CreateHost(ctx, host); err != nil {
+		t.Fatal(err)
+	}
+	return host
+}
+
+// TestApplyHostEdit_SchedulesRekeyForCertBoundFields: the whole point of the
+// shared applier — an edit to a certificate-bound field must come back out of
+// the store with the re-issuance scheduled.
+func TestApplyHostEdit_SchedulesRekeyForCertBoundFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*models.Host)
+	}{
+		{"name", func(h *models.Host) { h.Name = "web-2" }},
+		{"ips", func(h *models.Host) { h.NebulaIPs = []string{"10.0.0.9"} }},
+		{"groups added", func(h *models.Host) { h.Groups = []string{"web", "admin"} }},
+		{"groups removed", func(h *models.Host) { h.Groups = nil }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestStore(t)
+			ctx := context.Background()
+			host := seedEditableHost(t, s)
+
+			before := *host
+			after := *host
+			tt.mutate(&after)
+
+			if err := ApplyHostEdit(ctx, s, quietLogger(), &before, &after); err != nil {
+				t.Fatalf("ApplyHostEdit: %v", err)
+			}
+
+			// The flag has to be persisted, not just set on the struct — the
+			// agent learns about the rekey from the host row on its next poll.
+			stored, err := s.GetHost(ctx, host.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !stored.PendingRekey {
+				t.Error("PendingRekey was not persisted")
+			}
+			if !after.PendingRekey {
+				t.Error("PendingRekey was not reflected on the caller's host, which is what the API returns")
+			}
+		})
+	}
+}
+
+// TestApplyHostEdit_NoRekeyForConfigOnlyFields pins the other direction:
+// config-only edits must not churn certificates.
+func TestApplyHostEdit_NoRekeyForConfigOnlyFields(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	host := seedEditableHost(t, s)
+
+	before := *host
+	after := *host
+	after.PublicIP = "203.0.113.7"
+	after.ListenPort = 4242
+
+	if err := ApplyHostEdit(ctx, s, quietLogger(), &before, &after); err != nil {
+		t.Fatalf("ApplyHostEdit: %v", err)
+	}
+
+	stored, err := s.GetHost(ctx, host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.PendingRekey {
+		t.Error("a config-only edit must not schedule a certificate re-issuance")
+	}
+	if stored.PublicIP != "203.0.113.7" {
+		t.Errorf("PublicIP = %q, want the edited value", stored.PublicIP)
+	}
+}
+
+// TestApplyHostEdit_RekeyCommitsWithTheHostRow is the reason the flag is set
+// on the struct instead of through a second SetPendingRekey write: both land
+// in UpdateHost's single transaction, so there is no window in which the new
+// groups are persisted while the re-issuance that carries them is not.
+func TestApplyHostEdit_RekeyCommitsWithTheHostRow(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	host := seedEditableHost(t, s)
+
+	before := *host
+	after := *host
+	after.Groups = []string{"admin"}
+
+	if err := ApplyHostEdit(ctx, s, quietLogger(), &before, &after); err != nil {
+		t.Fatalf("ApplyHostEdit: %v", err)
+	}
+
+	stored, err := s.GetHost(ctx, host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stored.Groups; len(got) != 1 || got[0] != "admin" {
+		t.Fatalf("Groups = %v, want [admin]", got)
+	}
+	if !stored.PendingRekey {
+		t.Error("the new groups are visible but the re-issuance was not scheduled with them")
+	}
+	// SEC-PERSIST-001: the same transaction re-publishes the config.
+	version, err := s.GetHostConfigVersion(ctx, host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 0 {
+		t.Errorf("config_version = %d, want 0 (reset in the same commit)", version)
+	}
+}
+
+// TestApplyHostEdit_Idempotent: re-applying an edit over an already-pending
+// host must not error. The old SetPendingRekey path answered
+// ErrRekeyAlreadyPending here and every caller had to special-case it.
+func TestApplyHostEdit_Idempotent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	host := seedEditableHost(t, s)
+
+	before := *host
+	after := *host
+	after.Groups = []string{"admin"}
+
+	for i := range 2 {
+		if err := ApplyHostEdit(ctx, s, quietLogger(), &before, &after); err != nil {
+			t.Fatalf("ApplyHostEdit call %d: %v", i+1, err)
+		}
+	}
+
+	stored, err := s.GetHost(ctx, host.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored.PendingRekey {
+		t.Error("PendingRekey should still be set after a repeated apply")
+	}
+}
+
+// TestApplyHostEdit_RoleChangeBumpsNetworkVersion: a role change alters the
+// topology every peer renders, so it has to re-publish network-wide.
+func TestApplyHostEdit_RoleChangeBumpsNetworkVersion(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	host := seedEditableHost(t, s)
+
+	initial, err := s.GetNetworkConfigVersion(ctx, "n-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := *host
+	after := *host
+	after.Role = models.HostRoleLighthouse
+	after.IsLighthouse = true
+
+	if err := ApplyHostEdit(ctx, s, quietLogger(), &before, &after); err != nil {
+		t.Fatalf("ApplyHostEdit: %v", err)
+	}
+
+	bumped, err := s.GetNetworkConfigVersion(ctx, "n-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bumped <= initial {
+		t.Errorf("network config version = %d, want greater than %d", bumped, initial)
+	}
+}
+
+// TestApplyHostEdit_PropagatesStoreError: a failed persist must reach the
+// caller so it can map the status, and must not be masked by the follow-up
+// writes.
+func TestApplyHostEdit_PropagatesStoreError(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	missing := &models.Host{
+		ID: "nope", NetworkID: "n-1", Name: "ghost",
+		Role: models.HostRoleHost, Status: models.HostStatusEnrolled,
+	}
+	before := *missing
+	after := *missing
+	after.Name = "ghost-2"
+
+	err := ApplyHostEdit(ctx, s, quietLogger(), &before, &after)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1900,9 +1900,17 @@ func (s *SQLiteStore) enrollHostInTx(ctx context.Context, tx *sql.Tx, hostID str
 		return err
 	}
 
-	// Update host: status=enrolled, cert_fingerprint, cert_expires_at
+	// Update host: status=enrolled, cert_fingerprint, cert_expires_at.
+	//
+	// pending_rekey clears here, in the same transaction as the certificate
+	// it was asking for, and nowhere else. Clearing it earlier — when the
+	// poll handler mints the rekey token — drops the request on the floor if
+	// the agent then fails to re-enroll: nothing retries, and the host row
+	// reads as settled while the agent keeps serving the superseded
+	// certificate. Enrollment completing is the only evidence the rekey
+	// actually happened.
 	result, err := tx.ExecContext(ctx,
-		`UPDATE hosts SET status=?, cert_fingerprint=?, cert_expires_at=?, updated_at=? WHERE id=?`,
+		`UPDATE hosts SET status=?, cert_fingerprint=?, cert_expires_at=?, pending_rekey=0, updated_at=? WHERE id=?`,
 		models.HostStatusEnrolled, fp, notAfter, time.Now(), hostID,
 	)
 	if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -843,9 +843,14 @@ func (s *SQLiteStore) setHostAddresses(ctx context.Context, tx *sql.Tx, hostID, 
 	return nil
 }
 
-// loadHostAddresses retrieves all addresses for a host in order.
-func (s *SQLiteStore) loadHostAddresses(ctx context.Context, hostID string) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx,
+type hostAddressQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// queryHostAddresses retrieves all addresses for a host in order from either a
+// database handle or an existing transaction.
+func queryHostAddresses(ctx context.Context, querier hostAddressQuerier, hostID string) ([]string, error) {
+	rows, err := querier.QueryContext(ctx,
 		`SELECT address FROM host_addresses WHERE host_id = ? ORDER BY position`,
 		hostID,
 	)
@@ -875,6 +880,11 @@ func (s *SQLiteStore) loadHostAddresses(ctx context.Context, hostID string) ([]s
 		addrs = make([]string, 0)
 	}
 	return addrs, nil
+}
+
+// loadHostAddresses retrieves all addresses for a host in order.
+func (s *SQLiteStore) loadHostAddresses(ctx context.Context, hostID string) ([]string, error) {
+	return queryHostAddresses(ctx, s.db, hostID)
 }
 
 func (s *SQLiteStore) CreateHost(ctx context.Context, h *models.Host) error {
@@ -1814,7 +1824,7 @@ func (s *SQLiteStore) SaveCertificateAndEnrollHost(ctx context.Context, hostID s
 		}
 	}()
 
-	if err := s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter); err != nil {
+	if err := s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter, nil); err != nil {
 		return err
 	}
 
@@ -1864,7 +1874,7 @@ func (s *SQLiteStore) SaveCertificateIfIssuanceAllowed(
 	}
 
 	if expectedStatus == models.HostStatusPending {
-		err = s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter)
+		err = s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter, nil)
 	} else {
 		err = s.updateHostCertificateInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter)
 	}
@@ -1883,18 +1893,19 @@ func (s *SQLiteStore) SaveCertificateIfIssuanceAllowed(
 // on their next poll. Shared by SaveCertificateAndEnrollHost (token-less paths)
 // and ConsumeTokenAndEnrollHost (agent enrollment, which also consumes the
 // enrollment token in the same transaction).
-func (s *SQLiteStore) enrollHostInTx(ctx context.Context, tx *sql.Tx, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
-	var isLighthouse bool
-	var networkID string
-	err := tx.QueryRowContext(ctx,
-		`SELECT is_lighthouse, network_id FROM hosts WHERE id = ?`, hostID,
-	).Scan(&isLighthouse, &networkID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return ErrNotFound
-	}
+func (s *SQLiteStore) enrollHostInTx(ctx context.Context, tx *sql.Tx, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time, signedIdentity *models.CertificateIdentity) error {
+	state, err := s.loadEnrollmentHostStateInTx(ctx, tx, hostID)
 	if err != nil {
-		return fmt.Errorf("get host role: %w", err)
+		return err
 	}
+
+	// Enrollment signs outside the transaction, so a host PATCH can commit
+	// certificate-bound fields while the signer is working. The token must not
+	// let that older certificate clear the rekey requested by the PATCH
+	// (SEC-PERSIST-001). Persisting the certificate is safe because the retained
+	// flag makes the next poll request another re-enrollment for the durable
+	// identity.
+	preservePendingRekey := signedIdentity != nil && !signedIdentity.Equal(state.identity)
 
 	if err := s.saveCertificateInTx(ctx, tx, hostID, fp, certPEM, notBefore, notAfter); err != nil {
 		return err
@@ -1902,16 +1913,12 @@ func (s *SQLiteStore) enrollHostInTx(ctx context.Context, tx *sql.Tx, hostID str
 
 	// Update host: status=enrolled, cert_fingerprint, cert_expires_at.
 	//
-	// pending_rekey clears here, in the same transaction as the certificate
-	// it was asking for, and nowhere else. Clearing it earlier — when the
-	// poll handler mints the rekey token — drops the request on the floor if
-	// the agent then fails to re-enroll: nothing retries, and the host row
-	// reads as settled while the agent keeps serving the superseded
-	// certificate. Enrollment completing is the only evidence the rekey
-	// actually happened.
+	// pending_rekey clears here, in the same transaction as the certificate it
+	// was asking for. If certificate-bound fields changed after signing, retain
+	// it instead: that certificate does not satisfy the newer host identity.
 	result, err := tx.ExecContext(ctx,
-		`UPDATE hosts SET status=?, cert_fingerprint=?, cert_expires_at=?, pending_rekey=0, updated_at=? WHERE id=?`,
-		models.HostStatusEnrolled, fp, notAfter, time.Now(), hostID,
+		`UPDATE hosts SET status=?, cert_fingerprint=?, cert_expires_at=?, pending_rekey=?, updated_at=? WHERE id=?`,
+		models.HostStatusEnrolled, fp, notAfter, preservePendingRekey, time.Now(), hostID,
 	)
 	if err != nil {
 		return fmt.Errorf("update host: %w", err)
@@ -1924,15 +1931,46 @@ func (s *SQLiteStore) enrollHostInTx(ctx context.Context, tx *sql.Tx, hostID str
 		return ErrNotFound
 	}
 
-	if isLighthouse {
+	if state.isLighthouse {
 		if _, err := tx.ExecContext(ctx,
 			`UPDATE networks SET config_version = config_version + 1 WHERE id = ?`,
-			networkID,
+			state.networkID,
 		); err != nil {
 			return fmt.Errorf("bump config version: %w", err)
 		}
 	}
 	return nil
+}
+
+type enrollmentHostState struct {
+	isLighthouse bool
+	networkID    string
+	identity     models.CertificateIdentity
+}
+
+// loadEnrollmentHostStateInTx retrieves the fields enrollment must check and
+// update while holding the same transaction that consumes the enrollment token.
+func (s *SQLiteStore) loadEnrollmentHostStateInTx(ctx context.Context, tx *sql.Tx, hostID string) (enrollmentHostState, error) {
+	var state enrollmentHostState
+	var groupsJSON string
+	err := tx.QueryRowContext(ctx,
+		`SELECT is_lighthouse, network_id, name, groups_json FROM hosts WHERE id = ?`, hostID,
+	).Scan(&state.isLighthouse, &state.networkID, &state.identity.Name, &groupsJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return enrollmentHostState{}, ErrNotFound
+	}
+	if err != nil {
+		return enrollmentHostState{}, fmt.Errorf("get enrollment host state: %w", err)
+	}
+	if err := json.Unmarshal([]byte(groupsJSON), &state.identity.Groups); err != nil {
+		return enrollmentHostState{}, fmt.Errorf("unmarshal host groups for enrollment: %w", err)
+	}
+	addrs, err := queryHostAddresses(ctx, tx, hostID)
+	if err != nil {
+		return enrollmentHostState{}, fmt.Errorf("get host addresses for enrollment: %w", err)
+	}
+	state.identity.NebulaIPs = addrs
+	return state, nil
 }
 
 // ConsumeTokenAndEnrollHost atomically consumes the single-use enrollment token
@@ -1946,12 +1984,12 @@ func (s *SQLiteStore) enrollHostInTx(ctx context.Context, tx *sql.Tx, hostID str
 // transaction. The caller is expected to have validated the token via
 // GetEnrollmentToken first, so a zero-row CAS here means the race was lost.
 func (s *SQLiteStore) ConsumeTokenAndEnrollHost(ctx context.Context, hostID, token string, certPEM []byte, fp string, notBefore, notAfter time.Time) error {
-	return s.enrollHostWithConsumedToken(ctx, hostID, token, certPEM, fp, notBefore, notAfter, "", nil, nil)
+	return s.enrollHostWithConsumedToken(ctx, hostID, token, certPEM, fp, notBefore, notAfter, "", nil, nil, nil)
 }
 
 func (s *SQLiteStore) ConsumeTokenAndEnrollHostWithProfile(
 	ctx context.Context, hostID, token string, certPEM []byte, fp string,
-	notBefore, notAfter time.Time, signingPubPEM string, profile models.AgentProfile,
+	notBefore, notAfter time.Time, signingPubPEM string, profile models.AgentProfile, signedIdentity *models.CertificateIdentity,
 ) (int, error) {
 	if signingPubPEM == "" {
 		return 0, errors.New("signing public key is required")
@@ -1960,13 +1998,13 @@ func (s *SQLiteStore) ConsumeTokenAndEnrollHostWithProfile(
 		return 0, err
 	}
 	var configVersion int
-	err := s.enrollHostWithConsumedToken(ctx, hostID, token, certPEM, fp, notBefore, notAfter, signingPubPEM, &profile, &configVersion)
+	err := s.enrollHostWithConsumedToken(ctx, hostID, token, certPEM, fp, notBefore, notAfter, signingPubPEM, &profile, &configVersion, signedIdentity)
 	return configVersion, err
 }
 
 func (s *SQLiteStore) enrollHostWithConsumedToken(
 	ctx context.Context, hostID, token string, certPEM []byte, fp string,
-	notBefore, notAfter time.Time, signingPubPEM string, profile *models.AgentProfile, configVersion *int,
+	notBefore, notAfter time.Time, signingPubPEM string, profile *models.AgentProfile, configVersion *int, signedIdentity *models.CertificateIdentity,
 ) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -1993,7 +2031,7 @@ func (s *SQLiteStore) enrollHostWithConsumedToken(
 		return ErrTokenUsed
 	}
 
-	if err := s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter); err != nil {
+	if err := s.enrollHostInTx(ctx, tx, hostID, certPEM, fp, notBefore, notAfter, signedIdentity); err != nil {
 		return err
 	}
 	if profile != nil {

--- a/internal/store/sqlite_enroll_token_test.go
+++ b/internal/store/sqlite_enroll_token_test.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
 )
 
 // TestGetEnrollmentToken_PeekDoesNotConsume verifies the read-only peek resolves
@@ -103,6 +105,61 @@ func TestConsumeTokenAndEnrollHost_NoBurnOnEnrollFailure(t *testing.T) {
 	// And a subsequent valid enrollment still succeeds.
 	if err := s.ConsumeTokenAndEnrollHost(ctx, h.ID, raw, []byte("cert"), "fp-burn-2", time.Now(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("retry enroll: %v", err)
+	}
+}
+
+// TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterIdentityChange
+// simulates the signing/enrollment race: the caller signs the original host,
+// then a PATCH persists a new certificate identity before the token is
+// consumed. The older certificate may be recorded, but it must not clear the
+// rekey that causes the agent to obtain a certificate for the durable identity.
+func TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterIdentityChange(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "identity-race-host")
+
+	signedHost, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedIdentity := models.CertificateIdentityFromHost(signedHost)
+	const raw = "identity-race-token"
+	if err := s.CreateTokenForHost(ctx, h.ID, raw, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The concurrent PATCH changes Groups, a certificate-bound field, and
+	// persists its rekey request before the earlier enrollment transaction
+	// starts.
+	edited := *signedHost
+	edited.Groups = []string{"g", "admin"}
+	edited.PendingRekey = true
+	if err := s.UpdateHost(ctx, &edited); err != nil {
+		t.Fatal(err)
+	}
+
+	profileDir := t.TempDir()
+	profile := models.AgentProfile{
+		NebulaConfigPath: filepath.Join(profileDir, "config.yml"),
+		NebulaCAPath:     filepath.Join(profileDir, "ca.crt"),
+		NebulaCertPath:   filepath.Join(profileDir, "host.crt"),
+		NebulaKeyPath:    filepath.Join(profileDir, "host.key"),
+		ConfigAckV1:      true,
+	}
+	if _, err := s.ConsumeTokenAndEnrollHostWithProfile(ctx, h.ID, raw, []byte("stale-cert"), "stale-fp",
+		time.Now(), time.Now().Add(time.Hour), "signing-pub", profile, &signedIdentity); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.PendingRekey {
+		t.Fatal("concurrent certificate identity change was cleared; the stale certificate would never be replaced")
+	}
+	if got.CertFingerprint != "stale-fp" {
+		t.Errorf("cert fingerprint = %q, want stale-fp", got.CertFingerprint)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -138,7 +138,11 @@ type Store interface {
 	SaveCertificateAndEnrollHost(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	SaveCertificateIfIssuanceAllowed(ctx context.Context, hostID string, expectedStatus models.HostStatus, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	ConsumeTokenAndEnrollHost(ctx context.Context, hostID, token string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
-	ConsumeTokenAndEnrollHostWithProfile(ctx context.Context, hostID, token string, certPEM []byte, fp string, notBefore, notAfter time.Time, signingPubPEM string, profile models.AgentProfile) (int, error)
+	// ConsumeTokenAndEnrollHostWithProfile atomically binds an enrollment to a
+	// signed certificate identity snapshot. If Name, NebulaIPs, or Groups changed after
+	// signing, the transaction keeps pending_rekey set so a stale certificate is
+	// never treated as satisfying the newer identity.
+	ConsumeTokenAndEnrollHostWithProfile(ctx context.Context, hostID, token string, certPEM []byte, fp string, notBefore, notAfter time.Time, signingPubPEM string, profile models.AgentProfile, signedIdentity *models.CertificateIdentity) (int, error)
 	SaveCertificateAndUpdateHostCert(ctx context.Context, hostID string, certPEM []byte, fp string, notBefore, notAfter time.Time) error
 	GetCurrentCertificate(ctx context.Context, hostID string) ([]byte, error)
 	GetCertificateInfo(ctx context.Context, hostID string) (*models.CertificateInfo, error)

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -1272,11 +1272,10 @@ func (w *Web) handleHostUpdate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update host; set PendingRekey if cert-bound fields (NebulaIPs, Name) changed
-	if !slicesEqual(before.NebulaIPs, host.NebulaIPs) || before.Name != host.Name {
-		host.PendingRekey = true
-	}
-	if err := w.store.UpdateHost(r.Context(), host); err != nil {
+	// Persist, schedule a cert re-issuance if a cert-bound field moved, and
+	// bump the network config version on a role change. config_version reset
+	// and the pending-rekey flag commit inside UpdateHost (SEC-PERSIST-001).
+	if err := store.ApplyHostEdit(r.Context(), w.store, w.logger, &before, host); err != nil {
 		w.logger.Error("update host", "error", err)
 		http.Error(rw, "Failed to update host", http.StatusInternalServerError)
 		return
@@ -1285,15 +1284,6 @@ func (w *Web) handleHostUpdate(rw http.ResponseWriter, r *http.Request) {
 	// Audit entry
 	if err := w.store.AddAuditEntry(r.Context(), op.Username, "host.update", host.ID, string(jsonDiff)); err != nil {
 		w.logger.Error("add audit entry", "error", err)
-	}
-
-	// config_version reset now happens atomically inside UpdateHost (SEC-PERSIST-001).
-
-	// Role change bumps network config version for topology propagation
-	if before.Role != host.Role {
-		if err := w.store.BumpNetworkConfigVersion(r.Context(), host.NetworkID); err != nil {
-			w.logger.Error("bump network config version", "error", err)
-		}
 	}
 
 	http.Redirect(rw, r, "/ui/hosts/"+host.ID, http.StatusSeeOther) // #nosec G710 -- same-origin redirect: host.ID is a server-generated UUID, hardcoded /ui/hosts/ prefix keeps Location on the current host
@@ -1552,17 +1542,4 @@ func (w *Web) renderMobileBundle(rw http.ResponseWriter, r *http.Request, host *
 		"DownloadHref": template.URL(downloadHref), // #nosec G203 -- downloadHref is "data:application/yaml;base64," + base64(server-built bundle); prefix is hardcoded and base64 cannot inject scheme characters
 		"Active":       "hosts",
 	})
-}
-
-// slicesEqual reports whether two string slices are equal (same length and same elements in same order).
-func slicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/web/host_edit_groups_test.go
+++ b/internal/web/host_edit_groups_test.go
@@ -1,0 +1,128 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// seedHostWithGroups creates a network and one enrolled host carrying groups.
+func seedHostWithGroups(t *testing.T, s store.Store, groups []string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := s.CreateNetwork(ctx, &models.Network{
+		ID: "n-1", Name: "test-net", CIDRs: []string{"192.168.100.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateHost(ctx, &models.Host{
+		ID: "h-1", NetworkID: "n-1", Name: "web-1",
+		NebulaIPs: []string{"192.168.100.10"},
+		Groups:    groups,
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// postHostEditGroups submits the host edit form with everything unchanged
+// except the groups field.
+func postHostEditGroups(t *testing.T, w *Web, cookies []*http.Cookie, groups string) *httptest.ResponseRecorder {
+	t.Helper()
+	csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/hosts/h-1/edit", cookies)
+	form := url.Values{
+		"network_id": {"n-1"},
+		"name":       {"web-1"},
+		"nebula_ips": {"192.168.100.10"},
+		"groups":     {groups},
+		"role":       {"host"},
+		"_csrf":      {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/h-1/edit", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range updatedCookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestHostUpdate_POST_GroupChangeSetsPendingRekey: the UI edit form has its
+// own copy of the cert-bound-field check, so it needs its own guard — a group
+// edit made here must schedule a re-issuance exactly as the API PATCH does.
+// Groups ride in the certificate and firewall rules select by group, so until
+// the cert is replaced the edit changes nothing on the mesh.
+func TestHostUpdate_POST_GroupChangeSetsPendingRekey(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+	seedHostWithGroups(t, s, []string{"web"})
+
+	if rec := postHostEditGroups(t, w, cookies, "web, prod"); rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+
+	updated, err := s.GetHost(context.Background(), "h-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(updated.Groups, ","); got != "web,prod" {
+		t.Errorf("Groups = %q, want %q", got, "web,prod")
+	}
+	if !updated.PendingRekey {
+		t.Error("PendingRekey should be true after a group change")
+	}
+}
+
+// TestHostUpdate_POST_GroupRemovalSetsPendingRekey covers the direction that
+// matters for access control: a host dropped from a group keeps that group's
+// access until its certificate stops claiming membership.
+func TestHostUpdate_POST_GroupRemovalSetsPendingRekey(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+	seedHostWithGroups(t, s, []string{"admin", "web"})
+
+	if rec := postHostEditGroups(t, w, cookies, "web"); rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+
+	updated, err := s.GetHost(context.Background(), "h-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(updated.Groups, ","); got != "web" {
+		t.Errorf("Groups = %q, want %q", got, "web")
+	}
+	if !updated.PendingRekey {
+		t.Error("PendingRekey should be true after a group removal")
+	}
+}
+
+// TestHostUpdate_POST_UnchangedGroupsDoesNotRekey: resubmitting the form
+// untouched must stay idempotent rather than churning the fleet's certs.
+func TestHostUpdate_POST_UnchangedGroupsDoesNotRekey(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+	seedHostWithGroups(t, s, []string{"web"})
+
+	if rec := postHostEditGroups(t, w, cookies, "web"); rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+
+	updated, err := s.GetHost(context.Background(), "h-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.PendingRekey {
+		t.Error("resubmitting identical groups must not schedule a rekey")
+	}
+}

--- a/internal/web/hosts_list_groups_test.go
+++ b/internal/web/hosts_list_groups_test.go
@@ -1,0 +1,55 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// getHostsList performs an authenticated GET of the host list page.
+func getHostsList(t *testing.T, w *Web, cookies []*http.Cookie) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/ui/hosts", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("hosts list: status = %d, want 200", rec.Code)
+	}
+	return rec.Body.String()
+}
+
+// TestHostsList_ShowsGroups: group membership drives firewall policy, so the
+// host list is where an operator needs to see it — otherwise checking which
+// hosts hold which groups means opening every host in turn.
+func TestHostsList_ShowsGroups(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+	seedHostWithGroups(t, s, []string{"admin", "web"})
+
+	body := getHostsList(t, w, cookies)
+
+	if !strings.Contains(body, "<th>Groups</th>") {
+		t.Error("host list is missing the Groups column header")
+	}
+	if !strings.Contains(body, "admin, web") {
+		t.Error("host list does not render the host's groups")
+	}
+}
+
+// TestHostsList_GroupsEmptyPlaceholder keeps a host with no groups from
+// rendering a blank cell that reads as a broken column.
+func TestHostsList_GroupsEmptyPlaceholder(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+	seedHostWithGroups(t, s, []string{})
+
+	body := getHostsList(t, w, cookies)
+
+	if !strings.Contains(body, `<td class="host-groups">—</td>`) {
+		t.Error("a host with no groups should render the em-dash placeholder")
+	}
+}

--- a/internal/web/templates/hosts.html
+++ b/internal/web/templates/hosts.html
@@ -9,12 +9,13 @@
 {{if .Hosts}}
 <div class="card">
     <table id="hosts-table">
-        <thead><tr><th>Name</th><th>Overlay Addresses</th><th>Network</th><th>Role</th><th>Status</th><th>Online</th><th>Last Seen</th><th></th></tr></thead>
+        <thead><tr><th>Name</th><th>Overlay Addresses</th><th>Groups</th><th>Network</th><th>Role</th><th>Status</th><th>Online</th><th>Last Seen</th><th></th></tr></thead>
         <tbody>
         {{range .Hosts}}
         <tr id="host-{{.ID}}" data-host-id="{{.ID}}">
             <td><a href="/ui/hosts/{{.ID}}">{{.Name}}</a></td>
             <td>{{range $i, $ip := .NebulaIPs}}{{if $i}}, {{end}}{{$ip}}{{end}}</td>
+            <td class="host-groups">{{if .Groups}}{{range $i, $g := .Groups}}{{if $i}}, {{end}}{{$g}}{{end}}{{else}}—{{end}}</td>
             <td><span title="{{.NetworkID}}">{{if .NetworkName}}{{.NetworkName}}{{else}}{{.NetworkID}}{{end}}</span></td>
             <td>{{.Role}}</td>
             <td><span class="badge badge-{{.Status}}">{{.Status}}</span></td>

--- a/tests/integration/e2e_edit_host_test.go
+++ b/tests/integration/e2e_edit_host_test.go
@@ -279,15 +279,31 @@ func TestE2E_RenameHost_TriggersRekey(t *testing.T) {
 	}
 	t.Logf("poll2: RekeyRequired=%v, EnrollmentToken=%s", poll2.RekeyRequired, poll2.EnrollmentToken[:8]+"...")
 
-	// 6. Verify PendingRekey was cleared after poll
+	// 6. Handing out the token is not the same as the rekey having happened.
+	// The flag stays set until the agent completes the enrollment, so an
+	// agent that cannot finish gets the offer again on its next poll instead
+	// of being stranded on the superseded certificate.
 	hostAfterPoll, err := s.GetHost(context.Background(), host.ID)
 	if err != nil {
 		t.Fatalf("get host: %v", err)
 	}
-	if hostAfterPoll.PendingRekey {
-		t.Error("host.PendingRekey should be cleared after poll")
+	if !hostAfterPoll.PendingRekey {
+		t.Error("host.PendingRekey should still be set until the agent re-enrolls")
 	}
-	t.Logf("host after poll: PendingRekey=%v", hostAfterPoll.PendingRekey)
+
+	pollResp3 := signedGetUpdates(t, ts, fp, signingPriv)
+	defer pollResp3.Body.Close()
+	var poll3 struct {
+		RekeyRequired   bool   `json:"rekey_required"`
+		EnrollmentToken string `json:"enrollment_token"`
+	}
+	if err := json.NewDecoder(pollResp3.Body).Decode(&poll3); err != nil {
+		t.Fatalf("decode poll3: %v", err)
+	}
+	if !poll3.RekeyRequired || poll3.EnrollmentToken == "" {
+		t.Error("poll3: an unanswered rekey must still be on offer")
+	}
+	t.Logf("rekey re-offered on the following poll: RekeyRequired=%v", poll3.RekeyRequired)
 
 	// 7. Verify audit entry was created with "name" in details
 	t.Log("Verify audit entry")


### PR DESCRIPTION
Groups are carried in the Nebula certificate, and firewall rules select their counterparties by group, so editing a host's groups had no effect on the mesh until the certificate was replaced. This bit hardest in the removing direction: a host dropped from a privileged group kept that access for as long as it held a certificate still claiming membership.

The API PATCH handler and the web UI edit form each kept their own copy of the "which fields are cert-bound" rule, and both omitted groups. They now share models.CertIdentityChanged and store.ApplyHostEdit.

ApplyHostEdit sets pending_rekey on the host struct so it commits inside UpdateHost's transaction alongside the config_version reset (SEC-PERSIST-001). That closes an atomicity gap in the API path, which previously issued a separate SetPendingRekey write and so could persist the new groups while failing to schedule the re-issuance that carries them.

Also adds a Groups column to the web UI and CLI host listings.

## Checklist

- [X] `go test -race ./...` passes
- [X] `golangci-lint run ./...` passes
- [X] New behaviour has tests
- [X] User-facing changes are reflected in README / configs
- [X] No breaking API changes, or they are called out above
