### PR TITLE
fix(networks): resolve CA before persisting to avoid empty ca_id

### DIFF
--- a/docs/security/invariants.md
+++ b/docs/security/invariants.md
@@ -311,6 +311,10 @@ leave a weaker or partially applied security state.
 - Mobile bundle generation reads the durable CA blocklist and current enrolled
   relay inventory. After the full bundle has been generated, it atomically
   re-checks the durable Host and owner status while persisting the certificate.
+- Network and host creation resolves the CA ID to the server default CA when
+  the caller omits `ca_id`, ensuring a non-empty value persists. The startup
+  invariant `CountEmptyCAIDRows` (serve.go:134-140) rejects any empty `ca_id`
+  rows in the networks, hosts, certificates, or blocklist tables.
 - Migration tests exercise upgrade, repeated migrate, rollback, and foreign-key
   enforcement.
 
@@ -333,6 +337,11 @@ leave a weaker or partially applied security state.
 - `internal/store/sqlite_update_host_atomic_test.go`:
   `TestUpdateHost_ResetsConfigVersion` and
   `TestUpdateHost_SECPERSIST001_RollbackIsAtomic`.
+- `internal/api/networks_test.go`:
+  `TestCreateNetwork_SEC_PERSIST_001_OmittingCAIDResolvesDefaultAndPersistsNonEmpty`
+  verifies that omitting `ca_id` resolves to the default CA and persists a
+  non-empty value, and `TestCreateNetwork_NoDefaultCA_RejectsEmptyCAID` verifies
+  rejection when no default CA is configured.
 - `internal/store/migration_023_test.go`, `migration_024_test.go`, and
   `migration_pinned_conn_test.go`: migration repeatability and constraints.
 

--- a/internal/api/networks.go
+++ b/internal/api/networks.go
@@ -41,28 +41,40 @@ func (s *Server) handleCreateNetwork(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.CAID != "" {
-		ca, err := s.store.GetCA(r.Context(), req.CAID)
-		if errors.Is(err, store.ErrNotFound) {
-			writeError(w, http.StatusNotFound, "CA not found")
-			return
-		}
-		if err != nil {
-			s.logger.Error("load network CA", "error", err)
-			writeError(w, http.StatusInternalServerError, "failed to load CA")
-			return
-		}
-		if ca.Status != models.CAStatusActive {
-			writeError(w, http.StatusConflict, "CA must be active")
-			return
-		}
+
+	// Resolve CA ID: use explicit ca_id from request, or fall back to server default CA.
+	// Enforces SEC-PERSIST-001: never persist an empty ca_id. Startup invariant
+	// CountEmptyCAIDRows (serve.go:134-140) rejects empty ca_id rows at restart.
+	caID := req.CAID
+	if caID == "" {
+		caID = s.defaultCAID
+	}
+	if caID == "" {
+		writeError(w, http.StatusBadRequest, "ca_id is required and no default CA is configured")
+		return
+	}
+
+	// Validate resolved CA exists and is active (even for default CA).
+	ca, err := s.store.GetCA(r.Context(), caID)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "CA not found")
+		return
+	}
+	if err != nil {
+		s.logger.Error("load network CA", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load CA")
+		return
+	}
+	if ca.Status != models.CAStatusActive {
+		writeError(w, http.StatusConflict, "CA must be active")
+		return
 	}
 
 	network := &models.Network{
 		ID:        uuid.New().String(),
 		Name:      req.Name,
 		CIDRs:     req.CIDRs,
-		CAID:      req.CAID,
+		CAID:      caID,
 		CreatedAt: time.Now(),
 	}
 

--- a/internal/api/networks_test.go
+++ b/internal/api/networks_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -125,5 +126,95 @@ func TestCreateNetwork_RejectsDuplicateCIDRs(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for duplicate CIDRs, got %d, body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateNetwork_SEC_PERSIST_001_OmittingCAIDResolvesDefaultAndPersistsNonEmpty
+// enforces SEC-PERSIST-001: creating a network without ca_id must resolve the
+// server default CA and persist a non-empty ca_id. The startup invariant
+// CountEmptyCAIDRows (serve.go:134-140) must remain zero after creation.
+func TestCreateNetwork_SEC_PERSIST_001_OmittingCAIDResolvesDefaultAndPersistsNonEmpty(t *testing.T) {
+	srv, s := newTestServer(t)
+	ctx := context.Background()
+
+	// Get the default CA ID that newTestServer configured
+	defaultCAID := srv.defaultCAID
+	if defaultCAID == "" {
+		t.Fatal("newTestServer did not set defaultCAID")
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":  "test-net",
+		"cidrs": []string{"10.0.0.0/24"},
+		// Note: no ca_id field submitted
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var net models.Network
+	if err := json.NewDecoder(w.Body).Decode(&net); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// CAID must be resolved to the default CA, not empty
+	if net.CAID != defaultCAID {
+		t.Errorf("CAID = %q, want defaultCAID %q (empty CAID would break startup invariant)", net.CAID, defaultCAID)
+	}
+
+	// Startup invariant CountEmptyCAIDRows must be zero
+	empty, err := s.CountEmptyCAIDRows(ctx)
+	if err != nil {
+		t.Fatalf("CountEmptyCAIDRows: %v", err)
+	}
+	if empty != 0 {
+		t.Errorf("CountEmptyCAIDRows = %d, want 0 (startup invariant would reject server restart)", empty)
+	}
+}
+
+// TestCreateNetwork_NoDefaultCA_RejectsEmptyCAID verifies that omitting ca_id
+// when the server has no default CA configured returns 400 and does not persist
+// a network. This ensures the reject path works correctly.
+func TestCreateNetwork_NoDefaultCA_RejectsEmptyCAID(t *testing.T) {
+	srv, s := newTestServer(t)
+	ctx := context.Background()
+
+	// Clear the default CA to simulate a server without one configured
+	srv.defaultCAID = ""
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":  "test-net",
+		"cidrs": []string{"10.0.0.0/24"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d, body: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the error message mentions the requirement
+	var errResp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp["error"] == "" {
+		t.Fatal("error message is empty")
+	}
+
+	// Verify no network was persisted (CountEmptyCAIDRows should still be 0)
+	empty, err := s.CountEmptyCAIDRows(ctx)
+	if err != nil {
+		t.Fatalf("CountEmptyCAIDRows: %v", err)
+	}
+	if empty != 0 {
+		t.Errorf("CountEmptyCAIDRows = %d, want 0 (network should not have been persisted)", empty)
 	}
 }

--- a/internal/web/form_inline_errors_test.go
+++ b/internal/web/form_inline_errors_test.go
@@ -128,7 +128,8 @@ func TestHostCreate_InlineErrorPreservesRole(t *testing.T) {
 // TestNetworkCreate_InlineErrorPreservesForm — issue #91 for the network
 // create form (which lives expanded on /ui/networks).
 func TestNetworkCreate_InlineErrorPreservesForm(t *testing.T) {
-	w, _ := newTestWeb(t)
+	w, s := newTestWeb(t)
+	seedActiveCA(t, s, "ca-1", "admin-test-id", "seed-ca")
 	cookies := loginSession(t, w)
 
 	csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/networks", cookies)
@@ -172,7 +173,8 @@ func TestNetworkCreate_InlineErrorPreservesForm(t *testing.T) {
 }
 
 func TestNetworkCreate_InlineErrorRequiredFields(t *testing.T) {
-	w, _ := newTestWeb(t)
+	w, s := newTestWeb(t)
+	seedActiveCA(t, s, "ca-1", "admin-test-id", "seed-ca")
 	cookies := loginSession(t, w)
 
 	csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/networks", cookies)

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -1422,10 +1422,10 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "Failed to load CAs", http.StatusInternalServerError)
 		return
 	}
-	// Non-admins must own at least one active CA. admins fall through
-	// to the legacy "no CA tied to network" path so existing deployments
-	// keep working until they migrate.
-	if op.Role != "admin" && len(cas) == 0 {
+	// All operators (including admins) must own at least one active CA.
+	// Enforces SEC-PERSIST-001: never persist an empty ca_id. Startup invariant
+	// CountEmptyCAIDRows (serve.go:134-140) rejects empty ca_id rows at restart.
+	if len(cas) == 0 {
 		w.renderNetworksError(rw, r, form, cas, "You must create a CA before adding a network. Open the CAs page to mint one.")
 		return
 	}
@@ -1448,7 +1448,7 @@ func (w *Web) handleNetworkCreate(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	caID := form.CAID
-	if caID == "" && op.Role != "admin" {
+	if caID == "" {
 		if len(cas) != 1 {
 			w.renderNetworksError(rw, r, form, cas, "pick a CA to sign certificates for this network")
 			return

--- a/internal/web/networks_test.go
+++ b/internal/web/networks_test.go
@@ -1,0 +1,155 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// TestHandleCreateNetwork_AdminWithoutCA_RejectsEmptyCAID verifies that
+// an admin operator without selecting a CA is rejected when creating a network.
+// This enforces SEC-PERSIST-001: the admin should not be allowed to persist an
+// empty ca_id (the legacy fallthrough path).
+func TestHandleCreateNetwork_AdminWithoutCA_RejectsEmptyCAID(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	adminCookie := mintSession(t, s, "admin", "admin")
+
+	// Get CSRF token from the networks page
+	csrfToken, cookies := getCSRFTokenFromCookies(t, w, "/ui/networks", []*http.Cookie{adminCookie})
+
+	// Form submission without ca_id selected
+	form := url.Values{}
+	form.Set("name", "test-net")
+	form["cidrs"] = []string{"10.0.0.0/24"}
+	form.Set("_csrf", csrfToken)
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	rw := httptest.NewRecorder()
+	w.ServeHTTP(rw, req)
+
+	// Must reject with error
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rw.Code)
+	}
+	body := rw.Body.String()
+	if !strings.Contains(body, "pick a CA") && !strings.Contains(body, "must create a CA") {
+		t.Errorf("response should mention CA selection requirement, got: %s", body)
+	}
+
+	// Verify no network was persisted with empty ca_id
+	networks, err := s.ListNetworks(context.Background())
+	if err != nil {
+		t.Fatalf("ListNetworks: %v", err)
+	}
+	for _, net := range networks {
+		if net.Name == "test-net" && net.CAID == "" {
+			t.Error("network was persisted with empty CAID, violates SEC-PERSIST-001")
+		}
+	}
+}
+
+// TestHandleCreateNetwork_NonAdminWithoutCA_Rejects is a sanity check that
+// non-admin operators without CAs are also rejected (existing behavior).
+func TestHandleCreateNetwork_NonAdminWithoutCA_Rejects(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	userCookie := mintSession(t, s, "user", "user")
+
+	csrfToken, cookies := getCSRFTokenFromCookies(t, w, "/ui/networks", []*http.Cookie{userCookie})
+
+	form := url.Values{}
+	form.Set("name", "test-net")
+	form.Add("cidr", "10.0.0.0/24")
+	form.Set("_csrf", csrfToken)
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	rw := httptest.NewRecorder()
+	w.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rw.Code)
+	}
+}
+
+// TestHandleCreateNetwork_AdminWithCA_Succeeds verifies that an admin who
+// explicitly selects a CA can create a network (existing behavior preserved).
+func TestHandleCreateNetwork_AdminWithCA_Succeeds(t *testing.T) {
+	w, s := newOperatorsWeb(t)
+	adminCookie := mintSession(t, s, "admin", "admin")
+
+	// Create a CA for the admin to select
+	ca := &models.CA{
+		ID:                   uuid.New().String(),
+		Name:                 "test-ca",
+		OwnerOperatorID:      "op-admin",
+		CertPEM:              "-----BEGIN CERTIFICATE-----\nstub\n-----END CERTIFICATE-----",
+		Fingerprint:          "fp-test",
+		NotBefore:            time.Now(),
+		NotAfter:             time.Now().Add(time.Hour),
+		Status:               models.CAStatusActive,
+		EncryptedKeyDEK:      []byte("dek"),
+		NonceDEK:             []byte("ndek"),
+		EncryptedKeyMaterial: []byte("key"),
+		NonceKey:             []byte("nkey"),
+		CreatedAt:            time.Now(),
+		UpdatedAt:            time.Now(),
+	}
+	if err := s.CreateCA(context.Background(), ca); err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+
+	csrfToken, cookies := getCSRFTokenFromCookies(t, w, "/ui/networks", []*http.Cookie{adminCookie})
+
+	// Form submission with explicit ca_id
+	form := url.Values{
+		"name":  {"test-net"},
+		"cidrs": {"10.0.0.0/24"},
+		"ca_id": {ca.ID},
+		"_csrf": {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/networks", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	rw := httptest.NewRecorder()
+	w.ServeHTTP(rw, req)
+
+	// Verify network was created with the selected CA
+	networks, err := s.ListNetworks(context.Background())
+	if err != nil {
+		t.Fatalf("ListNetworks: %v", err)
+	}
+
+	var found *models.Network
+	for _, net := range networks {
+		if net.Name == "test-net" {
+			found = net
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("network was not created")
+	}
+	if found.CAID != ca.ID {
+		t.Errorf("network CAID = %q, want %q", found.CAID, ca.ID)
+	}
+}


### PR DESCRIPTION
## Problem

Creating a network without `ca_id` succeeded and wrote a row with an empty `ca_id`. On the next server restart the startup invariant `CountEmptyCAIDRows` (SEC-PERSIST-001) rejected those rows and refused to boot:

> found N rows with empty ca_id; legacy migration required (see ADR-0007)

Two production paths allowed this: the API handler only validated the CA when `ca_id` was non-empty, and the Web handler had an admin-only fallthrough that bypassed CA selection entirely.

## Fix

**API (`POST /api/v1/networks`):** resolve `ca_id` to the server default CA when the caller omits it, and reject with 400 when neither an explicit `ca_id` nor a default CA is configured. The resolved CA is validated for existence and active status before persisting.

**Web (`handleNetworkCreate`):** require at least one active CA for all operators, including admins, removing the legacy fallthrough that let an empty `ca_id` reach the store.

Both paths now guarantee a non-empty, validated `ca_id` before persisting, so `CountEmptyCAIDRows` will never trip on freshly created data.

## How to verify

- `go test -race ./internal/api/ ./internal/web/` — new regression tests cover both paths.
- Tests reference SEC-PERSIST-001: omitting `ca_id` resolves the default CA and persists non-empty; no default CA configured returns 400 with no row written; an admin without a CA selection is rejected.

## Code anchors

- `internal/api/networks.go:45-71` — CA resolution + rejection
- `internal/web/handlers.go:1425-1457` — universal zero-CA guard, admin exemption removed
- `docs/security/invariants.md` — SEC-PERSIST-001 enforcement note + test anchor

Closes #339.
