### PR TITLE
fix(cliargs): omit unclassified argument values

### DIFF
--- a/cmd/nebula-agent/main.go
+++ b/cmd/nebula-agent/main.go
@@ -70,7 +70,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 			// park in standby forever, looking like a server-side failure.
 			if !strings.HasPrefix(args[0], "-") {
 				printUsage(stderr)
-				return argGuard.UnknownCommand("command", args[0])
+				return argGuard.UnknownCommand("command")
 			}
 		}
 	}

--- a/cmd/nebula-agent/main_test.go
+++ b/cmd/nebula-agent/main_test.go
@@ -298,36 +298,42 @@ func TestRun_UnknownSubcommand_FailsFast(t *testing.T) {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		t.Fatalf("mistyped subcommand parked in standby instead of failing: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unknown command") || !strings.Contains(err.Error(), "enrool") {
-		t.Errorf("error = %v, want it to name the unknown command", err)
+	if !strings.Contains(err.Error(), "unknown command") || strings.Contains(err.Error(), "enrool") {
+		t.Errorf("error = %v, want an unknown-command error without the command value", err)
 	}
 	if !strings.Contains(stderr.String(), "nebula-agent enroll") {
 		t.Errorf("usage not printed on unknown command; stderr = %q", stderr.String())
 	}
 }
 
-// TestRun_UnknownSubcommand_RedactsBootstrapToken — SEC-SECRET-001 forbids
-// plaintext secrets in error messages. A mistyped command line can put the
-// bootstrap token where the subcommand belongs, and the usage error echoes
-// that word back into logs and terminals.
-func TestRun_UnknownSubcommand_RedactsBootstrapToken(t *testing.T) {
-	const token = "nme_ThisIsNotARealTokenJustTestData_0123456789"
-	var stdout, stderr bytes.Buffer
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+// TestRun_UnknownSubcommandDoesNotEchoUnclassifiedInput — SEC-DIAGNOSTIC-001:
+// command words can be passwords, API keys, or current and legacy enrollment
+// tokens, so neither the error nor CLI output may copy them.
+func TestRun_UnknownSubcommandDoesNotEchoUnclassifiedInput(t *testing.T) {
+	values := []string{
+		"correct-horse-battery-staple",
+		"test-api-key-ThisIsNotReal",
+		"legacy-enrollment-token-ThisIsNotReal",
+		"nme_ThisIsNotARealTokenJustTestData_0123456789",
+		"nmi_ThisIsNotARealTokenJustTestData_0123456789",
+	}
+	for _, value := range values {
+		t.Run(value, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
 
-	err := run(ctx, []string{token, "--server", "https://mgmt.example.com"}, &stdout, &stderr)
-	if err == nil {
-		t.Fatal("token-as-subcommand returned nil; want a usage error")
-	}
-	if strings.Contains(err.Error(), token) {
-		t.Errorf("bootstrap token leaked into error message: %v", err)
-	}
-	if strings.Contains(stdout.String(), token) || strings.Contains(stderr.String(), token) {
-		t.Errorf("bootstrap token leaked into output: stdout=%q stderr=%q", stdout.String(), stderr.String())
-	}
-	if !strings.Contains(err.Error(), "[REDACTED]") {
-		t.Errorf("error = %v, want the redaction placeholder", err)
+			err := run(ctx, []string{value, "--server", "https://mgmt.example.com"}, &stdout, &stderr)
+			if err == nil {
+				t.Fatal("value-as-subcommand returned nil; want a usage error")
+			}
+			if strings.Contains(err.Error(), value) {
+				t.Errorf("unclassified input leaked into error message: %v", err)
+			}
+			if strings.Contains(stdout.String(), value) || strings.Contains(stderr.String(), value) {
+				t.Errorf("unclassified input leaked into output: stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+		})
 	}
 }
 
@@ -357,9 +363,9 @@ func TestRun_PositionalArgAfterFlags_Errors(t *testing.T) {
 		name string
 		args []string
 	}{
-		{"enroll", []string{"enroll", "--server", "https://mgmt.example.com", "oops", "--token", "tok"}},
-		{"unified", []string{"--config", "/nonexistent", "oops", "--server", "https://mgmt.example.com"}},
-		{"legacy run", []string{"run", "--config", "/nonexistent", "oops"}},
+		{"enroll", []string{"enroll", "--server", "https://mgmt.example.com", "correct-horse-battery-staple", "--token", "tok"}},
+		{"unified", []string{"--config", "/nonexistent", "correct-horse-battery-staple", "--server", "https://mgmt.example.com"}},
+		{"legacy run", []string{"run", "--config", "/nonexistent", "correct-horse-battery-staple"}},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
@@ -371,8 +377,11 @@ func TestRun_PositionalArgAfterFlags_Errors(t *testing.T) {
 			if err == nil {
 				t.Fatal("stray positional returned nil; want a usage error")
 			}
-			if !strings.Contains(err.Error(), "unexpected argument") || !strings.Contains(err.Error(), "oops") {
-				t.Errorf("error = %v, want it to name the stray argument", err)
+			if !strings.Contains(err.Error(), "unexpected argument") || strings.Contains(err.Error(), "correct-horse-battery-staple") {
+				t.Errorf("error = %v, want a positional-argument error without the value", err)
+			}
+			if strings.Contains(stdout.String(), "correct-horse-battery-staple") || strings.Contains(stderr.String(), "correct-horse-battery-staple") {
+				t.Errorf("positional value leaked into output: stdout=%q stderr=%q", stdout.String(), stderr.String())
 			}
 		})
 	}

--- a/cmd/nebula-agent/service.go
+++ b/cmd/nebula-agent/service.go
@@ -70,7 +70,7 @@ func parseAgentServiceCommand(args []string, stderr io.Writer) (agentServiceComm
 	switch action {
 	case "install", "start", "stop", "restart", "uninstall", "run":
 	default:
-		return agentServiceCommand{}, argGuard.UnknownCommand("service action", action)
+		return agentServiceCommand{}, argGuard.UnknownCommand("service action")
 	}
 
 	fs := flag.NewFlagSet("service "+action, flag.ContinueOnError)

--- a/cmd/nebula-agent/service_test.go
+++ b/cmd/nebula-agent/service_test.go
@@ -37,7 +37,7 @@ func TestParseAgentServiceCommand(t *testing.T) {
 		// Shares the binary-wide wording from internal/cliargs — the service
 		// path used to phrase this condition differently from every other
 		// flag set.
-		{name: "positional argument rejected", args: []string{"start", "extra"}, wantErr: `unexpected argument "extra"`},
+		{name: "positional argument rejected", args: []string{"start", "extra"}, wantErr: "unexpected argument"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/nebula-mgmt/main.go
+++ b/cmd/nebula-mgmt/main.go
@@ -53,7 +53,7 @@ func run() error {
 		return nil
 	default:
 		printUsage()
-		return argGuard.UnknownCommand("command", os.Args[1])
+		return argGuard.UnknownCommand("command")
 	}
 }
 
@@ -116,7 +116,7 @@ func runHost(args []string) error {
 	case "unblock":
 		return runHostAction(args[1:], "host unblock", cli.HostUnblock)
 	default:
-		return argGuard.UnknownCommand("host subcommand", args[0])
+		return argGuard.UnknownCommand("host subcommand")
 	}
 }
 
@@ -197,7 +197,7 @@ func runNetwork(args []string) error {
 	case "list":
 		return runNetworkList(args[1:])
 	default:
-		return argGuard.UnknownCommand("network subcommand", args[0])
+		return argGuard.UnknownCommand("network subcommand")
 	}
 }
 
@@ -235,7 +235,7 @@ func runUser(args []string) error {
 	case "enable":
 		return runHostAction(args[1:], "user enable", cli.UserEnable)
 	default:
-		return argGuard.UnknownCommand("user subcommand", args[0])
+		return argGuard.UnknownCommand("user subcommand")
 	}
 }
 
@@ -291,7 +291,7 @@ func runCA(args []string) error {
 	case "rotate":
 		return runCARotate(args[1:])
 	default:
-		return argGuard.UnknownCommand("ca subcommand", args[0])
+		return argGuard.UnknownCommand("ca subcommand")
 	}
 }
 
@@ -376,7 +376,7 @@ func runAPIKey(args []string) error {
 	case "revoke":
 		return runAPIKeyRevoke(args[1:])
 	default:
-		return argGuard.UnknownCommand("apikey subcommand", args[0])
+		return argGuard.UnknownCommand("apikey subcommand")
 	}
 }
 
@@ -446,7 +446,7 @@ func runOps(args []string) error {
 	case "restore":
 		return runOpsRestore(args[1:])
 	default:
-		return argGuard.UnknownCommand("ops subcommand", args[0])
+		return argGuard.UnknownCommand("ops subcommand")
 	}
 }
 

--- a/cmd/nebula-mgmt/main_test.go
+++ b/cmd/nebula-mgmt/main_test.go
@@ -23,12 +23,48 @@ func TestRunCAImport_IsWired(t *testing.T) {
 // command must be a usage error, never a silent no-op.
 func TestRun_UnknownCommand_Errors(t *testing.T) {
 	if err := runHost([]string{"crate", "--name", "x"}); err == nil ||
-		!strings.Contains(err.Error(), "unknown host subcommand") {
-		t.Errorf("runHost(crate) error = %v, want unknown-subcommand error", err)
+		!strings.Contains(err.Error(), "unknown host subcommand") || strings.Contains(err.Error(), "crate") {
+		t.Errorf("runHost(crate) error = %v, want unknown-subcommand error without the value", err)
 	}
 	if err := runCA([]string{"rotat"}); err == nil ||
-		!strings.Contains(err.Error(), "unknown ca subcommand") {
-		t.Errorf("runCA(rotat) error = %v, want unknown-subcommand error", err)
+		!strings.Contains(err.Error(), "unknown ca subcommand") || strings.Contains(err.Error(), "rotat") {
+		t.Errorf("runCA(rotat) error = %v, want unknown-subcommand error without the value", err)
+	}
+}
+
+// TestManagementCLI_SEC_DIAGNOSTIC_001_DoesNotEchoUnclassifiedInput covers
+// the management paths where an API key or password can land in a rejected
+// command word or positional operand.
+func TestManagementCLI_SEC_DIAGNOSTIC_001_DoesNotEchoUnclassifiedInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		call  func(string) error
+	}{
+		{
+			name:  "API-key-like host subcommand",
+			value: "test-api-key-ThisIsNotReal",
+			call:  func(value string) error { return runHost([]string{value}) },
+		},
+		{
+			name:  "password-like user create operand",
+			value: "correct-horse-battery-staple",
+			call: func(value string) error {
+				return runUser([]string{"create", value, "--api-key", "test-key"})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call(test.value)
+			if err == nil {
+				t.Fatal("unclassified input accepted; want a usage error")
+			}
+			if strings.Contains(err.Error(), test.value) {
+				t.Errorf("unclassified input leaked into error: %v", err)
+			}
+		})
 	}
 }
 
@@ -57,7 +93,7 @@ func TestRejectsStrayPositionalArgs(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.call()
-			if err == nil || !strings.Contains(err.Error(), "unexpected argument") {
+			if err == nil || !strings.Contains(err.Error(), "unexpected argument") || strings.Contains(err.Error(), "extra") {
 				t.Errorf("error = %v, want the stray operand rejected", err)
 			}
 		})

--- a/docs/security/invariants.md
+++ b/docs/security/invariants.md
@@ -155,13 +155,6 @@ does not permit avoidable application-level copies.
 - `internal/web/cas_test.go`:
   `TestCAImport_WebDoesNotRetainSecretFormCopies` and Web transport/body-limit
   coverage.
-- `internal/cliargs/cliargs_test.go`: `TestRedactsBootstrapTokens` — a mistyped
-  command line can put a bootstrap token where a command word belongs; CLI
-  usage errors redact it instead of echoing it into logs, terminals and shell
-  history.
-- `cmd/nebula-agent/main_test.go`:
-  `TestRun_UnknownSubcommand_RedactsBootstrapToken` — the same guard, proven
-  wired into the agent entrypoint.
 
 ### Review checklist
 
@@ -174,6 +167,48 @@ When a change touches secret ingress, verify:
 4. Are transport and identity checks executed before the first body read?
 5. Do negative tests prove rejection and cleanup, rather than only a successful
    round trip?
+
+## SEC-DIAGNOSTIC-001: CLI unclassified argument diagnostics
+
+### Rule
+
+When a CLI rejects an unclassified command word or positional operand, its
+diagnostic must describe the error category without copying the supplied value.
+It must retain the configured help hint and, for operands after flags, explain
+that later flags were ignored.
+
+Recognizer-based redaction is insufficient: arbitrary passwords, API keys,
+passphrases, and legacy enrollment tokens may not match a known prefix or
+format. The rule is limited to rejected unclassified CLI input; it does not
+define credential lifecycle or zeroization requirements.
+
+### Current enforcement
+
+- `internal/cliargs.Guard` reports an unknown command or unexpected positional
+  argument by category and retains the binary-specific usage hint without
+  interpolating the input value.
+
+### Test anchors
+
+- `internal/cliargs/cliargs_test.go`:
+  `TestUnclassifiedArgumentsAreNeverEchoed` covers password-like, API-key-like,
+  legacy-token, `nme_`, and `nmi_` values in both guard paths.
+- `cmd/nebula-agent/main_test.go`:
+  `TestRun_UnknownSubcommandDoesNotEchoUnclassifiedInput` proves errors and
+  CLI stdout/stderr do not disclose those values.
+- `cmd/nebula-mgmt/main_test.go`:
+  `TestManagementCLI_SEC_DIAGNOSTIC_001_DoesNotEchoUnclassifiedInput` covers
+  API-key-like subcommands and password-like positional operands.
+
+### Review checklist
+
+When changing rejected CLI argument diagnostics, verify:
+
+1. Does every unclassified command-word or operand error omit its value?
+2. Do negative tests cover values that no existing secret recognizer would
+   identify?
+3. Do the diagnostic category, ignored-flags explanation, and help hint remain
+   actionable?
 
 ## SEC-PERSIST-001: atomic durable security state
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -103,7 +103,7 @@ Trust zones, from least to most trusted:
 - **Open redirect**: post-login redirect hardcoded to `/ui/`.
 
 ### E6 — CLI / config / env
-- The deployer is trusted. Hardening: master key env-only; SSRF guards on `alerts.webhook_url` / `oidc.issuer` (#188); TLS required unless loopback or explicit `--insecure-http` (#179).
+- The deployer is trusted. Hardening: master key env-only; SSRF guards on `alerts.webhook_url` / `oidc.issuer` (#188); TLS required unless loopback or explicit `--insecure-http` (#179); rejected unclassified CLI arguments are described without echoing their values (`SEC-DIAGNOSTIC-001`).
 
 ### E7 — Unauthenticated probes
 - `/readyz` redacts DB error text (#187); `/debug/vars` and `/metrics` are bearer-gated / opt-in auth (#187).

--- a/internal/cliargs/cliargs.go
+++ b/internal/cliargs/cliargs.go
@@ -6,19 +6,14 @@
 // belongs therefore runs with every later flag silently dropped —
 // `nebula-agent enrool --server URL --token TOK` used to park in standby
 // without ever contacting the server, which reads as a server-side failure.
-// Both binaries reject that shape instead, with one message and one
-// redaction rule.
+// Both binaries reject that shape without copying the unclassified value into
+// diagnostics.
 package cliargs
 
 import (
 	"flag"
 	"fmt"
-
-	"github.com/forgekeep/nebula-mesh/internal/bootstraptoken"
 )
-
-// Redacted stands in for an operand that carries a bootstrap-token prefix.
-const Redacted = "[REDACTED]"
 
 // Guard reports argument-shape errors for a single binary. The zero value is
 // usable; New attaches the per-binary usage hint appended to every message.
@@ -32,20 +27,20 @@ func New(helpHint string) Guard {
 	return Guard{helpHint: helpHint}
 }
 
-// RejectPositional fails when flag parsing left unconsumed operands, naming
-// the first one. Commands that legitimately take an operand validate NArg
-// themselves rather than calling this.
+// RejectPositional fails when flag parsing left unconsumed operands. Commands
+// that legitimately take an operand validate NArg themselves rather than
+// calling this.
 func (g Guard) RejectPositional(fs *flag.FlagSet) error {
 	if fs.NArg() == 0 {
 		return nil
 	}
-	return g.errorf("unexpected argument %q after flags; flags that follow it were ignored", Redact(fs.Arg(0)))
+	return g.errorf("unexpected argument after flags; flags that follow it were ignored")
 }
 
 // UnknownCommand reports an unrecognized command word. kind names what was
 // expected — "command", "host subcommand", "service action".
-func (g Guard) UnknownCommand(kind, arg string) error {
-	return g.errorf("unknown %s %q", kind, Redact(arg))
+func (g Guard) UnknownCommand(kind string) error {
+	return g.errorf("unknown %s", kind)
 }
 
 func (g Guard) errorf(format string, args ...any) error {
@@ -54,16 +49,4 @@ func (g Guard) errorf(format string, args ...any) error {
 		return fmt.Errorf("%s", message)
 	}
 	return fmt.Errorf("%s; %s", message, g.helpHint)
-}
-
-// Redact hides operands that carry a bootstrap-token prefix. A mistyped
-// command line can put a token where a command word belongs, and these errors
-// reach logs, terminals and shell history — SEC-SECRET-001 keeps plaintext
-// secrets out of them. Non-secret operands pass through so the message still
-// tells the operator what to fix.
-func Redact(arg string) string {
-	if _, known := bootstraptoken.PurposeOf(arg); known {
-		return Redacted
-	}
-	return arg
 }

--- a/internal/cliargs/cliargs_test.go
+++ b/internal/cliargs/cliargs_test.go
@@ -34,8 +34,11 @@ func TestRejectPositional(t *testing.T) {
 	if err == nil {
 		t.Fatal("stray operand accepted")
 	}
-	if !strings.Contains(err.Error(), `"stray"`) {
-		t.Errorf("error = %v, want it to name the operand", err)
+	if strings.Contains(err.Error(), "stray") {
+		t.Errorf("error = %v, must not copy the operand", err)
+	}
+	if !strings.Contains(err.Error(), "unexpected argument after flags; flags that follow it were ignored") {
+		t.Errorf("error = %v, want the positional-argument category and ignored-flags explanation", err)
 	}
 	if !strings.Contains(err.Error(), "run `x help` for usage") {
 		t.Errorf("error = %v, want the usage hint appended", err)
@@ -43,41 +46,35 @@ func TestRejectPositional(t *testing.T) {
 }
 
 func TestGuardWithoutHint(t *testing.T) {
-	err := Guard{}.UnknownCommand("command", "bogus")
+	err := Guard{}.UnknownCommand("command")
 	if err == nil || strings.HasSuffix(err.Error(), "; ") {
 		t.Fatalf("error = %v, want no dangling hint separator", err)
 	}
-	if !strings.Contains(err.Error(), `unknown command "bogus"`) {
+	if !strings.Contains(err.Error(), "unknown command") || strings.Contains(err.Error(), "bogus") {
 		t.Errorf("error = %v", err)
 	}
 }
 
-// TestRedactsBootstrapTokens — SEC-SECRET-001: a mistyped command line can put
-// a bootstrap token where a command word belongs, and these errors land in
-// logs, terminals and shell history. Both token purposes must be hidden while
-// ordinary operands stay visible, or the message stops being actionable.
-func TestRedactsBootstrapTokens(t *testing.T) {
-	secrets := []string{
+// TestUnclassifiedArgumentsAreNeverEchoed — SEC-DIAGNOSTIC-001: command words
+// and positional operands are unclassified input, so diagnostics must not rely
+// on recognizer-based redaction before deciding whether to copy them.
+func TestUnclassifiedArgumentsAreNeverEchoed(t *testing.T) {
+	values := []string{
+		"correct-horse-battery-staple",
+		"test-api-key-ThisIsNotReal",
+		"legacy-enrollment-token-ThisIsNotReal",
 		"nme_ThisIsNotARealTokenJustTestData",
 		"nmi_ThisIsNotARealTokenJustTestData",
 	}
-	for _, secret := range secrets {
-		if got := Redact(secret); got != Redacted {
-			t.Errorf("Redact(%q) = %q, want %q", secret, got, Redacted)
-		}
-		err := New("hint").UnknownCommand("command", secret)
-		if strings.Contains(err.Error(), secret) {
-			t.Errorf("token leaked into error: %v", err)
-		}
-		err = New("hint").RejectPositional(parsed(t, secret))
-		if strings.Contains(err.Error(), secret) {
-			t.Errorf("token leaked into operand error: %v", err)
-		}
-	}
-
-	for _, harmless := range []string{"enrool", "host", "--name", "", "nme", "nmi"} {
-		if got := Redact(harmless); got != harmless {
-			t.Errorf("Redact(%q) = %q, want it unchanged", harmless, got)
-		}
+	guard := New("hint")
+	for _, value := range values {
+		t.Run(value, func(t *testing.T) {
+			if err := guard.UnknownCommand("command"); strings.Contains(err.Error(), value) {
+				t.Errorf("unknown-command error leaked unclassified input: %v", err)
+			}
+			if err := guard.RejectPositional(parsed(t, value)); strings.Contains(err.Error(), value) {
+				t.Errorf("positional-argument error leaked unclassified input: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Purpose

Prevent the CLI validation introduced in #324 from copying unclassified command
words and positional operands into diagnostics.

## Changes

- Make `UnknownCommand` accept only the diagnostic category, so callers cannot
  pass the rejected value into the formatter.
- Reject stray positional operands without echoing their values while keeping
  the ignored-flags explanation and usage hint.
- Add `SEC-DIAGNOSTIC-001` and anchor it in the threat model.
- Add negative regression tests for password-like and API-key-like values,
  legacy enrollment tokens, and `nme_`/`nmi_` tokens.

## Impact

Mistyped commands still fail immediately, but arbitrary credentials supplied in
the rejected argument position no longer reach terminal or log output.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -race ./...`
- `make lint`
- `make gosec`
- `make govulncheck`
- Manual `nebula-mgmt` password-like operand and `nebula-agent` legacy-token
  invocations

## Code pointers

- `internal/cliargs/cliargs.go`: generic argument-shape diagnostics
- `internal/cliargs/cliargs_test.go`: shared negative regression coverage
- `cmd/nebula-agent/main_test.go`: agent CLI output coverage
- `cmd/nebula-mgmt/main_test.go`: management CLI coverage
- `docs/security/invariants.md`: `SEC-DIAGNOSTIC-001`
