### PR TITLE
fix(services): update binary paths for nebula-agent and nebula-mgmt

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -4,7 +4,7 @@
 
 ```sh
 sudo useradd --system --no-create-home --shell /usr/sbin/nologin nebula-mgmt
-sudo install -m 0755 bin/nebula-mgmt /usr/local/bin/nebula-mgmt
+sudo install -m 0755 bin/nebula-mgmt /usr/bin/nebula-mgmt
 
 sudo install -d -o nebula-mgmt -g nebula-mgmt -m 0750 \
   /etc/nebula-mgmt /var/lib/nebula-mgmt
@@ -30,7 +30,7 @@ The service reads `NEBULA_MGMT_CA_PASSPHRASE` from `passphrase.env` and unlocks 
 ## nebula-agent.service
 
 ```sh
-sudo install -m 0755 bin/nebula-agent /usr/local/bin/nebula-agent
+sudo install -m 0755 bin/nebula-agent /usr/bin/nebula-agent
 
 # First run: enrolls the host and writes /etc/nebula-agent/agent.yml (mode 0600).
 sudo nebula-agent \

--- a/deploy/systemd/nebula-agent.service
+++ b/deploy/systemd/nebula-agent.service
@@ -29,7 +29,7 @@ Type=simple
 User=root
 Group=root
 
-ExecStart=/usr/local/bin/nebula-agent --config /etc/nebula-agent/agent.yml
+ExecStart=/usr/bin/nebula-agent --config /etc/nebula-agent/agent.yml
 Restart=on-failure
 RestartSec=5s
 

--- a/deploy/systemd/nebula-mgmt.service
+++ b/deploy/systemd/nebula-mgmt.service
@@ -13,7 +13,7 @@ Group=nebula-mgmt
 # Format: NEBULA_MGMT_CA_PASSPHRASE=your-passphrase-here
 EnvironmentFile=/etc/nebula-mgmt/passphrase.env
 
-ExecStart=/usr/local/bin/nebula-mgmt serve --config /etc/nebula-mgmt/server.yml
+ExecStart=/usr/bin/nebula-mgmt serve --config /etc/nebula-mgmt/server.yml
 Restart=on-failure
 RestartSec=5s
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -931,7 +931,12 @@ affected files.
 
 ## Upgrading
 
-1. Download the new release archive and `install -m 0755 nebula-agent /usr/local/bin/`.
+1. Replace the binary in place — `apt install ./nebula-agent_<version>_linux_<arch>.deb`
+   (or `dnf install ./…rpm`) for a packaged install, or
+   `install -m 0755 nebula-agent <path from the unit's ExecStart>` for an
+   archive install. Installing to a different directory than the running
+   service leaves the old binary in place and the upgrade silently does
+   nothing.
 2. `systemctl restart nebula-agent.service`.
 3. Watch `journalctl -u nebula-agent -f` to confirm it polls successfully.
 


### PR DESCRIPTION
When you install using binaries on Ubuntu, they are installed in `/usr/bin` rather than `/usr/local/bin`, preventing the services from running.

## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
