### PR TITLE
fix(cliargs): add guards for unknown commands and stray positional ar…

### DIFF
--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/forgekeep/nebula-mesh/internal/agent"
+	"github.com/forgekeep/nebula-mesh/internal/cliargs"
 	"github.com/forgekeep/nebula-mesh/internal/config"
 	"github.com/forgekeep/nebula-mesh/internal/models"
 	"github.com/forgekeep/nebula-mesh/internal/version"
@@ -60,11 +61,25 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		case "-h", "--help", "help":
 			printUsage(stderr)
 			return nil
+		default:
+			// A leading word that is not a known subcommand is a typo, not a
+			// daemon invocation. Fail loudly here: Go's flag package stops
+			// parsing at the first positional argument, so falling through to
+			// runUnified would silently discard every flag that follows —
+			// `nebula-agent enrool --server U --token T` would drop both and
+			// park in standby forever, looking like a server-side failure.
+			if !strings.HasPrefix(args[0], "-") {
+				printUsage(stderr)
+				return argGuard.UnknownCommand("command", args[0])
+			}
 		}
 	}
 
 	return runUnified(ctx, args, stderr)
 }
+
+// argGuard carries this binary's usage hint into every argument-shape error.
+var argGuard = cliargs.New("run `nebula-agent help` for usage")
 
 func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "Usage: nebula-agent [--config PATH] [--token-file PATH --server URL] [--nebula-config-path PATH] [--yes] [--force]")
@@ -74,6 +89,9 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, "First run on a fresh host: nebula-agent --token-file PATH --server URL")
 	_, _ = fmt.Fprintln(w, "Every subsequent run    : nebula-agent")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "--token TOKEN is accepted wherever --token-file is, but it exposes the")
+	_, _ = fmt.Fprintln(w, "token in argv and shell history; prefer --token-file.")
 }
 
 // standbyTick is how often the daemon re-checks the filesystem for a
@@ -151,6 +169,9 @@ func runUnifiedWithLogger(ctx context.Context, args []string, stderr io.Writer, 
 	yes := fs.Bool("yes", false, "confirm import of the discovered existing Nebula installation")
 	insecureHTTP := fs.Bool("insecure-http", false, "allow a plaintext http:// server URL on a non-loopback host (enrollment token and Nebula config transit in cleartext)")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 
@@ -476,6 +497,9 @@ func runEnroll(ctx context.Context, args []string, stdout, stderr io.Writer) err
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return err
+	}
 	bootstrapToken, err := readBootstrapToken(*token, *tokenFile, stderr)
 	if err != nil {
 		return err
@@ -669,6 +693,9 @@ func runLegacyRun(ctx context.Context, args []string, stderr io.Writer) error {
 	fs.SetOutput(stderr)
 	configPath := fs.String("config", defaultConfigPath, "config file path")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 	cfg, err := config.LoadAgentConfig(*configPath)

--- a/cmd/nebula-agent/main_test.go
+++ b/cmd/nebula-agent/main_test.go
@@ -277,3 +277,103 @@ func TestRun_DeprecatedSubcommand_Run(t *testing.T) {
 		t.Errorf("enroll subcommand should NOT print deprecation warning; got %q", stderr.String())
 	}
 }
+
+// TestRun_UnknownSubcommand_FailsFast pins the fix for the enrollment trap:
+// a mistyped subcommand used to fall through to runUnified, where Go's flag
+// parser stops at the first positional and silently discarded --server and
+// --token. The agent then parked in standby forever and never contacted the
+// server, which reads as a server-side enrollment failure. It must be a
+// usage error instead.
+func TestRun_UnknownSubcommand_FailsFast(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	// A generous deadline: if the command still parks in standby the test
+	// fails on the error value, not on the timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := run(ctx, []string{"enrool", "--server", "https://mgmt.example.com", "--token-file", "/nonexistent"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("mistyped subcommand returned nil; want a usage error")
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		t.Fatalf("mistyped subcommand parked in standby instead of failing: %v", err)
+	}
+	if !strings.Contains(err.Error(), "unknown command") || !strings.Contains(err.Error(), "enrool") {
+		t.Errorf("error = %v, want it to name the unknown command", err)
+	}
+	if !strings.Contains(stderr.String(), "nebula-agent enroll") {
+		t.Errorf("usage not printed on unknown command; stderr = %q", stderr.String())
+	}
+}
+
+// TestRun_UnknownSubcommand_RedactsBootstrapToken — SEC-SECRET-001 forbids
+// plaintext secrets in error messages. A mistyped command line can put the
+// bootstrap token where the subcommand belongs, and the usage error echoes
+// that word back into logs and terminals.
+func TestRun_UnknownSubcommand_RedactsBootstrapToken(t *testing.T) {
+	const token = "nme_ThisIsNotARealTokenJustTestData_0123456789"
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := run(ctx, []string{token, "--server", "https://mgmt.example.com"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("token-as-subcommand returned nil; want a usage error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Errorf("bootstrap token leaked into error message: %v", err)
+	}
+	if strings.Contains(stdout.String(), token) || strings.Contains(stderr.String(), token) {
+		t.Errorf("bootstrap token leaked into output: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Errorf("error = %v, want the redaction placeholder", err)
+	}
+}
+
+// TestRun_LeadingFlagStillReachesUnified guards the daemon entrypoint: only a
+// bare word is treated as a subcommand, so `nebula-agent --config X` (and the
+// help/version flags) must keep working exactly as before.
+func TestRun_LeadingFlagStillReachesUnified(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := run(ctx, []string{"--config", filepath.Join(t.TempDir(), "agent.yml")}, &stdout, &stderr)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want the standby loop to run until the deadline", err)
+	}
+	if strings.Contains(stderr.String(), "unknown command") {
+		t.Errorf("leading flag misread as a subcommand; stderr = %q", stderr.String())
+	}
+}
+
+// TestRun_PositionalArgAfterFlags_Errors — a stray operand means Go stopped
+// parsing there and every later flag was dropped. Both the enroll subcommand
+// and the unified daemon path must reject it rather than run with a partial
+// flag set.
+func TestRun_PositionalArgAfterFlags_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"enroll", []string{"enroll", "--server", "https://mgmt.example.com", "oops", "--token", "tok"}},
+		{"unified", []string{"--config", "/nonexistent", "oops", "--server", "https://mgmt.example.com"}},
+		{"legacy run", []string{"run", "--config", "/nonexistent", "oops"}},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			err := run(ctx, test.args, &stdout, &stderr)
+			if err == nil {
+				t.Fatal("stray positional returned nil; want a usage error")
+			}
+			if !strings.Contains(err.Error(), "unexpected argument") || !strings.Contains(err.Error(), "oops") {
+				t.Errorf("error = %v, want it to name the stray argument", err)
+			}
+		})
+	}
+}

--- a/cmd/nebula-agent/service.go
+++ b/cmd/nebula-agent/service.go
@@ -70,7 +70,7 @@ func parseAgentServiceCommand(args []string, stderr io.Writer) (agentServiceComm
 	switch action {
 	case "install", "start", "stop", "restart", "uninstall", "run":
 	default:
-		return agentServiceCommand{}, fmt.Errorf("unknown service action %q", action)
+		return agentServiceCommand{}, argGuard.UnknownCommand("service action", action)
 	}
 
 	fs := flag.NewFlagSet("service "+action, flag.ContinueOnError)
@@ -79,8 +79,8 @@ func parseAgentServiceCommand(args []string, stderr io.Writer) (agentServiceComm
 	if err := fs.Parse(args[1:]); err != nil {
 		return agentServiceCommand{}, err
 	}
-	if fs.NArg() != 0 {
-		return agentServiceCommand{}, fmt.Errorf("unexpected service arguments: %s", strings.Join(fs.Args(), " "))
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return agentServiceCommand{}, err
 	}
 	if (action == "install" || action == "run") && *configPath == "" {
 		return agentServiceCommand{}, fmt.Errorf("--config is required for service %s", action)

--- a/cmd/nebula-agent/service_test.go
+++ b/cmd/nebula-agent/service_test.go
@@ -34,7 +34,10 @@ func TestParseAgentServiceCommand(t *testing.T) {
 		{name: "install requires config", args: []string{"install"}, wantErr: "--config is required"},
 		{name: "run requires config", args: []string{"run"}, wantErr: "--config is required"},
 		{name: "config rejected for control", args: []string{"start", "--config", "agent.yml"}, wantErr: "--config is only valid"},
-		{name: "positional argument rejected", args: []string{"start", "extra"}, wantErr: "unexpected service arguments"},
+		// Shares the binary-wide wording from internal/cliargs — the service
+		// path used to phrase this condition differently from every other
+		// flag set.
+		{name: "positional argument rejected", args: []string{"start", "extra"}, wantErr: `unexpected argument "extra"`},
 	}
 
 	for _, tt := range tests {

--- a/cmd/nebula-mgmt/main.go
+++ b/cmd/nebula-mgmt/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/forgekeep/nebula-mesh/internal/cli"
+	"github.com/forgekeep/nebula-mesh/internal/cliargs"
 	"github.com/forgekeep/nebula-mesh/internal/version"
 )
 
@@ -52,9 +53,12 @@ func run() error {
 		return nil
 	default:
 		printUsage()
-		return fmt.Errorf("unknown command: %s", os.Args[1])
+		return argGuard.UnknownCommand("command", os.Args[1])
 	}
 }
+
+// argGuard carries this binary's usage hint into every argument-shape error.
+var argGuard = cliargs.New("run `nebula-mgmt` with no arguments for usage")
 
 func printUsage() {
 	fmt.Fprintln(os.Stderr, "usage: nebula-mgmt <command> [flags]")
@@ -73,6 +77,9 @@ func runInit(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return err
+	}
 	return cli.Init(*configPath)
 }
 
@@ -81,6 +88,9 @@ func runServe(args []string) error {
 	configPath := fs.String("config", "", "config file path (required)")
 	insecureHTTP := fs.Bool("insecure-http", false, "allow serving plaintext HTTP on a non-loopback address (overrides allow_insecure_http; credentials transit in cleartext)")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 	if *configPath == "" {
@@ -106,7 +116,7 @@ func runHost(args []string) error {
 	case "unblock":
 		return runHostAction(args[1:], "host unblock", cli.HostUnblock)
 	default:
-		return fmt.Errorf("unknown host subcommand: %s", args[0])
+		return argGuard.UnknownCommand("host subcommand", args[0])
 	}
 }
 
@@ -116,6 +126,9 @@ func runHostAction(args []string, name string, action func(serverURL, apiKey, ho
 	apiKey := fs.String("api-key", "", "API key")
 	id := fs.String("id", "", "host ID")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 	if *id == "" || *apiKey == "" {
@@ -136,6 +149,9 @@ func runHostCreate(args []string) error {
 	publicIP := fs.String("public-ip", "", "public IP (for lighthouse/relay)")
 	listenPort := fs.Int("listen-port", 0, "listen port (for lighthouse/relay)")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 
@@ -159,6 +175,9 @@ func runHostList(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return err
+	}
 
 	if *apiKey == "" {
 		return fmt.Errorf("--api-key is required")
@@ -178,7 +197,7 @@ func runNetwork(args []string) error {
 	case "list":
 		return runNetworkList(args[1:])
 	default:
-		return fmt.Errorf("unknown network subcommand: %s", args[0])
+		return argGuard.UnknownCommand("network subcommand", args[0])
 	}
 }
 
@@ -189,6 +208,9 @@ func runNetworkCreate(args []string) error {
 	name := fs.String("name", "", "network name")
 	cidr := fs.String("cidr", "", "network CIDR")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 
@@ -213,7 +235,7 @@ func runUser(args []string) error {
 	case "enable":
 		return runHostAction(args[1:], "user enable", cli.UserEnable)
 	default:
-		return fmt.Errorf("unknown user subcommand: %s", args[0])
+		return argGuard.UnknownCommand("user subcommand", args[0])
 	}
 }
 
@@ -228,6 +250,9 @@ func runUserCreate(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return err
+	}
 	if *apiKey == "" {
 		return fmt.Errorf("--api-key is required")
 	}
@@ -239,6 +264,9 @@ func runUserList(args []string) error {
 	server := fs.String("server", "http://localhost:8080", "management server URL")
 	apiKey := fs.String("api-key", "", "API key")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 	if *apiKey == "" {
@@ -263,7 +291,7 @@ func runCA(args []string) error {
 	case "rotate":
 		return runCARotate(args[1:])
 	default:
-		return fmt.Errorf("unknown ca subcommand: %s", args[0])
+		return argGuard.UnknownCommand("ca subcommand", args[0])
 	}
 }
 
@@ -278,6 +306,9 @@ func runCAImport(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return err
+	}
 	return cli.CAImport(*server, *apiKey, *name, *certFile, *keyFile, *passphraseFile)
 }
 
@@ -288,6 +319,9 @@ func runCACreate(args []string) error {
 	name := fs.String("name", "", "CA name")
 	duration := fs.String("duration", "8760h", "CA lifetime, Go duration string (default 1 year)")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 	if *apiKey == "" || *name == "" {
@@ -303,6 +337,9 @@ func runCAList(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return err
+	}
 	if *apiKey == "" {
 		return fmt.Errorf("--api-key is required")
 	}
@@ -316,7 +353,10 @@ func runCARotate(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if fs.NArg() < 1 {
+	// `ca rotate` is the one command that takes a positional operand: exactly
+	// one CA id. More than one means a mistyped flag was swallowed as an
+	// operand, which would otherwise rotate the wrong CA.
+	if fs.NArg() != 1 {
 		return fmt.Errorf("usage: nebula-mgmt ca rotate [flags] <id>")
 	}
 	if *apiKey == "" {
@@ -336,7 +376,7 @@ func runAPIKey(args []string) error {
 	case "revoke":
 		return runAPIKeyRevoke(args[1:])
 	default:
-		return fmt.Errorf("unknown apikey subcommand: %s", args[0])
+		return argGuard.UnknownCommand("apikey subcommand", args[0])
 	}
 }
 
@@ -347,6 +387,9 @@ func runAPIKeyCreate(args []string) error {
 	operator := fs.String("operator", "", "operator ID")
 	name := fs.String("name", "", "key name (optional)")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 	if *apiKey == "" || *operator == "" {
@@ -364,6 +407,9 @@ func runAPIKeyRevoke(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return err
+	}
 	if *apiKey == "" || *operator == "" || *id == "" {
 		return fmt.Errorf("--api-key, --operator, --id are required")
 	}
@@ -375,6 +421,9 @@ func runNetworkList(args []string) error {
 	server := fs.String("server", "http://localhost:8080", "management server URL")
 	apiKey := fs.String("api-key", "", "API key")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 
@@ -397,7 +446,7 @@ func runOps(args []string) error {
 	case "restore":
 		return runOpsRestore(args[1:])
 	default:
-		return fmt.Errorf("unknown ops subcommand: %s", args[0])
+		return argGuard.UnknownCommand("ops subcommand", args[0])
 	}
 }
 
@@ -407,6 +456,9 @@ func runOpsBackup(args []string) error {
 	output := fs.String("output", "", "backup archive path (required)")
 	passphrase := fs.String("passphrase", "", "encrypt the archive with this passphrase (optional)")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 	if *configPath == "" || *output == "" {
@@ -424,6 +476,9 @@ func runOpsRestore(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if err := argGuard.RejectPositional(fs); err != nil {
+		return err
+	}
 	if *configPath == "" || *input == "" {
 		return fmt.Errorf("--config and --input are required")
 	}
@@ -434,6 +489,9 @@ func runOpsMintAdminKey(args []string) error {
 	fs := flag.NewFlagSet("ops mint-admin-key", flag.ExitOnError)
 	configPath := fs.String("config", "", "config file path (required)")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := argGuard.RejectPositional(fs); err != nil {
 		return err
 	}
 	if *configPath == "" {

--- a/cmd/nebula-mgmt/main_test.go
+++ b/cmd/nebula-mgmt/main_test.go
@@ -18,3 +18,62 @@ func TestRunCAImport_IsWired(t *testing.T) {
 		t.Fatalf("runCA(import) error = %v", err)
 	}
 }
+
+// TestRun_UnknownCommand_Errors pins the top-level dispatch: an unrecognized
+// command must be a usage error, never a silent no-op.
+func TestRun_UnknownCommand_Errors(t *testing.T) {
+	if err := runHost([]string{"crate", "--name", "x"}); err == nil ||
+		!strings.Contains(err.Error(), "unknown host subcommand") {
+		t.Errorf("runHost(crate) error = %v, want unknown-subcommand error", err)
+	}
+	if err := runCA([]string{"rotat"}); err == nil ||
+		!strings.Contains(err.Error(), "unknown ca subcommand") {
+		t.Errorf("runCA(rotat) error = %v, want unknown-subcommand error", err)
+	}
+}
+
+// TestRejectsStrayPositionalArgs — Go's flag parser stops at the first
+// non-flag token, so a stray operand silently drops every flag after it.
+// `host create extra --name x` used to run with no name at all; it must be a
+// usage error instead.
+func TestRejectsStrayPositionalArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"host create", func() error {
+			return runHost([]string{"create", "extra", "--name", "x", "--api-key", "k", "--ip", "10.0.0.1", "--network", "n"})
+		}},
+		{"host list", func() error { return runHost([]string{"list", "extra", "--api-key", "k"}) }},
+		{"network create", func() error {
+			return runNetwork([]string{"create", "extra", "--name", "n", "--cidr", "10.0.0.0/24", "--api-key", "k"})
+		}},
+		{"user create", func() error { return runUser([]string{"create", "extra", "--api-key", "k"}) }},
+		{"apikey create", func() error {
+			return runAPIKey([]string{"create", "extra", "--api-key", "k", "--operator", "o"})
+		}},
+		{"ops mint-admin-key", func() error { return runOps([]string{"mint-admin-key", "extra", "--config", "c"}) }},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call()
+			if err == nil || !strings.Contains(err.Error(), "unexpected argument") {
+				t.Errorf("error = %v, want the stray operand rejected", err)
+			}
+		})
+	}
+}
+
+// TestCARotate_RequiresExactlyOneOperand — `ca rotate` is the one command
+// with a positional operand. A second one means a flag was swallowed, which
+// would otherwise rotate whichever CA happened to be parsed first.
+func TestCARotate_RequiresExactlyOneOperand(t *testing.T) {
+	if err := runCA([]string{"rotate", "--api-key", "k", "ca-1", "ca-2"}); err == nil ||
+		!strings.Contains(err.Error(), "usage:") {
+		t.Errorf("two operands: error = %v, want usage error", err)
+	}
+	if err := runCA([]string{"rotate", "--api-key", "k"}); err == nil ||
+		!strings.Contains(err.Error(), "usage:") {
+		t.Errorf("no operand: error = %v, want usage error", err)
+	}
+}

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -873,6 +873,17 @@ creating or decoding combined-role hosts.
 
 ## Troubleshooting
 
+### `unknown command "…"` / the agent never contacts the server
+
+A mistyped subcommand — `nebula-agent enrool --server URL --token TOK` — is now
+rejected with a usage error. Older builds fell through to the daemon path,
+where Go's flag parser stops at the first bare word and silently dropped
+`--server` and `--token`; the agent then parked in standby and never issued an
+enrollment request. If a host "cannot enroll" but the server logs show no
+`POST /api/v1/enroll` at all, check the command line before suspecting the
+server. The same rule now applies to a stray operand between flags
+(`unexpected argument "…" after flags`).
+
 ### `dial tcp ...: connect: connection refused`
 
 The host cannot reach the management server's `server_url`. Verify with

--- a/docs/security/invariants.md
+++ b/docs/security/invariants.md
@@ -155,6 +155,13 @@ does not permit avoidable application-level copies.
 - `internal/web/cas_test.go`:
   `TestCAImport_WebDoesNotRetainSecretFormCopies` and Web transport/body-limit
   coverage.
+- `internal/cliargs/cliargs_test.go`: `TestRedactsBootstrapTokens` — a mistyped
+  command line can put a bootstrap token where a command word belongs; CLI
+  usage errors redact it instead of echoing it into logs, terminals and shell
+  history.
+- `cmd/nebula-agent/main_test.go`:
+  `TestRun_UnknownSubcommand_RedactsBootstrapToken` — the same guard, proven
+  wired into the agent entrypoint.
 
 ### Review checklist
 

--- a/internal/cliargs/cliargs.go
+++ b/internal/cliargs/cliargs.go
@@ -1,0 +1,69 @@
+// Package cliargs holds the argument-shape guards shared by the nebula-agent
+// and nebula-mgmt entrypoints.
+//
+// Go's flag package stops parsing at the first non-flag token and leaves the
+// rest as operands. A command line with a typo where a subcommand or flag
+// belongs therefore runs with every later flag silently dropped —
+// `nebula-agent enrool --server URL --token TOK` used to park in standby
+// without ever contacting the server, which reads as a server-side failure.
+// Both binaries reject that shape instead, with one message and one
+// redaction rule.
+package cliargs
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/forgekeep/nebula-mesh/internal/bootstraptoken"
+)
+
+// Redacted stands in for an operand that carries a bootstrap-token prefix.
+const Redacted = "[REDACTED]"
+
+// Guard reports argument-shape errors for a single binary. The zero value is
+// usable; New attaches the per-binary usage hint appended to every message.
+type Guard struct {
+	helpHint string
+}
+
+// New returns a Guard whose errors end with helpHint (e.g. "run `nebula-agent
+// help` for usage"). An empty hint is omitted.
+func New(helpHint string) Guard {
+	return Guard{helpHint: helpHint}
+}
+
+// RejectPositional fails when flag parsing left unconsumed operands, naming
+// the first one. Commands that legitimately take an operand validate NArg
+// themselves rather than calling this.
+func (g Guard) RejectPositional(fs *flag.FlagSet) error {
+	if fs.NArg() == 0 {
+		return nil
+	}
+	return g.errorf("unexpected argument %q after flags; flags that follow it were ignored", Redact(fs.Arg(0)))
+}
+
+// UnknownCommand reports an unrecognized command word. kind names what was
+// expected — "command", "host subcommand", "service action".
+func (g Guard) UnknownCommand(kind, arg string) error {
+	return g.errorf("unknown %s %q", kind, Redact(arg))
+}
+
+func (g Guard) errorf(format string, args ...any) error {
+	message := fmt.Sprintf(format, args...)
+	if g.helpHint == "" {
+		return fmt.Errorf("%s", message)
+	}
+	return fmt.Errorf("%s; %s", message, g.helpHint)
+}
+
+// Redact hides operands that carry a bootstrap-token prefix. A mistyped
+// command line can put a token where a command word belongs, and these errors
+// reach logs, terminals and shell history — SEC-SECRET-001 keeps plaintext
+// secrets out of them. Non-secret operands pass through so the message still
+// tells the operator what to fix.
+func Redact(arg string) string {
+	if _, known := bootstraptoken.PurposeOf(arg); known {
+		return Redacted
+	}
+	return arg
+}

--- a/internal/cliargs/cliargs_test.go
+++ b/internal/cliargs/cliargs_test.go
@@ -1,0 +1,83 @@
+package cliargs
+
+import (
+	"flag"
+	"io"
+	"strings"
+	"testing"
+)
+
+func parsed(t *testing.T, args ...string) *flag.FlagSet {
+	t.Helper()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.String("name", "", "name")
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("Parse(%v): %v", args, err)
+	}
+	return fs
+}
+
+func TestRejectPositional(t *testing.T) {
+	guard := New("run `x help` for usage")
+
+	if err := guard.RejectPositional(parsed(t, "--name", "ok")); err != nil {
+		t.Errorf("clean flag set rejected: %v", err)
+	}
+
+	// Go stops parsing at "stray", so --name never reaches the flag set.
+	fs := parsed(t, "stray", "--name", "dropped")
+	if fs.Lookup("name").Value.String() != "" {
+		t.Fatal("precondition: expected the flag after the operand to be dropped")
+	}
+	err := guard.RejectPositional(fs)
+	if err == nil {
+		t.Fatal("stray operand accepted")
+	}
+	if !strings.Contains(err.Error(), `"stray"`) {
+		t.Errorf("error = %v, want it to name the operand", err)
+	}
+	if !strings.Contains(err.Error(), "run `x help` for usage") {
+		t.Errorf("error = %v, want the usage hint appended", err)
+	}
+}
+
+func TestGuardWithoutHint(t *testing.T) {
+	err := Guard{}.UnknownCommand("command", "bogus")
+	if err == nil || strings.HasSuffix(err.Error(), "; ") {
+		t.Fatalf("error = %v, want no dangling hint separator", err)
+	}
+	if !strings.Contains(err.Error(), `unknown command "bogus"`) {
+		t.Errorf("error = %v", err)
+	}
+}
+
+// TestRedactsBootstrapTokens — SEC-SECRET-001: a mistyped command line can put
+// a bootstrap token where a command word belongs, and these errors land in
+// logs, terminals and shell history. Both token purposes must be hidden while
+// ordinary operands stay visible, or the message stops being actionable.
+func TestRedactsBootstrapTokens(t *testing.T) {
+	secrets := []string{
+		"nme_ThisIsNotARealTokenJustTestData",
+		"nmi_ThisIsNotARealTokenJustTestData",
+	}
+	for _, secret := range secrets {
+		if got := Redact(secret); got != Redacted {
+			t.Errorf("Redact(%q) = %q, want %q", secret, got, Redacted)
+		}
+		err := New("hint").UnknownCommand("command", secret)
+		if strings.Contains(err.Error(), secret) {
+			t.Errorf("token leaked into error: %v", err)
+		}
+		err = New("hint").RejectPositional(parsed(t, secret))
+		if strings.Contains(err.Error(), secret) {
+			t.Errorf("token leaked into operand error: %v", err)
+		}
+	}
+
+	for _, harmless := range []string{"enrool", "host", "--name", "", "nme", "nmi"} {
+		if got := Redact(harmless); got != harmless {
+			t.Errorf("Redact(%q) = %q, want it unchanged", harmless, got)
+		}
+	}
+}


### PR DESCRIPTION
I was performing an enrollment on an Ubuntu client and accidentally typed "enrool" instead of "enroll"; this caused the CLI to hang without displaying any error, and I drove myself crazy trying to figure out what was going on.

## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
