### PR TITLE
chore(release): show build: commits in the generated changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -300,6 +300,13 @@ changelog:
     - title: "Dependency updates"
       regexp: '^.*?chore\(deps\):.+$'
       order: 4
+    # build: changes the shipped artifact (Go toolchain, Dockerfile), so it is
+    # worth showing even though ci: next to it is not: a toolchain bump is how
+    # stdlib CVE fixes reach users, and dropping it leaves a security rebuild
+    # looking like an empty release (v0.13.1).
+    - title: "Toolchain / build"
+      regexp: '^.*?build(\(.+\))?:.+$'
+      order: 5
 
 release:
   github:


### PR DESCRIPTION
## What

Adds a `Toolchain / build` group to the goreleaser changelog whitelist so `build:` commits reach the release notes.

## Why

The whitelist in `.goreleaser.yml` deliberately has no catch-all: anything outside `feat`/`fix`/`perf`/`chore(deps)` is dropped. That silently swallowed `59303da build: bump Go toolchain 1.26.5 to 1.26.6`.

v0.13.1 is a security rebuild — go1.26.5 carried 7 reachable stdlib vulnerabilities (GO-2026-6218, -6091, -6090, -6089, -6088, -5972, -5026), all fixed in go1.26.6, see #355. Without this change its notes would list two sqlite bumps and nothing about the reason to upgrade.

`build:` touches the shipped artifact (Go toolchain pins, Dockerfile). `ci:` next to it does not, and stays dropped — the no-catch-all rule is intact.

## Verification

`goreleaser check` passes (the `dockers`/`docker_manifests` deprecation warnings are pre-existing).
