### PR TITLE
ci(release): verify tagged commits before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,35 +6,69 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
+  checks: read
 
 jobs:
-  goreleaser:
+  verify:
+    name: verify release commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
+      - name: Verify tagged commit belongs to main
+        run: |
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Verify required CI checks passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          check_runs="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs?per_page=100")"
+          for check_name in "build / test / lint" "docker build"; do
+            if ! jq -e --arg name "$check_name" \
+              '.check_runs | any(.name == $name and .status == "completed" and .conclusion == "success")' \
+              <<<"$check_runs" >/dev/null; then
+              echo "required check did not pass: $check_name" >&2
+              exit 1
+            fi
+          done
+
+  goreleaser:
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## What

Harden the tag-triggered release workflow and repository release controls.

## Why

A `v*` tag could trigger publishing from a commit outside `main`, without proving that required CI passed. Mutable Action tags also let upstream tag movement change code that runs with release permissions.

Fixes #329.

## How

- Verify that the tagged commit belongs to `origin/main`.
- Require successful `build / test / lint` and `docker build` checks for the exact commit.
- Keep write permissions on the publishing job only.
- Pin every Action to a full commit SHA.
- Publish through the protected `release` environment.

Repository settings now restrict `v*` tag creation to organization admins. The `release` environment requires reviewer approval and accepts only `v*` tags.

Local validation parsed the workflow, resolved every pinned SHA against its documented major tag, and exercised the ancestry and check-run gates against the current `main`.

## Checklist

- [ ] `go test -race ./...` passes — not run; workflow-only change
- [ ] `golangci-lint run ./...` passes — not run; workflow-only change
- [ ] New behaviour has tests — validated against the current `main`; the PR workflow provides the integration check
- [ ] User-facing changes are reflected in README / configs — not applicable
- [x] No breaking API changes, or they are called out above
