### PR TITLE
docs: explain how proto rules behave on IPv6 after Nebula v1.11.1

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -368,6 +368,31 @@ That firewall rule is necessary but **not sufficient** — see
 [Routing to a non-Nebula network](#routing-to-a-non-nebula-network) for the
 certificate half, without which the rule is never even evaluated.
 
+#### IPv6 and protocols Nebula does not parse
+
+Nebula classifies an IPv6 packet by its next header. The protocols it does not
+parse — SCTP, GRE, IP-in-IP and the rest — carry no ports it can match on, so
+such a packet matches only a rule with `proto: any`. A `tcp`, `udp` or `icmp`
+rule never covers it.
+
+Before v1.11.1 that did not hold. A crafted payload could steer the classifier
+into reading one of these packets as TCP or UDP, and it then matched a `tcp` or
+`udp` rule. That was a firewall bypass, closed in
+[slackhq/nebula#1840](https://github.com/slackhq/nebula/pull/1840).
+
+This reaches existing meshes rather than new ones. If you carry one of these
+protocols over an IPv6 overlay and it works today under a `tcp` or `udp` rule,
+it is passing through the bypass and will stop once those hosts move to Nebula
+v1.11.1. Add a rule with `proto: any`, scoped by `group`, `cidr` or
+`local_cidr`, before you upgrade them. The rule vocabulary here is
+`any`/`tcp`/`udp`/`icmp`, so `any` is the only way to name these protocols at
+all.
+
+The same release fixed IPv6 ICMP classification: the type byte was read at the
+wrong offset, so conntrack never picked up the echo identifier. That affects
+`proto: icmp` rules on IPv6 overlays, which is the inbound policy a new network
+starts with.
+
 ### Routing to a non-Nebula network
 
 Reaching a network that does not run Nebula takes three independent pieces of


### PR DESCRIPTION
## What

Adds a subsection to `docs/agent.md` under *Per-host inbound firewall rules* explaining how `proto` rules match IPv6 traffic, and what changed with Nebula v1.11.1.

## Why

Fixes #366.

Nebula v1.11.1 (2026-08-21) closed a firewall bypass in [slackhq/nebula#1840](https://github.com/slackhq/nebula/pull/1840). An IPv6 packet whose next header names a protocol Nebula does not parse — SCTP, GRE, IP-in-IP — could be steered into the classifier as TCP or UDP and match a `tcp`/`udp` rule. It is now matched as its true protocol with no ports, so only `proto: any` lets it through.

Our code is unaffected, and I checked that rather than assuming it: we import `nebula/cert` (54 call sites) and `nebula/config` (5), and the `v1.11.0...v1.11.1` diff is 8 commits over 27 files with nothing under either package. The other three fixes in that release sit in `cmd/nebula-cert/ca.go`, the tunnel engine, and the root package's metrics dependency, none of which we import.

What is affected is the mesh our users run. We generate the firewall rules they deploy, and our rule vocabulary is `any`/`tcp`/`udp`/`icmp` — there is no `sctp` or `gre` to pick. So an operator carrying one of those protocols over an IPv6 overlay was passing through the bypass without knowing it, and that traffic stops when their hosts upgrade. Better they read it next to the rule semantics than reconstruct it from another project's release notes.

The same PR also fixed IPv6 ICMP classification: the type byte was read at the wrong offset, so conntrack never picked up the echo identifier. That one lands on `proto: icmp` rules over IPv6, which is the inbound policy `DefaultFirewallInbound` gives a new network.

## How

One new `####` subsection, placed after *Address-scoped rules: `cidr` and `local_cidr`* so it follows the existing explanation of how Nebula evaluates a rule, and before *Routing to a non-Nebula network*. No code, no config, no dependency bump — the module bump to v1.11.1 is pure hygiene and Dependabot will raise it on its own schedule in the `go-minor-and-patch` group.

Ran the repository's prose scanner over the file. It reports one dense-em-dash hit inside the new text, a paired appositive matching the style used throughout this document, kept deliberately; its other findings predate this branch.

## Checklist

- [ ] `go test -race ./...` passes — not run, documentation-only change with no Go files touched
- [ ] `golangci-lint run ./...` passes — same
- [ ] New behaviour has tests — no behaviour change
- [x] User-facing changes are reflected in README / configs — this is the documentation change
- [x] No breaking API changes
