### PR TITLE
test(web): date the mesh-import fixture cert with the test clock

### DIFF
--- a/internal/web/mesh_imports_test.go
+++ b/internal/web/mesh_imports_test.go
@@ -183,7 +183,7 @@ func TestMeshImportWebPreviewAndFinalize(t *testing.T) {
 	defer manager.Wipe()
 	hostCertificate, err := manager.Sign(pki.SignRequest{
 		Name: "adopted-host", PublicKey: make([]byte, 32), Networks: []netip.Prefix{netip.MustParsePrefix("10.75.0.10/16")},
-		Groups: []string{"prod"}, Duration: 90 * 24 * time.Hour,
+		Groups: []string{"prod"}, Duration: 90 * 24 * time.Hour, Now: now,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Problem

`test (race) / web` failed on `main` at f7a4c11 ([run 31802444778](https://github.com/forgekeep/nebula-mesh/actions/runs/31802444778)) on a commit that touched only `.goreleaser.yml`. The failure is a latent flake in `TestMeshImportWebPreviewAndFinalize`, not a regression:

```
--- FAIL: TestMeshImportWebPreviewAndFinalize (0.73s)
    mesh_imports_test.go:207: fixture reconcile = ... Code:"host_certificate_not_yet_valid" ...
```

## Mechanism

1. `mesh_imports_test.go:169` captures `now := time.Now()`.
2. `:184` signs the fixture certificate **without** passing it, so `pki.Sign` falls back to its own `time.Now()` (`internal/pki/signer.go:32`), a strictly later instant.
3. Nebula serializes `NotBefore` as whole Unix seconds — `b.AddASN1Int64WithTag(d.notBefore.Unix(), ...)` in `cert/cert_v2.go:542` — so after the PEM round-trip the certificate carries `floor(signTime)`.
4. `internal/meshimport/reconcile.go:154` blocks on `input.Now.Before(NotBefore())`.

So the test fails exactly when a second boundary falls between steps 1 and 2 — a few milliseconds of SQLite writes plus CA loading, and wider under `-race` on a loaded runner.

## Fix

Pass `Now: now` into the `SignRequest`, mirroring the sibling fixture at `:315` which already threads the same instant.

## Verification

Reproduced deterministically by sleeping 1.1s between the two instants: fails with exactly `host_certificate_not_yet_valid` before the change, passes after. Then `go test -race ./internal/web/ -run '^TestMeshImportWeb' -count=5` → ok.

Production behaviour is untouched and stays correct: a certificate that is not yet valid at the evaluation instant should block.

## Note

This is on the critical path for cutting v0.13.1 — the release workflow's `verify` job requires `build / test / lint` to be green on the tagged commit, and it is currently red on `main`.
