### PR TITLE
fix(ratelimit): trust forwarded IPs only from known proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ its files unchanged until you approve the reconciliation preview. See
 - **Docker** — `docker build -t nebula-mgmt .` (Dockerfile in repo).
 - **systemd** — unit files in [`deploy/systemd/`](deploy/systemd/).
 - **TLS** — set `tls_cert` + `tls_key` for in-process TLS, or front with nginx/caddy/traefik. Working snippets for all three live in [`deploy/reverse-proxy/`](deploy/reverse-proxy/) and ship inside the `.deb`/`.rpm` at `/usr/share/doc/nebula-mgmt/reverse-proxy/`. Each is opinionated, preserves `X-Forwarded-For`, and disables buffering on `/ui/events` so the SSE feed reaches the browser in real time.
-- **Rate limiting** — on by default. The Web UI, auth endpoints, `/api/v1/enroll`, and the bearer-authenticated admin API each run their own per-IP token bucket. Defaults: 5 req/s on login forms (burst 10), 2 req/s on enrolment (burst 5), 30 req/s on UI + admin API (burst 60), 60 req/s on agent polls (burst 120). Health (`/healthz`, `/readyz`, `/metrics`, `/debug/vars`, `/favicon.ico`, `/static/*`) is exempt. Run behind a reverse proxy? Set `rate_limit.trust_proxy_header: true` so the limiter keys on `X-Forwarded-For` instead of the proxy's connection address.
+- **Rate limiting** — on by default. The Web UI, auth endpoints, `/api/v1/enroll`, and the bearer-authenticated admin API each run their own per-IP token bucket. Defaults: 5 req/s on login forms (burst 10), 2 req/s on enrolment (burst 5), 30 req/s on UI + admin API (burst 60), 60 req/s on agent polls (burst 120). Health (`/healthz`, `/readyz`, `/metrics`, `/debug/vars`, `/favicon.ico`, `/static/*`) is exempt. Behind a reverse proxy, enable `rate_limit.trust_proxy_header`; non-loopback proxies must also appear in `rate_limit.trusted_proxies`.
 
 ### Backups & key handling
 
@@ -394,7 +394,7 @@ On by default; configurable in `server.yml`. Each group is a separate per-IP tok
 | `enroll` | 2 / 5 | `POST /api/v1/enroll` |
 | `agent_poll` | 60 / 120 | `GET /api/v1/agent/updates` |
 
-Ops endpoints (`/healthz`, `/readyz`, `/metrics`, `/debug/`, `/favicon.ico`, `/static/*`) are exempt so scrapes never get 429s. Behind a reverse proxy, set `rate_limit.trust_proxy_header: true` to key the buckets on `X-Forwarded-For` instead of the proxy's loopback connection.
+Ops endpoints (`/healthz`, `/readyz`, `/metrics`, `/debug/`, `/favicon.ico`, `/static/*`) are exempt so scrapes never get 429s. Behind a reverse proxy, set `rate_limit.trust_proxy_header: true` to key the buckets on `X-Forwarded-For`. Loopback proxies are trusted automatically; configure other proxy CIDRs in `rate_limit.trusted_proxies`.
 
 ### Optional: mTLS on the UI only
 

--- a/configs/server.example.yml
+++ b/configs/server.example.yml
@@ -79,12 +79,15 @@ allow_self_registration: false
 
 # Per-IP rate limiter (issue #52). Enabled by default; set `enabled: false`
 # in trusted networks. When the management server runs behind a reverse
-# proxy that adds X-Forwarded-For, set `trust_proxy_header: true` so the
-# limiter keys on the real client IP instead of the proxy's RemoteAddr.
+# proxy that adds X-Forwarded-For, set `trust_proxy_header: true`. Loopback
+# proxies are trusted automatically. List non-loopback proxy CIDRs under
+# `trusted_proxies`; never list client networks there.
 #
 # rate_limit:
 #   enabled: true
 #   trust_proxy_header: false
+#   trusted_proxies:
+#     - "10.42.0.0/16"
 #   groups:
 #     auth:        { rate: 5,  burst: 10 }   # /ui/login, /ui/register, /ui/2fa/*, /ui/oidc/callback
 #     ui:          { rate: 30, burst: 60 }   # all other /ui/* routes

--- a/deploy/reverse-proxy/README.md
+++ b/deploy/reverse-proxy/README.md
@@ -15,7 +15,8 @@ All three:
 
 - terminate TLS on `:443` and proxy plain HTTP to `127.0.0.1:8080`;
 - preserve the real client IP via `X-Forwarded-For` (works with
-  `rate_limit.trust_proxy_header: true` in `server.yml`);
+  `rate_limit.trust_proxy_header: true` in `server.yml`; the bundled
+  loopback upstream needs no `trusted_proxies` entry);
 - disable buffering on `/ui/events` so the Server-Sent Events feed
   (issue #43) reaches the browser in real time;
 - set HSTS, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
@@ -24,6 +25,10 @@ All three:
 The agent endpoints (`/api/v1/enroll`, `/api/v1/agent/updates`) carry
 their own bearer / token authentication — do **not** stack HTTP basic
 auth in the proxy on top of them.
+
+If the proxy connects from a non-loopback address, add that proxy's CIDR
+to `rate_limit.trusted_proxies`. Do not add client networks: only trusted
+direct peers may supply the rate-limit identity through `X-Forwarded-For`.
 
 ## Optional: mTLS on the UI only (issue #69)
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -75,7 +75,7 @@ Trust zones, from least to most trusted:
 - **Tampering**: write actions ownership-checked; input bounded (host name/groups #186, firewall selectors #195). Mobile profile settings reject unknown or missing fields, non-IP DNS resolvers, duplicates, and oversized lists or domains.
 - **Repudiation**: mutating actions write an audit-log entry; audit-log read is admin-gated.
 - **Information disclosure**: list/read scoped to owned CAs in SQL (#154); blocklist scoped per-CA (#203); mobile profile settings are scoped through their Network and owning CA; no cross-tenant IDOR (403 not 404 side-channel documented & accepted).
-- **DoS**: request body capped + HTTP timeouts (#185); per-IP rate limit (#52). Authenticated legitimate-use DoS is out of scope (SECURITY.md).
+- **DoS**: request body capped + HTTP timeouts (#185); per-IP rate limit (#52), with forwarded client addresses accepted only from configured proxy peers (#328). Authenticated legitimate-use DoS is out of scope (SECURITY.md).
 - **Elevation**: no general "update operator" sink → no `role` mass-assignment (Netmaker CVE-2026-29195 class refuted); admin-only operator/settings endpoints.
 
 ### E2 — Web UI

--- a/docs/server.md
+++ b/docs/server.md
@@ -106,8 +106,21 @@ Three working snippets ship in the package at
 - `traefik-dynamic.yml` — Traefik v3 file provider.
 
 All three preserve `X-Forwarded-For` so the management server's per-IP
-rate limiter (issue #52) keys on the real client IP — set
+rate limiter (issue #52) keys on the real client IP. Set
 `rate_limit.trust_proxy_header: true` in `server.yml` to opt into that.
+The bundled proxies connect from loopback, which is trusted automatically.
+If a container or cluster proxy connects from another address, list only
+the proxy network:
+
+```yaml
+rate_limit:
+  trust_proxy_header: true
+  trusted_proxies:
+    - "10.42.0.0/16"
+```
+
+Do not add client networks to `trusted_proxies`. An untrusted direct peer
+cannot select the rate-limit key through `X-Forwarded-For`.
 
 ## Upgrade
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -163,9 +163,14 @@ func Serve(configPath string, insecureHTTP bool) error {
 
 	// Build a single rate limiter shared by API and Web. The Web UI runs
 	// auth/ui groups; the API server runs api/enroll/agent_poll groups.
+	trustedProxyPrefixes, err := cfg.RateLimit.TrustedProxyPrefixes()
+	if err != nil {
+		return err
+	}
 	rlCfg := ratelimit.Default()
 	rlCfg.Enabled = cfg.RateLimit.IsEnabled()
 	rlCfg.TrustProxyHeader = cfg.RateLimit.TrustProxyHeader
+	rlCfg.TrustedProxyPrefixes = trustedProxyPrefixes
 	for name, gc := range cfg.RateLimit.Groups {
 		if gc.Rate > 0 && gc.Burst > 0 {
 			rlCfg.Groups[name] = ratelimit.GroupConfig{Rate: gc.Rate, Burst: gc.Burst}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -261,13 +261,15 @@ type PasswordConfig struct {
 // RateLimitConfig drives the rate-limit middleware. Enabled defaults to
 // true; turn it off in trusted-network deployments by setting
 // `rate_limit: { enabled: false }`. Set `trust_proxy_header: true` when
-// running behind a reverse proxy that adds X-Forwarded-For.
+// running behind a reverse proxy that adds X-Forwarded-For. Loopback is
+// trusted automatically; list every non-loopback proxy in `trusted_proxies`.
 type RateLimitConfig struct {
 	// Enabled is a pointer so an absent YAML block defaults to "true"
 	// (issue #52 requires on-by-default) while still allowing a
 	// `rate_limit: { enabled: false }` to disable it.
 	Enabled          *bool                           `yaml:"enabled,omitempty"`
 	TrustProxyHeader bool                            `yaml:"trust_proxy_header,omitempty"`
+	TrustedProxies   []string                        `yaml:"trusted_proxies,omitempty"`
 	Groups           map[string]RateLimitGroupConfig `yaml:"groups,omitempty"`
 }
 
@@ -283,6 +285,20 @@ func (c RateLimitConfig) IsEnabled() bool {
 		return true
 	}
 	return *c.Enabled
+}
+
+// TrustedProxyPrefixes parses the configured proxy CIDRs. Loopback peers are
+// trusted implicitly when TrustProxyHeader is enabled.
+func (c RateLimitConfig) TrustedProxyPrefixes() ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(c.TrustedProxies))
+	for _, raw := range c.TrustedProxies {
+		prefix, err := netip.ParsePrefix(raw)
+		if err != nil {
+			return nil, fmt.Errorf("rate_limit.trusted_proxies entry %q: %w", raw, err)
+		}
+		prefixes = append(prefixes, prefix.Masked())
+	}
+	return prefixes, nil
 }
 
 // AlertsConfig drives the periodic cert-expiry scanner and its sinks.
@@ -510,6 +526,9 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 	}
 	if cfg.TrustedSecretIngressProxy && !listenIsLoopback(cfg.Listen) {
 		return nil, fmt.Errorf("trusted_secret_ingress_proxy requires a loopback listen address, got %q", cfg.Listen)
+	}
+	if _, err := cfg.RateLimit.TrustedProxyPrefixes(); err != nil {
+		return nil, err
 	}
 
 	if err := cfg.OIDC.Validate(); err != nil {

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -67,6 +67,48 @@ func TestLoadServerConfig_Defaults(t *testing.T) {
 	}
 }
 
+func TestLoadServerConfig_TrustedProxyCIDRs(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "server.yml")
+	data := []byte(`rate_limit:
+  trust_proxy_header: true
+  trusted_proxies:
+    - "10.42.0.0/16"
+    - "2001:db8::/32"
+`)
+	if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadServerConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadServerConfig: %v", err)
+	}
+	prefixes, err := cfg.RateLimit.TrustedProxyPrefixes()
+	if err != nil {
+		t.Fatalf("TrustedProxyPrefixes: %v", err)
+	}
+	if len(prefixes) != 2 || prefixes[0].String() != "10.42.0.0/16" || prefixes[1].String() != "2001:db8::/32" {
+		t.Fatalf("prefixes = %v", prefixes)
+	}
+}
+
+func TestLoadServerConfig_RejectsInvalidTrustedProxyCIDR(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "server.yml")
+	data := []byte(`rate_limit:
+  trust_proxy_header: true
+  trusted_proxies: ["not-a-cidr"]
+`)
+	if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadServerConfig(cfgPath); err == nil {
+		t.Fatal("LoadServerConfig accepted invalid trusted proxy CIDR")
+	}
+}
+
 func TestLoadServerConfig_CAImportSecuritySettings(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "server.yml")

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -12,6 +12,7 @@ import (
 	"hash/fnv"
 	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,9 +29,10 @@ type GroupConfig struct {
 
 // Config drives the limiter.
 type Config struct {
-	Enabled          bool
-	TrustProxyHeader bool
-	Groups           map[string]GroupConfig
+	Enabled              bool
+	TrustProxyHeader     bool
+	TrustedProxyPrefixes []netip.Prefix
+	Groups               map[string]GroupConfig
 	// MaxEntriesPerShard caps the per-shard LRU. Default 65536.
 	MaxEntriesPerShard int
 	// Shards is the number of shards. Power-of-two recommended. Default 4.
@@ -122,7 +124,7 @@ func (l *Limiter) Allow(ip, group string) (allowed bool, retryAfter time.Duratio
 // rightmost entry does not parse, or trust_proxy_header is off,
 // RemoteAddr is used.
 func (l *Limiter) ClientIP(r *http.Request) string {
-	if l != nil && l.cfg.TrustProxyHeader {
+	if l != nil && l.cfg.TrustProxyHeader && l.isTrustedProxy(r.RemoteAddr) {
 		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 			parts := strings.Split(xff, ",")
 			last := strings.TrimSpace(parts[len(parts)-1])
@@ -136,6 +138,27 @@ func (l *Limiter) ClientIP(r *http.Request) string {
 		return r.RemoteAddr
 	}
 	return host
+}
+
+func (l *Limiter) isTrustedProxy(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return false
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	addr = addr.Unmap()
+	if addr.IsLoopback() {
+		return true
+	}
+	for _, prefix := range l.cfg.TrustedProxyPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }
 
 // MaskIP collapses an IP to its rate-limit-friendly prefix so audit

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -139,6 +140,37 @@ func TestClientIP_NoTrust_UsesRemoteAddr(t *testing.T) {
 	r.Header.Set("X-Forwarded-For", "203.0.113.10")
 	if got := l.ClientIP(r); got != "192.0.2.5" {
 		t.Errorf("ClientIP = %q, want 192.0.2.5 (X-Forwarded-For ignored)", got)
+	}
+}
+
+func TestClientIP_UntrustedDirectPeerIgnoresForwardedHeader(t *testing.T) {
+	l := New(Config{
+		Enabled:          true,
+		TrustProxyHeader: true,
+		Groups:           map[string]GroupConfig{"auth": {Rate: 5, Burst: 10}},
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "192.0.2.5:1234"
+	r.Header.Set("X-Forwarded-For", "203.0.113.10")
+	if got := l.ClientIP(r); got != "192.0.2.5" {
+		t.Errorf("ClientIP = %q, want direct peer 192.0.2.5", got)
+	}
+}
+
+func TestClientIP_ConfiguredProxyUsesForwardedHeader(t *testing.T) {
+	l := New(Config{
+		Enabled:              true,
+		TrustProxyHeader:     true,
+		TrustedProxyPrefixes: []netip.Prefix{netip.MustParsePrefix("10.42.0.0/16")},
+		Groups:               map[string]GroupConfig{"auth": {Rate: 5, Burst: 10}},
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.42.7.9:1234"
+	r.Header.Set("X-Forwarded-For", "198.51.100.25")
+	if got := l.ClientIP(r); got != "198.51.100.25" {
+		t.Errorf("ClientIP = %q, want forwarded client 198.51.100.25", got)
 	}
 }
 


### PR DESCRIPTION
## What

Trust `X-Forwarded-For` only when the direct peer is loopback or matches a configured proxy CIDR.

## Why

With `rate_limit.trust_proxy_header` enabled, a directly connected client could choose a new rate-limit key on every request by changing the forwarded address.

Fixes #328.

## How

- Add `rate_limit.trusted_proxies` as a validated CIDR list.
- Treat loopback proxies as trusted for compatibility with the bundled reverse-proxy setup.
- Ignore forwarded addresses from every other direct peer.
- Preserve the existing rightmost-address and fail-closed parsing for trusted proxies.
- Document the proxy boundary in the example config, deployment guides, and threat model.

Regression tests cover an untrusted direct client, a configured proxy, malformed headers, and multi-hop headers.

## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
