### PR TITLE
fix(release): anchor the changelog group regexps at the commit type

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -284,28 +284,37 @@ changelog:
   # This replaces exclude-by-prefix (which previously drifted out of sync
   # for scoped commits, e.g. chore(deps): leaking past a bare ^chore: filter
   # in v0.7.1/v0.7.2) with an explicit whitelist of what's worth showing.
+  #
+  # Every regexp is anchored at the type. The upstream examples lead with
+  # `^.*?`, which matches the type anywhere in the subject: v0.13.1 filed
+  # "chore(release): show build: commits ..." under Toolchain / build. goreleaser
+  # matches these against the bare commit message (internal/pipe/changelog:
+  # `re.MatchString(entry.Message)`) and only then renders the SHA prefix via
+  # the format template, so anchoring is safe. Checked against all 310 subjects
+  # in the repo's history: anchoring reclassifies that one commit and nothing
+  # else.
   groups:
     - title: "Breaking changes"
-      regexp: '^.*?(feat|fix|perf)(\(.+\))?!:.+$'
+      regexp: '^(feat|fix|perf)(\(.+\))?!:.+$'
       order: 0
     - title: Features
-      regexp: '^.*?feat(\(.+\))?:.+$'
+      regexp: '^feat(\(.+\))?:.+$'
       order: 1
     - title: "Bug fixes"
-      regexp: '^.*?fix(\(.+\))?:.+$'
+      regexp: '^fix(\(.+\))?:.+$'
       order: 2
     - title: "Performance"
-      regexp: '^.*?perf(\(.+\))?:.+$'
+      regexp: '^perf(\(.+\))?:.+$'
       order: 3
     - title: "Dependency updates"
-      regexp: '^.*?chore\(deps\):.+$'
+      regexp: '^chore\(deps\):.+$'
       order: 4
     # build: changes the shipped artifact (Go toolchain, Dockerfile), so it is
     # worth showing even though ci: next to it is not: a toolchain bump is how
     # stdlib CVE fixes reach users, and dropping it leaves a security rebuild
     # looking like an empty release (v0.13.1).
     - title: "Toolchain / build"
-      regexp: '^.*?build(\(.+\))?:.+$'
+      regexp: '^build(\(.+\))?:.+$'
       order: 5
 
 release:


### PR DESCRIPTION
## Problem

The changelog whitelist patterns lead with `^.*?`, copied from the upstream examples. That matches the conventional-commit type *anywhere* in the subject, not at its start. v0.13.1 showed the cost — `chore(release): show build: commits in the generated changelog` was filed under **Toolchain / build**, because the pattern found `build:` in the middle of the sentence.

## Why anchoring is safe

goreleaser applies these regexps to the bare commit message, not to the rendered line. `internal/pipe/changelog/changelog.go:185`:

```go
match := re.MatchString(entry.Message)
```

The `<sha>: <subject> (@author)` shape comes later, from the format template (`changelog.go:59`) inside `formatEntry`. So `^` sees the subject.

## Measurement

Ran both pattern sets over **all 310 commit subjects** in the repository, using Go's `regexp` (the same engine goreleaser uses, not grep's ERE) and goreleaser's first-match-wins group ordering:

```
CHANGED "chore(release): show build: commits in the generated changelog"
  before: Toolchain / build
  after:  (dropped)

310 subjects, 1 reclassified
```

One subject changes — the miscategorised one — and it drops out, which is what the no-catch-all whitelist says should happen to a `chore` that is not `chore(deps)`. Every other group is byte-identical.

All five patterns are anchored rather than just the `build` one, so the file does not end up half in one style and half in the other.

## Verification

`goreleaser check` passes (the `dockers`/`docker_manifests` deprecation warnings are pre-existing).
