### PR TITLE
Fix flaky TestPoller_ReloadCommandSuccess_Acks under -race

### DIFF
--- a/internal/agent/reload_test.go
+++ b/internal/agent/reload_test.go
@@ -171,6 +171,23 @@ func newReloadCommandPoller(t *testing.T, serverURL, dir, command string) *Polle
 	return p
 }
 
+// waitForAck blocks until acked is set, mirroring waitForFile. The happy-path
+// reload test observes the ack this way rather than asserting after a fixed
+// interval, so it does not care how long a slow runner takes to deliver it.
+func waitForAck(t *testing.T, acked *atomic.Bool, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		if acked.Load() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("config was not acked within %v", within)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestPoller_ReloadCommandFailure_BlocksAck: with nebula_reload_command
 // configured, a failing command must behave like a failed SIGHUP with a
 // configured pid file — the config version is NOT acknowledged so the
@@ -218,7 +235,9 @@ func TestPoller_ReloadCommandTimeout_BlocksAck(t *testing.T) {
 }
 
 // TestPoller_ReloadCommandSuccess_Acks: the happy path — the command runs,
-// the config is acknowledged.
+// the config is acknowledged. It polls for the ack instead of racing a fixed
+// wall-clock window, so a loaded CI runner cannot turn a delivered reload
+// into a spurious failure (see issue #346).
 func TestPoller_ReloadCommandSuccess_Acks(t *testing.T) {
 	dir := t.TempDir()
 	seedSigningKeyAt(t, dir)
@@ -228,12 +247,18 @@ func TestPoller_ReloadCommandSuccess_Acks(t *testing.T) {
 
 	p := newReloadCommandPoller(t, server.URL, dir, scriptSucceed)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_ = p.Run(ctx)
+	done := make(chan struct{})
+	go func() { defer close(done); _ = p.Run(ctx) }()
 
-	if !acked.Load() {
-		t.Error("config should be acked when nebula_reload_command succeeds")
+	waitForAck(t, &acked, 10*time.Second)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("Run did not return after the ack within %v", 15*time.Second)
 	}
 }
 


### PR DESCRIPTION
## Summary

`TestPoller_ReloadCommandSuccess_Acks` intermittently failed the `test (race) / remainder` job on `main` (issue #346). It is timing-sensitive, not a code regression, and this PR makes it deterministic. No production code changes.

## The flake

The happy-path test ran the poller for a fixed 200ms (50ms interval, ~4 iterations) and asserted the config was acked:

```go
ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
defer cancel()
_ = p.Run(ctx)

if !acked.Load() {
    t.Error("config should be acked when nebula_reload_command succeeds")
}
```

Under the race detector on a loaded CI runner, the instant-exit `scriptSucceed` hook sometimes did not complete inside that window, so the ack never landed and the assertion tripped. Evidence that it is load-driven, not a regression:

- The push of `e95d1fd` triggered two identical runs at the same instant: `30527523504` failed, `30527523595` passed. Same code, opposite outcomes.
- `go test -race -count=40` over the reload tests passed locally.
- `internal/agent/reload.go` was last touched in #312; the recent `main` commits are unrelated to the reload path.

## Change

Poll for the ack instead of racing a wall-clock slice, following the pattern already used in `reload_cancel_test.go` (`TestPoller_ReloadCommandShutdown_DoesNotWaitOutTimeout`): run `Poller.Run` in a goroutine with a cancellable context, observe the ack via a new `waitForAck` helper with a 10s budget, then cancel and join.

The test now waits for delivery and is indifferent to runner load. A 10s deadline is far above the sub-second delivery time on any runner, yet still bounds the test if delivery genuinely breaks.

## Verification

- `go vet ./internal/agent/` — clean
- `go test -race -count=20 -run 'TestPoller_ReloadCommand|TestNebulaReloader' ./internal/agent/` — `ok ... 75.104s`
- `go test -race ./internal/agent/` (whole package) — `ok ... 8.084s`
- `make lint` — `0 issues`

## Code references

- `internal/agent/reload_test.go` — `TestPoller_ReloadCommandSuccess_Acks`, new `waitForAck`
- pattern source: `internal/agent/reload_cancel_test.go` (`waitForFile`, `TestPoller_ReloadCommandShutdown_DoesNotWaitOutTimeout`)

Fixes #346
