### PR TITLE
ci(codeql): add Go and Actions analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 6 * * 2"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## What

Add CodeQL analysis for Go and GitHub Actions.

## Why

The existing CI covers tests, lint, `gosec`, and `govulncheck`, but GitHub code scanning is not configured for Go or workflow code.

Fixes #332.

## How

- Analyze pull requests and pushes to `main`.
- Run a scheduled analysis every Tuesday.
- Use `autobuild` for Go and interpreted analysis for Actions.
- Limit permissions to repository reads and code-scanning result uploads.
- Pin checkout and CodeQL Actions to immutable commit SHAs.

Local validation parsed the workflow and verified both pinned releases. The new CodeQL jobs on this PR are the integration verification.

## Checklist

- [ ] `go test -race ./...` passes — not run; workflow-only change
- [ ] `golangci-lint run ./...` passes — not run; workflow-only change
- [x] New behaviour has tests — CodeQL runs on this PR
- [ ] User-facing changes are reflected in README / configs — not applicable
- [x] No breaking API changes, or they are called out above
