### PR TITLE
feat(config): add punchy.respond configuration option for NAT traversal

### DIFF
--- a/internal/agent/discovery.go
+++ b/internal/agent/discovery.go
@@ -240,6 +240,10 @@ func sanitizeNebulaConfig(configuration *nebulaconfig.C, caFingerprint string) m
 		value := configuration.GetBool("punchy.punch", false)
 		config.Punchy = &value
 	}
+	if configuration.IsSet("punchy.respond") {
+		value := configuration.GetBool("punchy.respond", false)
+		config.PunchyRespond = &value
+	}
 	config.UnsupportedKeys = sortedUniqueStrings(unsupported)
 	return config
 }
@@ -354,7 +358,7 @@ func supportedConfigLeaf(path string) bool {
 	case "pki.ca", "pki.cert", "pki.key", "pki.blocklist[]",
 		"lighthouse.am_lighthouse", "lighthouse.hosts[]",
 		"relay.am_relay", "relay.relays[]",
-		"listen.host", "listen.port", "punchy.punch", "tun.dev", "tun.mtu",
+		"listen.host", "listen.port", "punchy.punch", "punchy.respond", "tun.dev", "tun.mtu",
 		"tun.unsafe_routes[].route", "tun.unsafe_routes[].via",
 		"firewall.inbound[].port", "firewall.inbound[].proto", "firewall.inbound[].group", "firewall.inbound[].host",
 		"firewall.inbound[].cidr", "firewall.inbound[].local_cidr",

--- a/internal/configgen/advanced_test.go
+++ b/internal/configgen/advanced_test.go
@@ -141,6 +141,49 @@ func TestGenerate_PunchyOverride(t *testing.T) {
 	}
 }
 
+// TestGenerate_PunchyRespondOverride pins punchy.respond, the setting that
+// makes a host behind a difficult NAT connect back out to a peer that could
+// not reach it. Unset must stay absent so existing configs render unchanged.
+func TestGenerate_PunchyRespondOverride(t *testing.T) {
+	base := GeneratorInput{
+		HostName:   "h",
+		NebulaIPs:  []string{"10.0.0.1"},
+		CACertPath: "/etc/nebula/ca.crt",
+		CertPath:   "/etc/nebula/host.crt",
+		KeyPath:    "/etc/nebula/host.key",
+	}
+
+	out, err := Generate(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "respond:") {
+		t.Errorf("unset override must not emit respond; got:\n%s", out)
+	}
+
+	for _, tc := range []struct {
+		name string
+		want string
+		val  bool
+	}{
+		{name: "enabled", want: "respond: true", val: true},
+		{name: "disabled", want: "respond: false", val: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := base
+			v := tc.val
+			in.PunchyRespondOverride = &v
+			out, err := Generate(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(out), tc.want) {
+				t.Errorf("expected %q; got:\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
 // TestGenerate_TunDevice_StructuralBreakCharsAreQuoted is the GHSA-7hp6
 // defense-in-depth assertion (issue #126): even if the upstream TunDevice
 // validator were bypassed, yaml.v3 marshaling MUST emit structural-break

--- a/internal/configgen/generator.go
+++ b/internal/configgen/generator.go
@@ -52,10 +52,13 @@ type GeneratorInput struct {
 
 	// Optional per-host overrides. Zero values mean "use the default".
 	PunchyOverride *bool
-	ListenHost     string
-	MTU            int
-	TunDevice      string
-	UnsafeRoutes   []AdvancedUnsafeRoute
+	// PunchyRespondOverride maps to punchy.respond. Nil leaves Nebula's own
+	// default (false) in place, so an unset override renders as before.
+	PunchyRespondOverride *bool
+	ListenHost            string
+	MTU                   int
+	TunDevice             string
+	UnsafeRoutes          []AdvancedUnsafeRoute
 
 	// Optional inline PEM blocks. When CACertPEM is non-empty, CertPEM and
 	// KeyPEM must also be non-empty; all three are emitted as literal-block

--- a/internal/configgen/marshal.go
+++ b/internal/configgen/marshal.go
@@ -306,8 +306,14 @@ func buildConfig(input GeneratorInput) nebulaConfig {
 		punch = *input.PunchyOverride
 	}
 	cfg.Punchy = punchySection{Punch: punch}
+	// Mobile clients pin respond:false; the mobile app drives its own
+	// reconnection. Everything else inherits Nebula's default unless the host
+	// explicitly asks for it, so an unset override renders exactly as before.
 	if input.Mobile != nil {
 		cfg.Punchy.Respond = boolPtr(false)
+	}
+	if input.PunchyRespondOverride != nil {
+		cfg.Punchy.Respond = boolPtr(*input.PunchyRespondOverride)
 	}
 
 	dev := input.TunDevice

--- a/internal/configinput/configinput.go
+++ b/internal/configinput/configinput.go
@@ -29,6 +29,7 @@ func ApplyHostAdvanced(input *configgen.GeneratorInput, adv *models.HostAdvanced
 		return
 	}
 	input.PunchyOverride = adv.Punchy
+	input.PunchyRespondOverride = adv.PunchyRespond
 	input.ListenHost = adv.ListenHost
 	input.MTU = adv.MTU
 	input.TunDevice = adv.TunDevice

--- a/internal/configinput/configinput_test.go
+++ b/internal/configinput/configinput_test.go
@@ -14,11 +14,13 @@ import (
 // override from every rendered config.
 func TestApplyHostAdvanced_CopiesEveryField(t *testing.T) {
 	punchy := false
+	punchyRespond := true
 	adv := &models.HostAdvanced{
-		Punchy:     &punchy,
-		ListenHost: "10.0.0.1",
-		MTU:        1300,
-		TunDevice:  "nebula1",
+		Punchy:        &punchy,
+		PunchyRespond: &punchyRespond,
+		ListenHost:    "10.0.0.1",
+		MTU:           1300,
+		TunDevice:     "nebula1",
 		UnsafeRoutes: []models.UnsafeRoute{
 			{Route: "192.168.10.0/24", Via: "10.0.0.99"},
 		},
@@ -34,6 +36,9 @@ func TestApplyHostAdvanced_CopiesEveryField(t *testing.T) {
 
 	if input.PunchyOverride == nil || *input.PunchyOverride {
 		t.Errorf("PunchyOverride = %v, want explicit false", input.PunchyOverride)
+	}
+	if input.PunchyRespondOverride == nil || !*input.PunchyRespondOverride {
+		t.Errorf("PunchyRespondOverride = %v, want explicit true", input.PunchyRespondOverride)
 	}
 	if input.ListenHost != "10.0.0.1" || input.MTU != 1300 || input.TunDevice != "nebula1" {
 		t.Errorf("scalar overrides not copied: %+v", input)
@@ -54,7 +59,7 @@ func TestApplyHostAdvanced_CopiesEveryField(t *testing.T) {
 	// Every exported field of HostAdvanced must be represented above, so that
 	// adding one to the model breaks this test rather than silently rendering
 	// nothing.
-	const wantFields = 6
+	const wantFields = 7
 	if got := reflect.TypeOf(models.HostAdvanced{}).NumField(); got != wantFields {
 		t.Errorf("models.HostAdvanced has %d fields, this test covers %d — wire the new field "+
 			"into ApplyHostAdvanced and extend this test", got, wantFields)

--- a/internal/meshimport/reconcile.go
+++ b/internal/meshimport/reconcile.go
@@ -251,7 +251,8 @@ func (r *reconcileState) addressWithinNetwork(hostPrefix netip.Prefix) bool {
 
 func advancedFromConfig(config ConfigSnapshot) *models.HostAdvanced {
 	advanced := &models.HostAdvanced{
-		Punchy: config.Punchy, ListenHost: config.ListenHost, MTU: config.MTU, TunDevice: config.TunDevice,
+		Punchy: config.Punchy, PunchyRespond: config.PunchyRespond,
+		ListenHost: config.ListenHost, MTU: config.MTU, TunDevice: config.TunDevice,
 	}
 	for _, route := range config.UnsafeRoutes {
 		advanced.UnsafeRoutes = append(advanced.UnsafeRoutes, models.UnsafeRoute{Route: route.Route, Via: route.Via})
@@ -262,7 +263,7 @@ func advancedFromConfig(config ConfigSnapshot) *models.HostAdvanced {
 		}
 		return advanced.UnsafeRoutes[i].Route < advanced.UnsafeRoutes[j].Route
 	})
-	if advanced.Punchy == nil && advanced.ListenHost == "" && advanced.MTU == 0 && advanced.TunDevice == "" && len(advanced.UnsafeRoutes) == 0 {
+	if advanced.Punchy == nil && advanced.PunchyRespond == nil && advanced.ListenHost == "" && advanced.MTU == 0 && advanced.TunDevice == "" && len(advanced.UnsafeRoutes) == 0 {
 		return nil
 	}
 	return advanced

--- a/internal/meshimport/types.go
+++ b/internal/meshimport/types.go
@@ -38,6 +38,7 @@ type ConfigSnapshot struct {
 	ListenHost         string              `json:"listen_host,omitempty"`
 	ListenPort         int                 `json:"listen_port,omitempty"`
 	Punchy             *bool               `json:"punchy,omitempty"`
+	PunchyRespond      *bool               `json:"punchy_respond,omitempty"`
 	MTU                int                 `json:"mtu,omitempty"`
 	TunDevice          string              `json:"tun_device,omitempty"`
 	UnsafeRoutes       []UnsafeRoute       `json:"unsafe_routes,omitempty"`

--- a/internal/models/host.go
+++ b/internal/models/host.go
@@ -225,11 +225,17 @@ const MaxHostFirewallRules = 64
 // config. All fields are optional. A field set to its zero value means
 // "inherit network default"; a field set to a non-zero value overrides.
 //
-// Punchy is a tri-state pointer so an operator can explicitly disable
-// hole-punching for a host (false) without it being indistinguishable from
-// "not set".
+// Punchy and PunchyRespond are tri-state pointers so an operator can
+// explicitly disable hole-punching for a host (false) without it being
+// indistinguishable from "not set".
+//
+// PunchyRespond maps to Nebula's punchy.respond. With it enabled a host that
+// cannot be reached inbound will connect back out to the peer that tried,
+// which is what makes a host behind a difficult (symmetric) NAT reachable
+// without waiting for it to initiate traffic on its own.
 type HostAdvanced struct {
 	Punchy          *bool              `json:"punchy,omitempty" yaml:"punchy,omitempty"`
+	PunchyRespond   *bool              `json:"punchy_respond,omitempty" yaml:"punchy_respond,omitempty"`
 	ListenHost      string             `json:"listen_host,omitempty" yaml:"listen_host,omitempty"`
 	MTU             int                `json:"mtu,omitempty" yaml:"mtu,omitempty"`
 	TunDevice       string             `json:"tun_device,omitempty" yaml:"tun_device,omitempty"`

--- a/internal/models/hostdiff.go
+++ b/internal/models/hostdiff.go
@@ -12,7 +12,8 @@ import (
 // For basic fields (Name, NebulaIPs, Groups, UnsafeNetworks, Role, PublicIP,
 // ListenPort), the diff key is the field name in snake_case.
 //
-// For Advanced sub-fields (ListenHost, MTU, TunDevice, Punchy, UnsafeRoutes),
+// For Advanced sub-fields (ListenHost, MTU, TunDevice, Punchy, PunchyRespond,
+// UnsafeRoutes),
 // the diff key uses dot-notation: "advanced.mtu", "advanced.punchy", etc.
 //
 // The JSON format for each changed field is:
@@ -120,6 +121,14 @@ func HostDiff(before, after *Host) ([]byte, bool, error) {
 		changes["advanced.punchy"] = map[string]any{
 			"before": beforeAdv.Punchy,
 			"after":  afterAdv.Punchy,
+		}
+	}
+
+	// PunchyRespond (tri-state)
+	if !punchyEqual(beforeAdv.PunchyRespond, afterAdv.PunchyRespond) {
+		changes["advanced.punchy_respond"] = map[string]any{
+			"before": beforeAdv.PunchyRespond,
+			"after":  afterAdv.PunchyRespond,
 		}
 	}
 

--- a/internal/web/advanced.go
+++ b/internal/web/advanced.go
@@ -43,6 +43,16 @@ func parseAdvancedFromForm(r *http.Request) (*models.HostAdvanced, error) {
 		adv.Punchy = &v
 		used = true
 	}
+	switch r.FormValue("adv_punchy_respond") {
+	case "true":
+		v := true
+		adv.PunchyRespond = &v
+		used = true
+	case "false":
+		v := false
+		adv.PunchyRespond = &v
+		used = true
+	}
 	if raw := strings.TrimSpace(r.FormValue("adv_unsafe_routes")); raw != "" {
 		for _, line := range strings.Split(raw, "\n") {
 			line = strings.TrimSpace(line)

--- a/internal/web/form_state.go
+++ b/internal/web/form_state.go
@@ -70,6 +70,7 @@ type hostFormState struct {
 	AdvMTU             string
 	AdvTunDevice       string
 	AdvPunchy          string
+	AdvPunchyRespond   string
 	AdvUnsafeRoutes    string
 	AdvFirewallInbound string
 	Kind               string
@@ -91,6 +92,7 @@ func newHostFormState(r *http.Request) hostFormState {
 		AdvMTU:             r.FormValue("adv_mtu"),
 		AdvTunDevice:       r.FormValue("adv_tun_device"),
 		AdvPunchy:          r.FormValue("adv_punchy"),
+		AdvPunchyRespond:   r.FormValue("adv_punchy_respond"),
 		AdvUnsafeRoutes:    r.FormValue("adv_unsafe_routes"),
 		AdvFirewallInbound: r.FormValue("adv_firewall_inbound"),
 		Kind:               r.FormValue("kind"),
@@ -297,6 +299,13 @@ func hostFormStateFromHost(h *models.Host) hostFormState {
 				state.AdvPunchy = "true"
 			} else {
 				state.AdvPunchy = "false"
+			}
+		}
+		if h.Advanced.PunchyRespond != nil {
+			if *h.Advanced.PunchyRespond {
+				state.AdvPunchyRespond = "true"
+			} else {
+				state.AdvPunchyRespond = "false"
 			}
 		}
 

--- a/internal/web/templates/host_detail.html
+++ b/internal/web/templates/host_detail.html
@@ -61,6 +61,7 @@
         {{if .Host.Advanced.MTU}}<tr><th>MTU</th><td>{{.Host.Advanced.MTU}}</td></tr>{{end}}
         {{if .Host.Advanced.TunDevice}}<tr><th>TUN device</th><td>{{.Host.Advanced.TunDevice}}</td></tr>{{end}}
         {{if .Host.Advanced.Punchy}}<tr><th>Punchy</th><td>{{if deref .Host.Advanced.Punchy}}true{{else}}false{{end}}</td></tr>{{end}}
+        {{if .Host.Advanced.PunchyRespond}}<tr><th>Punchy respond</th><td>{{if deref .Host.Advanced.PunchyRespond}}true{{else}}false{{end}}</td></tr>{{end}}
         {{if .Host.Advanced.UnsafeRoutes}}<tr><th>Unsafe routes</th><td>{{range .Host.Advanced.UnsafeRoutes}}{{.Route}} via {{.Via}}<br>{{end}}</td></tr>{{end}}
         {{end}}
     </table>

--- a/internal/web/templates/host_edit.html
+++ b/internal/web/templates/host_edit.html
@@ -78,7 +78,7 @@
             <input type="number" name="listen_port" class="form-control" placeholder="4242" value="{{.Form.ListenPort}}">
         </div>
 
-        <details style="margin: 16px 0;"{{if or .Form.AdvListenHost .Form.AdvMTU .Form.AdvTunDevice .Form.AdvPunchy .Form.AdvUnsafeRoutes .Form.AdvFirewallInbound}} open{{end}}>
+        <details style="margin: 16px 0;"{{if or .Form.AdvListenHost .Form.AdvMTU .Form.AdvTunDevice .Form.AdvPunchy .Form.AdvPunchyRespond .Form.AdvUnsafeRoutes .Form.AdvFirewallInbound}} open{{end}}>
             <summary style="cursor: pointer; padding: 8px; color: var(--text-muted); font-size: 14px;">Advanced configuration (optional)</summary>
             <p style="font-size: 12px; color: var(--text-muted); margin: 8px 0;">Empty fields inherit the network default. See <a href="https://nebula.defined.net/docs/config" target="_blank">Nebula config docs</a>.</p>
             <div class="form-group"><label>Listen host (advanced.listen_host)</label><input type="text" name="adv_listen_host" class="form-control" placeholder="0.0.0.0" value="{{.Form.AdvListenHost}}"></div>
@@ -91,6 +91,15 @@
                     <option value="true"{{if eq .Form.AdvPunchy "true"}} selected{{end}}>force true</option>
                     <option value="false"{{if eq .Form.AdvPunchy "false"}} selected{{end}}>disable</option>
                 </select>
+            </div>
+            <div class="form-group">
+                <label>Punchy respond (advanced.punchy_respond)</label>
+                <select name="adv_punchy_respond" class="form-control">
+                    <option value=""{{if eq .Form.AdvPunchyRespond ""}} selected{{end}}>inherit (false)</option>
+                    <option value="true"{{if eq .Form.AdvPunchyRespond "true"}} selected{{end}}>force true</option>
+                    <option value="false"{{if eq .Form.AdvPunchyRespond "false"}} selected{{end}}>disable</option>
+                </select>
+                <small class="form-text">Enable for a host behind a difficult NAT: it connects back out to any peer that failed to reach it, instead of staying unreachable until it sends traffic itself.</small>
             </div>
             <div class="form-group"><label>Unsafe routes (one per line: <code>CIDR via NEBULA_IP</code>)</label><textarea name="adv_unsafe_routes" class="form-control" rows="3" placeholder="192.168.10.0/24 via 10.0.0.99">{{.Form.AdvUnsafeRoutes}}</textarea></div>
             <div class="form-group"><label>Inbound firewall rules (one per line: <code>PORT/PROTO from GROUP</code>, added after the network policy)</label><textarea name="adv_firewall_inbound" class="form-control" rows="3" placeholder="443/tcp from web">{{.Form.AdvFirewallInbound}}</textarea><small class="form-text">Select the peer by group (<code>from web</code>) or by prefix (<code>cidr=10.0.0.0/24</code>) — not both. Append <code>local_cidr=&lt;CIDR&gt;</code> to match traffic for a local address, which is required for prefixes you serve via unsafe routes.</small></div>

--- a/internal/web/templates/host_new.html
+++ b/internal/web/templates/host_new.html
@@ -100,7 +100,7 @@
             <input type="number" name="listen_port" class="form-control" placeholder="4242" value="{{.Form.ListenPort}}">
         </div>
 
-        <details style="margin: 16px 0;"{{if or .Form.AdvListenHost .Form.AdvMTU .Form.AdvTunDevice .Form.AdvPunchy .Form.AdvUnsafeRoutes .Form.AdvFirewallInbound}} open{{end}}>
+        <details style="margin: 16px 0;"{{if or .Form.AdvListenHost .Form.AdvMTU .Form.AdvTunDevice .Form.AdvPunchy .Form.AdvPunchyRespond .Form.AdvUnsafeRoutes .Form.AdvFirewallInbound}} open{{end}}>
             <summary style="cursor: pointer; padding: 8px; color: var(--text-muted); font-size: 14px;">
                 Advanced configuration (optional)
             </summary>
@@ -127,6 +127,15 @@
                     <option value="true"{{if eq .Form.AdvPunchy "true"}} selected{{end}}>force true</option>
                     <option value="false"{{if eq .Form.AdvPunchy "false"}} selected{{end}}>disable</option>
                 </select>
+            </div>
+            <div class="form-group">
+                <label>Punchy respond (advanced.punchy_respond)</label>
+                <select name="adv_punchy_respond" class="form-control">
+                    <option value=""{{if eq .Form.AdvPunchyRespond ""}} selected{{end}}>inherit (false)</option>
+                    <option value="true"{{if eq .Form.AdvPunchyRespond "true"}} selected{{end}}>force true</option>
+                    <option value="false"{{if eq .Form.AdvPunchyRespond "false"}} selected{{end}}>disable</option>
+                </select>
+                <small class="form-text">Enable for a host behind a difficult NAT: it connects back out to any peer that failed to reach it, instead of staying unreachable until it sends traffic itself.</small>
             </div>
             <div class="form-group">
                 <label>Unsafe routes (one per line: <code>CIDR via NEBULA_IP</code>)</label>


### PR DESCRIPTION
## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
