### PR TITLE
fix(hosts): explain duplicate host names instead of returning a generic 500

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -324,6 +324,15 @@ paths:
                 $ref: "#/components/schemas/CreateHostResponse"
         "400":
           $ref: "#/components/responses/Error"
+        "409":
+          description: >-
+            The name is already taken by another host in the network, one of
+            the requested nebula_ips is already assigned, or a mesh import is
+            collecting for this network.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /api/v1/hosts/{id}:
     get:

--- a/internal/api/host_duplicate_name_test.go
+++ b/internal/api/host_duplicate_name_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// postHost submits a host-create request and returns the recorder.
+func postHost(t *testing.T, srv *Server, networkID, name, ip string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(createHostRequest{
+		NetworkID: networkID,
+		Name:      name,
+		NebulaIPs: []string{ip},
+		Role:      "host",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hosts", bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
+}
+
+// TestCreateHost_DuplicateNameConflicts pins the API side of the same gap the
+// web form had: the handler already maps the overlay-address collision to 409
+// (ErrIPTaken) but let the UNIQUE(network_id, name) violation fall through to
+// a 500, reporting an operator input error as a server fault.
+func TestCreateHost_DuplicateNameConflicts(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	if w := postHost(t, srv, netID, "blai", "192.168.100.10"); w.Code != http.StatusCreated {
+		t.Fatalf("first create: status = %d, want 201; body=%s", w.Code, w.Body.String())
+	}
+
+	w := postHost(t, srv, netID, "blai", "192.168.100.11")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate name: status = %d, want 409; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "blai") || !strings.Contains(body, "already exists") {
+		t.Errorf("error should name the colliding host and say it already exists; got: %s", body)
+	}
+}
+
+// TestCreateHost_SameNameDifferentNetworkAllowed keeps the 409 scoped to the
+// network the constraint actually covers.
+func TestCreateHost_SameNameDifferentNetworkAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	body := `{"name":"second-net","cidrs":["192.168.200.0/24"]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/networks", bytes.NewBufferString(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	var second struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&second); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec := postHost(t, srv, netID, "shared", "192.168.100.20"); rec.Code != http.StatusCreated {
+		t.Fatalf("create in first network: status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := postHost(t, srv, second.ID, "shared", "192.168.200.20"); rec.Code != http.StatusCreated {
+		t.Errorf("same name in another network must succeed: status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// patchHostName submits a rename and returns the recorder.
+func patchHostName(t *testing.T, srv *Server, hostID, name string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(updateHostRequest{Name: &name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/hosts/"+hostID, bytes.NewBuffer(body))
+	authRequest(req)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
+}
+
+// TestUpdateHost_DuplicateNameRejected covers the rename half of the gap. The
+// handler already answers 409 for a colliding overlay address; a colliding
+// name is the same class of operator error and trips the same table's unique
+// index, so it must not surface as a 500.
+func TestUpdateHost_DuplicateNameRejected(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	createHostHelper(t, srv, netID, "tauro", "192.168.100.30", nil)
+	mover := createHostHelper(t, srv, netID, "agricer", "192.168.100.31", nil)
+
+	w := patchHostName(t, srv, mover.ID, "tauro")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("rename onto a taken name: status = %d, want 409; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "tauro") || !strings.Contains(body, "already exists") {
+		t.Errorf("error should name the colliding host and say it already exists; got: %s", body)
+	}
+}
+
+// TestUpdateHost_RenameToOwnNameAllowed guards the self-exclusion: resubmitting
+// a host's existing name is not a conflict.
+func TestUpdateHost_RenameToOwnNameAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	netID := createNetwork(t, srv)
+
+	host := createHostHelper(t, srv, netID, "isis", "192.168.100.40", nil)
+
+	if w := patchHostName(t, srv, host.ID, "isis"); w.Code != http.StatusOK {
+		t.Errorf("keeping its own name: status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -194,6 +194,17 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// Friendly fast-path, as validateHostIPs is for addresses: answer the
+	// collision before the write so the client reads a cause rather than a
+	// constraint failure. The store's UNIQUE guard below still covers the race.
+	if existing, err := conflictingHostName(r.Context(), s.store, host.NetworkID, host.Name, ""); err != nil {
+		s.logger.Error("check host name", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create host")
+		return
+	} else if existing != nil {
+		writeError(w, http.StatusConflict, duplicateHostNameMsg(host.Name))
+		return
+	}
 	if err := validateHostGroups(host.Groups); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -222,6 +233,14 @@ func (s *Server) handleCreateHost(w http.ResponseWriter, r *http.Request) {
 		// guard means another writer claimed the IP in between.
 		if errors.Is(err, store.ErrIPTaken) {
 			writeError(w, http.StatusConflict, "one or more nebula_ips are already assigned to another host in this network")
+			return
+		}
+		// Duplicate name in the same network — the table's only unique
+		// index. Like ErrIPTaken above this is a request the operator can
+		// fix, so answer 409 naming the collision rather than a 500 that
+		// reads as a server fault.
+		if errors.Is(err, store.ErrDuplicateEntry) {
+			writeError(w, http.StatusConflict, duplicateHostNameMsg(host.Name))
 			return
 		}
 		s.logger.Error("create host and token", "error", err)
@@ -696,6 +715,14 @@ func (s *Server) handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		if existing, err := conflictingHostName(r.Context(), s.store, host.NetworkID, name, host.ID); err != nil {
+			s.logger.Error("check host name", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to update host")
+			return
+		} else if existing != nil {
+			writeError(w, http.StatusConflict, duplicateHostNameMsg(name))
+			return
+		}
 		host.Name = name
 	}
 
@@ -805,6 +832,14 @@ func (s *Server) handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 		// IP in between.
 		if errors.Is(err, store.ErrIPTaken) {
 			writeError(w, http.StatusConflict, "one or more nebula_ips are already assigned to another host in this network")
+			return
+		}
+		// Same TOCTOU framing as ErrIPTaken: the fast-path above answered any
+		// name collision visible at request time, so reaching the store's
+		// UNIQUE(network_id, name) guard means another writer took the name in
+		// between.
+		if errors.Is(err, store.ErrDuplicateEntry) {
+			writeError(w, http.StatusConflict, duplicateHostNameMsg(host.Name))
 			return
 		}
 		s.logger.Error("update host", "error", err)

--- a/internal/api/validate_name.go
+++ b/internal/api/validate_name.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// conflictingHostName returns the host that already holds name inside the
+// network, or nil when the name is free.
+//
+// This is the friendly fast-path counterpart of validateHostIPs: looking the
+// name up before the write lets the operator read a cause that names the
+// incumbent, instead of a constraint failure the handler can only report as a
+// server fault. excludeHostID keeps a rename that leaves the name unchanged
+// from conflicting with itself.
+//
+// It is a courtesy, not a guarantee — two concurrent writers can both find the
+// name free. UNIQUE(network_id, name) stays the authority, and the store still
+// reports ErrDuplicateEntry when this check loses the race.
+func conflictingHostName(ctx context.Context, s store.Store, networkID, name, excludeHostID string) (*models.Host, error) {
+	existing, err := s.GetHostByName(ctx, networkID, name)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if existing.ID == excludeHostID {
+		return nil, nil
+	}
+	return existing, nil
+}
+
+// duplicateHostNameMsg phrases the collision for the API client.
+func duplicateHostNameMsg(name string) string {
+	return fmt.Sprintf("a host named %q already exists in this network", name)
+}

--- a/internal/store/host_duplicate_name_test.go
+++ b/internal/store/host_duplicate_name_test.go
@@ -1,0 +1,179 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// newDupNameHost builds a host fixture that differs from its sibling only in
+// id and overlay address, so the sole constraint a second insert can trip is
+// UNIQUE(network_id, name).
+func newDupNameHost(networkID, id, name, ip string) *models.Host {
+	return &models.Host{
+		ID:        id,
+		NetworkID: networkID,
+		Name:      name,
+		NebulaIPs: []string{ip},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusPending,
+		Groups:    []string{},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+// TestCreateHostAndToken_DuplicateNameIsDuplicateEntry pins the agent-create
+// path. A second host reusing a name already taken in the same network is an
+// operator input error, not a server fault, so the store must report it as
+// ErrDuplicateEntry — the sentinel the transports already translate into a
+// friendly 400/409 — instead of leaking the raw SQLite constraint text and
+// leaving handlers no choice but a generic 500.
+func TestCreateHostAndToken_DuplicateNameIsDuplicateEntry(t *testing.T) {
+	s := newTestStore(t)
+	n := createTestNetwork(t, s)
+	ctx := context.Background()
+
+	tok := func(id, hostID string) *models.EnrollmentToken {
+		return &models.EnrollmentToken{
+			ID: id, HostID: hostID,
+			ExpiresAt: time.Now().Add(time.Hour), CreatedAt: time.Now(),
+		}
+	}
+
+	if err := s.CreateHostAndToken(ctx, newDupNameHost(n.ID, "h1", "blai", "192.168.100.10"), tok("t1", "h1"), "raw-token-1"); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	err := s.CreateHostAndToken(ctx, newDupNameHost(n.ID, "h2", "blai", "192.168.100.11"), tok("t2", "h2"), "raw-token-2")
+	if err == nil {
+		t.Fatal("second create with a duplicate name succeeded; want an error")
+	}
+	if !errors.Is(err, ErrDuplicateEntry) {
+		t.Errorf("errors.Is(err, ErrDuplicateEntry) = false, want true; got %v", err)
+	}
+}
+
+// TestCreateHost_DuplicateNameIsDuplicateEntry pins the mobile-create path,
+// which bypasses CreateHostAndToken and so needs the same mapping.
+func TestCreateHost_DuplicateNameIsDuplicateEntry(t *testing.T) {
+	s := newTestStore(t)
+	n := createTestNetwork(t, s)
+	ctx := context.Background()
+
+	if err := s.CreateHost(ctx, newDupNameHost(n.ID, "m1", "movil", "192.168.100.20")); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	err := s.CreateHost(ctx, newDupNameHost(n.ID, "m2", "movil", "192.168.100.21"))
+	if err == nil {
+		t.Fatal("second create with a duplicate name succeeded; want an error")
+	}
+	if !errors.Is(err, ErrDuplicateEntry) {
+		t.Errorf("errors.Is(err, ErrDuplicateEntry) = false, want true; got %v", err)
+	}
+}
+
+// TestCreateHost_SameNameDifferentNetworkAllowed guards the blast radius: the
+// constraint is per network, so the mapping must not turn a legitimate insert
+// into a duplicate error.
+func TestCreateHost_SameNameDifferentNetworkAllowed(t *testing.T) {
+	s := newTestStore(t)
+	n1 := createTestNetwork(t, s)
+	ctx := context.Background()
+
+	n2 := &models.Network{ID: "net_test2", Name: "second", CIDRs: []string{"192.168.200.0/24"}, CreatedAt: time.Now()}
+	if err := s.CreateNetwork(ctx, n2); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.CreateHost(ctx, newDupNameHost(n1.ID, "a1", "shared", "192.168.100.30")); err != nil {
+		t.Fatalf("create in first network: %v", err)
+	}
+	if err := s.CreateHost(ctx, newDupNameHost(n2.ID, "a2", "shared", "192.168.200.30")); err != nil {
+		t.Errorf("same name in a different network must be allowed; got %v", err)
+	}
+}
+
+// TestUpdateHost_DuplicateNameIsDuplicateEntry covers the rename half of the
+// same constraint. Renaming a host onto a name another host already holds in
+// the network trips UNIQUE(network_id, name) exactly like an insert does, so
+// it must reach callers as the same sentinel rather than a raw SQLite error
+// they can only report as a 500.
+func TestUpdateHost_DuplicateNameIsDuplicateEntry(t *testing.T) {
+	s := newTestStore(t)
+	n := createTestNetwork(t, s)
+	ctx := context.Background()
+
+	if err := s.CreateHost(ctx, newDupNameHost(n.ID, "keep", "tauro", "192.168.100.40")); err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	if err := s.CreateHost(ctx, newDupNameHost(n.ID, "move", "agricer", "192.168.100.41")); err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+
+	renamed := newDupNameHost(n.ID, "move", "tauro", "192.168.100.41")
+	err := s.UpdateHost(ctx, renamed)
+	if err == nil {
+		t.Fatal("rename onto a taken name succeeded; want an error")
+	}
+	if !errors.Is(err, ErrDuplicateEntry) {
+		t.Errorf("errors.Is(err, ErrDuplicateEntry) = false, want true; got %v", err)
+	}
+}
+
+// TestUpdateHost_RenameToOwnNameSucceeds guards the exclusion rule: a host
+// keeping its own name across an edit is not a collision with itself.
+func TestUpdateHost_RenameToOwnNameSucceeds(t *testing.T) {
+	s := newTestStore(t)
+	n := createTestNetwork(t, s)
+	ctx := context.Background()
+
+	if err := s.CreateHost(ctx, newDupNameHost(n.ID, "self", "isis", "192.168.100.50")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	same := newDupNameHost(n.ID, "self", "isis", "192.168.100.50")
+	same.Groups = []string{"edited"}
+	if err := s.UpdateHost(ctx, same); err != nil {
+		t.Errorf("keeping its own name must not be a conflict; got %v", err)
+	}
+}
+
+// TestGetHostByName_ScopedToNetwork pins the lookup the transports use for
+// their friendly pre-check: it resolves within a network and reports
+// ErrNotFound rather than matching a same-named host in another network.
+func TestGetHostByName_ScopedToNetwork(t *testing.T) {
+	s := newTestStore(t)
+	n1 := createTestNetwork(t, s)
+	ctx := context.Background()
+
+	n2 := &models.Network{ID: "net_other", Name: "other", CIDRs: []string{"192.168.200.0/24"}, CreatedAt: time.Now()}
+	if err := s.CreateNetwork(ctx, n2); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateHost(ctx, newDupNameHost(n1.ID, "lookup", "zeus", "192.168.100.60")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetHostByName(ctx, n1.ID, "zeus")
+	if err != nil {
+		t.Fatalf("GetHostByName in owning network: %v", err)
+	}
+	if got.ID != "lookup" {
+		t.Errorf("id = %q, want %q", got.ID, "lookup")
+	}
+	if len(got.NebulaIPs) != 1 || got.NebulaIPs[0] != "192.168.100.60" {
+		t.Errorf("NebulaIPs = %v, want [192.168.100.60]", got.NebulaIPs)
+	}
+
+	if _, err := s.GetHostByName(ctx, n2.ID, "zeus"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("lookup in another network: err = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetHostByName(ctx, n1.ID, "nonexistent"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("lookup of a missing name: err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1130,6 +1130,20 @@ func (s *SQLiteStore) CreateHost(ctx context.Context, h *models.Host) error {
 		h.NetworkID, models.MeshImportStatusCollecting,
 	)
 	if err != nil {
+		// A unique violation here is almost certainly the name, since
+		// UNIQUE(network_id, name) is the table's only unique index today —
+		// but confirm it instead of assuming. Were a later migration to add
+		// another unique index, guessing would blame the name for an
+		// unrelated failure; unconfirmed, the raw error stands and the caller
+		// reports a server fault, which is the honest answer. Non-constraint
+		// failures stay clear of this path entirely (a full disk raises
+		// SQLITE_FULL, not SQLITE_CONSTRAINT_UNIQUE). Overlay-address
+		// collisions are separate: setHostAddresses maps those to ErrIPTaken.
+		if isSQLiteUniqueViolation(err) {
+			if taken, lookupErr := hostNameTaken(ctx, tx, h.NetworkID, h.Name, h.ID); lookupErr == nil && taken {
+				return fmt.Errorf("host name %q: %w", h.Name, ErrDuplicateEntry)
+			}
+		}
 		return fmt.Errorf("insert host: %w", err)
 	}
 	if rows, err := result.RowsAffected(); err != nil {
@@ -1255,6 +1269,51 @@ func (s *SQLiteStore) GetHost(ctx context.Context, id string) (*models.Host, err
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get host: %w", err)
+	}
+
+	addrs, err := s.loadHostAddresses(ctx, h.ID)
+	if err != nil {
+		return nil, err
+	}
+	h.NebulaIPs = addrs
+
+	return h, nil
+}
+
+// GetHostByName resolves a host by the name it holds inside a network. The
+// UNIQUE(network_id, name) constraint makes the pair a key, so the lookup is
+// an index seek and can return at most one row. Transports use it as the
+// friendly pre-check before a create or rename, mirroring what
+// validateHostIPs does for overlay addresses: report the collision — naming
+// the host that already holds it — before attempting the write.
+// hostNameTaken reports whether some host *other than* excludeID already
+// holds name in the network. It runs on the caller's transaction rather than
+// s.db on purpose: an in-memory store caps the pool at a single connection
+// (see NewSQLiteStore), so querying s.db while a transaction is open would
+// deadlock. Reusing tx after a failed statement is sound — SQLite's default
+// ABORT conflict resolution rolls back only the offending statement, leaving
+// the transaction usable.
+func hostNameTaken(ctx context.Context, tx *sql.Tx, networkID, name, excludeID string) (bool, error) {
+	var taken int
+	err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM hosts WHERE network_id = ? AND name = ? AND id <> ?)`,
+		networkID, name, excludeID).Scan(&taken)
+	if err != nil {
+		return false, fmt.Errorf("check host name taken: %w", err)
+	}
+	return taken == 1, nil
+}
+
+func (s *SQLiteStore) GetHostByName(ctx context.Context, networkID, name string) (*models.Host, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+hostColumns+` FROM hosts WHERE network_id = ? AND name = ?`,
+		networkID, name)
+	h, err := s.scanHost(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get host by name: %w", err)
 	}
 
 	addrs, err := s.loadHostAddresses(ctx, h.ID)
@@ -1407,6 +1466,15 @@ func (s *SQLiteStore) UpdateHost(ctx context.Context, h *models.Host) error {
 		unsafeNetworksJSON, h.ID,
 	)
 	if err != nil {
+		// Same reasoning as the insert paths: a rename onto a name another
+		// host already holds trips UNIQUE(network_id, name). Excluding this
+		// host's own id keeps an edit that leaves the name untouched from
+		// looking like a collision with itself.
+		if isSQLiteUniqueViolation(err) {
+			if taken, lookupErr := hostNameTaken(ctx, tx, h.NetworkID, h.Name, h.ID); lookupErr == nil && taken {
+				return fmt.Errorf("host name %q: %w", h.Name, ErrDuplicateEntry)
+			}
+		}
 		return fmt.Errorf("update host: %w", err)
 	}
 
@@ -1875,6 +1943,20 @@ func (s *SQLiteStore) CreateHostAndToken(ctx context.Context, h *models.Host, t 
 		h.NetworkID, models.MeshImportStatusCollecting,
 	)
 	if err != nil {
+		// A unique violation here is almost certainly the name, since
+		// UNIQUE(network_id, name) is the table's only unique index today —
+		// but confirm it instead of assuming. Were a later migration to add
+		// another unique index, guessing would blame the name for an
+		// unrelated failure; unconfirmed, the raw error stands and the caller
+		// reports a server fault, which is the honest answer. Non-constraint
+		// failures stay clear of this path entirely (a full disk raises
+		// SQLITE_FULL, not SQLITE_CONSTRAINT_UNIQUE). Overlay-address
+		// collisions are separate: setHostAddresses maps those to ErrIPTaken.
+		if isSQLiteUniqueViolation(err) {
+			if taken, lookupErr := hostNameTaken(ctx, tx, h.NetworkID, h.Name, h.ID); lookupErr == nil && taken {
+				return fmt.Errorf("host name %q: %w", h.Name, ErrDuplicateEntry)
+			}
+		}
 		return fmt.Errorf("insert host: %w", err)
 	}
 	if rows, err := result.RowsAffected(); err != nil {

--- a/internal/store/sqlite_mesh_import.go
+++ b/internal/store/sqlite_mesh_import.go
@@ -1048,3 +1048,13 @@ func isSQLiteConstraint(err error) bool {
 	var sqliteErr interface{ Code() int }
 	return errors.As(err, &sqliteErr) && (sqliteErr.Code() == sqliteConstraintUnique || sqliteErr.Code() == sqliteConstraintPrimaryKey)
 }
+
+// isSQLiteUniqueViolation reports whether err is a UNIQUE constraint failure
+// specifically. Unlike isSQLiteConstraint it excludes PRIMARY KEY collisions,
+// so a caller can attribute the failure to the table's unique index without
+// also swallowing a duplicate server-generated id — which would be a genuine
+// bug, not operator input.
+func isSQLiteUniqueViolation(err error) bool {
+	var sqliteErr interface{ Code() int }
+	return errors.As(err, &sqliteErr) && sqliteErr.Code() == sqliteConstraintUnique
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -90,6 +90,7 @@ type Store interface {
 	CreateHost(ctx context.Context, h *models.Host) error
 	GetHost(ctx context.Context, id string) (*models.Host, error)
 	GetHostByFingerprint(ctx context.Context, fingerprint string) (*models.Host, error)
+	GetHostByName(ctx context.Context, networkID, name string) (*models.Host, error)
 	ListHosts(ctx context.Context, filter HostFilter) ([]*models.Host, error)
 	// UpdateHost persists the host row and atomically resets its
 	// config_version to 0 in the same transaction (SEC-PERSIST-001), so the

--- a/internal/web/form_state.go
+++ b/internal/web/form_state.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -388,4 +389,11 @@ func (w *Web) renderOperatorNewError(rw http.ResponseWriter, r *http.Request, fo
 		"Form":         form,
 		"PasswordHint": hint,
 	})
+}
+
+// duplicateHostNameMsg phrases a UNIQUE(network_id, name) collision in the
+// operator's terms and points at both ways out, because the name may belong
+// to a host they no longer want — a stale pending enrolment, say.
+func duplicateHostNameMsg(name string) string {
+	return fmt.Sprintf("a host named %q already exists in this network — choose a different name, or delete the existing host first", name)
 }

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -879,8 +879,24 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 		network = n
 	}
 
-	// Validate NebulaIPs against the network if selected
+	// Friendly fast-path for the name, alongside the one the IP rows get
+	// below: resolve the collision before writing so the form comes back
+	// with a reason. The store's UNIQUE guard still covers a lost race.
 	networkID := form.NetworkID
+	if networkID != "" {
+		existing, err := conflictingHostName(r.Context(), w.store, networkID, form.Name, "")
+		if err != nil {
+			w.logger.Error("check host name", "error", err)
+			http.Error(rw, "Failed to create host", http.StatusInternalServerError)
+			return
+		}
+		if existing != nil {
+			w.renderHostNewError(rw, r, form, duplicateHostNameMsg(form.Name))
+			return
+		}
+	}
+
+	// Validate NebulaIPs against the network if selected
 	if len(form.NebulaIPs) > 0 && networkID != "" {
 		perRowErrors := make(map[int]string)
 		for i, ip := range form.NebulaIPs {
@@ -1013,6 +1029,10 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 				http.Error(rw, "Mesh import collection is in progress for this network", http.StatusConflict)
 				return
 			}
+			if errors.Is(err, store.ErrDuplicateEntry) {
+				w.renderHostNewError(rw, r, form, duplicateHostNameMsg(form.Name))
+				return
+			}
 			w.logger.Error("create mobile host", "error", err)
 			http.Error(rw, "Failed to create host", http.StatusInternalServerError)
 			return
@@ -1036,6 +1056,15 @@ func (w *Web) handleHostCreate(rw http.ResponseWriter, r *http.Request) {
 	if err := w.store.CreateHostAndToken(r.Context(), host, token, rawToken); err != nil {
 		if errors.Is(err, store.ErrMeshImportInProgress) {
 			http.Error(rw, "Mesh import collection is in progress for this network", http.StatusConflict)
+			return
+		}
+		// A name already taken in this network is operator input, not a
+		// server fault: route it through the same inline-error path as
+		// every other field so the form comes back populated with the
+		// reason, instead of the bare 500 that left operators unable to
+		// tell a typo from an outage.
+		if errors.Is(err, store.ErrDuplicateEntry) {
+			w.renderHostNewError(rw, r, form, duplicateHostNameMsg(form.Name))
 			return
 		}
 		w.logger.Error("create host and token", "error", err)
@@ -1169,6 +1198,15 @@ func (w *Web) handleHostUpdate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if existing, err := conflictingHostName(r.Context(), w.store, host.NetworkID, name, host.ID); err != nil {
+		w.logger.Error("check host name", "error", err)
+		http.Error(rw, "Failed to update host", http.StatusInternalServerError)
+		return
+	} else if existing != nil {
+		w.renderHostEditError(rw, r, host, network, form, duplicateHostNameMsg(name))
+		return
+	}
+
 	// Validate NebulaIPs
 	if len(form.NebulaIPs) == 0 {
 		w.renderHostEditError(rw, r, host, network, form, "at least one IP address is required")
@@ -1279,6 +1317,13 @@ func (w *Web) handleHostUpdate(rw http.ResponseWriter, r *http.Request) {
 	// bump the network config version on a role change. config_version reset
 	// and the pending-rekey flag commit inside UpdateHost (SEC-PERSIST-001).
 	if err := store.ApplyHostEdit(r.Context(), w.store, w.logger, &before, host); err != nil {
+		// The fast-path above answered any collision visible at request time,
+		// so reaching the store's UNIQUE(network_id, name) guard means another
+		// writer claimed the name in between. Still the operator's to fix.
+		if errors.Is(err, store.ErrDuplicateEntry) {
+			w.renderHostEditError(rw, r, host, network, form, duplicateHostNameMsg(host.Name))
+			return
+		}
 		w.logger.Error("update host", "error", err)
 		http.Error(rw, "Failed to update host", http.StatusInternalServerError)
 		return

--- a/internal/web/host_duplicate_name_test.go
+++ b/internal/web/host_duplicate_name_test.go
@@ -1,0 +1,189 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+)
+
+// createHostViaForm posts the host-create form and returns the recorder, so a
+// test can assert on the response of a second, colliding submission.
+func createHostViaForm(t *testing.T, w *Web, cookies []*http.Cookie, networkID, name, ip string) *httptest.ResponseRecorder {
+	t.Helper()
+	csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/hosts", cookies)
+	form := url.Values{
+		"network_id": {networkID},
+		"name":       {name},
+		"nebula_ips": {ip},
+		"role":       {"host"},
+		"_csrf":      {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range updatedCookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestHostCreate_DuplicateNameRendersInlineError reproduces the production
+// failure behind issue "cannot add a new host": reusing a host name already
+// present in the network returned a bare 500 "Failed to create host" with no
+// hint of the cause, so an operator could not tell an input mistake from a
+// server outage. A duplicate name is form input, so it must come back through
+// the same inline-error path as every other field: 400, the form re-rendered
+// with the submitted values, and a message naming the collision.
+func TestHostCreate_DuplicateNameRendersInlineError(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "n-dup", Name: "n", CIDRs: []string{"10.0.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec := createHostViaForm(t, w, cookies, "n-dup", "blai", "10.0.0.10"); rec.Code != http.StatusOK {
+		t.Fatalf("first create: status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec := createHostViaForm(t, w, cookies, "n-dup", "blai", "10.0.0.11")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("duplicate name: status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "Failed to create host") {
+		t.Errorf("body must not fall through to the generic failure text; got:\n%s", body)
+	}
+	if !strings.Contains(body, "blai") || !strings.Contains(body, "already exists") {
+		t.Errorf("body should name the colliding host and say it already exists; got:\n%s", body)
+	}
+	// The form must come back populated so the operator can correct the name
+	// without retyping the rest.
+	if !strings.Contains(body, `value="10.0.0.11"`) {
+		t.Errorf("submitted nebula_ip should be preserved in the re-rendered form; got:\n%s", body)
+	}
+}
+
+// TestHostCreate_SameNameDifferentNetworkSucceeds guards against the fix
+// over-reaching: names are unique per network, not globally.
+func TestHostCreate_SameNameDifferentNetworkSucceeds(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	ctx := context.Background()
+	for _, n := range []*models.Network{
+		{ID: "n-one", Name: "one", CIDRs: []string{"10.1.0.0/24"}, CreatedAt: time.Now()},
+		{ID: "n-two", Name: "two", CIDRs: []string{"10.2.0.0/24"}, CreatedAt: time.Now()},
+	} {
+		if err := s.CreateNetwork(ctx, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if rec := createHostViaForm(t, w, cookies, "n-one", "shared", "10.1.0.10"); rec.Code != http.StatusOK {
+		t.Fatalf("create in first network: status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := createHostViaForm(t, w, cookies, "n-two", "shared", "10.2.0.10"); rec.Code != http.StatusOK {
+		t.Errorf("same name in another network must succeed: status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// seedHost inserts a host directly, bypassing the form, so a rename test can
+// set up the collision without depending on the create path.
+func seedHost(t *testing.T, s hostSeeder, id, networkID, name, ip string) {
+	t.Helper()
+	if err := s.CreateHost(context.Background(), &models.Host{
+		ID:        id,
+		NetworkID: networkID,
+		Name:      name,
+		NebulaIPs: []string{ip},
+		Groups:    []string{},
+		Role:      models.HostRoleHost,
+		Status:    models.HostStatusEnrolled,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type hostSeeder interface {
+	CreateHost(ctx context.Context, h *models.Host) error
+}
+
+// renameHostViaForm submits the host edit form with a new name.
+func renameHostViaForm(t *testing.T, w *Web, cookies []*http.Cookie, hostID, networkID, name, ip string) *httptest.ResponseRecorder {
+	t.Helper()
+	csrfToken, updatedCookies := getCSRFTokenFromCookies(t, w, "/ui/hosts/"+hostID+"/edit", cookies)
+	form := url.Values{
+		"network_id": {networkID},
+		"name":       {name},
+		"nebula_ips": {ip},
+		"role":       {"host"},
+		"_csrf":      {csrfToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/ui/hosts/"+hostID+"/edit", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range updatedCookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	w.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestHostUpdate_POST_DuplicateName is the rename counterpart of the create
+// test: renaming onto a taken name must re-render the edit form with the
+// reason rather than emitting a bare 500 "Failed to update host".
+func TestHostUpdate_POST_DuplicateName(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "n-ren", Name: "n", CIDRs: []string{"10.5.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seedHost(t, s, "h-keep", "n-ren", "tauro", "10.5.0.10")
+	seedHost(t, s, "h-move", "n-ren", "agricer", "10.5.0.11")
+
+	rec := renameHostViaForm(t, w, cookies, "h-move", "n-ren", "tauro", "10.5.0.11")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("rename onto a taken name: status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "Failed to update host") {
+		t.Errorf("body must not fall through to the generic failure text; got:\n%s", body)
+	}
+	if !strings.Contains(body, "tauro") || !strings.Contains(body, "already exists") {
+		t.Errorf("body should name the colliding host and say it already exists; got:\n%s", body)
+	}
+}
+
+// TestHostUpdate_POST_RenameToOwnNameSucceeds guards the self-exclusion on the
+// web path: an edit that leaves the name alone must still save.
+func TestHostUpdate_POST_RenameToOwnNameSucceeds(t *testing.T) {
+	w, s := newTestWeb(t)
+	cookies := loginSession(t, w)
+
+	if err := s.CreateNetwork(context.Background(), &models.Network{
+		ID: "n-self", Name: "n", CIDRs: []string{"10.6.0.0/24"}, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seedHost(t, s, "h-self", "n-self", "isis", "10.6.0.10")
+
+	rec := renameHostViaForm(t, w, cookies, "h-self", "n-self", "isis", "10.6.0.10")
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("keeping its own name: status = %d, want 303; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/web/validate_name.go
+++ b/internal/web/validate_name.go
@@ -1,0 +1,33 @@
+package web
+
+import (
+	"context"
+	"errors"
+
+	"github.com/forgekeep/nebula-mesh/internal/models"
+	"github.com/forgekeep/nebula-mesh/internal/store"
+)
+
+// conflictingHostName returns the host that already holds name inside the
+// network, or nil when the name is free.
+//
+// Mirrors validateHostIPForNetwork: resolve the collision before writing so
+// the form comes back with a reason naming the incumbent, rather than the
+// bare 500 a raw constraint failure leaves the handler with. excludeHostID
+// keeps an edit that leaves the name unchanged from conflicting with itself.
+//
+// The lookup can be raced by a concurrent writer; UNIQUE(network_id, name)
+// stays the authority and the store still reports ErrDuplicateEntry if so.
+func conflictingHostName(ctx context.Context, s store.Store, networkID, name, excludeHostID string) (*models.Host, error) {
+	existing, err := s.GetHostByName(ctx, networkID, name)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if existing.ID == excludeHostID {
+		return nil, nil
+	}
+	return existing, nil
+}


### PR DESCRIPTION

Creating a host whose name was already taken in its network failed with a bare "500 Failed to create host": the UNIQUE(network_id, name) violation reached the handlers as a raw SQLite error, leaving an operator unable to tell a typo from an outage. Renaming onto a taken name failed the same way.

Both paths now follow the two-layer shape the codebase already uses for overlay addresses:

- A friendly pre-check (conflictingHostName, mirroring validateHostIPs) resolves the collision before the write and names the incumbent, on create and on rename, in both the web form and the API. A host keeping its own name is excluded, so an edit that leaves the name alone still saves.

- The UNIQUE index remains the authority, since the pre-check can be raced. CreateHost, CreateHostAndToken and UpdateHost map the violation to ErrDuplicateEntry, which the transports answer with an inline form error (web) or 409 (API). UpdateHost mapped nothing at all before, which is why a colliding rename surfaced as a 500.

Attribution is confirmed rather than assumed: a unique violation triggers a lookup before it is blamed on the name. UNIQUE(network_id, name) is the table's only unique index today, but a later migration adding another would otherwise make this silently misreport an unrelated failure. Unconfirmed, the raw error stands and the caller reports a server fault. Non-constraint failures never reach the path at all: a full disk raises SQLITE_FULL, not SQLITE_CONSTRAINT_UNIQUE.

Adds GetHostByName to the store, and documents the 409 that POST /api/v1/hosts has been able to return since ErrIPTaken.


## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] New behaviour has tests
- [x] User-facing changes are reflected in README / configs
- [x] No breaking API changes, or they are called out above
