### PR TITLE
fix(release): remove stale credential cutover notice

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -312,8 +312,6 @@ release:
     ## nebula-mesh {{ .Tag }}
 
     **Install:** see [README](https://github.com/forgekeep/nebula-mesh#install) for install snippets (all packages/archives are in the assets below).
-
-    **Breaking credential-verifier upgrade:** this release invalidates Web sessions, operator API keys, TOTP recovery codes, and pending enrollment tokens. Password hashes, OIDC bindings, TOTP secrets, enrolled agents, and their certificates remain valid. Collecting mesh imports block startup until finalized or canceled. Read the [cutover guide](https://github.com/forgekeep/nebula-mesh/blob/{{ .Tag }}/docs/upgrade-credential-hmac-cutover.md) before upgrading.
   footer: |
     ---
 

--- a/internal/releaseconfig/release_config_test.go
+++ b/internal/releaseconfig/release_config_test.go
@@ -142,6 +142,15 @@ func TestReleaseConfigPackagesCredentialHMACCutoverGuide(t *testing.T) {
 	}
 }
 
+func TestReleaseConfigDoesNotRepeatCredentialHMACCutoverNotice(t *testing.T) {
+	repoRoot := repositoryRoot(t)
+	releaseConfig := readFile(t, filepath.Join(repoRoot, ".goreleaser.yml"))
+
+	if strings.Contains(releaseConfig, "Breaking credential-verifier upgrade:") {
+		t.Error("release header must not repeat the one-time v0.12.0 credential cutover notice")
+	}
+}
+
 type changelogGroup struct {
 	Title  string `yaml:"title"`
 	Regexp string `yaml:"regexp"`


### PR DESCRIPTION
## What

Remove the one-time v0.12.0 credential cutover notice from the shared GoReleaser header and add regression coverage.

## Why

v0.12.0 is already published with the required warning and upgrade guide. Keeping the notice in the shared header would repeat obsolete v0.12.0 migration guidance in every later release.

## Impact

- The published v0.12.0 release notes remain unchanged.
- The cutover guide remains in server archives and Linux packages.
- Commits marked with `!` still appear under `Breaking changes`.

## Verification

- `go test ./internal/releaseconfig -count=1`
- `goreleaser check`
- `go build ./...`
- `go vet ./...`
- `go test -race ./...`
- `make lint`

## Code pointers

- `.goreleaser.yml`: shared release header
- `internal/releaseconfig/release_config_test.go`: one-time notice regression guard
