### PR TITLE
test(security): cover unsafe network rekey race

### DIFF
--- a/docs/security/invariants.md
+++ b/docs/security/invariants.md
@@ -299,8 +299,9 @@ leave a weaker or partially applied security state.
   transactional SQLite store methods.
 - Enrollment compares the certificate-bound Host identity read for signing with
   the durable row inside its consume transaction. If a concurrent edit changed
-  `Name`, `NebulaIPs`, or `Groups`, the transaction retains `pending_rekey` so
-  the signed stale certificate cannot settle the newer identity.
+  `Name`, `NebulaIPs`, `Groups`, or `UnsafeNetworks`, the transaction retains
+  `pending_rekey` so the signed stale certificate cannot settle the newer
+  identity.
 - Mesh import finalize applies Host state, firewall, blocklist, version, and
   challenge cleanup in one transaction with revision and scope checks.
 - Host updates persist Host fields and reset `config_version` in the same
@@ -333,7 +334,8 @@ leave a weaker or partially applied security state.
   rejects blocked Hosts and disabled owners.
 - `internal/store/sqlite_enroll_token_test.go`:
   `TestConsumeTokenAndEnrollHost_NoBurnOnEnrollFailure` and
-  `TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterIdentityChange`.
+  `TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterIdentityChange`, and
+  `TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterUnsafeNetworksChange`.
 - `internal/store/sqlite_update_host_atomic_test.go`:
   `TestUpdateHost_ResetsConfigVersion` and
   `TestUpdateHost_SECPERSIST001_RollbackIsAtomic`.

--- a/internal/store/sqlite_enroll_token_test.go
+++ b/internal/store/sqlite_enroll_token_test.go
@@ -163,6 +163,61 @@ func TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfte
 	}
 }
 
+// TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterUnsafeNetworksChange
+// proves that a stale certificate cannot settle an UnsafeNetworks edit made
+// after the signing snapshot. UnsafeNetworks authorizes gateway routing in the
+// certificate, so clearing this rekey would leave a gateway on its old routing
+// authority indefinitely.
+func TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterUnsafeNetworksChange(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	h := newHostFixture(t, s, "unsafe-networks-identity-race-host")
+
+	signedHost, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedIdentity := models.CertificateIdentityFromHost(signedHost)
+	const raw = "unsafe-networks-identity-race-token"
+	if err := s.CreateTokenForHost(ctx, h.ID, raw, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	edited := *signedHost
+	edited.UnsafeNetworks = []string{"10.42.0.0/16"}
+	edited.PendingRekey = true
+	if err := s.UpdateHost(ctx, &edited); err != nil {
+		t.Fatal(err)
+	}
+
+	profileDir := t.TempDir()
+	profile := models.AgentProfile{
+		NebulaConfigPath: filepath.Join(profileDir, "config.yml"),
+		NebulaCAPath:     filepath.Join(profileDir, "ca.crt"),
+		NebulaCertPath:   filepath.Join(profileDir, "host.crt"),
+		NebulaKeyPath:    filepath.Join(profileDir, "host.key"),
+		ConfigAckV1:      true,
+	}
+	if _, err := s.ConsumeTokenAndEnrollHostWithProfile(ctx, h.ID, raw, []byte("stale-cert"), "stale-fp",
+		time.Now(), time.Now().Add(time.Hour), "signing-pub", profile, &signedIdentity); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetHost(ctx, h.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.PendingRekey {
+		t.Fatal("concurrent unsafe networks change was cleared; the stale certificate would never be replaced")
+	}
+	if got.CertFingerprint != "stale-fp" {
+		t.Errorf("cert fingerprint = %q, want stale-fp", got.CertFingerprint)
+	}
+	if len(got.UnsafeNetworks) != 1 || got.UnsafeNetworks[0] != "10.42.0.0/16" {
+		t.Errorf("unsafe networks = %v, want [10.42.0.0/16]", got.UnsafeNetworks)
+	}
+}
+
 // TestConsumeTokenAndEnrollHost_ConcurrentSameToken_ExactlyOneEnrolls fires N
 // goroutines at one token (as two agents racing a leaked token would) and
 // asserts exactly one enrolls while the rest get ErrTokenUsed — single-use holds


### PR DESCRIPTION
Этот follow-up закрывает пробел в SEC-PERSIST-001 после PR #348: concurrent изменение UnsafeNetworks между signing snapshot и enrollment transaction не должно очищать pending_rekey.

Добавлен regression test для этого сценария и обновлён нормативный инвариант с точным test anchor.

Ориентиры в коде:
- internal/store/sqlite_enroll_token_test.go
- docs/security/invariants.md

Проверка:
- go test -race -count=1 ./internal/store -run ^TestConsumeTokenAndEnrollHostWithProfile_SEC_PERSIST_001_PreservesRekeyAfterUnsafeNetworksChange$
- go test -race -count=1 ./internal/store
- go test -race ./...
- go build ./...
- go vet ./...
- make lint