### PR TITLE
build: bump Go toolchain 1.26.5 to 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: go vet
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: test (race)
@@ -102,7 +102,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       # nebula_reload_command's Windows half — the cmd.exe command line and the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: generative fuzz
@@ -85,7 +85,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: govulncheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 
 FROM golang:${GO_VERSION}-alpine AS build
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/forgekeep/nebula-mesh
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/boombuler/barcode v1.1.0


### PR DESCRIPTION
Fixes #355

## Problem

The nightly `govulncheck (Go vuln DB)` job fails (exit code 3) because the
Go toolchain is pinned to `1.26.5`, whose standard library carries 7
reachable vulnerabilities, all fixed in `go1.26.6`:

GO-2026-6218 (net/url), GO-2026-6091 (html/template), GO-2026-6090
(crypto/tls), GO-2026-6089 (net/http), GO-2026-6088 (encoding/xml),
GO-2026-5972 (encoding/asn1), GO-2026-5026 (net/http / x/net/idna).

Failed run: https://github.com/forgekeep/nebula-mesh/actions/runs/31785273642/job/94719679927

## Changes

Bump Go `1.26.5` -> `1.26.6` (latest stable patch of the 1.26 line) in every
pin:

- `go.mod` — go directive
- `.github/workflows/ci.yml` — go-version in all 3 jobs
- `.github/workflows/scheduled.yml` — go-version in both jobs
- `.github/workflows/release.yml` — go-version
- `Dockerfile` — `ARG GO_VERSION`

## Verification

- `go build ./...` and `go vet ./...` pass locally under the auto-downloaded
  go1.26.6 toolchain (test files included via vet)
- `go mod tidy` produces no changes; `go.sum` untouched (stdlib-only bump)
- Full gates (`go test -race`, lint, fuzz seed corpora) run in CI on this PR
