### PR TITLE
feat(firewall): add cidr and local_cidr fields to firewall rules for enhanced traffic scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ When this beats hand-rolled scripts or a managed service:
 - **Multi-address overlays** — networks and hosts can carry multiple overlay IPs (e.g. for dual-stack or multi-segment routing).
 - **Per-host advanced overrides** — `listen_host`, `mtu`, `tun_device`, `punchy`, `unsafe_routes` opt-in per host without touching the network default. Host records are editable via UI/API after creation (`PATCH /api/v1/hosts/{id}`).
 - **Audit trail** — every mutating UI / API / CLI call is recorded with actor, action, target, plus a stable `ca_id` on host events.
-- **Per-network firewall rules** — managed declaratively via API, distributed to all hosts; plus additive per-host inbound rules (`advanced.firewall_inbound`) to open ports for specific groups on a single host.
+- **Per-network firewall rules** — managed declaratively via API, distributed to all hosts; plus additive per-host inbound rules (`advanced.firewall_inbound`) to open ports for specific groups on a single host. Rules select their peer by group or by `cidr`, and can be scoped to a local address with `local_cidr` — required to allow traffic for prefixes served via `unsafe_routes`.
 - **Production-ready basics** — `/healthz`, `/readyz`, Prometheus exporter at `/metrics` (legacy `expvar` view at `/debug/vars`), built-in cert-expiry alerter (audit + webhook + per-host Prometheus gauge), structured `slog` logs, optional in-process TLS, SQLite (WAL) with tracked migrations.
 - **Tiny footprint** — two static binaries (~15–25 MiB each), SQLite, no external deps. Runs on a $5 VM.
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -881,6 +881,18 @@ components:
         port: { type: string }
         proto: { type: string }
         group: { type: string }
+        cidr:
+          type: string
+          description: >-
+            Nebula `cidr`: restricts the rule to peers inside the prefix. A CIDR
+            or "any". An alternative to group, not a companion — Nebula OR's the
+            peer selectors, so a rule carries one or the other.
+        local_cidr:
+          type: string
+          description: >-
+            Nebula `local_cidr`: restricts the rule to traffic for a local
+            address. A CIDR or "any". AND'd with the peer selector, and required
+            to allow traffic for prefixes served via unsafe_routes.
 
     AgentImportFirewallPolicy:
       type: object

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -294,7 +294,10 @@ object in the API:
       { "route": "192.168.10.0/24", "via": "10.0.0.99" }
     ],
     "firewall_inbound": [
-      { "port": "22", "proto": "tcp", "group": "admin" }
+      { "port": "22", "proto": "tcp", "group": "admin" },
+      { "port": "443", "proto": "tcp", "cidr": "10.0.5.0/24" },
+      { "port": "any", "proto": "any", "group": "gw",
+        "local_cidr": "192.168.10.0/24" }
     ]
   }
 }
@@ -310,20 +313,56 @@ advanced block. Server-side validation rejects:
 - malformed CIDR or non-IP `via` in `unsafe_routes`;
 - `firewall_inbound` rules with a proto outside `any`/`tcp`/`udp`/`icmp`, a
   port that is not `any`, a single port `1-65535` or an ascending range
-  `a-b`, an empty or overlong (>64 chars) group, or more than 64 rules.
+  `a-b`, an overlong (>64 chars) group, no peer selector at all, both a
+  `group` and a `cidr`, a `cidr`/`local_cidr` that is neither a CIDR nor
+  `any`, or more than 64 rules.
 
 ### Per-host inbound firewall rules
 
 `advanced.firewall_inbound` appends host-specific inbound rules **after** the
 network-wide firewall policy in the rendered `config.yml` — additive only,
 inbound only; the network policy and the outbound section are never modified.
-In the UI the rules are entered one per line as `PORT/PROTO from GROUP`
+In the UI the rules are entered one per line as
+`PORT/PROTO from GROUP [cidr=<CIDR>] [local_cidr=<CIDR>]`
 (e.g. `443/tcp from web`, `8000-9000/udp from monitoring`). A rule with group
 `any` renders as `host: any` (matches every peer), same as the network
 policy. Changing these rules re-publishes only the affected host's config on
 its next poll. Mobile bundles include them too. Note that mesh import always
 captures firewall policy at network level — per-host rules are never derived
 from imported configs.
+
+#### Address-scoped rules: `cidr` and `local_cidr`
+
+Both the network policy and per-host rules accept Nebula's
+[`cidr` and `local_cidr`](https://nebula.defined.net/docs/config/firewall/)
+fields. Each takes a prefix (`10.0.0.0/24`, `fd00::/8`, `0.0.0.0/0`, `::/0`) or
+the literal `any`, meaning any address of any family.
+
+- **`cidr`** scopes the rule by the *peer's* overlay address. It is a peer
+  selector, so it stands in place of `group` rather than alongside it:
+  `{"port": "443", "proto": "tcp", "cidr": "10.0.5.0/24"}` allows 443/tcp from
+  any peer addressed in `10.0.5.0/24`, whatever its groups.
+- **`local_cidr`** scopes the rule by the *local* address the traffic is
+  destined to (inbound) or sourced from (outbound). It is not a selector — it
+  narrows whichever selector the rule already has:
+  `{"port": "any", "proto": "any", "group": "gw", "local_cidr": "192.168.10.0/24"}`
+  allows the `gw` group to reach only the addresses in `192.168.10.0/24`.
+
+Nebula evaluates a rule as
+`port AND proto AND (ca_sha OR ca_name) AND (host OR group OR groups OR cidr) AND local_cidr`.
+Because the peer selectors are OR'd, a rule listing both a `group` and a `cidr`
+matches "that group **or** that prefix" — wider than either alone, and rarely
+what an operator means. Both the API and the renderer therefore reject a rule
+carrying both; write two rules when you genuinely want the union. A rule with
+no selector at all is likewise rejected: Nebula reads the empty selector as
+match-any.
+
+`local_cidr` is what makes a rule apply to addresses you serve through
+`unsafe_routes`. By default Nebula restricts `local_cidr` to the overlay
+networks in the host's own certificate, so traffic for an unsafe-routed prefix
+matches no inbound rule until a rule names that prefix (or `any`) explicitly.
+A relay/gateway host advertising `192.168.10.0/24` via `unsafe_routes` needs a
+rule whose `local_cidr` covers `192.168.10.0/24` before peers can reach it.
 
 ### Multiple overlay addresses per host
 

--- a/internal/agent/discovery.go
+++ b/internal/agent/discovery.go
@@ -279,20 +279,42 @@ func sanitizeFirewallRules(path string, value any, unsupported *[]string) []mesh
 			*unsupported = append(*unsupported, fmt.Sprintf("%s[%d]", path, index))
 			continue
 		}
-		group := fmt.Sprint(entry["group"])
-		if group == "<nil>" || group == "" {
-			if host := fmt.Sprint(entry["host"]); host == "any" {
+		group := optionalConfigString(entry["group"])
+		// A cidr is a peer selector in its own right, so a cidr-selected rule
+		// is not a rule with a missing principal.
+		cidr := optionalConfigString(entry["cidr"])
+		if group == "" && cidr == "" {
+			if host := optionalConfigString(entry["host"]); host == "any" {
 				group = "any"
 			} else {
 				group = "any"
 				*unsupported = append(*unsupported, fmt.Sprintf("%s[%d].principal", path, index))
 			}
 		}
+		// Every field goes through optionalConfigString: a missing key must
+		// read as empty, which reconciliation reports as a rule requiring
+		// port and proto, rather than as the literal "<nil>" that would pass
+		// the non-empty check and reach the renderer.
 		rules = append(rules, meshimport.FirewallRule{
-			Port: fmt.Sprint(entry["port"]), Proto: fmt.Sprint(entry["proto"]), Group: group,
+			Port: optionalConfigString(entry["port"]), Proto: optionalConfigString(entry["proto"]), Group: group,
+			Cidr: cidr, LocalCidr: optionalConfigString(entry["local_cidr"]),
 		})
 	}
 	return rules
+}
+
+// optionalConfigString reads a scalar config field that may be absent,
+// yielding "" rather than the "<nil>" that fmt.Sprint produces for a missing
+// key.
+func optionalConfigString(value any) string {
+	if value == nil {
+		return ""
+	}
+	s := fmt.Sprint(value)
+	if s == "<nil>" {
+		return ""
+	}
+	return s
 }
 
 func collectUnsupportedConfigKeys(settings map[string]any) []string {
@@ -335,7 +357,9 @@ func supportedConfigLeaf(path string) bool {
 		"listen.host", "listen.port", "punchy.punch", "tun.dev", "tun.mtu",
 		"tun.unsafe_routes[].route", "tun.unsafe_routes[].via",
 		"firewall.inbound[].port", "firewall.inbound[].proto", "firewall.inbound[].group", "firewall.inbound[].host",
-		"firewall.outbound[].port", "firewall.outbound[].proto", "firewall.outbound[].group", "firewall.outbound[].host":
+		"firewall.inbound[].cidr", "firewall.inbound[].local_cidr",
+		"firewall.outbound[].port", "firewall.outbound[].proto", "firewall.outbound[].group", "firewall.outbound[].host",
+		"firewall.outbound[].cidr", "firewall.outbound[].local_cidr":
 		return true
 	}
 	return strings.HasPrefix(normalized, "static_host_map.")

--- a/internal/agent/discovery_test.go
+++ b/internal/agent/discovery_test.go
@@ -309,3 +309,60 @@ func indentYAML(value string) string {
 	}
 	return strings.Join(lines, "\n")
 }
+
+// TestDiscoverExistingCapturesFirewallCIDRFields checks that an existing
+// deployment's cidr / local_cidr rules survive discovery: they must be carried
+// into the snapshot rather than dropped, and must not be reported as
+// unsupported config keys (which would block the import).
+func TestDiscoverExistingCapturesFirewallCIDRFields(t *testing.T) {
+	fixture := newDiscoveryFixture(t)
+	fixture.writeConfig(t, fmt.Sprintf(`
+pki:
+  ca: %s
+  cert: %s
+  key: %s
+static_host_map:
+  "10.42.0.1": ["198.51.100.1:4242"]
+lighthouse:
+  am_lighthouse: true
+  hosts: ["10.42.0.1"]
+listen: {host: "0.0.0.0", port: 4242}
+firewall:
+  inbound:
+    - {port: "22", proto: tcp, group: ops, local_cidr: "192.0.2.0/24"}
+    - {port: "443", proto: tcp, cidr: "10.42.0.0/24"}
+  outbound:
+    - {port: any, proto: any, host: any, local_cidr: any}
+`, fixture.caPath, fixture.certPath, fixture.keyPath))
+
+	discovery, err := DiscoverExisting(fixture.configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer discovery.Wipe()
+	if discovery.State != DiscoveryComplete {
+		t.Fatalf("state = %q, issues = %v", discovery.State, discovery.Issues)
+	}
+
+	config := discovery.Snapshot.Config
+	if len(config.Firewall.Inbound) != 2 {
+		t.Fatalf("inbound = %#v", config.Firewall.Inbound)
+	}
+	if got := config.Firewall.Inbound[0]; got.Group != "ops" || got.LocalCidr != "192.0.2.0/24" || got.Cidr != "" {
+		t.Errorf("inbound[0] = %#v, want group ops with local_cidr 192.0.2.0/24", got)
+	}
+	// A cidr-selected rule has a principal, so it must not be rewritten to
+	// group "any" the way a rule with no selector at all is.
+	if got := config.Firewall.Inbound[1]; got.Cidr != "10.42.0.0/24" || got.Group != "" {
+		t.Errorf("inbound[1] = %#v, want cidr 10.42.0.0/24 and no group", got)
+	}
+	if got := config.Firewall.Outbound[0]; got.Group != "any" || got.LocalCidr != "any" {
+		t.Errorf("outbound[0] = %#v, want group any with local_cidr any", got)
+	}
+	for _, key := range config.UnsupportedKeys {
+		if strings.Contains(key, "cidr") || strings.Contains(key, "principal") {
+			t.Errorf("unsupported keys %v should not flag cidr fields", config.UnsupportedKeys)
+			break
+		}
+	}
+}

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/forgekeep/nebula-mesh/internal/bootstraptoken"
 	"github.com/forgekeep/nebula-mesh/internal/configgen"
+	"github.com/forgekeep/nebula-mesh/internal/configinput"
 	"github.com/forgekeep/nebula-mesh/internal/models"
 	"github.com/forgekeep/nebula-mesh/internal/pki"
 	"github.com/forgekeep/nebula-mesh/internal/store"
@@ -350,18 +351,7 @@ func (s *Server) renderHostConfig(ctx context.Context, host *models.Host) ([]byt
 		FirewallInbound:  fwInbound,
 		FirewallOutbound: fwOutbound,
 	}
-	if adv := host.Advanced; adv != nil {
-		input.PunchyOverride = adv.Punchy
-		input.ListenHost = adv.ListenHost
-		input.MTU = adv.MTU
-		input.TunDevice = adv.TunDevice
-		for _, u := range adv.UnsafeRoutes {
-			input.UnsafeRoutes = append(input.UnsafeRoutes, configgen.AdvancedUnsafeRoute{Route: u.Route, Via: u.Via})
-		}
-		for _, fr := range adv.FirewallInbound {
-			input.HostFirewallInbound = append(input.HostFirewallInbound, configgen.FirewallRule{Port: fr.Port, Proto: fr.Proto, Group: fr.Group})
-		}
-	}
+	configinput.ApplyHostAdvanced(&input, host.Advanced)
 
 	// Emit the per-CA blocklist into pki.blocklist so the Nebula daemon
 	// rejects handshakes from revoked peers (GHSA-cm26-5974-52h8).

--- a/internal/api/firewall.go
+++ b/internal/api/firewall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/forgekeep/nebula-mesh/internal/configgen"
+	"github.com/forgekeep/nebula-mesh/internal/models"
 	"github.com/forgekeep/nebula-mesh/internal/store"
 )
 
@@ -22,11 +23,59 @@ type firewallRule struct {
 	Port  string `json:"port"`
 	Proto string `json:"proto"`
 	Group string `json:"group"`
+	// Cidr selects peers by Nebula address instead of by group; LocalCidr
+	// constrains the local address the traffic is destined to (or sourced
+	// from, outbound), and is required to allow traffic for prefixes served
+	// via unsafe_routes. Both accept a CIDR or "any".
+	Cidr      string `json:"cidr,omitempty"`
+	LocalCidr string `json:"local_cidr,omitempty"`
 }
 
+// defaultFirewallRules is the policy reported for a network that has never
+// stored one. It is derived from the renderer's baseline rather than restated,
+// so the rules the API reports cannot drift from the rules agents actually
+// receive when the baseline changes.
 var defaultFirewallRules = firewallRulesRequest{
-	Inbound:  []firewallRule{{Port: "any", Proto: "icmp", Group: "any"}},
-	Outbound: []firewallRule{{Port: "any", Proto: "any", Group: "any"}},
+	Inbound:  apiFirewallRules(configgen.DefaultFirewallInbound),
+	Outbound: apiFirewallRules(configgen.DefaultFirewallOutbound),
+}
+
+// validateFirewallRule bounds one rule of a network-wide policy.
+//
+// A rule without a peer selector is marshaled into network_config and pushed to
+// every agent, where Nebula treats the empty selector as match-any — a broader
+// allow than intended. So exactly one selector is required (group or cidr;
+// Nebula OR's them, so both at once widens the rule), the group length is
+// bounded consistently with host group caps, and the prefixes must be values
+// Nebula can parse.
+func validateFirewallRule(rule firewallRule) error {
+	if rule.Port == "" {
+		return errors.New("port must not be empty")
+	}
+	if rule.Proto == "" {
+		return errors.New("proto must not be empty")
+	}
+	if err := models.ValidateFirewallSelectors(rule.Group, rule.Cidr); err != nil {
+		return err
+	}
+	if len(rule.Group) > maxGroupNameLen {
+		return fmt.Errorf("group must be at most %d characters", maxGroupNameLen)
+	}
+	return models.ValidateFirewallCIDR("local_cidr", rule.LocalCidr)
+}
+
+func apiFirewallRules(in []configgen.FirewallRule) []firewallRule {
+	out := make([]firewallRule, 0, len(in))
+	for _, r := range in {
+		out = append(out, firewallRule{
+			Port:      r.Port,
+			Proto:     r.Proto,
+			Group:     r.Group,
+			Cidr:      r.Cidr,
+			LocalCidr: r.LocalCidr,
+		})
+	}
+	return out
 }
 
 func (s *Server) handleGetFirewall(w http.ResponseWriter, r *http.Request) {
@@ -95,24 +144,8 @@ func (s *Server) handleUpdateFirewall(w http.ResponseWriter, r *http.Request) {
 
 	for _, rules := range [][]firewallRule{req.Inbound, req.Outbound} {
 		for _, rule := range rules {
-			if rule.Port == "" {
-				writeError(w, http.StatusBadRequest, "firewall rule port must not be empty")
-				return
-			}
-			if rule.Proto == "" {
-				writeError(w, http.StatusBadRequest, "firewall rule proto must not be empty")
-				return
-			}
-			// A rule without a target group is marshaled into network_config and
-			// pushed to every agent, where Nebula treats the empty selector as
-			// match-any — a broader allow than intended. Require an explicit
-			// selector and bound its length, consistent with host group caps.
-			if rule.Group == "" {
-				writeError(w, http.StatusBadRequest, "firewall rule must specify a target group")
-				return
-			}
-			if len(rule.Group) > maxGroupNameLen {
-				writeError(w, http.StatusBadRequest, fmt.Sprintf("firewall rule group must be at most %d characters", maxGroupNameLen))
+			if err := validateFirewallRule(rule); err != nil {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("firewall rule: %s", err))
 				return
 			}
 		}

--- a/internal/api/firewall_render_test.go
+++ b/internal/api/firewall_render_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/forgekeep/nebula-mesh/internal/models"
 )
 
@@ -145,5 +147,85 @@ func TestRenderHostConfig_AppendsHostFirewallInbound(t *testing.T) {
 	}
 	if netIdx, hostIdx := strings.Index(out, "auditors-only"), strings.Index(out, "bastion-admins"); netIdx > hostIdx {
 		t.Errorf("network rule should render before the per-host rule\n%s", out)
+	}
+}
+
+// TestRenderHostConfig_AppliesStoredCIDRRules is the end-to-end path for the
+// cidr / local_cidr fields: a stored policy using them must reach the agent
+// config as `cidr:` / `local_cidr:` keys, and a cidr-selected rule must not
+// pick up a `host: any` on the way — Nebula OR's the peer selectors, so that
+// would match every peer and discard the prefix restriction.
+func TestRenderHostConfig_AppliesStoredCIDRRules(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	const policy = `{"inbound":[` +
+		`{"port":"443","proto":"tcp","cidr":"10.77.0.0/24"},` +
+		`{"port":"22","proto":"tcp","group":"admins-only","local_cidr":"192.0.2.0/24"}],` +
+		`"outbound":[{"port":"any","proto":"any","group":"any"}]}`
+	if err := srv.store.SetNetworkConfig(ctx, netID, "firewall", policy); err != nil {
+		t.Fatal(err)
+	}
+
+	host := renderTestHost(t, srv, netID)
+	cfg, err := srv.renderHostConfig(ctx, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed struct {
+		Firewall struct {
+			Inbound []map[string]any `yaml:"inbound"`
+		} `yaml:"firewall"`
+	}
+	if err := yaml.Unmarshal(cfg, &parsed); err != nil {
+		t.Fatalf("rendered config is not valid YAML: %v\n%s", err, cfg)
+	}
+	in := parsed.Firewall.Inbound
+	if len(in) != 2 {
+		t.Fatalf("inbound rules = %d, want 2\n%s", len(in), cfg)
+	}
+
+	// The cidr-selected rule must carry the prefix and no host/group.
+	if in[0]["cidr"] != "10.77.0.0/24" {
+		t.Errorf("inbound[0].cidr = %v, want 10.77.0.0/24", in[0]["cidr"])
+	}
+	if _, ok := in[0]["host"]; ok {
+		t.Errorf("cidr-selected rule gained host, widening it to every peer: %v", in[0])
+	}
+	if _, ok := in[0]["group"]; ok {
+		t.Errorf("cidr-selected rule gained group: %v", in[0])
+	}
+
+	if in[1]["group"] != "admins-only" || in[1]["local_cidr"] != "192.0.2.0/24" {
+		t.Errorf("inbound[1] = %v, want group admins-only with local_cidr 192.0.2.0/24", in[1])
+	}
+}
+
+// TestRenderHostConfig_WiderCIDRRuleFallsBackToDefault pins that a stored rule
+// carrying both a group and a cidr — which Nebula would OR into a wider rule —
+// is refused at render time and the host receives the safe baseline instead.
+func TestRenderHostConfig_WiderCIDRRuleFallsBackToDefault(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+	ctx := context.Background()
+
+	const policy = `{"inbound":[{"port":"443","proto":"tcp","group":"web","cidr":"10.77.0.0/24"}],` +
+		`"outbound":[{"port":"any","proto":"any","group":"any"}]}`
+	if err := srv.store.SetNetworkConfig(ctx, netID, "firewall", policy); err != nil {
+		t.Fatal(err)
+	}
+
+	host := renderTestHost(t, srv, netID)
+	cfg, err := srv.renderHostConfig(ctx, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(cfg)
+	if strings.Contains(out, "10.77.0.0/24") || strings.Contains(out, "group: web") {
+		t.Errorf("rule with both group and cidr was rendered instead of falling back\n%s", out)
+	}
+	if !strings.Contains(out, "proto: icmp") {
+		t.Errorf("expected the icmp baseline after fallback\n%s", out)
 	}
 }

--- a/internal/api/firewall_validation_test.go
+++ b/internal/api/firewall_validation_test.go
@@ -112,3 +112,122 @@ func TestUpdateFirewall_AcceptsValidGroup(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code, "well-formed rule at the length bound must be accepted")
 }
+
+// TestUpdateFirewall_CIDRSelectors covers the cidr / local_cidr rule fields on
+// the network policy endpoint: a cidr may stand in for a group, local_cidr may
+// accompany either, and the combinations Nebula would widen or reject are
+// refused.
+func TestUpdateFirewall_CIDRSelectors(t *testing.T) {
+	cases := []struct {
+		name     string
+		inbound  map[string]string
+		wantCode int
+	}{
+		{
+			name:     "cidr instead of group",
+			inbound:  map[string]string{"port": "443", "proto": "tcp", "cidr": "10.0.0.0/24"},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "group with local_cidr",
+			inbound:  map[string]string{"port": "443", "proto": "tcp", "group": "web", "local_cidr": "192.168.50.0/24"},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "any is a valid cidr and local_cidr",
+			inbound:  map[string]string{"port": "any", "proto": "any", "cidr": "any", "local_cidr": "any"},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "ipv6 prefixes",
+			inbound:  map[string]string{"port": "any", "proto": "any", "cidr": "fd00::/8", "local_cidr": "::/0"},
+			wantCode: http.StatusOK,
+		},
+		{
+			// Nebula OR's the peer selectors, so a rule carrying both matches
+			// more than either alone.
+			name:     "group and cidr together rejected",
+			inbound:  map[string]string{"port": "443", "proto": "tcp", "group": "web", "cidr": "10.0.0.0/24"},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "local_cidr alone is not a selector",
+			inbound:  map[string]string{"port": "443", "proto": "tcp", "local_cidr": "10.0.0.0/24"},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "unparseable cidr rejected",
+			inbound:  map[string]string{"port": "443", "proto": "tcp", "cidr": "10.0.0.0/33"},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "bare IP as cidr rejected",
+			inbound:  map[string]string{"port": "443", "proto": "tcp", "cidr": "10.0.0.1"},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "unparseable local_cidr rejected",
+			inbound:  map[string]string{"port": "443", "proto": "tcp", "group": "web", "local_cidr": "nope"},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, testDB := newTestServer(t)
+			opKey, _, ca := createOperatorWithCA(t, srv)
+			net := &models.Network{
+				ID:    fmt.Sprintf("net-fw-cidr-%d", i),
+				Name:  fmt.Sprintf("Net FW CIDR %d", i),
+				CAID:  ca.ID,
+				CIDRs: []string{"10.0.0.0/8"},
+			}
+			require.NoError(t, testDB.CreateNetwork(context.Background(), net))
+
+			body, _ := json.Marshal(map[string]any{
+				"inbound":  []map[string]string{tc.inbound},
+				"outbound": []map[string]string{{"port": "any", "proto": "any", "group": "any"}},
+			})
+			w := putFirewall(t, srv, opKey, net.ID, body)
+			assert.Equal(t, tc.wantCode, w.Code, "rule %v", tc.inbound)
+		})
+	}
+}
+
+// TestUpdateFirewall_CIDRRulesRoundTripThroughGet verifies the new fields
+// survive the store round-trip and are echoed back by GET, so an operator
+// editing an existing policy does not silently drop them.
+func TestUpdateFirewall_CIDRRulesRoundTripThroughGet(t *testing.T) {
+	srv, testDB := newTestServer(t)
+	opKey, _, ca := createOperatorWithCA(t, srv)
+	net := &models.Network{
+		ID:    "net-fw-cidr-roundtrip",
+		Name:  "Net FW CIDR Roundtrip",
+		CAID:  ca.ID,
+		CIDRs: []string{"10.0.0.0/8"},
+	}
+	require.NoError(t, testDB.CreateNetwork(context.Background(), net))
+
+	body, _ := json.Marshal(map[string]any{
+		"inbound": []map[string]string{
+			{"port": "443", "proto": "tcp", "cidr": "10.0.0.0/24"},
+			{"port": "22", "proto": "tcp", "group": "admin", "local_cidr": "192.168.50.0/24"},
+		},
+		"outbound": []map[string]string{{"port": "any", "proto": "any", "group": "any"}},
+	})
+	require.Equal(t, http.StatusOK, putFirewall(t, srv, opKey, net.ID, body).Code)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/networks/%s/firewall", net.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+opKey)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got firewallRulesRequest
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got.Inbound, 2)
+	assert.Equal(t, "10.0.0.0/24", got.Inbound[0].Cidr)
+	assert.Empty(t, got.Inbound[0].Group, "a cidr-selected rule must not gain a group")
+	assert.Equal(t, "admin", got.Inbound[1].Group)
+	assert.Equal(t, "192.168.50.0/24", got.Inbound[1].LocalCidr)
+}

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -47,8 +47,10 @@ type updateHostRequest struct {
 // then distributed to every peer; without caps an operator could bloat certs
 // mesh-wide (#186). Generous relative to real use, but bounded.
 const (
-	maxHostNameLen  = 255
-	maxGroupNameLen = 64
+	maxHostNameLen = 255
+	// maxGroupNameLen is the domain-layer bound, aliased here so the API and
+	// models.ValidateHostAdvanced cannot enforce different caps.
+	maxGroupNameLen = models.MaxGroupNameLen
 	maxHostGroups   = 64
 )
 

--- a/internal/configgen/firewall.go
+++ b/internal/configgen/firewall.go
@@ -3,6 +3,7 @@ package configgen
 import (
 	"encoding/json"
 	"fmt"
+	"net/netip"
 )
 
 // DefaultFirewallInbound and DefaultFirewallOutbound are the baseline policy a
@@ -23,9 +24,11 @@ type storedFirewallRules struct {
 }
 
 type storedFirewallRule struct {
-	Port  string `json:"port"`
-	Proto string `json:"proto"`
-	Group string `json:"group"`
+	Port      string `json:"port"`
+	Proto     string `json:"proto"`
+	Group     string `json:"group"`
+	Cidr      string `json:"cidr,omitempty"`
+	LocalCidr string `json:"local_cidr,omitempty"`
 }
 
 // FirewallRulesFromJSON converts the management API's stored firewall JSON
@@ -36,9 +39,10 @@ type storedFirewallRule struct {
 // gets the baseline, which is not an error condition.
 //
 // It returns the safe defaults together with a non-nil error when the JSON is
-// malformed or any rule is unusable (an empty port, proto, or group). The
-// empty group in particular is the work-322fy footgun: Nebula rejects a rule
-// with neither group nor host, failing the whole config on load. Returning
+// malformed or any rule is unusable (an empty port or proto, no peer selector,
+// or an unparseable cidr/local_cidr). The missing selector in particular is
+// the work-322fy footgun: Nebula rejects a rule with neither group nor host,
+// failing the whole config on load. Returning
 // the defaults rather than the bad rules guarantees that wiring a network's
 // stored policy into a host config can never produce an agent config Nebula
 // refuses to load; the non-nil error lets the caller surface that the
@@ -71,12 +75,38 @@ func convertStoredRules(direction string, in []storedFirewallRule) ([]FirewallRu
 		// Mirror the API write-time validation: a rule missing any selector
 		// would render a config Nebula rejects (empty group/host) or an
 		// ambiguous match (empty port/proto).
-		if r.Port == "" || r.Proto == "" || r.Group == "" {
-			return nil, fmt.Errorf("%s rule %d: port, proto, and group must all be non-empty", direction, i)
+		if r.Port == "" || r.Proto == "" {
+			return nil, fmt.Errorf("%s rule %d: port and proto must both be non-empty", direction, i)
+		}
+		if r.Group == "" && r.Cidr == "" {
+			return nil, fmt.Errorf("%s rule %d: a group or cidr must be set", direction, i)
+		}
+		// Nebula OR's group and cidr, so a rule carrying both matches more
+		// than either alone. Refuse rather than render the wider rule.
+		if r.Group != "" && r.Cidr != "" {
+			return nil, fmt.Errorf("%s rule %d: group and cidr are mutually exclusive", direction, i)
+		}
+		if err := validateStoredCIDR(r.Cidr); err != nil {
+			return nil, fmt.Errorf("%s rule %d: cidr: %w", direction, i, err)
+		}
+		if err := validateStoredCIDR(r.LocalCidr); err != nil {
+			return nil, fmt.Errorf("%s rule %d: local_cidr: %w", direction, i, err)
 		}
 		// storedFirewallRule and FirewallRule share the same field layout;
 		// the conversion drops only the json tags.
 		out = append(out, FirewallRule(r))
 	}
 	return out, nil
+}
+
+// validateStoredCIDR accepts an unset field, the literal "any", or a prefix
+// Nebula can parse. Anything else would fail the agent's config load.
+func validateStoredCIDR(value string) error {
+	if value == "" || value == "any" {
+		return nil
+	}
+	if _, err := netip.ParsePrefix(value); err != nil {
+		return fmt.Errorf("%q is not a CIDR or \"any\"", value)
+	}
+	return nil
 }

--- a/internal/configgen/firewall_test.go
+++ b/internal/configgen/firewall_test.go
@@ -185,3 +185,212 @@ func TestGenerate_HostFirewallInbound_DoesNotMutateDefaults(t *testing.T) {
 		t.Fatalf("DefaultFirewallInbound mutated: %#v", DefaultFirewallInbound)
 	}
 }
+
+// TestFirewallRulesFromJSON_CIDRFields covers the cidr / local_cidr rule
+// fields: accepted forms round-trip verbatim, and the combinations Nebula
+// would either reject or silently widen fall back to the baseline.
+func TestFirewallRulesFromJSON_CIDRFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		json        string
+		wantErr     bool
+		wantInbound []FirewallRule
+	}{
+		{
+			name:        "cidr selects the peer without a group",
+			json:        `{"inbound":[{"port":"443","proto":"tcp","cidr":"10.0.0.0/24"}],"outbound":[]}`,
+			wantInbound: []FirewallRule{{Port: "443", Proto: "tcp", Cidr: "10.0.0.0/24"}},
+		},
+		{
+			name:        "local_cidr accompanies a group",
+			json:        `{"inbound":[{"port":"any","proto":"any","group":"web","local_cidr":"172.16.0.0/16"}],"outbound":[]}`,
+			wantInbound: []FirewallRule{{Port: "any", Proto: "any", Group: "web", LocalCidr: "172.16.0.0/16"}},
+		},
+		{
+			name:        "any is a valid cidr and local_cidr value",
+			json:        `{"inbound":[{"port":"any","proto":"any","cidr":"any","local_cidr":"any"}],"outbound":[]}`,
+			wantInbound: []FirewallRule{{Port: "any", Proto: "any", Cidr: "any", LocalCidr: "any"}},
+		},
+		{
+			name:        "ipv6 prefixes accepted",
+			json:        `{"inbound":[{"port":"any","proto":"any","cidr":"fd00::/8","local_cidr":"::/0"}],"outbound":[]}`,
+			wantInbound: []FirewallRule{{Port: "any", Proto: "any", Cidr: "fd00::/8", LocalCidr: "::/0"}},
+		},
+		{
+			// Nebula OR's group and cidr, so a rule with both is wider than
+			// either alone — refuse rather than render the wider rule.
+			name:        "group and cidr together -> defaults + error",
+			json:        `{"inbound":[{"port":"443","proto":"tcp","group":"web","cidr":"10.0.0.0/24"}],"outbound":[]}`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+		},
+		{
+			name:        "no group and no cidr -> defaults + error",
+			json:        `{"inbound":[{"port":"443","proto":"tcp","local_cidr":"10.0.0.0/24"}],"outbound":[]}`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+		},
+		{
+			name:        "unparseable cidr -> defaults + error",
+			json:        `{"inbound":[{"port":"443","proto":"tcp","cidr":"10.0.0.0/33"}],"outbound":[]}`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+		},
+		{
+			name:        "bare IP is not a cidr -> defaults + error",
+			json:        `{"inbound":[{"port":"443","proto":"tcp","cidr":"10.0.0.1"}],"outbound":[]}`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+		},
+		{
+			name:        "unparseable local_cidr -> defaults + error",
+			json:        `{"outbound":[{"port":"any","proto":"any","group":"any","local_cidr":"nope"}],"inbound":[]}`,
+			wantErr:     true,
+			wantInbound: DefaultFirewallInbound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in, _, err := FirewallRulesFromJSON(tc.json)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if len(in) != len(tc.wantInbound) {
+				t.Fatalf("inbound = %+v, want %+v", in, tc.wantInbound)
+			}
+			for i := range tc.wantInbound {
+				if in[i] != tc.wantInbound[i] {
+					t.Errorf("inbound[%d] = %+v, want %+v", i, in[i], tc.wantInbound[i])
+				}
+			}
+		})
+	}
+}
+
+// TestGenerate_FirewallCIDRRendering pins the YAML shape of cidr / local_cidr
+// rules. The critical property is that a cidr-selected rule emits neither
+// `host` nor `group`: Nebula OR's the peer selectors, so a stray `host: any`
+// alongside `cidr` would match every peer and discard the restriction.
+func TestGenerate_FirewallCIDRRendering(t *testing.T) {
+	input := GeneratorInput{
+		HostName:   "gw",
+		NebulaIPs:  []string{"192.168.100.7"},
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+		FirewallInbound: []FirewallRule{
+			{Port: "443", Proto: "tcp", Cidr: "10.0.0.0/24"},
+			{Port: "22", Proto: "tcp", Group: "admin", LocalCidr: "192.168.50.0/24"},
+			{Port: "any", Proto: "icmp", Group: "any", LocalCidr: "any"},
+		},
+		FirewallOutbound: []FirewallRule{
+			{Port: "any", Proto: "any", Cidr: "any"},
+		},
+	}
+
+	data, err := Generate(input)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var parsed struct {
+		Firewall struct {
+			Inbound  []map[string]any `yaml:"inbound"`
+			Outbound []map[string]any `yaml:"outbound"`
+		} `yaml:"firewall"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid YAML: %v\n%s", err, string(data))
+	}
+
+	in := parsed.Firewall.Inbound
+	if len(in) != 3 {
+		t.Fatalf("inbound rules = %d, want 3: %s", len(in), string(data))
+	}
+
+	// cidr-selected rule: cidr only, no host/group, no local_cidr key.
+	if in[0]["cidr"] != "10.0.0.0/24" {
+		t.Errorf("inbound[0].cidr = %v, want 10.0.0.0/24", in[0]["cidr"])
+	}
+	if _, ok := in[0]["host"]; ok {
+		t.Errorf("inbound[0] must not emit host alongside cidr (Nebula OR's them, matching every peer): %v", in[0])
+	}
+	if _, ok := in[0]["group"]; ok {
+		t.Errorf("inbound[0] must not emit group alongside cidr: %v", in[0])
+	}
+	if _, ok := in[0]["local_cidr"]; ok {
+		t.Errorf("inbound[0] should omit an unset local_cidr: %v", in[0])
+	}
+
+	// group + local_cidr: both emitted, AND'd by Nebula.
+	if in[1]["group"] != "admin" || in[1]["local_cidr"] != "192.168.50.0/24" {
+		t.Errorf("inbound[1] = %v, want group admin with local_cidr 192.168.50.0/24", in[1])
+	}
+	if _, ok := in[1]["cidr"]; ok {
+		t.Errorf("inbound[1] should omit an unset cidr: %v", in[1])
+	}
+
+	// group "any" still renders host: any, now with local_cidr alongside.
+	if in[2]["host"] != "any" || in[2]["local_cidr"] != "any" {
+		t.Errorf("inbound[2] = %v, want host any with local_cidr any", in[2])
+	}
+
+	out := parsed.Firewall.Outbound
+	if len(out) != 1 {
+		t.Fatalf("outbound rules = %d, want 1", len(out))
+	}
+	if out[0]["cidr"] != "any" {
+		t.Errorf("outbound[0].cidr = %v, want any", out[0]["cidr"])
+	}
+	if _, ok := out[0]["host"]; ok {
+		t.Errorf("outbound[0] must not emit host alongside cidr: %v", out[0])
+	}
+}
+
+// TestGenerate_FirewallIPv6CIDRSurvivesYAML guards the YAML scalar safety of
+// IPv6 prefixes. "::/0" starts with a colon, an indicator character, so it is
+// exactly the kind of value a plain scalar can mangle — if it ever emitted
+// unquoted in a way the loader retyped, agents would fail to load the config or
+// silently match a different prefix. safeString's "!!str" tag is what makes it
+// safe; this test fails if that changes.
+func TestGenerate_FirewallIPv6CIDRSurvivesYAML(t *testing.T) {
+	input := GeneratorInput{
+		HostName:   "v6",
+		NebulaIPs:  []string{"fd00::1"},
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+		FirewallInbound: []FirewallRule{
+			{Port: "any", Proto: "any", Cidr: "::/0", LocalCidr: "::/0"},
+			{Port: "any", Proto: "any", Cidr: "fd00::/8", LocalCidr: "fe80::/10"},
+		},
+		FirewallOutbound: []FirewallRule{{Port: "any", Proto: "any", Group: "any"}},
+	}
+	data, err := Generate(input)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var parsed struct {
+		Firewall struct {
+			Inbound []map[string]any `yaml:"inbound"`
+		} `yaml:"firewall"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("IPv6 firewall prefixes broke the config's YAML: %v\n%s", err, data)
+	}
+	want := []struct{ cidr, localCidr string }{
+		{"::/0", "::/0"},
+		{"fd00::/8", "fe80::/10"},
+	}
+	if len(parsed.Firewall.Inbound) != len(want) {
+		t.Fatalf("inbound rules = %d, want %d\n%s", len(parsed.Firewall.Inbound), len(want), data)
+	}
+	for i, w := range want {
+		if got := parsed.Firewall.Inbound[i]["cidr"]; got != w.cidr {
+			t.Errorf("inbound[%d].cidr = %#v (%T), want %q as a string", i, got, got, w.cidr)
+		}
+		if got := parsed.Firewall.Inbound[i]["local_cidr"]; got != w.localCidr {
+			t.Errorf("inbound[%d].local_cidr = %#v (%T), want %q as a string", i, got, got, w.localCidr)
+		}
+	}
+}

--- a/internal/configgen/generator.go
+++ b/internal/configgen/generator.go
@@ -6,11 +6,15 @@ type LighthouseInfo struct {
 	PublicAddr string // "1.2.3.4:4242"
 }
 
-// FirewallRule represents a single firewall rule.
+// FirewallRule represents a single firewall rule. A rule carries exactly one
+// peer selector — Group or Cidr — because Nebula OR's them; LocalCidr is an
+// independent constraint AND'd into the matched selector.
 type FirewallRule struct {
-	Port  string // "any", "22", "443"
-	Proto string // "any", "tcp", "udp", "icmp"
-	Group string // "any", "admin", etc.
+	Port      string // "any", "22", "443"
+	Proto     string // "any", "tcp", "udp", "icmp"
+	Group     string // "any", "admin", etc.
+	Cidr      string // "", "any", "10.0.0.0/24" — remote (peer) address
+	LocalCidr string // "", "any", "10.0.0.0/24" — local address
 }
 
 // AdvancedUnsafeRoute mirrors models.UnsafeRoute for the generator input.

--- a/internal/configgen/marshal.go
+++ b/internal/configgen/marshal.go
@@ -217,14 +217,18 @@ type mobileNebulaSection struct {
 	MatchDomains []safeString `yaml:"match_domains"`
 }
 
-// firewallRule is constructed with exactly one of {Group, Host} set per rule —
-// matching the shape the previous template emitted: `group: <name>` for named
-// groups, `host: any` for the catch-all.
+// firewallRule is constructed with exactly one of {Group, Host, Cidr} set per
+// rule — matching the shape the previous template emitted: `group: <name>` for
+// named groups, `host: any` for the catch-all — plus `cidr` for prefix-selected
+// peers. Nebula OR's those three, so emitting more than one per rule would
+// widen it; LocalCidr is AND'd into whichever matched and is independent.
 type firewallRule struct {
-	Port  safeString `yaml:"port"`
-	Proto safeString `yaml:"proto"`
-	Group safeString `yaml:"group,omitempty"`
-	Host  safeString `yaml:"host,omitempty"`
+	Port      safeString `yaml:"port"`
+	Proto     safeString `yaml:"proto"`
+	Group     safeString `yaml:"group,omitempty"`
+	Host      safeString `yaml:"host,omitempty"`
+	Cidr      safeString `yaml:"cidr,omitempty"`
+	LocalCidr safeString `yaml:"local_cidr,omitempty"`
 }
 
 // Generate produces a Nebula config.yml from the given input by marshaling
@@ -413,10 +417,20 @@ func boolPtr(v bool) *bool {
 func mapFirewallRules(in []FirewallRule) []firewallRule {
 	out := make([]firewallRule, 0, len(in))
 	for _, r := range in {
-		fr := firewallRule{Port: safeString(r.Port), Proto: safeString(r.Proto)}
-		if r.Group == "any" {
+		fr := firewallRule{
+			Port:      safeString(r.Port),
+			Proto:     safeString(r.Proto),
+			LocalCidr: safeString(r.LocalCidr),
+		}
+		// Exactly one peer selector. A cidr-selected rule emits neither group
+		// nor host: `host: any` alongside `cidr` would be OR'd by Nebula and
+		// match every peer, silently discarding the prefix restriction.
+		switch {
+		case r.Cidr != "":
+			fr.Cidr = safeString(r.Cidr)
+		case r.Group == "any":
 			fr.Host = "any"
-		} else {
+		default:
 			fr.Group = safeString(r.Group)
 		}
 		out = append(out, fr)

--- a/internal/configinput/configinput.go
+++ b/internal/configinput/configinput.go
@@ -1,0 +1,47 @@
+// Package configinput bridges domain hosts onto the config renderer's input.
+//
+// internal/configgen deliberately mirrors the few domain types it needs
+// (configgen.FirewallRule, configgen.AdvancedUnsafeRoute) rather than importing
+// internal/models, so that GeneratorInput stays an explicit render contract
+// instead of a view onto the domain model. The cost of that boundary is that
+// every caller building a GeneratorInput has to translate models.HostAdvanced
+// field by field — and each new advanced field then has to be wired into every
+// caller identically or it is silently dropped from one of them.
+//
+// This package holds that translation once. It is the only place that knows how
+// a host's advanced overrides map onto the renderer, so adding an advanced
+// field is a single edit.
+package configinput
+
+import (
+	"github.com/forgekeep/nebula-mesh/internal/configgen"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// ApplyHostAdvanced copies a host's advanced overrides onto input.
+//
+// A nil adv leaves input untouched, so a host with no advanced block renders
+// byte-identically to before. Slice-valued overrides are appended, not
+// assigned: HostFirewallInbound is additive on top of the network-wide policy
+// the caller has already put in FirewallInbound.
+func ApplyHostAdvanced(input *configgen.GeneratorInput, adv *models.HostAdvanced) {
+	if input == nil || adv == nil {
+		return
+	}
+	input.PunchyOverride = adv.Punchy
+	input.ListenHost = adv.ListenHost
+	input.MTU = adv.MTU
+	input.TunDevice = adv.TunDevice
+	for _, u := range adv.UnsafeRoutes {
+		input.UnsafeRoutes = append(input.UnsafeRoutes, configgen.AdvancedUnsafeRoute{Route: u.Route, Via: u.Via})
+	}
+	for _, fr := range adv.FirewallInbound {
+		input.HostFirewallInbound = append(input.HostFirewallInbound, configgen.FirewallRule{
+			Port:      fr.Port,
+			Proto:     fr.Proto,
+			Group:     fr.Group,
+			Cidr:      fr.Cidr,
+			LocalCidr: fr.LocalCidr,
+		})
+	}
+}

--- a/internal/configinput/configinput_test.go
+++ b/internal/configinput/configinput_test.go
@@ -1,0 +1,96 @@
+package configinput
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/forgekeep/nebula-mesh/internal/configgen"
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// TestApplyHostAdvanced_CopiesEveryField is the guard that makes this package
+// worth having: it fails when a field is added to models.HostAdvanced without
+// being wired into ApplyHostAdvanced, which would otherwise silently drop the
+// override from every rendered config.
+func TestApplyHostAdvanced_CopiesEveryField(t *testing.T) {
+	punchy := false
+	adv := &models.HostAdvanced{
+		Punchy:     &punchy,
+		ListenHost: "10.0.0.1",
+		MTU:        1300,
+		TunDevice:  "nebula1",
+		UnsafeRoutes: []models.UnsafeRoute{
+			{Route: "192.168.10.0/24", Via: "10.0.0.99"},
+		},
+		FirewallInbound: []models.HostFirewallRule{
+			{Port: "22", Proto: "tcp", Group: "admin"},
+			{Port: "443", Proto: "tcp", Cidr: "10.0.5.0/24"},
+			{Port: "any", Proto: "any", Group: "gw", LocalCidr: "192.168.10.0/24"},
+		},
+	}
+
+	var input configgen.GeneratorInput
+	ApplyHostAdvanced(&input, adv)
+
+	if input.PunchyOverride == nil || *input.PunchyOverride {
+		t.Errorf("PunchyOverride = %v, want explicit false", input.PunchyOverride)
+	}
+	if input.ListenHost != "10.0.0.1" || input.MTU != 1300 || input.TunDevice != "nebula1" {
+		t.Errorf("scalar overrides not copied: %+v", input)
+	}
+	wantRoutes := []configgen.AdvancedUnsafeRoute{{Route: "192.168.10.0/24", Via: "10.0.0.99"}}
+	if !reflect.DeepEqual(input.UnsafeRoutes, wantRoutes) {
+		t.Errorf("UnsafeRoutes = %+v, want %+v", input.UnsafeRoutes, wantRoutes)
+	}
+	wantRules := []configgen.FirewallRule{
+		{Port: "22", Proto: "tcp", Group: "admin"},
+		{Port: "443", Proto: "tcp", Cidr: "10.0.5.0/24"},
+		{Port: "any", Proto: "any", Group: "gw", LocalCidr: "192.168.10.0/24"},
+	}
+	if !reflect.DeepEqual(input.HostFirewallInbound, wantRules) {
+		t.Errorf("HostFirewallInbound = %+v, want %+v", input.HostFirewallInbound, wantRules)
+	}
+
+	// Every exported field of HostAdvanced must be represented above, so that
+	// adding one to the model breaks this test rather than silently rendering
+	// nothing.
+	const wantFields = 6
+	if got := reflect.TypeOf(models.HostAdvanced{}).NumField(); got != wantFields {
+		t.Errorf("models.HostAdvanced has %d fields, this test covers %d — wire the new field "+
+			"into ApplyHostAdvanced and extend this test", got, wantFields)
+	}
+}
+
+// TestApplyHostAdvanced_NilIsNoOp pins that a host with no advanced block
+// renders exactly as it did before, and that a nil input cannot panic.
+func TestApplyHostAdvanced_NilIsNoOp(t *testing.T) {
+	input := configgen.GeneratorInput{HostName: "h", MTU: 1400}
+	ApplyHostAdvanced(&input, nil)
+	if input.MTU != 1400 || input.HostName != "h" {
+		t.Errorf("nil adv modified input: %+v", input)
+	}
+	if input.UnsafeRoutes != nil || input.HostFirewallInbound != nil {
+		t.Errorf("nil adv appended slices: %+v", input)
+	}
+	ApplyHostAdvanced(nil, &models.HostAdvanced{MTU: 1300}) // must not panic
+}
+
+// TestApplyHostAdvanced_AppendsRatherThanReplaces pins that per-host firewall
+// rules land after the network-wide policy the caller already set.
+func TestApplyHostAdvanced_AppendsRatherThanReplaces(t *testing.T) {
+	input := configgen.GeneratorInput{
+		FirewallInbound: []configgen.FirewallRule{{Port: "any", Proto: "icmp", Group: "any"}},
+		HostFirewallInbound: []configgen.FirewallRule{
+			{Port: "80", Proto: "tcp", Group: "web"},
+		},
+	}
+	ApplyHostAdvanced(&input, &models.HostAdvanced{
+		FirewallInbound: []models.HostFirewallRule{{Port: "22", Proto: "tcp", Group: "admin"}},
+	})
+	if len(input.FirewallInbound) != 1 {
+		t.Errorf("network policy was modified: %+v", input.FirewallInbound)
+	}
+	if len(input.HostFirewallInbound) != 2 || input.HostFirewallInbound[1].Group != "admin" {
+		t.Errorf("host rules should be appended in order: %+v", input.HostFirewallInbound)
+	}
+}

--- a/internal/meshimport/reconcile.go
+++ b/internal/meshimport/reconcile.go
@@ -403,9 +403,31 @@ func normalizeFirewall(policy FirewallPolicy) (FirewallPolicy, error) {
 		name  string
 		rules []FirewallRule
 	}{{"inbound", out.Inbound}, {"outbound", out.Outbound}} {
-		for i, rule := range direction.rules {
-			if strings.TrimSpace(rule.Port) == "" || strings.TrimSpace(rule.Proto) == "" || strings.TrimSpace(rule.Group) == "" {
-				return FirewallPolicy{}, fmt.Errorf("%s rule %d requires port, proto and group", direction.name, i)
+		for i := range direction.rules {
+			// Trim into the stored rule, not just for the checks below. The
+			// renderer re-validates these values and does not trim, so a rule
+			// that is only valid once trimmed would pass the import and then
+			// drop the whole network policy to the baseline at render time.
+			// Trimming here also keeps whitespace from reading as a policy
+			// difference in the divergence comparison.
+			rule := &direction.rules[i]
+			rule.Port = strings.TrimSpace(rule.Port)
+			rule.Proto = strings.TrimSpace(rule.Proto)
+			rule.Group = strings.TrimSpace(rule.Group)
+			rule.Cidr = strings.TrimSpace(rule.Cidr)
+			rule.LocalCidr = strings.TrimSpace(rule.LocalCidr)
+
+			if rule.Port == "" || rule.Proto == "" {
+				return FirewallPolicy{}, fmt.Errorf("%s rule %d requires port and proto", direction.name, i)
+			}
+			// An imported policy is held to the same selector and prefix rules
+			// as one an operator writes through the API: exactly one peer
+			// selector, and cidr / local_cidr either a prefix or "any".
+			if err := models.ValidateFirewallSelectors(rule.Group, rule.Cidr); err != nil {
+				return FirewallPolicy{}, fmt.Errorf("%s rule %d: %w", direction.name, i, err)
+			}
+			if err := models.ValidateFirewallCIDR("local_cidr", rule.LocalCidr); err != nil {
+				return FirewallPolicy{}, fmt.Errorf("%s rule %d: %w", direction.name, i, err)
 			}
 		}
 	}
@@ -416,19 +438,25 @@ func normalizeFirewall(policy FirewallPolicy) (FirewallPolicy, error) {
 
 func sortFirewallRules(rules []FirewallRule) {
 	sort.Slice(rules, func(i, j int) bool {
-		left := rules[i].Port + "\x00" + rules[i].Proto + "\x00" + rules[i].Group
-		right := rules[j].Port + "\x00" + rules[j].Proto + "\x00" + rules[j].Group
-		return left < right
+		return firewallRuleKey(rules[i]) < firewallRuleKey(rules[j])
 	})
+}
+
+// firewallRuleKey renders every field of a rule, so that two policies
+// differing only in cidr or local_cidr sort apart and compare unequal — the
+// divergence check would otherwise treat them as the same policy and apply one
+// host's rules to every imported host.
+func firewallRuleKey(rule FirewallRule) string {
+	return rule.Port + "\x00" + rule.Proto + "\x00" + rule.Group + "\x00" + rule.Cidr + "\x00" + rule.LocalCidr
 }
 
 func firewallKey(policy FirewallPolicy) string {
 	var builder strings.Builder
 	for _, rule := range policy.Inbound {
-		fmt.Fprintf(&builder, "i:%s:%s:%s;", rule.Port, rule.Proto, rule.Group)
+		fmt.Fprintf(&builder, "i:%s;", firewallRuleKey(rule))
 	}
 	for _, rule := range policy.Outbound {
-		fmt.Fprintf(&builder, "o:%s:%s:%s;", rule.Port, rule.Proto, rule.Group)
+		fmt.Fprintf(&builder, "o:%s;", firewallRuleKey(rule))
 	}
 	return builder.String()
 }

--- a/internal/meshimport/reconcile_test.go
+++ b/internal/meshimport/reconcile_test.go
@@ -385,3 +385,134 @@ func requireIssueCode(t *testing.T, issues []Issue, code string) {
 	}
 	t.Fatalf("issue %q not found in %#v", code, issues)
 }
+
+// TestReconcileFirewallCIDRFields checks that cidr / local_cidr participate in
+// the firewall policy comparison. Were they excluded from the rule key, two
+// hosts whose policies differ only in local_cidr would compare equal and one
+// host's rules would be applied to every imported host.
+func TestReconcileFirewallCIDRFields(t *testing.T) {
+	fixture := newCertificateFixture(t)
+	first := fixture.snapshot(t, "first", "first", "10.42.0.20/24", []string{"ops"})
+	second := fixture.snapshot(t, "second", "second", "10.42.0.21/24", []string{"ops"})
+	policy := FirewallPolicy{
+		Inbound: []FirewallRule{
+			{Port: "22", Proto: "tcp", Group: "ops", LocalCidr: "192.0.2.0/24"},
+			{Port: "443", Proto: "tcp", Cidr: "10.42.0.0/24"},
+		},
+		Outbound: []FirewallRule{{Port: "any", Proto: "any", Group: "any"}},
+	}
+	first.Config.Firewall = policy
+	second.Config.Firewall = policy
+
+	report := fixture.reconcile(first, second)
+	if len(report.Blockers) != 0 {
+		t.Fatalf("identical cidr policies blocked: %#v", report.Blockers)
+	}
+	if !reflect.DeepEqual(report.Proposal.Firewall, policy) {
+		t.Fatalf("firewall proposal = %#v, want %#v", report.Proposal.Firewall, policy)
+	}
+
+	// Diverging only in local_cidr must still be caught.
+	second.Config.Firewall.Inbound = []FirewallRule{
+		{Port: "22", Proto: "tcp", Group: "ops", LocalCidr: "198.51.100.0/24"},
+		{Port: "443", Proto: "tcp", Cidr: "10.42.0.0/24"},
+	}
+	report = fixture.reconcile(first, second)
+	requireIssueCode(t, report.Blockers, IssueDivergentFirewall)
+
+	// Diverging only in cidr must also be caught.
+	second.Config.Firewall.Inbound = []FirewallRule{
+		{Port: "22", Proto: "tcp", Group: "ops", LocalCidr: "192.0.2.0/24"},
+		{Port: "443", Proto: "tcp", Cidr: "10.43.0.0/24"},
+	}
+	report = fixture.reconcile(first, second)
+	requireIssueCode(t, report.Blockers, IssueDivergentFirewall)
+}
+
+// TestNormalizeFirewallSelectors pins the selector rules: a cidr stands in for
+// a group, neither is rejected, and both together are rejected because Nebula
+// OR's them into a wider rule.
+func TestNormalizeFirewallSelectors(t *testing.T) {
+	cases := []struct {
+		name    string
+		rule    FirewallRule
+		wantErr bool
+	}{
+		{"group only", FirewallRule{Port: "22", Proto: "tcp", Group: "ops"}, false},
+		{"cidr only", FirewallRule{Port: "22", Proto: "tcp", Cidr: "10.0.0.0/8"}, false},
+		{"group with local_cidr", FirewallRule{Port: "22", Proto: "tcp", Group: "ops", LocalCidr: "any"}, false},
+		{"neither", FirewallRule{Port: "22", Proto: "tcp"}, true},
+		{"both", FirewallRule{Port: "22", Proto: "tcp", Group: "ops", Cidr: "10.0.0.0/8"}, true},
+		{"local_cidr is not a selector", FirewallRule{Port: "22", Proto: "tcp", LocalCidr: "10.0.0.0/8"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := normalizeFirewall(FirewallPolicy{Inbound: []FirewallRule{tc.rule}})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("normalizeFirewall(%+v) err = %v, wantErr %v", tc.rule, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestNormalizeFirewallTrimsIntoStoredRule pins that normalization trims the
+// values it stores, not just the ones it checks. The renderer re-validates the
+// persisted policy without trimming, so a rule that only parses once trimmed
+// would clear the import and then drop the entire network policy to the ICMP
+// baseline on every host at render time.
+func TestNormalizeFirewallTrimsIntoStoredRule(t *testing.T) {
+	policy := FirewallPolicy{
+		Inbound: []FirewallRule{
+			{Port: " 22 ", Proto: " tcp ", Group: " ops ", LocalCidr: " 192.0.2.0/24 "},
+			{Port: "443", Proto: "tcp", Cidr: " 10.42.0.0/24 "},
+		},
+		Outbound: []FirewallRule{{Port: " any ", Proto: " any ", Group: " any "}},
+	}
+	out, err := normalizeFirewall(policy)
+	if err != nil {
+		t.Fatalf("normalizeFirewall: %v", err)
+	}
+
+	for _, rule := range append(append([]FirewallRule{}, out.Inbound...), out.Outbound...) {
+		for field, value := range map[string]string{
+			"port": rule.Port, "proto": rule.Proto, "group": rule.Group,
+			"cidr": rule.Cidr, "local_cidr": rule.LocalCidr,
+		} {
+			if value != strings.TrimSpace(value) {
+				t.Errorf("%s = %q retained whitespace; the renderer would reject it", field, value)
+			}
+		}
+	}
+
+	// The trimmed values must be exactly what the renderer accepts.
+	if got := out.Inbound[1].Cidr; got != "10.42.0.0/24" {
+		t.Errorf("cidr = %q, want 10.42.0.0/24", got)
+	}
+	if got := out.Inbound[0].LocalCidr; got != "192.0.2.0/24" {
+		t.Errorf("local_cidr = %q, want 192.0.2.0/24", got)
+	}
+}
+
+// TestNormalizeFirewallWhitespaceIsNotDivergence follows from the same fix:
+// two hosts whose policies differ only in whitespace describe the same policy
+// and must not block the import as divergent.
+func TestNormalizeFirewallWhitespaceIsNotDivergence(t *testing.T) {
+	spaced, err := normalizeFirewall(FirewallPolicy{
+		Inbound:  []FirewallRule{{Port: "22", Proto: "tcp", Group: " ops "}},
+		Outbound: []FirewallRule{{Port: "any", Proto: "any", Group: "any"}},
+	})
+	if err != nil {
+		t.Fatalf("normalizeFirewall: %v", err)
+	}
+	tight, err := normalizeFirewall(FirewallPolicy{
+		Inbound:  []FirewallRule{{Port: "22", Proto: "tcp", Group: "ops"}},
+		Outbound: []FirewallRule{{Port: "any", Proto: "any", Group: "any"}},
+	})
+	if err != nil {
+		t.Fatalf("normalizeFirewall: %v", err)
+	}
+	if firewallKey(spaced) != firewallKey(tight) {
+		t.Errorf("whitespace-only difference read as divergent policy:\n%q\n%q",
+			firewallKey(spaced), firewallKey(tight))
+	}
+}

--- a/internal/meshimport/types.go
+++ b/internal/meshimport/types.go
@@ -9,9 +9,11 @@ import (
 type AgentProfile = models.AgentProfile
 
 type FirewallRule struct {
-	Port  string `json:"port"`
-	Proto string `json:"proto"`
-	Group string `json:"group"`
+	Port      string `json:"port"`
+	Proto     string `json:"proto"`
+	Group     string `json:"group"`
+	Cidr      string `json:"cidr,omitempty"`
+	LocalCidr string `json:"local_cidr,omitempty"`
 }
 
 type FirewallPolicy struct {

--- a/internal/mobilebundle/builder.go
+++ b/internal/mobilebundle/builder.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/crypto/curve25519"
 
 	"github.com/forgekeep/nebula-mesh/internal/configgen"
+	"github.com/forgekeep/nebula-mesh/internal/configinput"
 	"github.com/forgekeep/nebula-mesh/internal/mobileconfig"
 	"github.com/forgekeep/nebula-mesh/internal/models"
 	"github.com/forgekeep/nebula-mesh/internal/pki"
@@ -158,18 +159,7 @@ func Build(ctx context.Context, s store.Store, resolver interface {
 			AllowPrivateRemotes: mobileSettings.AllowPrivateRemotes,
 		},
 	}
-	if adv := host.Advanced; adv != nil {
-		input.PunchyOverride = adv.Punchy
-		input.ListenHost = adv.ListenHost
-		input.MTU = adv.MTU
-		input.TunDevice = adv.TunDevice
-		for _, u := range adv.UnsafeRoutes {
-			input.UnsafeRoutes = append(input.UnsafeRoutes, configgen.AdvancedUnsafeRoute{Route: u.Route, Via: u.Via})
-		}
-		for _, fr := range adv.FirewallInbound {
-			input.HostFirewallInbound = append(input.HostFirewallInbound, configgen.FirewallRule{Port: fr.Port, Proto: fr.Proto, Group: fr.Group})
-		}
-	}
+	configinput.ApplyHostAdvanced(&input, host.Advanced)
 
 	configYAML, err := configgen.Generate(input)
 	if err != nil {

--- a/internal/models/host.go
+++ b/internal/models/host.go
@@ -181,10 +181,25 @@ type UnsafeRoute struct {
 // HostFirewallRule is a single per-host inbound firewall rule, appended
 // after the network-wide policy in the rendered Nebula config. Group "any"
 // renders as `host: any` (match every peer), mirroring the network policy.
+//
+// Cidr and LocalCidr map to Nebula's `cidr` and `local_cidr` rule fields.
+// Nebula OR's the peer selectors (`host` / `group` / `groups` / `cidr`) and
+// AND's `local_cidr` into whichever selector matched, so a rule carries
+// exactly one peer selector — either Group or Cidr, never both, since the two
+// together would widen the rule to "group OR cidr" rather than narrow it.
+// LocalCidr is an independent constraint on the local (this host) address and
+// may accompany either selector.
 type HostFirewallRule struct {
 	Port  string `json:"port" yaml:"port"`   // "any", a port, or a range "a-b"
 	Proto string `json:"proto" yaml:"proto"` // any | tcp | udp | icmp
 	Group string `json:"group" yaml:"group"`
+	// Cidr restricts the rule to peers whose Nebula address falls inside the
+	// prefix: a CIDR, or "any" for any address of any family.
+	Cidr string `json:"cidr,omitempty" yaml:"cidr,omitempty"`
+	// LocalCidr restricts the rule to traffic whose local address falls
+	// inside the prefix: a CIDR, or "any". Needed to reach addresses served
+	// via unsafe_routes, which Nebula excludes by default.
+	LocalCidr string `json:"local_cidr,omitempty" yaml:"local_cidr,omitempty"`
 }
 
 // MaxHostFirewallRules caps advanced.firewall_inbound per host. Generous

--- a/internal/models/validate_ip.go
+++ b/internal/models/validate_ip.go
@@ -183,23 +183,59 @@ func ValidateHostAdvanced(adv *HostAdvanced) error {
 	return nil
 }
 
-// maxFirewallGroupLen mirrors the API-side cap on group names embedded in
-// certificates (maxGroupNameLen in internal/api).
-const maxFirewallGroupLen = 64
+// MaxGroupNameLen bounds a group name. Group names are embedded in the signed
+// Nebula certificate and distributed to every peer, so without a cap an
+// operator could bloat certs mesh-wide (#186). It lives here, in the domain
+// layer, because both certificate group validation and firewall rule
+// validation must enforce the same bound.
+const MaxGroupNameLen = 64
 
 func validateHostFirewallRule(r HostFirewallRule) error {
-	if r.Port == "" || r.Proto == "" || r.Group == "" {
-		return fmt.Errorf("port, proto and group are required")
+	if r.Port == "" || r.Proto == "" {
+		return fmt.Errorf("port and proto are required")
+	}
+	if err := ValidateFirewallSelectors(r.Group, r.Cidr); err != nil {
+		return err
 	}
 	switch r.Proto {
 	case "any", "tcp", "udp", "icmp":
 	default:
 		return fmt.Errorf("proto must be one of any, tcp, udp, icmp")
 	}
-	if len(r.Group) > maxFirewallGroupLen {
-		return fmt.Errorf("group must be at most %d characters", maxFirewallGroupLen)
+	if len(r.Group) > MaxGroupNameLen {
+		return fmt.Errorf("group must be at most %d characters", MaxGroupNameLen)
+	}
+	if err := ValidateFirewallCIDR("local_cidr", r.LocalCidr); err != nil {
+		return err
 	}
 	return validateFirewallPort(r.Port)
+}
+
+// ValidateFirewallSelectors enforces that a firewall rule carries exactly one
+// peer selector. Nebula OR's `group` and `cidr` (a rule listing both matches
+// peers in the group *or* peers in the prefix, which is wider than either),
+// so the two are mutually exclusive here; expressing that union takes two
+// rules. An empty pair is rejected because Nebula treats a rule with no
+// selector as match-any, a broader allow than any operator intends.
+func ValidateFirewallSelectors(group, cidr string) error {
+	switch {
+	case group == "" && cidr == "":
+		return fmt.Errorf("a group or cidr is required")
+	case group != "" && cidr != "":
+		return fmt.Errorf("group and cidr are mutually exclusive; use one rule per selector")
+	}
+	return ValidateFirewallCIDR("cidr", cidr)
+}
+
+// ValidateFirewallCIDR validates a Nebula firewall `cidr` / `local_cidr`
+// value: empty (field unset), the literal "any" (any address of any family),
+// or a parseable prefix such as 10.0.0.0/24 or fd00::/8.
+func ValidateFirewallCIDR(field, value string) error {
+	if value == "" || value == "any" {
+		return nil
+	}
+	_, err := ValidateCIDR(field, value)
+	return err
 }
 
 // validateFirewallPort accepts "any", a single port 1-65535, or an

--- a/internal/models/validate_ip_test.go
+++ b/internal/models/validate_ip_test.go
@@ -236,3 +236,55 @@ func TestValidateHostAdvanced_FirewallInbound_CapsRuleCount(t *testing.T) {
 		t.Errorf("exactly MaxHostFirewallRules rules rejected: %v", err)
 	}
 }
+
+func TestValidateHostAdvanced_FirewallInbound_CIDRFields(t *testing.T) {
+	valid := []HostFirewallRule{
+		{Port: "443", Proto: "tcp", Cidr: "10.0.0.0/24"},
+		{Port: "443", Proto: "tcp", Group: "web", LocalCidr: "192.168.50.0/24"},
+		{Port: "any", Proto: "any", Cidr: "any", LocalCidr: "any"},
+		{Port: "any", Proto: "any", Cidr: "fd00::/8", LocalCidr: "::/0"},
+		{Port: "any", Proto: "any", Cidr: "0.0.0.0/0"},
+	}
+	for _, rule := range valid {
+		if err := ValidateHostAdvanced(&HostAdvanced{FirewallInbound: []HostFirewallRule{rule}}); err != nil {
+			t.Errorf("valid rule %+v rejected: %v", rule, err)
+		}
+	}
+
+	rejected := []struct {
+		name string
+		rule HostFirewallRule
+	}{
+		// Nebula OR's group and cidr, so both together widen the rule.
+		{"group and cidr together", HostFirewallRule{Port: "443", Proto: "tcp", Group: "web", Cidr: "10.0.0.0/24"}},
+		{"local_cidr is not a selector", HostFirewallRule{Port: "443", Proto: "tcp", LocalCidr: "10.0.0.0/24"}},
+		{"unparseable cidr", HostFirewallRule{Port: "443", Proto: "tcp", Cidr: "10.0.0.0/33"}},
+		{"bare IP as cidr", HostFirewallRule{Port: "443", Proto: "tcp", Cidr: "10.0.0.1"}},
+		{"unparseable local_cidr", HostFirewallRule{Port: "443", Proto: "tcp", Group: "web", LocalCidr: "nope"}},
+		{"bare IP as local_cidr", HostFirewallRule{Port: "443", Proto: "tcp", Group: "web", LocalCidr: "192.168.50.1"}},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHostAdvanced(&HostAdvanced{FirewallInbound: []HostFirewallRule{tc.rule}})
+			if err == nil {
+				t.Fatalf("rule %+v accepted, want error", tc.rule)
+			}
+			if !strings.Contains(err.Error(), "advanced.firewall_inbound[0]") {
+				t.Errorf("error %q should reference advanced.firewall_inbound[0]", err)
+			}
+		})
+	}
+}
+
+func TestValidateFirewallCIDR(t *testing.T) {
+	for _, ok := range []string{"", "any", "10.0.0.0/8", "0.0.0.0/0", "::/0", "fd00::/8"} {
+		if err := ValidateFirewallCIDR("cidr", ok); err != nil {
+			t.Errorf("ValidateFirewallCIDR(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"10.0.0.1", "10.0.0.0/33", "nope", "ANY", "10.0.0.0/8 "} {
+		if err := ValidateFirewallCIDR("cidr", bad); err == nil {
+			t.Errorf("ValidateFirewallCIDR(%q) = nil, want error", bad)
+		}
+	}
+}

--- a/internal/web/advanced.go
+++ b/internal/web/advanced.go
@@ -63,15 +63,11 @@ func parseAdvancedFromForm(r *http.Request) (*models.HostAdvanced, error) {
 			if line == "" {
 				continue
 			}
-			parts := strings.Fields(line)
-			var port, proto string
-			if len(parts) == 3 && parts[1] == "from" {
-				port, proto, _ = strings.Cut(parts[0], "/")
+			rule, err := parseFirewallInboundLine(line)
+			if err != nil {
+				return nil, err
 			}
-			if port == "" || proto == "" || strings.Contains(proto, "/") {
-				return nil, fmt.Errorf("adv_firewall_inbound line %q: expected '<PORT>/<PROTO> from <GROUP>'", line)
-			}
-			adv.FirewallInbound = append(adv.FirewallInbound, models.HostFirewallRule{Port: port, Proto: proto, Group: parts[2]})
+			adv.FirewallInbound = append(adv.FirewallInbound, rule)
 			used = true
 		}
 	}
@@ -80,4 +76,72 @@ func parseAdvancedFromForm(r *http.Request) (*models.HostAdvanced, error) {
 		return nil, nil
 	}
 	return adv, nil
+}
+
+// firewallInboundSyntax is the one-line grammar the host form accepts for a
+// per-host inbound rule. The peer is selected either by group (`from web`) or
+// by prefix (`cidr=10.0.0.0/24`) — never both, since Nebula OR's the two —
+// and `local_cidr=` optionally narrows the local address, which is what makes
+// a rule apply to prefixes served via unsafe_routes.
+const firewallInboundSyntax = `'<PORT>/<PROTO> from <GROUP>' with optional 'cidr=<CIDR>' / 'local_cidr=<CIDR>' clauses`
+
+// isFirewallClause reports whether a field is one of the keyed clauses rather
+// than a bare value such as a group name.
+func isFirewallClause(field string) bool {
+	return strings.HasPrefix(field, "cidr=") || strings.HasPrefix(field, "local_cidr=")
+}
+
+// parseFirewallInboundLine parses one line of the adv_firewall_inbound
+// textarea. Accepted forms:
+//
+//	443/tcp from web
+//	443/tcp from web local_cidr=10.10.0.5/32
+//	443/tcp cidr=192.168.50.0/24
+//	any/icmp from any local_cidr=any
+func parseFirewallInboundLine(line string) (models.HostFirewallRule, error) {
+	fail := func() (models.HostFirewallRule, error) {
+		return models.HostFirewallRule{}, fmt.Errorf("adv_firewall_inbound line %q: expected %s", line, firewallInboundSyntax)
+	}
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return fail()
+	}
+	port, proto, _ := strings.Cut(fields[0], "/")
+	if port == "" || proto == "" || strings.Contains(proto, "/") {
+		return fail()
+	}
+	rule := models.HostFirewallRule{Port: port, Proto: proto}
+	for i := 1; i < len(fields); i++ {
+		switch field := fields[i]; {
+		case field == "from":
+			// `from` takes the next field as the group name. Reject a clause
+			// keyword there: `from cidr=10.0.0.0/24` is a plausible way to
+			// mistype the prefix selector, and consuming it as a group name
+			// would silently define a group called "cidr=10.0.0.0/24" that no
+			// certificate can ever carry — a rule that matches nothing.
+			if i+1 >= len(fields) || rule.Group != "" || isFirewallClause(fields[i+1]) {
+				return fail()
+			}
+			i++
+			rule.Group = fields[i]
+		case strings.HasPrefix(field, "cidr="):
+			if rule.Cidr != "" {
+				return fail()
+			}
+			rule.Cidr = strings.TrimPrefix(field, "cidr=")
+		case strings.HasPrefix(field, "local_cidr="):
+			if rule.LocalCidr != "" {
+				return fail()
+			}
+			rule.LocalCidr = strings.TrimPrefix(field, "local_cidr=")
+		default:
+			return fail()
+		}
+	}
+	// Surface the selector rules here, where the offending line can be named,
+	// rather than letting model validation report a bare field index.
+	if err := models.ValidateFirewallSelectors(rule.Group, rule.Cidr); err != nil {
+		return models.HostFirewallRule{}, fmt.Errorf("adv_firewall_inbound line %q: %w", line, err)
+	}
+	return rule, nil
 }

--- a/internal/web/advanced_firewall_test.go
+++ b/internal/web/advanced_firewall_test.go
@@ -247,3 +247,119 @@ func TestCreateHostViaUI_FirewallInbound_InvalidRerenders(t *testing.T) {
 		t.Errorf("re-rendered form should preserve the submitted textarea input\n%s", body)
 	}
 }
+
+// TestParseAdvancedFromForm_FirewallInbound_CIDRClauses covers the cidr= and
+// local_cidr= clauses of the textarea grammar.
+func TestParseAdvancedFromForm_FirewallInbound_CIDRClauses(t *testing.T) {
+	req := advForm(t, url.Values{
+		"adv_firewall_inbound": {
+			"443/tcp from web local_cidr=192.168.50.0/24\n" +
+				"22/tcp cidr=10.0.0.0/24\n" +
+				"any/icmp cidr=any local_cidr=any\n" +
+				"53/udp local_cidr=fd00::/8 from dns",
+		},
+	})
+	adv, err := parseAdvancedFromForm(req)
+	if err != nil {
+		t.Fatalf("parseAdvancedFromForm: %v", err)
+	}
+	want := []models.HostFirewallRule{
+		{Port: "443", Proto: "tcp", Group: "web", LocalCidr: "192.168.50.0/24"},
+		{Port: "22", Proto: "tcp", Cidr: "10.0.0.0/24"},
+		{Port: "any", Proto: "icmp", Cidr: "any", LocalCidr: "any"},
+		{Port: "53", Proto: "udp", Group: "dns", LocalCidr: "fd00::/8"},
+	}
+	if len(adv.FirewallInbound) != len(want) {
+		t.Fatalf("rules = %+v, want %+v", adv.FirewallInbound, want)
+	}
+	for i := range want {
+		if adv.FirewallInbound[i] != want[i] {
+			t.Errorf("rule[%d] = %+v, want %+v", i, adv.FirewallInbound[i], want[i])
+		}
+	}
+}
+
+func TestParseAdvancedFromForm_FirewallInbound_CIDRMalformed(t *testing.T) {
+	cases := map[string]string{
+		"no selector at all":        "443/tcp local_cidr=10.0.0.0/24",
+		"group and cidr together":   "443/tcp from web cidr=10.0.0.0/24",
+		"from without a group":      "443/tcp from",
+		"duplicate cidr":            "443/tcp cidr=10.0.0.0/24 cidr=10.1.0.0/24",
+		"duplicate local_cidr":      "443/tcp from web local_cidr=any local_cidr=any",
+		"duplicate from":            "443/tcp from web from ops",
+		"unknown clause":            "443/tcp from web zone=dmz",
+		"bare cidr without keyword": "443/tcp 10.0.0.0/24",
+	}
+	for name, line := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := advForm(t, url.Values{"adv_firewall_inbound": {line}})
+			if _, err := parseAdvancedFromForm(req); err == nil {
+				t.Fatalf("line %q accepted, want error", line)
+			}
+		})
+	}
+}
+
+// TestHostFormState_FirewallInboundCIDRRoundTrip guards that rendering a rule
+// back into the textarea produces a line the parser accepts unchanged.
+func TestHostFormState_FirewallInboundCIDRRoundTrip(t *testing.T) {
+	rules := []models.HostFirewallRule{
+		{Port: "443", Proto: "tcp", Group: "web", LocalCidr: "192.168.50.0/24"},
+		{Port: "22", Proto: "tcp", Cidr: "10.0.0.0/24"},
+		{Port: "any", Proto: "icmp", Group: "any", LocalCidr: "any"},
+	}
+	h := &models.Host{
+		Name: "h", NebulaIPs: []string{"10.0.0.1"},
+		Advanced: &models.HostAdvanced{FirewallInbound: rules},
+	}
+	state := hostFormStateFromHost(h)
+	want := "443/tcp from web local_cidr=192.168.50.0/24\n" +
+		"22/tcp cidr=10.0.0.0/24\n" +
+		"any/icmp from any local_cidr=any"
+	if state.AdvFirewallInbound != want {
+		t.Fatalf("AdvFirewallInbound = %q, want %q", state.AdvFirewallInbound, want)
+	}
+
+	// Feeding the rendered text back through the parser must reproduce the
+	// original rules — otherwise an unrelated host edit would mutate them.
+	req := advForm(t, url.Values{"adv_firewall_inbound": {state.AdvFirewallInbound}})
+	adv, err := parseAdvancedFromForm(req)
+	if err != nil {
+		t.Fatalf("reparsing rendered text: %v", err)
+	}
+	for i := range rules {
+		if adv.FirewallInbound[i] != rules[i] {
+			t.Errorf("round-trip rule[%d] = %+v, want %+v", i, adv.FirewallInbound[i], rules[i])
+		}
+	}
+}
+
+// TestParseAdvancedFromForm_FirewallInbound_ClauseAsGroupRejected pins that a
+// clause keyword cannot be swallowed as a group name. `from cidr=10.0.0.0/24`
+// is a plausible mistyping of the prefix selector; accepting it would define a
+// group no certificate can carry, yielding a rule that silently matches
+// nothing instead of the prefix rule the operator meant.
+func TestParseAdvancedFromForm_FirewallInbound_ClauseAsGroupRejected(t *testing.T) {
+	for _, line := range []string{
+		"443/tcp from cidr=10.0.0.0/24",
+		"443/tcp from local_cidr=any",
+	} {
+		t.Run(line, func(t *testing.T) {
+			req := advForm(t, url.Values{"adv_firewall_inbound": {line}})
+			adv, err := parseAdvancedFromForm(req)
+			if err == nil {
+				t.Fatalf("line %q accepted as group %q, want error", line, adv.FirewallInbound[0].Group)
+			}
+		})
+	}
+
+	// The correct spelling of the same intent still works.
+	req := advForm(t, url.Values{"adv_firewall_inbound": {"443/tcp cidr=10.0.0.0/24"}})
+	adv, err := parseAdvancedFromForm(req)
+	if err != nil {
+		t.Fatalf("valid prefix rule rejected: %v", err)
+	}
+	if adv.FirewallInbound[0].Cidr != "10.0.0.0/24" || adv.FirewallInbound[0].Group != "" {
+		t.Errorf("rule = %+v, want cidr 10.0.0.0/24 and no group", adv.FirewallInbound[0])
+	}
+}

--- a/internal/web/form_state.go
+++ b/internal/web/form_state.go
@@ -279,12 +279,23 @@ func hostFormStateFromHost(h *models.Host) hostFormState {
 			state.AdvUnsafeRoutes += ur.Route + " via " + ur.Via
 		}
 
-		// FirewallInbound: "PORT/PROTO from GROUP" per line
+		// FirewallInbound: "PORT/PROTO from GROUP [cidr=..] [local_cidr=..]"
+		// per line — the inverse of parseFirewallInboundLine, so an edit that
+		// touches no firewall field round-trips unchanged.
 		for _, fr := range h.Advanced.FirewallInbound {
 			if state.AdvFirewallInbound != "" {
 				state.AdvFirewallInbound += "\n"
 			}
-			state.AdvFirewallInbound += fr.Port + "/" + fr.Proto + " from " + fr.Group
+			state.AdvFirewallInbound += fr.Port + "/" + fr.Proto
+			if fr.Group != "" {
+				state.AdvFirewallInbound += " from " + fr.Group
+			}
+			if fr.Cidr != "" {
+				state.AdvFirewallInbound += " cidr=" + fr.Cidr
+			}
+			if fr.LocalCidr != "" {
+				state.AdvFirewallInbound += " local_cidr=" + fr.LocalCidr
+			}
 		}
 	}
 

--- a/internal/web/templates/host_edit.html
+++ b/internal/web/templates/host_edit.html
@@ -88,7 +88,7 @@
                 </select>
             </div>
             <div class="form-group"><label>Unsafe routes (one per line: <code>CIDR via NEBULA_IP</code>)</label><textarea name="adv_unsafe_routes" class="form-control" rows="3" placeholder="192.168.10.0/24 via 10.0.0.99">{{.Form.AdvUnsafeRoutes}}</textarea></div>
-            <div class="form-group"><label>Inbound firewall rules (one per line: <code>PORT/PROTO from GROUP</code>, added after the network policy)</label><textarea name="adv_firewall_inbound" class="form-control" rows="3" placeholder="443/tcp from web">{{.Form.AdvFirewallInbound}}</textarea></div>
+            <div class="form-group"><label>Inbound firewall rules (one per line: <code>PORT/PROTO from GROUP</code>, added after the network policy)</label><textarea name="adv_firewall_inbound" class="form-control" rows="3" placeholder="443/tcp from web">{{.Form.AdvFirewallInbound}}</textarea><small class="form-text">Select the peer by group (<code>from web</code>) or by prefix (<code>cidr=10.0.0.0/24</code>) — not both. Append <code>local_cidr=&lt;CIDR&gt;</code> to match traffic for a local address, which is required for prefixes you serve via unsafe routes.</small></div>
         </details>
 
         <button type="submit" class="btn btn-primary">Save changes</button>

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -130,6 +130,7 @@
             <div class="form-group">
                 <label>Inbound firewall rules (one per line: <code>PORT/PROTO from GROUP</code>, added after the network policy)</label>
                 <textarea name="adv_firewall_inbound" class="form-control" rows="3" placeholder="443/tcp from web">{{.Form.AdvFirewallInbound}}</textarea>
+                <small class="form-text">Select the peer by group (<code>from web</code>) or by prefix (<code>cidr=10.0.0.0/24</code>) — not both. Append <code>local_cidr=&lt;CIDR&gt;</code> to match traffic for a local address, which is required for prefixes you serve via unsafe routes.</small>
             </div>
         </details>
 


### PR DESCRIPTION
With the latest changes since Nebula 1.10.0 (default_local_cidr_any now defaults to false, meaning that any firewall rule intended to target an unsafe_routes entry must explicitly declare it via the local_cidr field), it is now necessary to define `local_cidr` or `cidr` rules to enable routing between nodes.

## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
